### PR TITLE
Fix Tavily and Perplexity API errors (400 Bad Request)

### DIFF
--- a/services/provider_perplexity.py
+++ b/services/provider_perplexity.py
@@ -6,7 +6,7 @@ from typing import List, Dict, Any
 LOGGER = logging.getLogger(__name__)
 PPLX_API_KEY = os.getenv("PERPLEXITY_API_KEY", "")
 PPLX_ENDPOINT = os.getenv("PPLX_ENDPOINT", "https://api.perplexity.ai/chat/completions")
-PPLX_MODEL = os.getenv("PPLX_MODEL", "llama-3.1-sonar-large-128k-online")
+PPLX_MODEL = os.getenv("PERPLEXITY_MODEL") or os.getenv("PPLX_MODEL", "sonar-pro")
 
 SYSTEM = "You are a research assistant. Return concise JSON with a list of items [{title, url, summary}]. No markdown."
 USER_TMPL = "Find the most recent (last {days} days) {topic}. Return JSON only."

--- a/services/provider_tavily.py
+++ b/services/provider_tavily.py
@@ -18,15 +18,29 @@ def search(query: str, max_results: int = 6, days: int = 30) -> List[Dict]:
     if not TAVILY_API_KEY:
         LOGGER.warning("TAVILY_API_KEY not set")
         return []
+
+    # Map days to valid Tavily time_range values
+    if days <= 1:
+        time_range = "day"
+    elif days <= 7:
+        time_range = "week"
+    elif days <= 30:
+        time_range = "month"
+    else:
+        time_range = "year"
+
     payload = {
         "api_key": TAVILY_API_KEY,
         "query": query,
         "max_results": max(1, min(max_results, 10)),
         "search_depth": "advanced",
-        "time_range": f"{max(1, days)}d",
         "include_answer": False,
         "include_raw_content": False,
     }
+
+    # Only add time_range if not searching all time
+    if days < 365:
+        payload["days"] = days  # Tavily uses 'days' parameter directly
     try:
         data = _post_json(TAVILY_ENDPOINT, payload)
         out = []


### PR DESCRIPTION
Perplexity:
- Use PERPLEXITY_MODEL env var (was using wrong PPLX_MODEL)
- Default to "sonar-pro" instead of deprecated model

Tavily:
- Remove invalid time_range parameter format
- Use 'days' parameter directly as Tavily expects