### PR TITLE
Fix: Enforce hard fail when profile directory or files are missing

### DIFF
--- a/scripts/generate_test_reports.py
+++ b/scripts/generate_test_reports.py
@@ -137,18 +137,24 @@ def main() -> None:
     profiles_dir = Path(args.profiles_dir)
 
     print("\n[check] Verwende Profile-Verzeichnis:")
-    print(f"  » {profiles_dir.resolve()}")
+    try:
+        resolved = profiles_dir.resolve()
+    except Exception:
+        resolved = profiles_dir
+    print(f"  » {resolved}")
 
     if not profiles_dir.exists():
-        print("  ⚠️  Ordner existiert nicht!")
-    else:
-        files = list(profiles_dir.glob("*.json"))
-        if not files:
-            print("  ⚠️  Keine JSON-Profile gefunden!")
-        else:
-            print(f"  {len(files)} Profile gefunden:")
-            for f in files:
-                print(f"   - {f.stem}")
+        print("  ❌ Profil-Ordner existiert nicht. Bitte prüfen:", resolved, file=sys.stderr)
+        sys.exit(1)
+
+    files = sorted(profiles_dir.glob("*.json"))
+    if not files:
+        print("  ❌ Keine JSON-Profile im Ordner gefunden.", file=sys.stderr)
+        sys.exit(1)
+
+    print(f"  {len(files)} Profile gefunden:")
+    for f in files:
+        print(f"   - {f.stem}")
 
     print("\n=== KI-Backend Test-Report-Generator ===")
     print(f"Base-URL:      {base_url}")


### PR DESCRIPTION
Problem: Script showed warnings (⚠️) but continued execution when:
- Profile directory didn't exist
- No JSON files were found in directory

Solution:
- Changed warnings to hard failures (❌) with sys.exit(1)
- Script now aborts immediately if:
  1. profiles_dir doesn't exist
  2. No *.json files found in profiles_dir
- Added sorted() to file listing for consistent output
- Improved error messages to stderr

Result: Clean fail-fast behavior. No more silent failures or phantom profile lists.

Verified behavior:
✓ Normal case: Shows 6 Gold-Standard profiles from data/test_profiles_gold ✓ Missing dir: Exits with '❌ Profil-Ordner existiert nicht' ✓ Empty dir: Exits with '❌ Keine JSON-Profile im Ordner gefunden'