### PR TITLE
Fix remaining MyPy unused-ignore errors

### DIFF
--- a/gpt_analyze.py
+++ b/gpt_analyze.py
@@ -40,7 +40,7 @@ except ImportError:
 try:
     import core.db
 except Exception:  # pragma: no cover
-    core.db = None  # type: ignore[assignment]
+    core.db = None
 
 from field_registry import fields  # added by Patch03
 from models import Analysis, Briefing, Report, User

--- a/services/html_sanitizer.py
+++ b/services/html_sanitizer.py
@@ -71,7 +71,7 @@ def sanitize_section_html(html: Optional[str], compress_ws: bool = True) -> str:
 def sanitize_sections_dict(sections: dict, truthy_env: Optional[bool] = True) -> dict:
     """Sanitisiert alle string‑Werte in einem Sections‑Dict."""
     if not isinstance(sections, dict):
-        return sections  # type: ignore[return-value]
+        return sections  # type: ignore[unreachable]
     out = {}
     for k, v in sections.items():
         if isinstance(v, str):


### PR DESCRIPTION
- Remove unused type: ignore in gpt_analyze.py:43
- Fix html_sanitizer.py:74 to ignore unreachable instead of return-value