### PR TITLE
Fix rate limiting and improve error logging

### DIFF
--- a/gpt_analyze.py
+++ b/gpt_analyze.py
@@ -38,9 +38,9 @@ except ImportError:
     resend = None
 
 try:
-    from core.db import SessionLocal
+    import core.db
 except Exception:  # pragma: no cover
-    SessionLocal = None
+    core.db = None  # type: ignore
 
 from field_registry import fields  # added by Patch03
 from models import Analysis, Briefing, Report, User
@@ -2185,9 +2185,9 @@ def run_analysis_for_briefing(briefing_id: int, email: Optional[str] = None) -> 
 
 def run_async(briefing_id: int, email: Optional[str] = None) -> None:
     run_id = f"run-{uuid.uuid4().hex[:8]}"
-    if SessionLocal is None: 
+    if core.db is None or not hasattr(core.db, 'SessionLocal'):
         raise RuntimeError("database_unavailable")
-    db = SessionLocal()
+    db = core.db.SessionLocal()
     rep: Optional[Report] = None
     try:
         log.info("[%s] 🚀 Starting analysis v4.14.0-GOLD-PLUS for briefing_id=%s", run_id, briefing_id)


### PR DESCRIPTION
Fixes:
- Rate limiter now persists state across requests by using module-level variable
- SessionLocal in gpt_analyze.py now uses core.db.SessionLocal directly for better test compatibility
- Added exc_info=True to all error logs for full traceback information

This fixes test_04_rate_limiting which was failing because:
1. RateLimiter was created fresh on each request, losing state
2. Test database was not properly used in gpt_analyze.py