### PR TITLE
Add symlink data/test_profiles -> test_profiles_gold for backwards co…

### DIFF
--- a/data/test_profiles
+++ b/data/test_profiles
@@ -1,0 +1,1 @@
+test_profiles_gold


### PR DESCRIPTION
…mpatibility

- Creates symlink to ensure older tools using data/test_profiles automatically see gold profiles
- generate_test_reports.py already uses data/test_profiles_gold as default
- All 6 gold profiles are now the single source of truth