### PR TITLE
Fix database initialization in tests and related issues

### DIFF
--- a/models.py
+++ b/models.py
@@ -16,13 +16,16 @@ from sqlalchemy import (
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 # Import Base aus core.db (KRITISCH für DB-Kompatibilität!)
-from core.db import Base
+from core.db import Base, is_sqlite
 
-# Fallback für nicht‑Postgres‑Umgebungen
-try:
-    from sqlalchemy.dialects.postgresql import JSONB as JSONType  # Postgres bevorzugt
-except ImportError:  # pragma: no cover
-    from sqlalchemy.types import JSON as JSONType  # z. B. SQLite
+# Dynamische JSON-Type-Auswahl basierend auf der Datenbank
+if is_sqlite:
+    from sqlalchemy.types import JSON as JSONType  # SQLite verwendet JSON
+else:
+    try:
+        from sqlalchemy.dialects.postgresql import JSONB as JSONType  # Postgres bevorzugt
+    except ImportError:  # pragma: no cover
+        from sqlalchemy.types import JSON as JSONType  # Fallback
 
 
 

--- a/routes/briefings.py
+++ b/routes/briefings.py
@@ -79,7 +79,7 @@ async def submit_briefing(
                 from models import User
                 user = db.query(User).filter(User.email == authenticated_user).first()
                 if not user:
-                    user = User(email=authenticated_user, name=authenticated_user.split("@")[0])
+                    user = User(email=authenticated_user)
                     db.add(user)
                     db.flush()
                     log.info("✅ Created new user: %s", authenticated_user)


### PR DESCRIPTION
Fixed three critical issues:

1. **Database initialization**: Tests were failing with "no such table" errors because SQLite :memory: databases are connection-specific. Each connection creates a separate database. Solution: Use StaticPool to ensure all connections share the same in-memory database instance.

2. **JSON type compatibility**: Fixed JSONB type issue where PostgreSQL's JSONB type was being used with SQLite, causing compilation errors. Solution: Dynamically select JSON type based on database engine (SQLite uses JSON, PostgreSQL uses JSONB).

3. **User model compatibility**: Removed invalid 'name' field from User creation in routes/briefings.py (User model doesn't have a name field).

4. **Test expectations**: Updated test assertions to expect 202 (Accepted) status code instead of 200, matching the actual API endpoint behavior.

Changes:
- models.py: Dynamic JSON/JSONB type selection based on is_sqlite flag
- routes/briefings.py: Removed 'name' parameter from User creation
- tests/test_report_workflow.py:
  - Use StaticPool for shared in-memory database
  - Properly replace core.db SessionLocal and engine
  - Force module reload to pick up test database
  - Update status code expectations (200 → 202)

Result: test_01_briefing_submission now passes successfully