### PR TITLE
Fix database URL access and expose legacy accessor

### DIFF
--- a/core/db.py
+++ b/core/db.py
@@ -41,7 +41,21 @@ def _normalize_dsn(url: str) -> str:
 class Base(DeclarativeBase):
     pass
 
-dsn = _normalize_dsn(settings.DATABASE_URL)
+try:
+    raw_dsn = settings.database_url
+except AttributeError as exc:  # pragma: no cover - safeguards legacy configs
+    raise AttributeError(
+        "AppSettings missing 'database_url'. Ensure settings expose a lower-case"
+        " attribute or update database configuration."
+    ) from exc
+
+if not raw_dsn:
+    raise RuntimeError(
+        "DATABASE_URL is empty. Please configure a valid connection string via the"
+        " environment variable DATABASE_URL."
+    )
+
+dsn = _normalize_dsn(raw_dsn)
 is_sqlite = dsn.startswith("sqlite")
 
 engine = create_engine(

--- a/settings.py
+++ b/settings.py
@@ -145,13 +145,21 @@ class AppSettings(BaseSettings):
     report_date: bool = True
 
     model_config = SettingsConfigDict(
-        env_prefix="", 
-        case_sensitive=False, 
+        env_prefix="",
+        case_sensitive=False,
         extra="ignore",
         # Deaktiviere automatisches ENV-Loading - wir nutzen from_env()
         env_ignore_empty=True,
         env_parse_none_str="null"
     )
+
+    # ------------------------------------------------------------------
+    # Backwards compatibility helpers
+    # ------------------------------------------------------------------
+    @property
+    def DATABASE_URL(self) -> str:
+        """Allow legacy uppercase access used in older modules."""
+        return self.database_url
 
     @field_validator("cors_origins", mode="before")
     @classmethod


### PR DESCRIPTION
## Summary
- ensure the SQLAlchemy engine reads the lower-case `database_url` setting and fail fast when the DSN is missing
- add a compatibility accessor so legacy code can still read `DATABASE_URL` on `AppSettings`

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'services')*


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691794c6f4b08330b624131edc741fe0)