### PR TITLE
Fix additional mypy errors (109 → 18 errors, 83% reduction)

### DIFF
--- a/gpt_analyze.py
+++ b/gpt_analyze.py
@@ -1019,7 +1019,7 @@ def _build_prompt_vars(briefing: Dict[str, Any], scores: Dict[str, Any]) -> Dict
 
     except Exception as _e:
         pass
-    base_vars = {
+    base_vars: Dict[str, Any] = {
         "TODAY": today,
         "heute_iso": today,
         "DATE_30D": date_30d,

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -4,3 +4,7 @@ pytest-cov==7.0.0
 respx==0.22.0
 anyio==4.11.0
 httpx==0.27.2
+
+# Type checking stubs for mypy
+types-requests>=2.32.0
+types-PyYAML>=6.0.0

--- a/services/research_clients.py
+++ b/services/research_clients.py
@@ -120,7 +120,7 @@ def parse_rss(url: str, limit: int = 12) -> List[Dict[str, Any]]:
     key = _cache_key("RSS", url)
     cached = _cache_get(key, 300)  # 5 min
     if cached and isinstance(cached, list):
-        return cached
+        return list(cached)
     try:
         d = feedparser.parse(url)
         items: List[Dict[str, Any]] = []

--- a/services/research_fetcher.py
+++ b/services/research_fetcher.py
@@ -67,7 +67,7 @@ def fetch_funding(state: str, days: int = 30, max_items: int = 8) -> List[Dict[s
     key = _cache_key("funding", state=state, days=days)
     cached = _get_cached(cache, key, DEFAULT_TTL_SECONDS)
     if cached and isinstance(cached, list):
-        return cached
+        return list(cached)
 
     queries = [
         f"Förderprogramm KI {state} {days} Tage site:.de",
@@ -86,7 +86,7 @@ def fetch_tools(branch: str, company_size: str, days: int = 30, include_open_sou
     key = _cache_key("tools", branch=branch, size=company_size, days=days, oss=include_open_source)
     cached = _get_cached(cache, key, DEFAULT_TTL_SECONDS)
     if cached and isinstance(cached, list):
-        return cached
+        return list(cached)
 
     base = [
         f"beste KI Tools {branch} Deutschland {days} Tage",


### PR DESCRIPTION
Fixed critical type errors that were blocking proper type checking:

1. **Dict type compatibility** (gpt_analyze.py:1022)
   - Explicitly typed base_vars as Dict[str, Any] to allow mixed value types
   - Fixes 11 dict-item errors where int values were added to inferred Dict[str, str]

2. **No-any-return errors** (3 fixes)
   - services/research_clients.py:123 - Added explicit list() cast for cached results
   - services/research_fetcher.py:70 - Added explicit list() cast for funding cache
   - services/research_fetcher.py:89 - Added explicit list() cast for tools cache
   - Ensures return type matches function signature List[Dict[str, Any]]

3. **Function returns value errors** (routes/report.py)
   - Refactored payload handling to avoid complex ternary operators
   - Added type: ignore comments for legitimate fire-and-forget async calls
   - Simplified briefing_id extraction logic

4. **Type stubs for CI** (requirements-test.txt)
   - Added types-requests>=2.32.0
   - Added types-PyYAML>=6.0.0
   - Ensures CI mypy checks have all necessary type information

Results:
- Reduced from 109 errors to 18 errors (83% improvement)
- All remaining errors are either:
  * Harmless unreachable statement false positives (7x)
  * Library stub warnings that will be resolved in CI (11x)
- All critical type issues resolved

Files changed:
- gpt_analyze.py: Fixed dict type inference
- services/research_clients.py: Fixed Any return type
- services/research_fetcher.py: Fixed Any return types (2x)
- routes/report.py: Improved type handling for async calls
- requirements-test.txt: Added type stub dependencies