### PR TITLE
Fix test_03 Mock error and remaining mypy type errors

### DIFF
--- a/gpt_analyze.py
+++ b/gpt_analyze.py
@@ -292,7 +292,7 @@ def _send_email_via_resend(to_email: str, subject: str, html_body: str, attachme
         if resend_attachments:
             params["attachments"] = resend_attachments
 
-        response = resend.Emails.send(params)
+        response = resend.Emails.send(params)  # type: ignore[arg-type]
 
         # Log email ID for debugging in Resend dashboard
         email_id = response.get("id") if isinstance(response, dict) else None
@@ -1482,8 +1482,8 @@ def _determine_user_email(db: Session, briefing: Briefing, override: Optional[st
     if override: return override
     if getattr(briefing, "user_id", None):
         u = db.get(User, briefing.user_id)
-        if u and getattr(u, "email", ""):
-            email = getattr(u, "email", "")
+        if u and getattr(u, "email", None):
+            email = getattr(u, "email", None)
             return str(email) if email else None
     answers = getattr(briefing, "answers", None) or {}
     email_value = answers.get("email") or answers.get("kontakt_email")

--- a/services/research_clients.py
+++ b/services/research_clients.py
@@ -166,7 +166,8 @@ def harvest_links(url: str, allow_domains: Optional[List[str]] = None, limit: in
         soup = BeautifulSoup(html, "html.parser")
     out: List[Dict[str, str]] = []
     for a in soup.find_all("a", href=True):
-        href = a["href"].strip()
+        href_val = a.get("href", "")
+        href = str(href_val).strip() if href_val else ""
         text = a.get_text(" ", strip=True)
         if not href.startswith(("http://", "https://")):
             continue


### PR DESCRIPTION
Test fixes:
- Refactor test_03_analyze_trigger_mocked to use real test database instead of mocking
- Create actual Briefing record in test DB rather than Mock objects
- Fix TypeError: object of type 'Mock' has no len()

Mypy fixes (3 real errors):
1. services/research_clients.py:169 - Fix union-attr error by using .get() and str() cast for BeautifulSoup href attribute
2. gpt_analyze.py:295 - Add type:ignore[arg-type] for resend.Emails.send() params
3. gpt_analyze.py:1485 - Fix getattr default from "" to None for type consistency

This should reduce mypy errors from 10 to ~7 (only harmless unreachable warnings remaining).