### PR TITLE
Fix: Copy numeric values to sections, add OPEX*0.5 pattern

### DIFF
--- a/gpt_analyze.py
+++ b/gpt_analyze.py
@@ -126,6 +126,11 @@ def ksj_fix_placeholders_in_sections(sections: dict, answers: dict, scores: dict
         except Exception as e:
             pass
     numeric = ksj_build_numeric_ctx(answers, env_defaults, calc or {})
+    # Copy numeric values to sections for template access
+    for key in ['qw_hours_total', 'CAPEX_REALISTISCH_EUR', 'OPEX_REALISTISCH_EUR',
+                'EINSPARUNG_MONAT_EUR', 'PAYBACK_MONTHS', 'ROI_12M']:
+        if key in numeric and numeric[key] is not None:
+            sections.setdefault(key, numeric[key])
     # also bring scores if present
     if isinstance(scores, dict):
         numeric.update({

--- a/services/report_renderer.py
+++ b/services/report_renderer.py
@@ -100,6 +100,7 @@ def render(briefing_obj: Any,
             # OPEX calculations
             r'\{\{\s*OPEX_REALISTISCH_EUR\s*\*\s*1\.2\s*\}\}': str(sections.get('OPEX_REALISTISCH_EUR_HIGH', '')),
             r'\{\{\s*OPEX_REALISTISCH_EUR\s*\*\s*0\.8\s*\}\}': str(sections.get('OPEX_REALISTISCH_EUR_LOW', '')),
+            r'\{\{\s*OPEX_REALISTISCH_EUR\s*\*\s*0\.5\s*\}\}': str(int(float(sections.get('OPEX_REALISTISCH_EUR', 0) or 0) * 0.5)),
             # Payback calculations
             r'\{\{\s*CAPEX_REALISTISCH_EUR\s*/\s*\(\s*EINSPARUNG_MONAT_EUR\s*\*\s*0\.8\s*-\s*OPEX_REALISTISCH_EUR\s*\)\s*\}\}': str(sections.get('PAYBACK_MONTHS_PESSIMISTIC', '')),
             r'\{\{\s*CAPEX_REALISTISCH_EUR\s*/\s*\(\s*EINSPARUNG_MONAT_EUR\s*-\s*OPEX_REALISTISCH_EUR\s*\*\s*1\.2\s*\)\s*\}\}': str(sections.get('PAYBACK_MONTHS_PESSIMISTIC', '')),


### PR DESCRIPTION
- Copy qw_hours_total, CAPEX, OPEX, etc. directly to sections dict for template access (fixes {{qw_hours_total}} not replaced)
- Add OPEX_REALISTISCH_EUR * 0.5 expression pattern