### PR TITLE
Fix Business Case placeholder replacement in HTML sections

### DIFF
--- a/gpt_analyze.py
+++ b/gpt_analyze.py
@@ -1996,6 +1996,21 @@ def analyze_briefing(db: Session, briefing_id: int, run_id: str) -> tuple[int, s
                  bc.get("PAYBACK_MONTHS", "N/A"),
                  bc.get("ROI_12M", "N/A"))
 
+        # FIX: Apply calculated values to HTML sections
+        for section_key in ['BUSINESS_CASE_HTML', 'LEAD_BUSINESS_DETAIL']:
+            if section_key in sections:
+                sections[section_key] = sections[section_key].replace(
+                    '{CAPEX_REALISTISCH_EUR}', str(bc.get('CAPEX_REALISTISCH_EUR', 6000))
+                ).replace(
+                    '{OPEX_REALISTISCH_EUR}', str(bc.get('OPEX_REALISTISCH_EUR', 120))
+                ).replace(
+                    '{EINSPARUNG_MONAT_EUR}', str(bc.get('EINSPARUNG_MONAT_EUR', 4500))
+                ).replace(
+                    '{PAYBACK_MONTHS}', str(bc.get('PAYBACK_MONTHS', 2.9))
+                ).replace(
+                    '{COMPANY_SIZE}', answers.get('unternehmensgroesse', 'solo')
+                )
+
     sections.update(build_extra_sections(answers, scores))
 
     # === Placeholder-Fix (jetzt mit Business Case Variablen verfügbar!) ===

--- a/gpt_analyze.py
+++ b/gpt_analyze.py
@@ -2047,7 +2047,7 @@ def analyze_briefing(db: Session, briefing_id: int, run_id: str) -> tuple[int, s
         br,
         run_id=run_id,
         generated_sections=sections,
-        use_fetchers=False,
+        use_fetchers=True,
         scores=scores,
         meta={
             "scores": scores,


### PR DESCRIPTION
Apply calculated CAPEX, OPEX, EINSPARUNG, PAYBACK values directly to BUSINESS_CASE_HTML and LEAD_BUSINESS_DETAIL sections after calculation.