### PR TITLE
Fix: Use direct assignment for numeric values, add more OPEX patterns

### DIFF
--- a/gpt_analyze.py
+++ b/gpt_analyze.py
@@ -126,11 +126,11 @@ def ksj_fix_placeholders_in_sections(sections: dict, answers: dict, scores: dict
         except Exception as e:
             pass
     numeric = ksj_build_numeric_ctx(answers, env_defaults, calc or {})
-    # Copy numeric values to sections for template access
+    # Copy numeric values to sections for template access (use direct assignment, not setdefault)
     for key in ['qw_hours_total', 'CAPEX_REALISTISCH_EUR', 'OPEX_REALISTISCH_EUR',
                 'EINSPARUNG_MONAT_EUR', 'PAYBACK_MONTHS', 'ROI_12M']:
         if key in numeric and numeric[key] is not None:
-            sections.setdefault(key, numeric[key])
+            sections[key] = numeric[key]
     # also bring scores if present
     if isinstance(scores, dict):
         numeric.update({

--- a/services/report_renderer.py
+++ b/services/report_renderer.py
@@ -97,10 +97,14 @@ def render(briefing_obj: Any,
             r'\{\{\s*ROI_12M\s*\*\s*1\.2\s*\*\s*100\s*\}\}': str(sections.get('ROI_12M_HIGH', '')),
             # ROI percentage expression
             r'\{\{\s*\(ROI_12M\s*\*\s*100\)\s*\|\s*round\s*\(\s*1\s*\)\s*\}\}': str(round(float(sections.get('ROI_12M', 0) or 0) * 100, 1)),
-            # OPEX calculations
+            # OPEX calculations - various multipliers GPT might generate
             r'\{\{\s*OPEX_REALISTISCH_EUR\s*\*\s*1\.2\s*\}\}': str(sections.get('OPEX_REALISTISCH_EUR_HIGH', '')),
             r'\{\{\s*OPEX_REALISTISCH_EUR\s*\*\s*0\.8\s*\}\}': str(sections.get('OPEX_REALISTISCH_EUR_LOW', '')),
             r'\{\{\s*OPEX_REALISTISCH_EUR\s*\*\s*0\.5\s*\}\}': str(int(float(sections.get('OPEX_REALISTISCH_EUR', 0) or 0) * 0.5)),
+            r'\{\{\s*OPEX_REALISTISCH_EUR\s*\*\s*0\.2\s*\}\}': str(int(float(sections.get('OPEX_REALISTISCH_EUR', 0) or 0) * 0.2)),
+            r'\{\{\s*OPEX_REALISTISCH_EUR\s*\*\s*0\.4\s*\}\}': str(int(float(sections.get('OPEX_REALISTISCH_EUR', 0) or 0) * 0.4)),
+            r'\{\{\s*OPEX_REALISTISCH_EUR\s*\*\s*2\.4\s*\}\}': str(int(float(sections.get('OPEX_REALISTISCH_EUR', 0) or 0) * 2.4)),
+            r'\{\{\s*OPEX_REALISTISCH_EUR\s*\*\s*12\s*\}\}': str(int(float(sections.get('OPEX_REALISTISCH_EUR', 0) or 0) * 12)),
             # Payback calculations
             r'\{\{\s*CAPEX_REALISTISCH_EUR\s*/\s*\(\s*EINSPARUNG_MONAT_EUR\s*\*\s*0\.8\s*-\s*OPEX_REALISTISCH_EUR\s*\)\s*\}\}': str(sections.get('PAYBACK_MONTHS_PESSIMISTIC', '')),
             r'\{\{\s*CAPEX_REALISTISCH_EUR\s*/\s*\(\s*EINSPARUNG_MONAT_EUR\s*-\s*OPEX_REALISTISCH_EUR\s*\*\s*1\.2\s*\)\s*\}\}': str(sections.get('PAYBACK_MONTHS_PESSIMISTIC', '')),


### PR DESCRIPTION
- Change setdefault to direct assignment for numeric values in sections
- Add OPEX multiplier patterns: 0.2, 0.4, 2.4, 12 (for yearly calc)