### PR TITLE
Implement PDF report fixes for encoding, HTML rendering, and variable…

### DIFF
--- a/routes/briefings.py
+++ b/routes/briefings.py
@@ -18,6 +18,7 @@ from settings import get_settings
 from services.rate_limit import RateLimiter
 from utils.idempotency import IdempotencyBox
 from routes._bootstrap import get_db
+from utils.encoding_fixer import clean_briefing_data
 
 router = APIRouter(prefix="/briefings", tags=["briefings"])
 log = logging.getLogger(__name__)
@@ -105,10 +106,14 @@ async def submit_briefing(
     try:
         from models import Briefing
 
+        # Fix UTF-8 encoding before saving
+        log.info("[ENCODING-FIX] Cleaning briefing data before save")
+        cleaned_answers = clean_briefing_data(payload.answers)
+
         briefing = Briefing(
             user_id=user_id,
             lang=payload.lang,
-            answers=payload.answers
+            answers=cleaned_answers
         )
         db.add(briefing)
         db.commit()

--- a/utils/encoding_fixer.py
+++ b/utils/encoding_fixer.py
@@ -1,0 +1,81 @@
+# -*- coding: utf-8 -*-
+"""
+UTF-8 Encoding fixer for German umlauts.
+Fixes double-encoded UTF-8 characters (Mojibake).
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, List, Union
+
+logger = logging.getLogger(__name__)
+
+
+def fix_utf8_encoding(text: str) -> str:
+    """
+    Fix double-encoded UTF-8 German umlauts.
+
+    Examples:
+        "FragebÃ¶gen" -> "Fragebögen"
+        "MarktfÃ¼hrer" -> "Marktführer"
+
+    Args:
+        text: Input string that may contain Mojibake
+
+    Returns:
+        Fixed string with correct German umlauts
+    """
+    if not isinstance(text, str):
+        return text
+
+    # Quick check if there's anything to fix
+    if 'Ã' not in text and 'â' not in text:
+        return text
+
+    # Direct replacements for common Mojibake patterns
+    replacements = {
+        'Ã¤': 'ä', 'Ã¶': 'ö', 'Ã¼': 'ü',
+        'Ã„': 'Ä', 'Ã–': 'Ö', 'Ãœ': 'Ü',
+        'ÃŸ': 'ß', 'Ã©': 'é', 'Ã¨': 'è',
+        'Ã ': 'à', 'Ã¡': 'á', 'Ãª': 'ê',
+        'Ã®': 'î', 'Ã¯': 'ï', 'Ã´': 'ô',
+        'Ã¹': 'ù', 'Ãº': 'ú', 'Ã±': 'ñ',
+        'â€™': "'", 'â€œ': '"', 'â€': '"',
+        'â€"': '–', 'â€"': '—', 'â€¢': '•',
+    }
+
+    original = text
+    for wrong, correct in replacements.items():
+        text = text.replace(wrong, correct)
+
+    # Fallback: encode/decode trick for remaining issues
+    if 'Ã' in text:
+        try:
+            text = text.encode('latin-1', errors='ignore').decode('utf-8', errors='ignore')
+        except (UnicodeDecodeError, UnicodeEncodeError):
+            pass
+
+    if original != text:
+        logger.debug(f"[ENCODING-FIX] Fixed: '{original[:50]}...' -> '{text[:50]}...'")
+
+    return text
+
+
+def clean_briefing_data(data: Union[Dict, List, str, Any]) -> Union[Dict, List, str, Any]:
+    """
+    Recursively clean all strings in data structure.
+
+    Args:
+        data: Dictionary, list, string, or other data type
+
+    Returns:
+        Cleaned data with all strings fixed for UTF-8 encoding
+    """
+    if isinstance(data, dict):
+        return {key: clean_briefing_data(value) for key, value in data.items()}
+    elif isinstance(data, list):
+        return [clean_briefing_data(item) for item in data]
+    elif isinstance(data, str):
+        return fix_utf8_encoding(data)
+    else:
+        return data


### PR DESCRIPTION
… handling

- Add utils/encoding_fixer.py with UTF-8 Mojibake fix for German umlauts
- Integrate encoding fix in routes/briefings.py before DB save
- Add double-check encoding fix in gpt_analyze.py for old DB data
- Add Markup support to report_renderer.py to prevent HTML escaping
- Save debug HTML to /tmp/ for troubleshooting

Fixes: UTF-8 encoding (Ã¶→ö), HTML tag escaping, unresolved variables