### PR TITLE
Fix indentation error in gpt_analyze.py line 1836-1837

### DIFF
--- a/gpt_analyze.py
+++ b/gpt_analyze.py
@@ -1833,16 +1833,16 @@ def analyze_briefing(db: Session, briefing_id: int, run_id: str) -> tuple[int, s
     except Exception as _exc:
         log.warning("[%s] ⚠️ Placeholder fix failed: %s", run_id, _exc)
 
-    result =     sections.update(build_extra_sections(answers, scores))
-render(
-        br, 
-        run_id=run_id, 
-        generated_sections=sections, 
-        use_fetchers=False, 
-        scores=scores, 
+    sections.update(build_extra_sections(answers, scores))
+    result = render(
+        br,
+        run_id=run_id,
+        generated_sections=sections,
+        use_fetchers=False,
+        scores=scores,
         meta={
-            "scores": scores, 
-            "score_details": score_wrap.get("details", {}), 
+            "scores": scores,
+            "score_details": score_wrap.get("details", {}),
             "research_last_updated": sections["research_last_updated"]
         }
     )


### PR DESCRIPTION
- Separated sections.update() call from render() assignment
- Fixed unexpected indent that caused Railway deployment failure
- Corrected result variable assignment to render() function call