### PR TITLE
Fix: Set SameSite=None for cross-site cookie authentication

### DIFF
--- a/routes/auth.py
+++ b/routes/auth.py
@@ -114,13 +114,13 @@ async def login(payload: LoginIn, request: Request, response: Response):
     log.debug("Token created successfully for user: %s", payload.email)
 
     # Phase 1: Set httpOnly cookie (hybrid mode)
-    # Cookie specs: name=auth_token, httpOnly, Secure, SameSite=Lax, max_age=3600
+    # Cookie specs: name=auth_token, httpOnly, Secure, SameSite=None, max_age=3600
     response.set_cookie(
         key="auth_token",
         value=token,
         httponly=True,
         secure=True,  # Only send over HTTPS
-        samesite="lax",  # CSRF protection
+        samesite="none",  # Allow cross-site cookies (required for cross-origin requests)
         max_age=3600,  # 1 hour in seconds
         path="/",  # Cookie available for entire domain
     )
@@ -167,7 +167,7 @@ async def logout(response: Response):
         path="/",
         httponly=True,
         secure=True,
-        samesite="lax",
+        samesite="none",
     )
     log.info("🚪 User logged out, cookie cleared")
 


### PR DESCRIPTION
Changed cookie SameSite attribute from 'lax' to 'none' to allow cross-site requests between frontend (make.ki-sicherheit.jetzt) and backend (api-ki-backend-neu-production.up.railway.app).

This fixes the issue where user_id was None during briefing submissions, as browsers were blocking the auth_token cookie on cross-site POST requests.

Changes:
- routes/auth.py: Login endpoint set_cookie SameSite=none
- routes/auth.py: Logout endpoint delete_cookie SameSite=none

The Secure flag is already set (required for SameSite=none), and CORS is properly configured with allow_credentials=True.