### PR TITLE
Fix: Remove unused type:ignore comments (mypy CI errors)

### DIFF
--- a/gpt_analyze.py
+++ b/gpt_analyze.py
@@ -1031,7 +1031,7 @@ def _parse_kreativ_tools(raw: str) -> List[Tuple[str, str]]:
         if m:
             out.append((m.group(1).strip(), m.group(2).strip()))
             continue
-        m = re.match(r"^\[(.+?)\]\((https?://[^)]+)\)$", ln)  # type: ignore[unreachable]
+        m = re.match(r"^\[(.+?)\]\((https?://[^)]+)\)$", ln)
         if m:
             out.append((m.group(1).strip(), m.group(2).strip()))
             continue
@@ -2026,7 +2026,7 @@ def _md_to_simple_html(md: str) -> str:
             continue
         if re.match(r"^\[\d+\]:\s*https?://", line):
             continue
-        if line.startswith("#### "):  # type: ignore[unreachable]
+        if line.startswith("#### "):
             if in_ul: out.append("</ul>"); in_ul = False
             out.append(f"<h4>{html.escape(line[5:].strip())}</h4>")
             continue

--- a/services/content_normalizer.py
+++ b/services/content_normalizer.py
@@ -58,7 +58,7 @@ def build_kreativ_tools_html(path: str) -> str:
             items.append(f"<li><a href='{_safe(url)}' target='_blank' rel='noopener'>{_safe(label)}</a></li>")
         else:
             # falls keine URL erkannt wird → als Text zeigen
-            items.append(f"<li>{_safe(ln)}</li>")  # type: ignore[unreachable]
+            items.append(f"<li>{_safe(ln)}</li>")
     return "<ul>" + "".join(items) + "</ul>"
 
 # ---------------- Tool-Stacks nach Branche/Größe ----------------


### PR DESCRIPTION
PROBLEM:
CI mypy check failed with 3 "unused-ignore" errors:
- services/content_normalizer.py:61
- gpt_analyze.py:1034
- gpt_analyze.py:2029

LÖSUNG:
Removed `# type: ignore[unreachable]` comments that are no longer needed in CI environment. These comments were originally added to suppress unreachable code warnings, but mypy in CI no longer detects these as errors, making the ignore comments unused.

TECHNICAL NOTE:
Local mypy may still report unreachable warnings due to version differences, but CI (the authoritative check) reported these as unused-ignore, which means the comments should be removed.