### PR TITLE
feat(platin): streamline prompts + expand fallbacks to 800-900 words

### DIFF
--- a/.github/workflows/platin-validation.yml
+++ b/.github/workflows/platin-validation.yml
@@ -1,0 +1,89 @@
+name: PLATIN+ Validation
+
+on:
+  push:
+    branches: ["main"]
+    paths:
+      - 'prompts/**'
+      - 'gpt_analyze.py'
+      - 'services/report_validator.py'
+      - 'data/test_profiles_gold/**'
+  pull_request:
+    branches: ["main"]
+    paths:
+      - 'prompts/**'
+      - 'gpt_analyze.py'
+      - 'services/report_validator.py'
+      - 'data/test_profiles_gold/**'
+
+jobs:
+  platin-validation:
+    name: PLATIN+ Quality Gate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: "pip"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          if [ -f requirements-test.txt ]; then pip install -r requirements-test.txt; fi
+      - name: Run PLATIN+ Word Length Tests
+        run: |
+          pytest -v tests/test_platin_word_lengths.py --maxfail=3
+      - name: Validate Test Profiles
+        run: |
+          python -c "
+import json
+import glob
+import sys
+
+required_fields = ['profile_id', 'description', 'lang', 'BRANCHE_LABEL', 'UNTERNEHMENSGROESSE_LABEL', 'HAUPTLEISTUNG', 'answers']
+errors = []
+
+for path in glob.glob('data/test_profiles_gold/*.json'):
+    with open(path) as f:
+        data = json.load(f)
+    missing = [f for f in required_fields if f not in data]
+    if missing:
+        errors.append(f'{path}: Missing fields: {missing}')
+
+if errors:
+    print('\\n'.join(errors))
+    sys.exit(1)
+else:
+    print(f'✅ All {len(glob.glob(\"data/test_profiles_gold/*.json\"))} test profiles valid')
+"
+      - name: Check Prompt Version Headers
+        run: |
+          python -c "
+import glob
+import re
+import sys
+
+platin_prompts = ['foerderpotenzial', 'risks', 'recommendations', 'roadmap_12m']
+errors = []
+
+for name in platin_prompts:
+    path = f'prompts/de/{name}.md'
+    try:
+        with open(path) as f:
+            content = f.read()
+        if 'PLATIN+' not in content and 'PLATIN' not in content:
+            errors.append(f'{path}: Missing PLATIN+ version marker')
+        # Check for streamlined header (no heavy ASCII boxes)
+        if '╔═' in content and content.count('╔═') > 2:
+            errors.append(f'{path}: Too many ASCII box headers - consider streamlining')
+    except FileNotFoundError:
+        errors.append(f'{path}: File not found')
+
+if errors:
+    for e in errors:
+        print(f'⚠️ {e}')
+    # Warning only, don't fail
+else:
+    print('✅ All PLATIN+ prompts have valid headers')
+"

--- a/gpt_analyze.py
+++ b/gpt_analyze.py
@@ -1511,7 +1511,9 @@ def _get_fallback_content(section_key: str, briefing: Dict[str, Any], scores: Di
     Unternehmen in der Branche <strong>{branche}</strong> im Bundesland <strong>{bundesland}</strong> und der Größe
     <strong>{size_label}</strong> verfügen für Vorhaben im Bereich <strong>{hauptleistung or "KI-gestützte Prozessoptimierung"}</strong>
     häufig über gute Voraussetzungen für eine Förderung. Die Kombination aus Digitalisierungsfokus, KI-Unterstützung und
-    klarer Prozessverbesserung entspricht den Schwerpunkten vieler Programme auf Landes- und Bundesebene.
+    klarer Prozessverbesserung entspricht den Schwerpunkten vieler Programme auf Landes- und Bundesebene. Gerade in Zeiten
+    des digitalen Wandels setzen Bund, Länder und EU verstärkt auf die Förderung von KI-Projekten, die nachweislich zur
+    Effizienzsteigerung und Wettbewerbsfähigkeit beitragen.
   </p>
 
   <h3>1. Einordnung des Business Case ohne Förderung</h3>
@@ -1519,7 +1521,8 @@ def _get_fallback_content(section_key: str, briefing: Dict[str, Any], scores: Di
     Der aktuelle Business Case zeigt einmalige Investitionen von etwa <strong>{capex}&nbsp;€</strong> sowie laufende Kosten von
     rund <strong>{opex}&nbsp;€ pro Monat</strong>. Die erwartete monatliche Entlastung liegt bei ungefähr
     <strong>{einsparung}&nbsp;€</strong>, was zu einer Amortisationsdauer von etwa <strong>{payback} Monaten</strong> und
-    einem realistischen ROI von rund <strong>{roi_12m}&nbsp;%</strong> im ersten Jahr führt.
+    einem realistischen ROI von rund <strong>{roi_12m}&nbsp;%</strong> im ersten Jahr führt. Diese Kennzahlen bilden eine
+    solide Grundlage für die Bewertung der Förderwürdigkeit durch öffentliche Stellen.
   </p>
   <p>
     Diese Ausgangslage ist für viele Förderstellen attraktiv: Das Projekt ist betriebswirtschaftlich plausibel, der Nutzen
@@ -1528,7 +1531,8 @@ def _get_fallback_content(section_key: str, briefing: Dict[str, Any], scores: Di
     Business Case und klarem Digitalisierungsfokus macht Ihr Vorhaben zu einem starken Kandidaten für öffentliche Förderung.
     Die Investition von {capex}&nbsp;€ amortisiert sich bei einer monatlichen Einsparung von {einsparung}&nbsp;€ nach etwa
     {payback} Monaten. Der ROI von {roi_12m}&nbsp;% zeigt, dass sich das Projekt auch ohne externe Unterstützung wirtschaftlich
-    rechnet – mit Förderung wird die Rentabilität noch deutlich attraktiver.
+    rechnet – mit Förderung wird die Rentabilität noch deutlich attraktiver. Fördergeber bewerten positiv, wenn Unternehmen
+    einen substanziellen Eigenanteil einbringen und das Projekt auch ohne Förderung wirtschaftlich tragfähig erscheint.
   </p>
 
   <h3>2. Wie Fördermittel den Business Case verbessern können</h3>
@@ -1575,7 +1579,17 @@ def _get_fallback_content(section_key: str, briefing: Dict[str, Any], scores: Di
     <li><strong>Beratungsförderung:</strong> Unterstützung für externe Expertise bei der KI-Strategieentwicklung und
       Umsetzung kann den Projekterfolg erheblich steigern. Programme wie go-digital oder regionale Beratungsförderung
       decken oft einen Großteil der Beratungskosten ab.</li>
+    <li><strong>Nachhaltigkeits- und Klimaförderung:</strong> KI-Projekte, die zur Ressourceneffizienz, Energieeinsparung
+      oder Reduzierung des ökologischen Fußabdrucks beitragen, können zusätzlich von spezialisierten Förderprogrammen
+      profitieren. Diese Kombination aus Digitalisierung und Nachhaltigkeit wird von vielen Fördergebern besonders
+      positiv bewertet und kann höhere Förderquoten ermöglichen.</li>
   </ul>
+  <p>
+    Die Kombination verschiedener Förderschwerpunkte kann besonders vorteilhaft sein. Prüfen Sie, ob Ihr Vorhaben
+    mehrere der genannten Kategorien abdeckt, da dies die Antragserfolgschancen erhöhen kann. Fördergeber sehen gerne
+    Projekte, die sowohl wirtschaftlichen Nutzen als auch gesellschaftlichen Mehrwert – etwa durch Digitalkompetenzaufbau
+    oder nachhaltige Geschäftsmodelle – nachweisen können.
+  </p>
 
   <h3>4. Nächste Schritte für die Förderprüfung</h3>
   <ol>
@@ -1591,6 +1605,9 @@ def _get_fallback_content(section_key: str, briefing: Dict[str, Any], scores: Di
       Finanzierungspartnern. Viele Beratungsstellen bieten kostenlose Erstgespräche zur Fördermittelprüfung an.</li>
     <li><strong>Zeitplanung:</strong> Förderanträge benötigen typischerweise 4–8 Wochen Vorlauf – berücksichtigen Sie
       dies bei der Projektplanung. Beachten Sie auch eventuelle Antragsfristen und Stichtage.</li>
+    <li><strong>Dokumentation vorbereiten:</strong> Sammeln Sie vorab wichtige Unterlagen wie Handelsregisterauszug,
+      aktuelle Jahresabschlüsse und eine De-minimis-Erklärung. Eine vollständige Dokumentation beschleunigt die
+      Antragsbearbeitung erheblich und erhöht die Erfolgsaussichten.</li>
   </ol>
 
   <p class="small muted">
@@ -1846,6 +1863,13 @@ def _get_fallback_content(section_key: str, briefing: Dict[str, Any], scores: Di
     wirksam einzusetzen. Die folgenden Empfehlungen sind priorisiert, praxisnah und auf realistische Ressourcen abgestimmt.
     Jede Empfehlung enthält konkrete Maßnahmen, erwarteten Nutzen, Aufwandsschätzung und Förderhinweise.
   </p>
+  <p>
+    Die Empfehlungen bauen aufeinander auf und sind so strukturiert, dass Sie mit einem Quick Win starten können und
+    sukzessive komplexere Anwendungen erschließen. Beginnen Sie mit Empfehlung 1, um schnelle Erfolgserlebnisse zu
+    generieren, und arbeiten Sie sich dann durch die weiteren Stufen. Parallelisieren Sie, wo Ressourcen es erlauben,
+    aber verlieren Sie nicht den Fokus auf messbare Ergebnisse bei jedem Schritt. So schaffen Sie eine solide Basis
+    für nachhaltigen Erfolg mit KI-gestützten Prozessen.
+  </p>
 
   <ol class="recommendations-list">
     <li>
@@ -1906,7 +1930,8 @@ def _get_fallback_content(section_key: str, briefing: Dict[str, Any], scores: Di
         3-10 Tage für einen fokussierten Pilot.</p>
       <p><strong>Verantwortlich:</strong> {verantwortlich_1}</p>
       <p><strong>Förderchance:</strong> Pilot-Use-Cases mit klarer Zielsetzung werden von vielen
-        Förderprogrammen priorisiert.</p>
+        Förderprogrammen priorisiert. Dokumentieren Sie den Pilot sorgfältig, um die Ergebnisse für
+        weitere Förderanträge und interne Entscheidungsvorlagen nutzen zu können.</p>
     </li>
 
     <li>
@@ -1967,6 +1992,25 @@ def _get_fallback_content(section_key: str, briefing: Dict[str, Any], scores: Di
       </tr>
     </tbody>
   </table>
+
+  <h3>Zusammenfassung und Erfolgsfaktoren</h3>
+  <p>
+    Die erfolgreiche Umsetzung dieser Empfehlungen hängt von mehreren kritischen Erfolgsfaktoren ab. Erstens ist
+    konsequentes Dranbleiben wichtiger als perfekte Planung – starten Sie lieber mit einem fokussierten Pilot und
+    lernen Sie im Prozess. Zweitens sollten Sie von Anfang an Erfolgskennzahlen definieren, um den Fortschritt
+    messbar zu machen. Drittens empfiehlt es sich, regelmäßige Retrospektiven einzuplanen, um Learnings festzuhalten
+    und Kurskorrekturen vorzunehmen.
+  </p>
+  <p>
+    Achten Sie darauf, nicht zu viele Initiativen gleichzeitig zu starten. Besser ein Use Case sauber umgesetzt als
+    drei halbfertige Experimente. Die Kombination aus schnellen Erfolgen (Empfehlung 1-2) und strukturierter
+    Absicherung (Empfehlung 5) schafft sowohl Momentum als auch Stabilität für Ihre KI-Transformation.
+  </p>
+  <p>
+    Dokumentieren Sie Ihre Erfahrungen von Anfang an: Welche Prompts funktionieren? Wo entstehen Fehler?
+    Welche Qualitätsprüfungen haben sich bewährt? Diese Erkenntnisse sind wertvoll für die Skalierung auf weitere
+    Anwendungsfälle und für das Onboarding zukünftiger Nutzer:innen der KI-Werkzeuge.
+  </p>
 
   <p class="small muted">
     Die Empfehlungen sind so formuliert, dass sie unmittelbar in die Projektplanung übernommen werden können

--- a/gpt_analyze.py
+++ b/gpt_analyze.py
@@ -1453,12 +1453,19 @@ def _build_prompt_vars(briefing: Dict[str, Any], scores: Dict[str, Any]) -> Dict
     return base_vars
 # -------------------- 🎯 NEW: Better fallbacks when GPT fails ----------------
 def _get_fallback_content(section_key: str, briefing: Dict[str, Any], scores: Dict[str, Any]) -> str:
-    """🎯 UPDATED v4.14.3: Size-aware inline fallback content (1000-1500 Zeichen) – GOLD-STANDARD+
-    
-    Änderungen v4.14.3:
-    - roadmap_90d: Erweitert auf 1000+ Zeichen (vorher 834)
-    - roadmap_12m: Erweitert auf 1400+ Zeichen (vorher 1367)
-    - next_actions: Jetzt size-aware (Solo: persönliche Tasks, keine Rollen)
+    """🎯 UPDATED v5.0.0-PLATIN+: Size-aware fallback content mit PLATIN+ Wortlängen
+
+    PLATIN+ Mindestlängen (WÖRTER, nicht Zeichen!):
+    - foerderpotenzial: 900 Wörter
+    - risks: 800 Wörter
+    - recommendations: 800 Wörter
+    - roadmap_12m: 900 Wörter
+
+    Änderungen v5.0.0:
+    - NEU: foerderpotenzial Fallback mit 900+ Wörtern
+    - NEU: risks Fallback mit 800+ Wörtern
+    - NEU: recommendations Fallback mit 800+ Wörtern
+    - roadmap_12m: Erweitert auf 900+ Wörter
     """
     branche = briefing.get("BRANCHE_LABEL") or briefing.get("branche", "Ihr Unternehmen")
     size_label = briefing.get("UNTERNEHMENSGROESSE_LABEL") or briefing.get("unternehmensgroesse", "")
@@ -1473,7 +1480,501 @@ def _get_fallback_content(section_key: str, briefing: Dict[str, Any], scores: Di
         size_group = "team"
     else:
         size_group = "kmu"
-    
+
+    # Business Case Variablen
+    bundesland = briefing.get("BUNDESLAND_LABEL") or briefing.get("bundesland", "Ihrem Bundesland")
+    capex = briefing.get("CAPEX_REALISTISCH_EUR", "—")
+    opex = briefing.get("OPEX_REALISTISCH_EUR", "—")
+    einsparung = briefing.get("EINSPARUNG_MONAT_EUR", "—")
+    payback = briefing.get("PAYBACK_MONTHS", "—")
+    roi_12m = briefing.get("ROI_12M", "—")
+
+    # ════════════════════════════════════════════════════════════════════════════
+    # 🎯 PLATIN+ FALLBACK: FOERDERPOTENZIAL (900+ Wörter)
+    # ════════════════════════════════════════════════════════════════════════════
+    if section_key == "foerderpotenzial":
+        # Size-aware Förderhinweise
+        if size_group == "solo":
+            foerder_focus = "Beratungsförderung, Gründerprogramme und niedrigschwellige Digitalisierungszuschüsse"
+            budget_hinweis = "Im Solo-Kontext sind Förderprogramme besonders attraktiv, da sie den Eigenanteil bei Investitionen deutlich reduzieren können"
+        elif size_group == "team":
+            foerder_focus = "go-digital, KMU-innovativ und regionale Digitalisierungsprogramme"
+            budget_hinweis = "Für kleine Teams bieten Förderprogramme die Möglichkeit, ambitioniertere Projekte umzusetzen ohne die Liquidität zu gefährden"
+        else:
+            foerder_focus = "Digital Jetzt, ZIM und strukturelle KMU-Förderprogramme"
+            budget_hinweis = "KMU können von umfangreichen Förderprogrammen profitieren, die sowohl Investitions- als auch Beratungskosten abdecken"
+
+        return f"""<section class="section funding-potential">
+  <h2>Förderpotenzial für Ihr KI-Projekt</h2>
+
+  <p>
+    Unternehmen in der Branche <strong>{branche}</strong> im Bundesland <strong>{bundesland}</strong> und der Größe
+    <strong>{size_label}</strong> verfügen für Vorhaben im Bereich <strong>{hauptleistung or "KI-gestützte Prozessoptimierung"}</strong>
+    häufig über gute Voraussetzungen für eine Förderung. Die Kombination aus Digitalisierungsfokus, KI-Unterstützung und
+    klarer Prozessverbesserung entspricht den Schwerpunkten vieler Programme auf Landes- und Bundesebene.
+  </p>
+
+  <h3>1. Einordnung des Business Case ohne Förderung</h3>
+  <p>
+    Der aktuelle Business Case zeigt einmalige Investitionen von etwa <strong>{capex}&nbsp;€</strong> sowie laufende Kosten von
+    rund <strong>{opex}&nbsp;€ pro Monat</strong>. Die erwartete monatliche Entlastung liegt bei ungefähr
+    <strong>{einsparung}&nbsp;€</strong>, was zu einer Amortisationsdauer von etwa <strong>{payback} Monaten</strong> und
+    einem realistischen ROI von rund <strong>{roi_12m}&nbsp;%</strong> im ersten Jahr führt.
+  </p>
+  <p>
+    Diese Ausgangslage ist für viele Förderstellen attraktiv: Das Projekt ist betriebswirtschaftlich plausibel, der Nutzen
+    klar erkennbar und der Eigenbeitrag grundsätzlich tragfähig. Fördermittel können diese Situation zusätzlich verbessern,
+    indem sie einen Teil der Investitionsbelastung abfedern. {budget_hinweis}. Die Kombination aus nachvollziehbarem
+    Business Case und klarem Digitalisierungsfokus macht Ihr Vorhaben zu einem starken Kandidaten für öffentliche Förderung.
+    Die Investition von {capex}&nbsp;€ amortisiert sich bei einer monatlichen Einsparung von {einsparung}&nbsp;€ nach etwa
+    {payback} Monaten. Der ROI von {roi_12m}&nbsp;% zeigt, dass sich das Projekt auch ohne externe Unterstützung wirtschaftlich
+    rechnet – mit Förderung wird die Rentabilität noch deutlich attraktiver.
+  </p>
+
+  <h3>2. Wie Fördermittel den Business Case verbessern können</h3>
+  <p>
+    Viele Programme in {bundesland} und auf Bundesebene unterstützen KI- und Digitalisierungsinitiativen, indem sie einen
+    Teil der förderfähigen Investitionskosten bezuschussen. Je nach Programm, Unternehmensgröße und Projektschwerpunkt
+    bewegen sich die Zuschussquoten typischerweise im Bereich von etwa <strong>30–50&nbsp;%</strong> der anerkannten Kosten.
+    Für ein Investitionsvolumen von {capex}&nbsp;€ könnte das eine Entlastung von mehreren tausend Euro bedeuten.
+  </p>
+  <ul>
+    <li><strong>Kürzere Amortisationsdauer:</strong> Durch eine Beteiligung an den Investitionskosten sinkt der Eigenanteil;
+      die Amortisation kann sich von {payback} Monaten auf deutlich weniger verkürzen, ohne dass der erwartete Nutzen
+      verändert wird. Bei einer angenommenen Förderquote von 40 Prozent reduziert sich der Eigenanteil erheblich.</li>
+    <li><strong>Höherer effektiver ROI:</strong> Wenn ein Teil der Investitionen über Zuschüsse abgedeckt wird, steigt der
+      Effektiv-Ertrag je eingesetztem Euro – der aktuelle ROI von {roi_12m}&nbsp;% kann sich bei 40% Förderung auf über
+      das Doppelte erhöhen. Dies macht das Projekt noch attraktiver für interne Budgetentscheidungen.</li>
+    <li><strong>Reduziertes finanzielles Risiko:</strong> Für <strong>{size_label}</strong> kann ein Zuschuss den Schritt
+      in ein ambitionierteres Projekt erleichtern, ohne die Liquidität unnötig zu belasten. Die laufenden Kosten von
+      {opex}&nbsp;€/Monat bleiben dabei tragbar und werden durch die monatliche Einsparung überkompensiert.</li>
+    <li><strong>Mehr Spielraum für Qualität und Schulung:</strong> Einsparungen durch Förderung können genutzt werden,
+      um zusätzliche Maßnahmen für Qualität, Sicherheit oder Qualifizierung vorzusehen. Dies erhöht die Nachhaltigkeit
+      des Projekts und verbessert die langfristige Wirkung.</li>
+    <li><strong>Bessere Planungssicherheit:</strong> Mit bewilligter Förderung lässt sich das Projektbudget verlässlicher
+      planen und das Risiko bei unerwarteten Mehrkosten besser abfedern. Dies ist besonders relevant für KI-Projekte,
+      bei denen Aufwände in der Pilotphase schwer vorherzusagen sind.</li>
+  </ul>
+
+  <h3>3. Passende Förderschwerpunkte für Ihr Vorhaben</h3>
+  <p>
+    Basierend auf der Branche <strong>{branche}</strong>, dem Schwerpunkt <strong>{hauptleistung or "KI-gestützte Prozessoptimierung"}</strong>
+    und der Unternehmensgröße <strong>{size_label}</strong> kommen folgende Förderkategorien in Frage. Der Fokus liegt
+    dabei auf {foerder_focus}.
+  </p>
+  <ul>
+    <li><strong>Digitalisierungsförderung:</strong> Programme für KI-gestützte Prozessoptimierung, Automatisierung und
+      digitale Werkzeuge sind besonders relevant für Ihr Vorhaben. Diese Programme fördern typischerweise sowohl
+      Hardware- und Softwareinvestitionen als auch externe Beratungsleistungen und Schulungen.</li>
+    <li><strong>Innovationsförderung:</strong> Zuschüsse für neuartige KI-Anwendungen, Pilotprojekte und Technologie-
+      entwicklung, abgestimmt auf die Branche {branche}. Besonders interessant, wenn Ihr Projekt innovative Elemente
+      enthält, die über Standardanwendungen hinausgehen.</li>
+    <li><strong>Qualifizierungsförderung:</strong> Mittel für Schulungen, Weiterbildungen und den Aufbau von KI-Kompetenzen
+      sind wichtig für die nachhaltige Nutzung. Viele Programme fördern explizit den Kompetenzaufbau als Teil von
+      Digitalisierungsprojekten.</li>
+    <li><strong>Beratungsförderung:</strong> Unterstützung für externe Expertise bei der KI-Strategieentwicklung und
+      Umsetzung kann den Projekterfolg erheblich steigern. Programme wie go-digital oder regionale Beratungsförderung
+      decken oft einen Großteil der Beratungskosten ab.</li>
+  </ul>
+
+  <h3>4. Nächste Schritte für die Förderprüfung</h3>
+  <ol>
+    <li><strong>Programmauswahl:</strong> Wählen Sie 1–2 Programme aus, die zu <strong>{branche}</strong>,
+      <strong>{size_label}</strong> und <strong>{hauptleistung or "Ihrem Vorhaben"}</strong> passen. Prüfen Sie dabei
+      sowohl Landes- als auch Bundesprogramme sowie mögliche EU-Förderungen.</li>
+    <li><strong>Projektbeschreibung:</strong> Erstellen Sie eine kompakte Projektbeschreibung mit Zielen, Maßnahmen,
+      Zeitplan, erwarteter Nutzen und groben Kosten mit Bezug auf die berechneten {capex}&nbsp;€. Eine klare
+      Beschreibung der Innovationskomponente stärkt den Antrag.</li>
+    <li><strong>Kumulierungsprüfung:</strong> Prüfen Sie, ob Programme aus {bundesland} mit Bundes- oder EU-Programmen
+      kombiniert werden dürfen. Bei geschickter Kombination lassen sich höhere Gesamtförderquoten erreichen.</li>
+    <li><strong>Beratung einholen:</strong> Halten Sie optional Rücksprache mit Förderberatungen, Kammern oder
+      Finanzierungspartnern. Viele Beratungsstellen bieten kostenlose Erstgespräche zur Fördermittelprüfung an.</li>
+    <li><strong>Zeitplanung:</strong> Förderanträge benötigen typischerweise 4–8 Wochen Vorlauf – berücksichtigen Sie
+      dies bei der Projektplanung. Beachten Sie auch eventuelle Antragsfristen und Stichtage.</li>
+  </ol>
+
+  <p class="small muted">
+    Hinweis: Förderquoten, Fristen und Anforderungen können sich ändern. Vor Antragstellung sollten die offiziellen
+    Richtlinien und Konditionen der jeweiligen Programme im Detail geprüft werden. Die genannten Zahlen basieren auf
+    dem Business Case und dienen der Orientierung – konkrete Förderzusagen erfordern eine individuelle Prüfung.
+  </p>
+</section>"""
+
+    # ════════════════════════════════════════════════════════════════════════════
+    # 🎯 PLATIN+ FALLBACK: RISKS (800+ Wörter)
+    # ════════════════════════════════════════════════════════════════════════════
+    if section_key == "risks":
+        score_gov = scores.get("governance", 50)
+        score_sec = scores.get("sicherheit", 50)
+
+        if size_group == "solo":
+            org_risk = "Als Solo-Selbstständige:r konzentriert sich Know-how und Verantwortung auf eine Person"
+            org_measure = "Dokumentation zentraler Workflows, Checklisten und bewusste Verankerung von KI-Routinen"
+        elif size_group == "team":
+            org_risk = "In kleinen Teams ist oft unklar, wer KI-Vorhaben priorisiert und wer für Qualität verantwortlich ist"
+            org_measure = "Klare Rollenverteilung (KI-Owner), gemeinsame Standards und regelmäßige Team-Abstimmungen"
+        else:
+            org_risk = "In größeren Strukturen können unklare Verantwortlichkeiten und fehlende Governance zu Insellösungen führen"
+            org_measure = "Governance-Framework, definierte Prozesse und bereichsübergreifende Koordination"
+
+        return f"""<section class="section risks">
+  <h2>Wesentliche Risiken beim Einsatz von KI in {hauptleistung or "Ihrem Kerngeschäft"}</h2>
+
+  <p>
+    Der Einsatz von KI im Bereich <strong>{hauptleistung or "Ihrem Kerngeschäft"}</strong> in der Branche
+    <strong>{branche}</strong> bietet erhebliche Chancen, bringt jedoch je nach Unternehmensgröße
+    <strong>{size_label}</strong> unterschiedliche Risikoprofile mit sich. Der aktuelle Governance-Score von
+    <strong>{score_gov}/100</strong> und der Sicherheits-Score von <strong>{score_sec}/100</strong> zeigen,
+    wie weit Strukturen für Steuerung, Dokumentation und Schutzmechanismen bereits entwickelt sind.
+    Die folgenden Abschnitte bündeln die wichtigsten Risikofelder und skizzieren konkrete Gegenmaßnahmen.
+  </p>
+
+  <h3>1. Strategische und organisatorische Risiken</h3>
+  <ul>
+    <li>
+      <strong>Unklare Zielbilder und Prioritäten für KI.</strong>
+      Ohne klar definierte Ziele für {hauptleistung or "Ihr Kerngeschäft"} besteht das Risiko, dass KI-Experimente
+      versanden, Insellösungen entstehen oder wichtige Chancen ungenutzt bleiben. Die Gefahr ist besonders groß,
+      wenn verschiedene Initiativen parallel laufen ohne gemeinsame Ausrichtung.
+      <em>Gegenmaßnahme:</em> Ein knappes Zielbild mit 2–3 priorisierten Anwendungsfällen, ein einfacher
+      Umsetzungsplan sowie regelmäßige Überprüfung, ob Maßnahmen zum übergeordneten Geschäftsmodell passen.
+    </li>
+    <li>
+      <strong>Abhängigkeit von einzelnen Personen (Single-Point-of-Failure).</strong>
+      {org_risk}. Fällt diese aus oder ist dauerhaft überlastet, kommen Experimente und Umsetzung ins Stocken.
+      <em>Gegenmaßnahme:</em> {org_measure}. Wichtig ist die Dokumentation von Wissen, damit es nicht verloren geht.
+    </li>
+    <li>
+      <strong>Fehlende Rollen- und Verantwortlichkeitsklarheit.</strong>
+      In wachsenden Setups ist oft unklar, wer KI-Vorhaben priorisiert, wer für Qualität verantwortlich ist
+      und wer Tools auswählt. Dies führt zu Verzögerungen und Doppelarbeit.
+      <em>Gegenmaßnahme:</em> Eine klar benannte Rolle für KI-Verantwortung, ein schlanker Entscheidungsprozess
+      für Tool-Einführung und transparente Kommunikation von Zuständigkeiten.
+    </li>
+    <li>
+      <strong>Überlastung durch zusätzliche Aufgaben.</strong>
+      Wenn KI-Einführung „on top" zum Tagesgeschäft läuft, werden neue Workflows nicht dauerhaft etabliert.
+      Die initiale Lernkurve kann frustrieren und zum Abbruch führen.
+      <em>Gegenmaßnahme:</em> Kleine, gut planbare Piloten mit klar begrenztem Umfang sowie bewusste
+      Entlastung an anderer Stelle, damit Zeit für Experimente und Lernphasen entsteht.
+    </li>
+  </ul>
+
+  <h3>2. Daten-, Sicherheits- und Compliance-Risiken</h3>
+  <ul>
+    <li>
+      <strong>Unzureichende Kontrolle über ein- und ausgehende Daten.</strong>
+      Wenn nicht geregelt ist, welche Informationen in KI-Systeme eingegeben werden dürfen, können vertrauliche
+      Kundendaten, interne Dokumente oder sensible Inhalte unkontrolliert verarbeitet werden.
+      <em>Gegenmaßnahme:</em> Klare Richtlinien für Datennutzung, ein kurzer Leitfaden für alle Beteiligten
+      sowie technische Schutzmechanismen wie Zugriffsbeschränkungen oder getrennte Arbeitsbereiche.
+    </li>
+    <li>
+      <strong>Lücken in Informationssicherheit und Zugriffsschutz.</strong>
+      Der Sicherheits-Score von {score_sec}/100 deutet darauf hin, dass bei Passwörtern, Zugriffsrechten
+      oder Backup-Konzepten noch Verbesserungspotenzial besteht.
+      <em>Gegenmaßnahme:</em> Ein kompaktes Sicherheitskonzept, regelmäßige Passwort- und Rechte-Reviews
+      sowie eine klare Dokumentation der eingesetzten Cloud- und KI-Dienste.
+    </li>
+    <li>
+      <strong>Unklare Verantwortlichkeit für rechtliche Anforderungen.</strong>
+      Ohne definierte Zuständigkeit besteht das Risiko, dass Vorgaben zu Datenschutz, Urheberrecht oder
+      branchenspezifischer Regulierung nur punktuell beachtet werden.
+      <em>Gegenmaßnahme:</em> Eine benannte Stelle, die Mindestanforderungen bündelt, praxisnahe Leitlinien
+      formuliert und bei Unsicherheiten externe fachliche Beratung einholt.
+    </li>
+    <li>
+      <strong>Fehlende Transparenz gegenüber Kund:innen und Partnern.</strong>
+      Wenn unklar bleibt, an welchen Stellen KI Beiträge leistet, kann dies zu Vertrauensverlust führen.
+      Der EU AI Act verlangt zudem Transparenzhinweise bei bestimmten KI-Anwendungen.
+      <em>Gegenmaßnahme:</em> Kurze, verständliche Hinweise zur Nutzung von KI sowie nachvollziehbare
+      Dokumentation im Hintergrund.
+    </li>
+  </ul>
+
+  <h3>3. Qualitäts-, Transparenz- und Akzeptanzrisiken</h3>
+  <ul>
+    <li>
+      <strong>Inkonsistente Ergebnisse und Qualitätsstreuung.</strong>
+      Werden Prompts, Vorlagen und Workflows nicht dokumentiert, hängen Qualität und Stil stark von der
+      jeweiligen Person ab. Dies erschwert reproduzierbare Ergebnisse und professionelle Standards.
+      <em>Gegenmaßnahme:</em> Einheitliche Templates, kurze Leitfäden und regelmäßige Reviews von Beispielausgaben.
+    </li>
+    <li>
+      <strong>Übervertrauen in KI-Ergebnisse (Halluzinationen).</strong>
+      Wenn Texte, Analysen oder Bewertungen ungeprüft übernommen werden, können Fehler oder Halluzinationen
+      direkt in Kundendokumente und Entscheidungen einfließen. Dies kann zu Reputationsschäden führen.
+      <em>Gegenmaßnahme:</em> Klare Regeln für manuelle Prüfung, Vier-Augen-Prinzip bei kritischen Inhalten
+      sowie einfache Checklisten für Qualitätskontrolle.
+    </li>
+    <li>
+      <strong>Akzeptanzprobleme im Alltag.</strong>
+      In Teams entsteht Widerstand, wenn der Nutzen von KI nicht nachvollziehbar ist oder Workflows als
+      zu komplex empfunden werden. Skepsis kann die Einführung blockieren.
+      <em>Gegenmaßnahme:</em> Verständliche Kommunikation der Ziele, kleine Pilotprojekte mit sichtbarem
+      Nutzen und aktives Einholen von Feedback, um Routinen anzupassen.
+    </li>
+    <li>
+      <strong>Unklare Nachvollziehbarkeit von Entscheidungen.</strong>
+      Wenn nicht dokumentiert ist, welche Rolle KI in der Vorbereitung von Angeboten, Reports oder
+      Entscheidungen spielt, wird es im Streitfall schwierig, Entscheidungswege zu rekonstruieren.
+      <em>Gegenmaßnahme:</em> Eine kurze interne Dokumentation zu „Wo unterstützt KI?" senkt dieses Risiko.
+    </li>
+  </ul>
+
+  <h3>4. Abhängigkeiten, Betriebs- und Lieferantenrisiken</h3>
+  <ul>
+    <li>
+      <strong>Starke Abhängigkeit von einzelnen Tools oder Plattformen.</strong>
+      Wenn zentrale Workflows ausschließlich auf einem Dienst oder Modell basieren, führen Preisänderungen,
+      Ausfälle oder geänderte Nutzungsbedingungen schnell zu Unterbrechungen.
+      <em>Gegenmaßnahme:</em> Einfache Fallback-Szenarien, Exportmöglichkeiten für Daten sowie Beobachtung von Alternativen.
+    </li>
+    <li>
+      <strong>Unklare Regelungen mit Dienstleistern.</strong>
+      Werden Auftragsverhältnisse, Datenverarbeitung oder Service-Level nicht explizit vereinbart, können
+      Lücken in Haftung und Verfügbarkeit entstehen.
+      <em>Gegenmaßnahme:</em> Klare Verträge, vereinbarte Reaktionszeiten und transparente Angaben zur Datenhaltung.
+    </li>
+    <li>
+      <strong>Fehlende Notfall- und Wiederanlaufplanung.</strong>
+      Wenn nicht vorab geklärt ist, wie bei Systemausfällen, Datenverlust oder Fehlkonfigurationen
+      reagiert wird, verzögert sich der Wiederanlauf erheblich.
+      <em>Gegenmaßnahme:</em> Einfache Notfallpläne, regelmäßige Backups sowie definierte Kontaktwege für kritische Vorfälle.
+    </li>
+    <li>
+      <strong>Überkomplexe Tool-Landschaft.</strong>
+      Werden zu viele spezialisierte KI-Tools parallel eingeführt, steigt der Aufwand für Pflege,
+      Schulung und Koordination exponentiell.
+      <em>Gegenmaßnahme:</em> Konsolidierung auf wenige Kernlösungen und eine bewusst schlanke Tool-Strategie.
+    </li>
+  </ul>
+
+  <h3>5. Risiko-Matrix – Überblick über zentrale Risiken</h3>
+  <p>
+    Die folgende Übersicht zeigt die wichtigsten Risikofelder nach Eintrittswahrscheinlichkeit und
+    Auswirkungsstärke, um die Priorisierung von Gegenmaßnahmen zu erleichtern.
+  </p>
+  <table class="table">
+    <thead>
+      <tr>
+        <th>Risikobereich</th>
+        <th>Typische Auswirkung</th>
+        <th>Eintrittswahrscheinlichkeit</th>
+        <th>Auswirkungsstärke</th>
+        <th>Empfohlene Schwerpunkt-Maßnahmen</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>Strategie & Organisation</td>
+        <td>Verzettelung, ausbleibende Wirkung</td>
+        <td>mittel</td>
+        <td>hoch</td>
+        <td>Klares Zielbild, priorisierte Use Cases, benannte Verantwortung</td>
+      </tr>
+      <tr>
+        <td>Daten & Sicherheit</td>
+        <td>Datenschutz-Verstöße, Vertrauensverlust</td>
+        <td>mittel bis hoch</td>
+        <td>hoch</td>
+        <td>Leitlinie für Datennutzung, Zugriffs- und Passwortkonzept</td>
+      </tr>
+      <tr>
+        <td>Qualität & Akzeptanz</td>
+        <td>Uneinheitliche Ergebnisse, Misstrauen</td>
+        <td>mittel</td>
+        <td>mittel bis hoch</td>
+        <td>Standards für Templates, Review-Loops, Kommunikation</td>
+      </tr>
+      <tr>
+        <td>Abhängigkeiten & Betrieb</td>
+        <td>Unterbrechungen, Mehrkosten, Lock-in</td>
+        <td>niedrig bis mittel</td>
+        <td>mittel</td>
+        <td>Fallback-Szenarien, Tool-Konsolidierung</td>
+      </tr>
+      <tr>
+        <td>KI-spezifisch: Halluzinationen</td>
+        <td>Fehlerhafte Informationen, Reputationsschaden</td>
+        <td>mittel bis hoch</td>
+        <td>hoch</td>
+        <td>Vier-Augen-Prinzip, Faktenprüfung</td>
+      </tr>
+    </tbody>
+  </table>
+
+  <p class="small muted">
+    Diese Risikoanalyse zeigt die wichtigsten Handlungsfelder für KI in <strong>{hauptleistung or "Ihrem Kerngeschäft"}</strong>
+    in einem Unternehmen der Größe <strong>{size_label}</strong>. Im nächsten Schritt sollten die Risiken nach
+    Eintrittswahrscheinlichkeit und Auswirkung priorisiert und in eine konkrete Maßnahmenplanung überführt werden.
+  </p>
+</section>"""
+
+    # ════════════════════════════════════════════════════════════════════════════
+    # 🎯 PLATIN+ FALLBACK: RECOMMENDATIONS (800+ Wörter)
+    # ════════════════════════════════════════════════════════════════════════════
+    if section_key == "recommendations":
+        if size_group == "solo":
+            verantwortlich_1 = "Inhaber:in"
+            verantwortlich_2 = "Inhaber:in"
+            zeitrahmen_1 = "0–3 Monate"
+            zeitrahmen_2 = "3–6 Monate"
+            aufwand_1 = "Niedrig – realisierbar in wenigen Tagen"
+            aufwand_5 = "Niedrig – persönliche Checkliste in 1-2 Tagen"
+        elif size_group == "team":
+            verantwortlich_1 = "Teamlead oder KI-Owner"
+            verantwortlich_2 = "Qualitätsverantwortliche"
+            zeitrahmen_1 = "0–6 Monate"
+            zeitrahmen_2 = "3–9 Monate"
+            aufwand_1 = "Mittel – 3-5 Tage Setup im Team"
+            aufwand_5 = "Mittel – Team-Workshop + Dokumentation in 3-5 Tagen"
+        else:
+            verantwortlich_1 = "Fachbereich + verantwortliche Leitung"
+            verantwortlich_2 = "Qualitätsmanagement + Fachbereich"
+            zeitrahmen_1 = "0–6 Monate"
+            zeitrahmen_2 = "6–9 Monate"
+            aufwand_1 = "Mittel bis hoch – strukturiertes Setup mit Abstimmung"
+            aufwand_5 = "Mittel bis hoch – Policy-Entwicklung in 2-4 Wochen"
+
+        return f"""<section class="section recommendations">
+  <h2>Handlungsempfehlungen – Ihre nächsten Schritte mit KI</h2>
+
+  <p>
+    Für ein Unternehmen in der Branche <strong>{branche}</strong> mit der Größe <strong>{size_label}</strong>
+    ergeben sich mehrere unmittelbar realisierbare Hebel, um KI im Prozess <strong>{hauptleistung or "Ihrem Kerngeschäft"}</strong>
+    wirksam einzusetzen. Die folgenden Empfehlungen sind priorisiert, praxisnah und auf realistische Ressourcen abgestimmt.
+    Jede Empfehlung enthält konkrete Maßnahmen, erwarteten Nutzen, Aufwandsschätzung und Förderhinweise.
+  </p>
+
+  <ol class="recommendations-list">
+    <li>
+      <h3>Empfehlung 1: Quick Win – Standard-Workflow einführen</h3>
+      <p><strong>Schwerpunkt:</strong> Verbesserung eines zentralen, wiederkehrenden Schritts in
+        {hauptleistung or "Ihrem Kerngeschäft"}, der häufig Zeit bindet und sich für KI-Unterstützung eignet.</p>
+      <p><strong>Maßnahme:</strong> Einführung eines KI-gestützten Standard-Workflows mit klaren Regeln für
+        Eingaben, Qualitätsprüfung und Freigabe. Dokumentation der Prompts und Best Practices, damit die
+        Ergebnisse reproduzierbar und konsistent sind.</p>
+      <p><strong>Nutzen &amp; Wirkung:</strong> Direkt messbare Entlastung bei wiederkehrenden Aufgaben,
+        höhere Konsistenz und stabilere Qualität. Die Zeitersparnis kann 10-25% im Zielbereich betragen.</p>
+      <p><strong>Aufwand &amp; Budget:</strong> {aufwand_1}; Toolkosten typischerweise im zweistelligen
+        bis niedrigen dreistelligen Bereich pro Monat.</p>
+      <p><strong>Verantwortlich:</strong> {verantwortlich_1}</p>
+      <p><strong>Förderchance:</strong> Je nach Bundesland {bundesland} bestehen Zuschussprogramme für
+        digitale Prozessoptimierung. Prüfen Sie go-digital oder regionale Digitalisierungsförderung.</p>
+    </li>
+
+    <li>
+      <h3>Empfehlung 2: Qualitätssicherung – KI-gestützte Konsistenzprüfung</h3>
+      <p><strong>Schwerpunkt:</strong> KI-gestützte Konsistenzprüfung für Dokumente, Inhalte oder
+        Datenstrukturen, abgestimmt auf branchentypische Anforderungen in {branche}.</p>
+      <p><strong>Maßnahme:</strong> Einrichten eines automatisierten Review-Schritts vor der Freigabe.
+        Dies kann Faktencheck, Tonalitätsprüfung, Markenrichtlinien oder Compliance-Checks umfassen.</p>
+      <p><strong>Nutzen &amp; Wirkung:</strong> Weniger Nachbearbeitung, geringeres Risiko von Fehlern,
+        stabilere Qualität über mehrere Aufträge hinweg. Reduziert Korrekturschleifen erheblich.</p>
+      <p><strong>Aufwand &amp; Budget:</strong> Mittel – 2-5 Tage Setup; Lizenzen abhängig von Nutzerzahl.
+        Oft in bestehende KI-Tools integrierbar.</p>
+      <p><strong>Verantwortlich:</strong> {verantwortlich_2}</p>
+      <p><strong>Förderchance:</strong> Programme für Qualitäts- und Effizienzsteigerungen in mehreren
+        Bundesländern verfügbar. Besonders relevant bei Compliance-Bezug.</p>
+    </li>
+
+    <li>
+      <h3>Empfehlung 3: Wissensmanagement – Dokumentation &amp; Wissensbasis</h3>
+      <p><strong>Schwerpunkt:</strong> Dokumentation und Wissensmanagement verbessern – ein typisches
+        Pain Point, das sich durch KI-Unterstützung deutlich entschärfen lässt.</p>
+      <p><strong>Maßnahme:</strong> Aufbau einer KI-gestützten Wissensbibliothek mit Vorlagen, Standards,
+        Checklisten und Best Practices. Zentrale Ablage für Prompts, Beispiele und Dokumentation.</p>
+      <p><strong>Nutzen &amp; Wirkung:</strong> Schnellere Einarbeitung, höhere Ersttrefferquote, weniger
+        Rückfragen und konsistentere Ergebnisse im Tagesgeschäft. Wissen geht nicht verloren.</p>
+      <p><strong>Aufwand &amp; Budget:</strong> Niedrig bis mittel – abhängig vom vorhandenen Material;
+        laufende Kosten gering. Initial 2-3 Tage für Strukturierung.</p>
+      <p><strong>Verantwortlich:</strong> {verantwortlich_1}</p>
+      <p><strong>Förderchance:</strong> Wissens- und Prozessdigitalisierung ist in vielen Programmen
+        förderfähig. Prüfung für {bundesland} empfohlen.</p>
+    </li>
+
+    <li>
+      <h3>Empfehlung 4: Branchenspezifischer Use Case</h3>
+      <p><strong>Schwerpunkt:</strong> Ein branchenspezifischer Use Case für {branche}, der hohe
+        Sichtbarkeit und schnellen ROI verspricht.</p>
+      <p><strong>Maßnahme:</strong> Pilotierung eines klar abgegrenzten KI-Use-Cases, der typische
+        Workflows der Branche adressiert. Fokus auf messbaren Nutzen und Lerneffekte.</p>
+      <p><strong>Nutzen &amp; Wirkung:</strong> Sichtbarer Nutzen unmittelbar im Alltag, Momentum für
+        weitere Digitalisierungsschritte. Erfolgsgeschichte für interne Kommunikation.</p>
+      <p><strong>Aufwand &amp; Budget:</strong> Variable je nach Größe und Komplexität; typischerweise
+        3-10 Tage für einen fokussierten Pilot.</p>
+      <p><strong>Verantwortlich:</strong> {verantwortlich_1}</p>
+      <p><strong>Förderchance:</strong> Pilot-Use-Cases mit klarer Zielsetzung werden von vielen
+        Förderprogrammen priorisiert.</p>
+    </li>
+
+    <li>
+      <h3>Empfehlung 5: Governance &amp; Sicherheit</h3>
+      <p><strong>Schwerpunkt:</strong> Klare Richtlinien und Kontrollen für den KI-Einsatz etablieren,
+        um Risiken zu minimieren und Compliance sicherzustellen.</p>
+      <p><strong>Maßnahme:</strong> Erstellung eines kompakten KI-Leitfadens mit Regeln zu Datenschutz,
+        Qualitätsprüfung und Freigabeprozessen. Definition von Verantwortlichkeiten und Eskalationswegen.</p>
+      <p><strong>Nutzen &amp; Wirkung:</strong> Höhere Rechtssicherheit, transparente Prozesse und
+        gestärktes Vertrauen bei Kund:innen und Partnern. Vorbereitung auf EU AI Act.</p>
+      <p><strong>Aufwand &amp; Budget:</strong> {aufwand_5}</p>
+      <p><strong>Verantwortlich:</strong> {verantwortlich_1}</p>
+      <p><strong>Förderchance:</strong> Beratungsförderung für Datenschutz und IT-Sicherheit in
+        {bundesland} prüfen. Auch KMU-Programme decken oft Governance ab.</p>
+    </li>
+  </ol>
+
+  <h3>Prioritäten-Überblick</h3>
+  <table class="table">
+    <thead>
+      <tr>
+        <th>Priorität</th>
+        <th>Empfehlung</th>
+        <th>Zeitrahmen</th>
+        <th>Hauptnutzen</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>1</td>
+        <td>Standard-Workflow einführen</td>
+        <td>{zeitrahmen_1}</td>
+        <td>Sofortige Entlastung & Qualitätssteigerung</td>
+      </tr>
+      <tr>
+        <td>2</td>
+        <td>KI-gestützte Konsistenzprüfung</td>
+        <td>{zeitrahmen_2}</td>
+        <td>Weniger Nacharbeit & geringeres Risiko</td>
+      </tr>
+      <tr>
+        <td>3</td>
+        <td>Wissensbibliothek zentralisieren</td>
+        <td>{zeitrahmen_2}</td>
+        <td>Schnellere Einarbeitung & stabile Ergebnisse</td>
+      </tr>
+      <tr>
+        <td>4</td>
+        <td>Branchenspezifischen Pilot umsetzen</td>
+        <td>6–12 Monate</td>
+        <td>Sichtbarer Nutzen & Skalierungsmomentum</td>
+      </tr>
+      <tr>
+        <td>5</td>
+        <td>Governance & Sicherheitsrichtlinien</td>
+        <td>{zeitrahmen_2}</td>
+        <td>Rechtssicherheit & Vertrauen</td>
+      </tr>
+    </tbody>
+  </table>
+
+  <p class="small muted">
+    Die Empfehlungen sind so formuliert, dass sie unmittelbar in die Projektplanung übernommen werden können
+    und konsistent mit Roadmap, Business Case und Risikoanalyse wirken. Die Zeitrahmen sind an die
+    Unternehmensgröße <strong>{size_label}</strong> angepasst.
+  </p>
+</section>"""
+
     # 🎯 SIZE-AWARE ROADMAP FALLBACKS (inline HTML, 1000+ Zeichen)
     if section_key in ("roadmap", "roadmap_90d"):
         # Bedingter Text für Phase 3 basierend auf size_group

--- a/prompts/de/foerderpotenzial.md
+++ b/prompts/de/foerderpotenzial.md
@@ -1,99 +1,29 @@
 Developer:
-<!-- foerderpotenzial.md – v7.0 PLATIN+ STABILIZED (business-case-integrated, size-aware, min 900 WÖRTER)
+<!-- foerderpotenzial.md – v8.0 PLATIN+ STREAMLINED
+     Ziel: 4 Abschnitte mit je 200-250 Wörtern (= 800-1000 Wörter gesamt).
+     Antworte ausschließlich mit validem HTML. Keine Markdown-Fences.
 
-     ╔══════════════════════════════════════════════════════════════════════════════╗
-     ║  KRITISCH: MINDESTLÄNGE = 900 WÖRTER (nicht Zeichen!)                        ║
-     ║  Antworte IMMER mit einem VOLLSTÄNDIGEN, AUSFÜHRLICHEN Text.                 ║
-     ║  Kurze Antworten sind INAKZEPTABEL und führen zu Validierungsfehlern.        ║
-     ╚══════════════════════════════════════════════════════════════════════════════╝
+     STRUKTUR (4 Pflicht-Abschnitte):
+       H3 1. Einordnung des Business Case ohne Förderung
+       H3 2. Wie Fördermittel den Business Case verbessern
+       H3 3. Passende Förderschwerpunkte für Ihr Vorhaben
+       H3 4. Nächste Schritte für die Förderprüfung
 
-     AUSGABEFORMAT:
-       - Antworte ausschließlich mit validem HTML.
-       - KEIN <html>, <head> oder <body>. KEINE Markdown-Fences.
+     VARIABLEN – nutze alle mindestens einmal:
+       {{BUNDESLAND_LABEL}}, {{BRANCHE_LABEL}}, {{UNTERNEHMENSGROESSE_LABEL}},
+       {{HAUPTLEISTUNG}}, {{CAPEX_REALISTISCH_EUR}}, {{OPEX_REALISTISCH_EUR}},
+       {{EINSPARUNG_MONAT_EUR}}, {{PAYBACK_MONTHS}}, {{ROI_12M}}
 
-     ZWECK:
-       - Qualitative Einschätzung des Förderpotenzials basierend auf Kern-Fördermatrix.
-       - Business-Case-Variablen AKTIV nutzen und einordnen, NICHT neu berechnen.
-       - Typische Zuschussbereiche nennen (z. B. „30–50 %"), KEINE neuen Eurobeträge erfinden.
-       - Kern-Matrix liefert realistische, geprüfte Programme (DE/AT/EU, 2025/26-aktuell).
-
-     VERFÜGBARE VARIABLEN (MÜSSEN ALLE im Text verwendet werden!):
-       {{BUNDESLAND_LABEL}}           ← Bundesland des Unternehmens
-       {{BRANCHE_LABEL}}              ← Branche des Unternehmens
-       {{UNTERNEHMENSGROESSE_LABEL}}  ← Größenkategorie (Solo/Team/KMU)
-       {{HAUPTLEISTUNG}}              ← Kernleistung des Unternehmens
-       {{CAPEX_REALISTISCH_EUR}}      ← Investitionskosten (einmalig)
-       {{OPEX_REALISTISCH_EUR}}       ← Laufende Kosten pro Monat
-       {{EINSPARUNG_MONAT_EUR}}       ← Monatliche Entlastung/Einsparung
-       {{PAYBACK_MONTHS}}             ← Amortisationsdauer in Monaten
-       {{ROI_12M}}                    ← Return on Investment nach 12 Monaten (%)
-
-     SIZE-AWARE LOGIK (COMPANY_SIZE ∈ {"solo","team","kmu"}):
-       SOLO:
-         - Fokus: niedrige Einstiegshürden, kleinere Projektvolumina (<10.000€), einfache Programme.
-         - Typische Programme: Beratungsförderung, Gründerzuschüsse, Digitalisierungsgutscheine.
-         - Förderquoten: häufig 50-80% bei Beratung, 30-50% bei Investitionen.
-       TEAM (2–10):
-         - Fokus: Prozessdigitalisierung, Weiterbildungen, leichtgewichtige Innovationsförderung.
-         - Typische Programme: Digitalbonus, KMU-innovativ, go-digital.
-         - Förderquoten: typisch 40-60% bei Digitalisierung, bis 50% bei Innovation.
-       KMU (11–100):
-         - Fokus: strukturelle Digitalisierungs-/Investitionsförderungen, Pilot- und Skalierungsprojekte.
-         - Typische Programme: Digital Jetzt, ZIM, ERP-Digitalisierungskredit.
-         - Förderquoten: typisch 30-50%, bei ZIM bis 55% möglich.
-
-     ╔══════════════════════════════════════════════════════════════════════════════╗
-     ║  PFLICHTSTRUKTUR – ALLE 4 ABSCHNITTE MÜSSEN VOLLSTÄNDIG AUSGEFÜHRT WERDEN!   ║
-     ╚══════════════════════════════════════════════════════════════════════════════╝
-
-     ABSCHNITT 1: "Einordnung des Business Case ohne Förderung" (mind. 200-250 Wörter)
-       PFLICHTINHALTE:
-       - Nenne EXPLIZIT alle 5 Zahlen: CAPEX, OPEX, Einsparung, Payback, ROI
-       - Ordne jede Zahl im Kontext der Branche {{BRANCHE_LABEL}} ein
-       - Erkläre, warum der Business Case auch ohne Förderung tragfähig ist
-       - Beschreibe die wirtschaftliche Attraktivität des Projekts
-       - Gehe auf die Besonderheiten für {{UNTERNEHMENSGROESSE_LABEL}} ein
-
-     ABSCHNITT 2: "Wie Fördermittel den Business Case verbessern können" (mind. 250-300 Wörter)
-       PFLICHTINHALTE (MINDESTENS 5 ausführliche Bulletpoints):
-       - Kürzere Amortisationsdauer: konkrete Rechnung mit {{PAYBACK_MONTHS}}
-       - Höherer effektiver ROI: wie sich {{ROI_12M}}% durch Förderung verdoppeln kann
-       - Reduziertes finanzielles Risiko: Bezug auf {{CAPEX_REALISTISCH_EUR}}
-       - Mehr Spielraum für Qualität und Schulung: wie Einsparungen genutzt werden können
-       - Bessere Planungssicherheit: Projektbudget-Planung mit bewilligter Förderung
-       - Optional: Skalierungsmöglichkeiten, Team-Entwicklung, Innovation
-
-     ABSCHNITT 3: "Passende Förderschwerpunkte für Ihr Vorhaben" (mind. 200-250 Wörter)
-       PFLICHTINHALTE (MINDESTENS 4 Förderkategorien mit Erklärung):
-       - Digitalisierungsförderung: spezifisch für {{HAUPTLEISTUNG}}
-       - Innovationsförderung: branchenspezifisch für {{BRANCHE_LABEL}}
-       - Qualifizierungsförderung: Schulungen und Kompetenzaufbau
-       - Beratungsförderung: externe Expertise und Strategieentwicklung
-       - Jede Kategorie mit 2-3 Sätzen Erklärung und Relevanz
-
-     ABSCHNITT 4: "Nächste Schritte für die Förderprüfung" (mind. 200-250 Wörter)
-       PFLICHTINHALTE (MINDESTENS 5 konkrete Schritte):
-       1. Programmauswahl mit Bezug auf {{BRANCHE_LABEL}} und {{BUNDESLAND_LABEL}}
-       2. Projektbeschreibung mit Bezug auf {{CAPEX_REALISTISCH_EUR}}
-       3. Kumulierungsprüfung für {{BUNDESLAND_LABEL}}
-       4. Beratung einholen (Kammern, Förderberatungen)
-       5. Zeitplanung (4-8 Wochen Vorlauf einplanen)
-       - Jeden Schritt mit 2-3 Sätzen erklären
-
-     ╔══════════════════════════════════════════════════════════════════════════════╗
-     ║  ABSOLUTE MINDESTLÄNGE: 900 WÖRTER Gesamttext (ohne HTML-Tags)               ║
-     ║  Ziel: 900-1200 Wörter für vollständige, professionelle Analyse              ║
-     ║  NIEMALS kürzer als 900 Wörter antworten!                                    ║
-     ╚══════════════════════════════════════════════════════════════════════════════╝
+     SIZE-AWARE (COMPANY_SIZE):
+       solo: niedrige Hürden, <10.000€, Beratungs-/Gründerförderung
+       team: Prozessdigitalisierung, KMU-innovativ, go-digital
+       kmu: Digital Jetzt, ZIM, strukturelle Förderung
 
      REGELN:
-       - Keine Platzhalter, keine internen Funktionshinweise im HTML.
-       - ALLE Business-Case-Zahlen EXPLIZIT im Text erwähnen und einordnen.
-       - Förderquoten nur als Bereiche formulieren („typischerweise 30–50 %").
-       - Sprachlich neutral, geschäftlich, ohne Werbung.
-       - Erkläre verständlich, WARUM sich das Projekt wirtschaftlich lohnt.
-       - Erkläre, wie Förderung das finanzielle Risiko reduziert.
-       - Jeder Abschnitt muss AUSFÜHRLICH und VOLLSTÄNDIG sein.
+       - Förderquoten nur als Bereiche (z.B. "30-50%")
+       - Business-Case-Zahlen explizit nennen und einordnen
+       - Sachlich, neutral, keine Werbung
+       - Keine Platzhalter, keine Developer-Sprache
 -->
 
 <section class="section funding-potential">
@@ -105,8 +35,7 @@ Developer:
     <strong>{{UNTERNEHMENSGROESSE_LABEL}}</strong> verfügen für Vorhaben im Bereich
     <strong>{{HAUPTLEISTUNG}}</strong> häufig über gute Voraussetzungen für eine Förderung.
     Die Kombination aus Digitalisierungsfokus, KI-Unterstützung und klarer Prozessverbesserung
-    entspricht den Schwerpunkten vieler Programme auf Landes- und Bundesebene – unabhängig davon,
-    ob es sich um ein Solo-Unternehmen, ein kleines Team oder ein wachsendes KMU handelt.
+    entspricht den Schwerpunkten vieler Programme auf Landes- und Bundesebene.
   </p>
 
   <h3>1. Einordnung des Business Case ohne Förderung</h3>
@@ -121,11 +50,8 @@ Developer:
   </p>
   <p>
     Diese Ausgangslage ist für viele Förderstellen attraktiv: Das Projekt ist betriebswirtschaftlich
-    plausibel, der Nutzen klar erkennbar und der Eigenbeitrag – je nach Unternehmensgröße –
-    grundsätzlich tragfähig. Fördermittel können diese Situation zusätzlich verbessern, indem
-    sie einen Teil der Investitionsbelastung abfedern.
-  </p>
-  <p>
+    plausibel, der Nutzen klar erkennbar und der Eigenbeitrag grundsätzlich tragfähig. Fördermittel
+    können diese Situation zusätzlich verbessern, indem sie einen Teil der Investitionsbelastung abfedern.
     Konkret bedeutet das für ein Unternehmen der Größe <strong>{{UNTERNEHMENSGROESSE_LABEL}}</strong>
     in der Branche <strong>{{BRANCHE_LABEL}}</strong>: Die Investition von {{CAPEX_REALISTISCH_EUR}}&nbsp;€
     amortisiert sich bei einer monatlichen Einsparung von {{EINSPARUNG_MONAT_EUR}}&nbsp;€ nach etwa
@@ -138,41 +64,24 @@ Developer:
     Viele Programme in {{BUNDESLAND_LABEL}} und auf Bundesebene unterstützen KI- und
     Digitalisierungsinitiativen, indem sie einen Teil der förderfähigen Investitionskosten
     bezuschussen. Je nach Programm, Unternehmensgröße und Projektschwerpunkt bewegen sich
-    die Zuschussquoten typischerweise im Bereich von etwa
-    <strong>30–50&nbsp;%</strong> der anerkannten Kosten. Für ein Investitionsvolumen von
-    {{CAPEX_REALISTISCH_EUR}}&nbsp;€ könnte das eine Entlastung von
-    mehreren tausend Euro bedeuten.
+    die Zuschussquoten typischerweise im Bereich von etwa <strong>30–50&nbsp;%</strong>
+    der anerkannten Kosten. Für ein Investitionsvolumen von {{CAPEX_REALISTISCH_EUR}}&nbsp;€
+    könnte das eine Entlastung von mehreren tausend Euro bedeuten.
   </p>
-
   <ul>
-    <li>
-      <strong>Kürzere Amortisationsdauer:</strong>
-      Durch eine Beteiligung an den Investitionskosten sinkt der Eigenanteil; die Amortisation
-      kann sich von {{PAYBACK_MONTHS}} Monaten auf deutlich weniger verkürzen, ohne dass der
-      erwartete Nutzen verändert wird.
-    </li>
-    <li>
-      <strong>Höherer effektiver ROI:</strong>
-      Wenn ein Teil der Investitionen über Zuschüsse abgedeckt wird, steigt der Effektiv-Ertrag
-      je eingesetztem Euro – der aktuelle ROI von {{ROI_12M}}&nbsp;% kann sich bei 40%
-      Förderung auf über das Doppelte erhöhen.
-    </li>
-    <li>
-      <strong>Reduziertes finanzielles Risiko:</strong>
-      Für <strong>{{UNTERNEHMENSGROESSE_LABEL}}</strong> kann ein Zuschuss den Schritt in ein
-      ambitionierteres Projekt erleichtern, ohne die Liquidität unnötig zu belasten. Die
-      laufenden Kosten von {{OPEX_REALISTISCH_EUR}}&nbsp;€/Monat bleiben dabei tragbar.
-    </li>
-    <li>
-      <strong>Mehr Spielraum für Qualität und Schulung:</strong>
-      Einsparungen durch Förderung können genutzt werden, um zusätzliche Maßnahmen für
-      Qualität, Sicherheit oder Qualifizierung vorzusehen – wichtig für nachhaltige KI-Nutzung.
-    </li>
-    <li>
-      <strong>Bessere Planungssicherheit:</strong>
-      Mit bewilligter Förderung lässt sich das Projektbudget verlässlicher planen und das
-      Risiko bei unerwarteten Mehrkosten besser abfedern.
-    </li>
+    <li><strong>Kürzere Amortisationsdauer:</strong> Durch eine Beteiligung an den Investitionskosten
+      sinkt der Eigenanteil; die Amortisation kann sich von {{PAYBACK_MONTHS}} Monaten auf
+      deutlich weniger verkürzen, ohne dass der erwartete Nutzen verändert wird.</li>
+    <li><strong>Höherer effektiver ROI:</strong> Wenn ein Teil der Investitionen über Zuschüsse
+      abgedeckt wird, steigt der Effektiv-Ertrag je eingesetztem Euro – der aktuelle ROI von
+      {{ROI_12M}}&nbsp;% kann sich bei 40% Förderung auf über das Doppelte erhöhen.</li>
+    <li><strong>Reduziertes finanzielles Risiko:</strong> Für <strong>{{UNTERNEHMENSGROESSE_LABEL}}</strong>
+      kann ein Zuschuss den Schritt in ein ambitionierteres Projekt erleichtern, ohne die Liquidität
+      unnötig zu belasten. Die laufenden Kosten von {{OPEX_REALISTISCH_EUR}}&nbsp;€/Monat bleiben dabei tragbar.</li>
+    <li><strong>Mehr Spielraum für Qualität und Schulung:</strong> Einsparungen durch Förderung können
+      genutzt werden, um zusätzliche Maßnahmen für Qualität, Sicherheit oder Qualifizierung vorzusehen.</li>
+    <li><strong>Bessere Planungssicherheit:</strong> Mit bewilligter Förderung lässt sich das Projektbudget
+      verlässlicher planen und das Risiko bei unerwarteten Mehrkosten besser abfedern.</li>
   </ul>
 
   <h3>3. Passende Förderschwerpunkte für Ihr Vorhaben</h3>
@@ -182,56 +91,34 @@ Developer:
     <strong>{{UNTERNEHMENSGROESSE_LABEL}}</strong> kommen folgende Förderkategorien in Frage:
   </p>
   <ul>
-    <li>
-      <strong>Digitalisierungsförderung:</strong>
-      Programme für KI-gestützte Prozessoptimierung, Automatisierung und digitale Werkzeuge.
-    </li>
-    <li>
-      <strong>Innovationsförderung:</strong>
-      Zuschüsse für neuartige KI-Anwendungen, Pilotprojekte und Technologieentwicklung.
-    </li>
-    <li>
-      <strong>Qualifizierungsförderung:</strong>
-      Mittel für Schulungen, Weiterbildungen und den Aufbau von KI-Kompetenzen im Team.
-    </li>
-    <li>
-      <strong>Beratungsförderung:</strong>
-      Unterstützung für externe Expertise bei der KI-Strategieentwicklung und Umsetzung.
-    </li>
+    <li><strong>Digitalisierungsförderung:</strong> Programme für KI-gestützte Prozessoptimierung,
+      Automatisierung und digitale Werkzeuge. Besonders relevant für {{HAUPTLEISTUNG}}.</li>
+    <li><strong>Innovationsförderung:</strong> Zuschüsse für neuartige KI-Anwendungen, Pilotprojekte
+      und Technologieentwicklung, abgestimmt auf die Branche {{BRANCHE_LABEL}}.</li>
+    <li><strong>Qualifizierungsförderung:</strong> Mittel für Schulungen, Weiterbildungen und den
+      Aufbau von KI-Kompetenzen – wichtig für nachhaltige Nutzung.</li>
+    <li><strong>Beratungsförderung:</strong> Unterstützung für externe Expertise bei der
+      KI-Strategieentwicklung und Umsetzung.</li>
   </ul>
 
   <h3>4. Nächste Schritte für die Förderprüfung</h3>
   <ol>
-    <li>
-      <strong>Programmauswahl:</strong> 1–2 Programme aus dem Förderkapitel auswählen, die zu
+    <li><strong>Programmauswahl:</strong> 1–2 Programme auswählen, die zu
       <strong>{{BRANCHE_LABEL}}</strong>, <strong>{{UNTERNEHMENSGROESSE_LABEL}}</strong>
-      und <strong>{{HAUPTLEISTUNG}}</strong> passen (z.&nbsp;B. mit Fokus auf
-      Digitalisierungsprojekte, Prozessoptimierung oder Qualifizierung).
-    </li>
-    <li>
-      <strong>Projektbeschreibung:</strong> Eine kompakte Projektbeschreibung erstellen (Ziele, Maßnahmen, Zeitplan,
-      erwarteter Nutzen, grobe Kosten mit Bezug auf die berechneten {{CAPEX_REALISTISCH_EUR}}&nbsp;€),
-      die als Grundlage für Antragsunterlagen und interne Entscheidungen genutzt werden kann.
-    </li>
-    <li>
-      <strong>Kumulierungsprüfung:</strong> Prüfen, ob Programme aus {{BUNDESLAND_LABEL}} mit Bundes- oder EU-Programmen
-      kombiniert werden dürfen und welche Vorgaben für Kumulierung gelten.
-    </li>
-    <li>
-      <strong>Beratung einholen:</strong> Optional Rücksprache mit Förderberatungen, Kammern oder Finanzierungspartnern halten,
-      um Chancen, Aufwand und sinnvolle Programmkombinationen realistisch einzuschätzen.
-    </li>
-    <li>
-      <strong>Zeitplanung:</strong> Förderanträge benötigen typischerweise 4–8 Wochen Vorlauf – dies bei der
-      Projektplanung berücksichtigen und frühzeitig mit der Antragsvorbereitung beginnen.
-    </li>
+      und <strong>{{HAUPTLEISTUNG}}</strong> passen.</li>
+    <li><strong>Projektbeschreibung:</strong> Eine kompakte Projektbeschreibung erstellen
+      (Ziele, Maßnahmen, Zeitplan, erwarteter Nutzen, grobe Kosten mit Bezug auf die
+      berechneten {{CAPEX_REALISTISCH_EUR}}&nbsp;€).</li>
+    <li><strong>Kumulierungsprüfung:</strong> Prüfen, ob Programme aus {{BUNDESLAND_LABEL}}
+      mit Bundes- oder EU-Programmen kombiniert werden dürfen.</li>
+    <li><strong>Beratung einholen:</strong> Optional Rücksprache mit Förderberatungen, Kammern
+      oder Finanzierungspartnern halten.</li>
+    <li><strong>Zeitplanung:</strong> Förderanträge benötigen typischerweise 4–8 Wochen Vorlauf –
+      dies bei der Projektplanung berücksichtigen.</li>
   </ol>
 
   <p class="small muted">
-    Hinweis: Förderquoten, Fristen und Anforderungen können sich ändern. Die hier
-    beschriebenen Einschätzungen beziehen sich auf Programme, die im Rahmen einer
-    aktuellen Fördermatrix (2025/2026) berücksichtigt wurden. Vor Antragstellung
-    sollten die offiziellen Richtlinien und Konditionen der jeweiligen Programme
-    im Detail geprüft werden.
+    Hinweis: Förderquoten, Fristen und Anforderungen können sich ändern. Vor Antragstellung
+    sollten die offiziellen Richtlinien und Konditionen der jeweiligen Programme im Detail geprüft werden.
   </p>
 </section>

--- a/prompts/de/recommendations.md
+++ b/prompts/de/recommendations.md
@@ -1,107 +1,33 @@
 Developer:
-<!-- recommendations.md – v7.0 PLATIN+ STABILIZED (branch-aware, size-aware, actionable, min 800 WÖRTER)
+<!-- recommendations.md – v8.0 PLATIN+ STREAMLINED
+     Ziel: 5-6 Empfehlungen mit je 100-120 Wörtern (= 800-1000 Wörter gesamt).
+     Antworte ausschließlich mit validem HTML. Keine Markdown-Fences.
 
-     ╔══════════════════════════════════════════════════════════════════════════════╗
-     ║  KRITISCH: MINDESTLÄNGE = 800 WÖRTER (nicht Zeichen!)                        ║
-     ║  Antworte IMMER mit einem VOLLSTÄNDIGEN, AUSFÜHRLICHEN Text.                 ║
-     ║  Kurze Antworten sind INAKZEPTABEL und führen zu Validierungsfehlern.        ║
-     ╚══════════════════════════════════════════════════════════════════════════════╝
+     STRUKTUR (Pflicht-Elemente):
+       1. Einleitung (50-80 Wörter)
+       2. 5-6 Empfehlungen, je mit:
+          - Schwerpunkt (1-2 Sätze)
+          - Maßnahme (2-3 Sätze, spezifisch)
+          - Nutzen & Wirkung (2 Sätze)
+          - Aufwand & Budget (1-2 Sätze, size-aware)
+          - Verantwortlich (1 Satz, size-aware)
+          - Förderchance (1-2 Sätze)
+       3. Prioritäten-Tabelle (5 Zeilen)
 
-     AUSGABEFORMAT:
-       - Antworte ausschließlich mit validem HTML.
-       - KEIN <html>, <head> oder <body>. KEINE Markdown-Fences im OUTPUT.
+     VARIABLEN – nutze alle mindestens einmal:
+       {{BRANCHE_LABEL}}, {{UNTERNEHMENSGROESSE_LABEL}}, {{HAUPTLEISTUNG}},
+       {{BUNDESLAND_LABEL}}, {{COMPANY_SIZE}}
 
-     ZIEL:
-       - Erzeuge 5–6 präzise, sofort nutzbare Handlungsempfehlungen.
-       - Jede Empfehlung muss vollständig ausformuliert sein:
-         Schwerpunkt → Maßnahme → Nutzen → Aufwand → Verantwortlich → Förderchance.
-       - Abhängig von Branche, Hauptleistung, Unternehmensgröße und Bundesland.
-       - Erstelle zusätzlich eine klare Prioritäten-Tabelle (5–6 Einträge).
-       - Verknüpfung mit Roadmap und Business Case.
+     SIZE-AWARE (COMPANY_SIZE):
+       solo: Inhaber:in, persönliche Schritte, niedriges Budget
+       team: Teamlead/KI-Owner, gemeinsame Workflows, mittleres Budget
+       kmu: Fachbereiche, Governance, strukturierte Investitionen
 
-     INPUT-VARIABLEN (MÜSSEN ALLE im Text verwendet werden!):
-       {{BRANCHE_LABEL}}              ← Branche des Unternehmens
-       {{UNTERNEHMENSGROESSE_LABEL}}  ← Größenkategorie
-       {{HAUPTLEISTUNG}}              ← Kernleistung/Anwendungsbereich
-       {{BUNDESLAND_LABEL}}           ← Bundesland für Förderhinweise
-       {{COMPANY_SIZE}}               ← "solo", "team", "kmu"
-
-     ╔══════════════════════════════════════════════════════════════════════════════╗
-     ║  PFLICHTSTRUKTUR – ALLE ELEMENTE MÜSSEN VOLLSTÄNDIG AUSGEFÜHRT WERDEN!       ║
-     ╚══════════════════════════════════════════════════════════════════════════════╝
-
-     TEIL 1: EINLEITUNG (mind. 50-80 Wörter)
-       - Kontextualisierung für {{BRANCHE_LABEL}} und {{UNTERNEHMENSGROESSE_LABEL}}
-       - Bezug auf {{HAUPTLEISTUNG}}
-       - Überleitung zu den Empfehlungen
-
-     TEIL 2: EMPFEHLUNGEN (mind. 5 Empfehlungen, je 100-120 Wörter = mind. 500-600 Wörter)
-       JEDE Empfehlung MUSS folgende 6 Elemente enthalten (alle ausführlich!):
-       1. <strong>Schwerpunkt:</strong> Was ist das Kernproblem/die Chance? (1-2 Sätze)
-       2. <strong>Maßnahme:</strong> Was konkret tun? (2-3 Sätze, sehr spezifisch)
-       3. <strong>Nutzen &amp; Wirkung:</strong> Welcher messbare Benefit? (2 Sätze)
-       4. <strong>Aufwand &amp; Budget:</strong> Zeit und Kosten, size-aware (1-2 Sätze)
-       5. <strong>Verantwortlich:</strong> Wer führt durch? (1 Satz, size-aware)
-       6. <strong>Förderchance:</strong> Welche Programme in {{BUNDESLAND_LABEL}}? (1-2 Sätze)
-
-       EMPFEHLUNG 1: Quick Win – Sofort umsetzbar (Standard-Workflow für {{HAUPTLEISTUNG}})
-       EMPFEHLUNG 2: Qualitätssicherung – KI-gestützte Konsistenzprüfung
-       EMPFEHLUNG 3: Wissensmanagement – Dokumentation & Wissensbasis aufbauen
-       EMPFEHLUNG 4: Branchenspezifisch – Use Case passend zu {{BRANCHE_LABEL}}
-       EMPFEHLUNG 5: Governance & Sicherheit – Richtlinien und Kontrollen
-       EMPFEHLUNG 6 (optional): Skalierung – Nächster Entwicklungsschritt
-
-     TEIL 3: PRIORITÄTEN-TABELLE (mind. 100-150 Wörter)
-       - Tabelle mit MINDESTENS 5 Zeilen
-       - Spalten: Priorität, Empfehlung, Zeitrahmen, Hauptnutzen
-       - Zeitrahmen size-aware:
-           SOLO: 0–3 / 3–6 / 6–12 Monate
-           TEAM: 0–6 / 6–9 / 9–12 Monate
-           KMU: 0–6 / 6–9 / 9–12 Monate
-       - Kurzer Abschlussabsatz zur Priorisierung
-
-     ╔══════════════════════════════════════════════════════════════════════════════╗
-     ║  ABSOLUTE MINDESTLÄNGE: 800 WÖRTER Gesamttext (ohne HTML-Tags)               ║
-     ║  Ziel: 800-1200 Wörter für vollständige, professionelle Empfehlungen         ║
-     ║  NIEMALS kürzer als 800 Wörter antworten!                                    ║
-     ╚══════════════════════════════════════════════════════════════════════════════╝
-
-     SIZE-AWARE REGELWERK:
-       SOLO:
-         - Keine Abteilungen/Teams/Bereiche beim Berichtsempfänger selbst.
-         - Falls Organisationsstrukturen erwähnt werden (z.B. bei Kunden-Zielgruppen),
-           IMMER klar als "auf Kundenseite" markieren.
-         - Empfehlungen = realistische, kleine Schritte.
-         - Verantwortlich = Inhaber:in / Geschäftsführung.
-         - Budget: niedrig bis mittel (zweistellig bis niedriger dreistelliger €/Monat).
-
-       TEAM (2–10):
-         - Rollen erlaubt (Teamlead, KI-Owner, Qualitätsverantwortliche).
-         - Gemeinsame Workflows, abgestimmte Prozesse.
-         - Verantwortlichkeiten klar zuweisen.
-         - Budget: mittel (bis niedrige vierstellige Beträge).
-
-       KMU (11–100):
-         - Bereichsübergreifende Maßnahmen.
-         - Governance, Standards, Dokumentation, Policies.
-         - Verantwortliche pro Fachbereich.
-         - Budget: kann höher sein, strukturierte Investitionen.
-
-     BRANCHEN-AWARE REGELWERK (aus CONTEXT_BLOCK holen):
-       - Marketing/Kreativ: Content-Qualität, Templates, Automatisierung, Brand Guidelines.
-       - Beratung/Dienstleistung: Wissensmanagement, Angebotsprozesse, Dokumentation.
-       - Finanzen/Versicherung: Compliance, DSGVO, Datengenauigkeit, Audit-Trail.
-       - Gesundheit/Pflege: sensible Daten + strenge Dokumentation, Patientendaten.
-       - IT/Software: Automatisierung, Code-Assistenz, Modellkontrolle, DevOps.
-       - Industrie/Produktion: Datenaufbereitung, Sensorik, Workflow-Optimierung.
-       - E-Commerce/Handel: Produktdaten, Textautomatisierung, Qualitätschecks.
-
-     VERBOTEN:
-       - Wörter wie „Platzhalter", „Freitextfeld", „TODO", „Beispieltext".
-       - Generische Formulierungen ohne konkreten Inhalt.
-       - Rohvariablen im sichtbaren Output.
-       - Mehrdeutige Aussagen ohne konkrete Handlungsanleitung.
-       - Zu kurze Empfehlungen (jede Empfehlung mindestens 80-100 Wörter!).
+     REGELN:
+       - Empfehlungen branchenspezifisch und umsetzbar
+       - Zeitrahmen size-aware (solo: 0-3/3-6/6-12, team/kmu: 0-6/6-9/9-12)
+       - Sachlich, konkret, keine Floskeln
+       - Keine Platzhalter, keine Developer-Sprache
 -->
 
 <section class="section recommendations">
@@ -119,7 +45,7 @@ Developer:
 
     <!-- EMPFEHLUNG 1 – branch- & size-aware -->
     <li>
-      <h3>Empfehlung&nbsp;1</h3>
+      <h3>Empfehlung&nbsp;1: Quick Win – Standard-Workflow einführen</h3>
       <p><strong>Schwerpunkt:</strong> Verbesserung eines zentralen, wiederkehrenden Schritts in {{HAUPTLEISTUNG}}, der laut branchentypischen Workflows häufig Zeit bindet.</p>
       <p><strong>Maßnahme:</strong>
         Einführung eines KI-gestützten Standard-Workflows (z.&nbsp;B. Analyse, Textentwurf, Qualitätscheck) mit klaren Regeln für Eingaben und Prüfschritte.
@@ -140,7 +66,7 @@ Developer:
 
     <!-- EMPFEHLUNG 2 -->
     <li>
-      <h3>Empfehlung&nbsp;2</h3>
+      <h3>Empfehlung&nbsp;2: Qualitätssicherung – KI-gestützte Konsistenzprüfung</h3>
       <p><strong>Schwerpunkt:</strong>
         KI-gestützte Konsistenzprüfung für Dokumente, Inhalte oder Datenstrukturen, abgestimmt auf branchentypische Anforderungen.
       </p>
@@ -163,7 +89,7 @@ Developer:
 
     <!-- EMPFEHLUNG 3 -->
     <li>
-      <h3>Empfehlung&nbsp;3</h3>
+      <h3>Empfehlung&nbsp;3: Wissensmanagement – Dokumentation &amp; Wissensbasis</h3>
       <p><strong>Schwerpunkt:</strong>
         Dokumentation & Wissensmanagement verbessern – ein typisches Pain Point laut Branchenkontext.
       </p>
@@ -184,9 +110,9 @@ Developer:
       </p>
     </li>
 
-    <!-- EMPFEHLUNG 4 – optionaler vierter Block -->
+    <!-- EMPFEHLUNG 4 – branchenspezifisch -->
     <li>
-      <h3>Empfehlung&nbsp;4</h3>
+      <h3>Empfehlung&nbsp;4: Branchenspezifischer Use Case</h3>
       <p><strong>Schwerpunkt:</strong> Ein branchenspezifischer Use Case aus dem CONTEXT_BLOCK (z.&nbsp;B. Content-Automation, Datenanalyse, Compliance, Produktionsoptimierung).</p>
       <p><strong>Maßnahme:</strong>
         Pilotierung eines einmaligen, klar abgegrenzten KI-Use-Cases, der hohe Sichtbarkeit und schnellen ROI verspricht.
@@ -195,7 +121,7 @@ Developer:
         Sichtbarer Nutzen unmittelbar im Alltag, Momentum für weitere Digitalisierungsschritte.
       </p>
       <p><strong>Aufwand &amp; Budget:</strong>
-        Abhängig von Größe: 
+        Abhängig von Größe:
         {% if COMPANY_SIZE == "solo" %}1–3 Tage{% elif COMPANY_SIZE == "team" %}3–7 Tage{% else %}1–3 Wochen inkl. Abstimmung{% endif %}.
       </p>
       <p><strong>Verantwortlich:</strong>
@@ -203,6 +129,29 @@ Developer:
       </p>
       <p><strong>Förderchance:</strong>
         Viele Förderprogramme priorisieren Pilot-Use-Cases mit klarer Zielsetzung.
+      </p>
+    </li>
+
+    <!-- EMPFEHLUNG 5 – Governance & Sicherheit -->
+    <li>
+      <h3>Empfehlung&nbsp;5: Governance &amp; Sicherheit</h3>
+      <p><strong>Schwerpunkt:</strong>
+        Klare Richtlinien und Kontrollen für den KI-Einsatz etablieren, um Risiken zu minimieren und Compliance sicherzustellen.
+      </p>
+      <p><strong>Maßnahme:</strong>
+        Erstellung eines kompakten KI-Leitfadens mit Regeln zu Datenschutz, Qualitätsprüfung und Freigabeprozessen. Definition von Verantwortlichkeiten und Eskalationswegen.
+      </p>
+      <p><strong>Nutzen &amp; Wirkung:</strong>
+        Höhere Rechtssicherheit, transparente Prozesse und gestärktes Vertrauen bei Kund:innen und Partnern.
+      </p>
+      <p><strong>Aufwand &amp; Budget:</strong>
+        {% if COMPANY_SIZE == "solo" %}Niedrig – persönliche Checkliste in 1-2 Tagen{% elif COMPANY_SIZE == "team" %}Mittel – Team-Workshop + Dokumentation in 3-5 Tagen{% else %}Mittel bis hoch – strukturierte Policy-Entwicklung in 2-4 Wochen{% endif %}.
+      </p>
+      <p><strong>Verantwortlich:</strong>
+        {% if COMPANY_SIZE == "solo" %}Inhaber:in{% elif COMPANY_SIZE == "team" %}KI-Owner + Teamlead{% else %}Governance-Verantwortliche + Datenschutz/IT{% endif %}.
+      </p>
+      <p><strong>Förderchance:</strong>
+        Beratungsförderung für Datenschutz und IT-Sicherheit in {{BUNDESLAND_LABEL}} prüfen.
       </p>
     </li>
 
@@ -249,11 +198,20 @@ Developer:
 
       <tr>
         <td>4</td>
-        <td>Klar definierten KI-Pilot umsetzen</td>
+        <td>Branchenspezifischen KI-Pilot umsetzen</td>
         <td>
           {% if COMPANY_SIZE == "kmu" %}9–12 Monate{% else %}6–12 Monate{% endif %}
         </td>
         <td>Sichtbarer Nutzen & Momentum für Skalierung</td>
+      </tr>
+
+      <tr>
+        <td>5</td>
+        <td>Governance & Sicherheitsrichtlinien etablieren</td>
+        <td>
+          {% if COMPANY_SIZE == "solo" %}3–6 Monate{% else %}6–9 Monate{% endif %}
+        </td>
+        <td>Rechtssicherheit & Vertrauen</td>
       </tr>
 
     </tbody>

--- a/prompts/de/risks.md
+++ b/prompts/de/risks.md
@@ -1,126 +1,31 @@
 risks.md
 Developer: <!--
-  risks.md – v5.0 PLATIN+ STABILIZED (size-aware Risk Section, min 800 WÖRTER)
+  risks.md – v6.0 PLATIN+ STREAMLINED
+  Ziel: 5 Abschnitte mit je 140-180 Wörtern (= 800-1000 Wörter gesamt).
+  Antworte ausschließlich mit validem HTML. Keine Markdown-Fences.
 
-  ╔══════════════════════════════════════════════════════════════════════════════╗
-  ║  KRITISCH: MINDESTLÄNGE = 800 WÖRTER (nicht Zeichen!)                        ║
-  ║  Antworte IMMER mit einem VOLLSTÄNDIGEN, AUSFÜHRLICHEN Text.                 ║
-  ║  Kurze Antworten sind INAKZEPTABEL und führen zu Validierungsfehlern.        ║
-  ╚══════════════════════════════════════════════════════════════════════════════╝
+  STRUKTUR (5 Pflicht-Abschnitte):
+    H3 1. Strategische und organisatorische Risiken (4 Risiken + Maßnahmen)
+    H3 2. Daten-, Sicherheits- und Compliance-Risiken (4 Risiken + Maßnahmen)
+    H3 3. Qualitäts-, Transparenz- und Akzeptanzrisiken (4 Risiken + Maßnahmen)
+    H3 4. Abhängigkeiten, Betriebs- und Lieferantenrisiken (4 Risiken + Maßnahmen)
+    H3 5. Risiko-Matrix (Tabelle mit 5 Zeilen)
 
-  ZIEL:
-  - Erzeuge eine präzise, praxisnahe Risikoanalyse für den KI-Einsatz im Bereich {{HAUPTLEISTUNG}}.
-  - Decke geschäftliche, organisatorische, technische und rechtliche Risiken ab.
-  - Liefere zu jedem Risiko klare, umsetzbare Gegenmaßnahmen.
-  - Berücksichtige explizit Branche {{BRANCHE_LABEL}} und Unternehmensgröße {{UNTERNEHMENSGROESSE_LABEL}}.
-  - Scores AKTIV interpretieren und bei Priorisierung berücksichtigen.
+  VARIABLEN – nutze alle mindestens einmal:
+    {{HAUPTLEISTUNG}}, {{BRANCHE_LABEL}}, {{UNTERNEHMENSGROESSE_LABEL}},
+    {{score_governance}}, {{score_sicherheit}}
 
-  VARIABLEN (MÜSSEN ALLE im Text verwendet werden!):
-  - {{HAUPTLEISTUNG}}                → Hauptanwendungsbereich im Unternehmen
-  - {{BRANCHE_LABEL}}                → Branchenlabel (z. B. „Beratung & Dienstleistungen")
-  - {{UNTERNEHMENSGROESSE_LABEL}}    → z. B. „1 (Solo)", „2–10 (Kleines Team)", „11–100 (KMU)"
-  - {{score_governance}}             → Governance-Score (0–100) – interpretieren!
-  - {{score_sicherheit}}             → Sicherheits-Score (0–100) – interpretieren!
-
-  ╔══════════════════════════════════════════════════════════════════════════════╗
-  ║  PFLICHTSTRUKTUR – ALLE 5 ABSCHNITTE MÜSSEN VOLLSTÄNDIG AUSGEFÜHRT WERDEN!   ║
-  ╚══════════════════════════════════════════════════════════════════════════════╝
-
-  ABSCHNITT 1: "Strategische und organisatorische Risiken" (mind. 150-180 Wörter)
-    PFLICHTINHALTE (mind. 4 Risiken mit je 2-3 Sätzen + Maßnahme):
-    - Unklare Zielbilder und Prioritäten für KI
-    - Abhängigkeit von einzelnen Personen (Single-Point-of-Failure)
-    - Fehlende Rollen- und Verantwortlichkeitsklarheit
-    - Überlastung durch zusätzliche Aufgaben
-    - Jedes Risiko mit konkreter, umsetzbarer Gegenmaßnahme
-
-  ABSCHNITT 2: "Daten-, Sicherheits- und Compliance-Risiken" (mind. 150-180 Wörter)
-    PFLICHTINHALTE (mind. 4 Risiken mit je 2-3 Sätzen + Maßnahme):
-    - Unzureichende Kontrolle über ein- und ausgehende Daten
-    - Lücken in Informationssicherheit und Zugriffsschutz (Bezug auf {{score_sicherheit}})
-    - Unklare Verantwortlichkeit für rechtliche Anforderungen
-    - Fehlende Transparenz gegenüber Kund:innen und Partnern
-    - Branchenspezifische Compliance-Risiken für {{BRANCHE_LABEL}}
-
-  ABSCHNITT 3: "Qualitäts-, Transparenz- und Akzeptanzrisiken" (mind. 150-180 Wörter)
-    PFLICHTINHALTE (mind. 4 Risiken mit je 2-3 Sätzen + Maßnahme):
-    - Inkonsistente Ergebnisse und Qualitätsstreuung
-    - Übervertrauen in KI-Ergebnisse (Halluzinationen)
-    - Akzeptanzprobleme im Alltag
-    - Unklare Nachvollziehbarkeit von Entscheidungen
-    - Maßnahmen size-aware formulieren
-
-  ABSCHNITT 4: "Abhängigkeiten, Betriebs- und Lieferantenrisiken" (mind. 150-180 Wörter)
-    PFLICHTINHALTE (mind. 4 Risiken mit je 2-3 Sätzen + Maßnahme):
-    - Starke Abhängigkeit von einzelnen Tools oder Plattformen
-    - Unklare Regelungen mit Dienstleistern
-    - Fehlende Notfall- und Wiederanlaufplanung
-    - Überkomplexe Tool-Landschaft
-    - Konkrete Fallback-Szenarien beschreiben
-
-  ABSCHNITT 5: "Risiko-Matrix – Überblick über zentrale Risiken" (mind. 100-150 Wörter)
-    PFLICHTINHALTE:
-    - Tabelle mit MINDESTENS 5 Zeilen
-    - Spalten: Risikobereich, Typische Auswirkung, Eintrittswahrscheinlichkeit, Auswirkungsstärke, Empfohlene Schwerpunkt-Maßnahmen
-    - Für jeden der 4 Risikoabschnitte eine Zeile + 1 KI-spezifisches Risiko
-    - Einleitender Absatz zur Priorisierung
-
-  ╔══════════════════════════════════════════════════════════════════════════════╗
-  ║  ABSOLUTE MINDESTLÄNGE: 800 WÖRTER Gesamttext (ohne HTML-Tags)               ║
-  ║  Ziel: 800-1000 Wörter für vollständige, professionelle Risikoanalyse        ║
-  ║  NIEMALS kürzer als 800 Wörter antworten!                                    ║
-  ╚══════════════════════════════════════════════════════════════════════════════╝
-
-  AUSGABEFORMAT:
-  - Antworte AUSSCHLIESSLICH mit validem HTML.
-  - KEINE <html>, <head> oder <body>-Tags.
-  - KEINE Markdown-Fences, KEINE Kommentare im Output.
-  - Struktur:
-      <section class="section risks">
-        <h2>...</h2>
-        <p>Einleitung ...</p>
-        <h3>1. ...</h3>
-        <ul>...</ul>
-        <h3>2. ...</h3>
-        <ul>...</ul>
-        <h3>3. ...</h3>
-        <ul>...</ul>
-        <h3>4. ...</h3>
-        <ul>...</ul>
-        <h3>5. Risiko-Matrix</h3>
-        <table>...</table>
-        <p class="small muted">...</p>
-      </section>
-
-  SIZE-AWARE-LOGIK (verbindlich):
-  - SOLO („1 (Solo)" im Label):
-      - Fokus: persönliche Überlastung, Single-Point-of-Failure, fehlende Vertretung.
-      - Begrenzte Zeit und Ressourcen, wenig formale Prozesse.
-      - Risiken und Maßnahmen so formulieren, dass sie von einer Person realistisch umsetzbar sind.
-
-  - TEAM („2–10"):
-      - Fokus: Rollen, einfache Abstimmungen, informelle Strukturen.
-      - Risiken: fehlende Klarheit, wer was entscheidet; Wissensinseln; unterschiedliche Tool-Nutzung.
-      - Maßnahmen: klare Rollen, einfache Vereinbarungen, kurze Check-ins.
-
-  - KMU („11–100"):
-      - Fokus: Bereiche, Prozesse, Governance, Dokumentation.
-      - Risiken: unklare Verantwortlichkeiten, Schatten-IT, fehlende Richtlinien, Compliance-Anforderungen.
-      - Maßnahmen: Standards, Policies, Transparenz, regelmäßige Reviews.
+  SIZE-AWARE (COMPANY_SIZE):
+    solo: persönliche Überlastung, Single-Point-of-Failure, keine Vertretung
+    team: Rollenklärung, Abstimmung, Wissensinseln
+    kmu: Governance, Prozesse, Dokumentation, Compliance
 
   REGELN:
-  - Nutze den vorangestellten CONTEXT_BLOCK (Branchen- und Größen-Context) aktiv.
-  - Wenn die Branche stark reguliert ist (z. B. Gesundheit, Finanzen, öffentliche Verwaltung, Recht), betone branchenspezifische Compliance- und Datenschutzrisiken.
-  - Schreibe konkret, unternehmensnah und ohne Floskeln.
-  - Jede genannte Gefahr muss nachvollziehbar mit {{HAUPTLEISTUNG}} zusammenhängen.
-  - Leite aus {{score_governance}} und {{score_sicherheit}} ab, ob Governance und Sicherheit eher gut, mittel oder schwach ausgeprägt sind.
-  - JEDES Risiko muss 2-3 Sätze Beschreibung + konkrete Maßnahme haben.
-  - Keine Hinweise auf Fragebögen, interne Felder oder Systemlogik.
-  - Keine Platzhaltertexte oder Formulierungen wie „wird später ergänzt".
-
-  STIL:
-  - Sachlich, klar, beratend.
-  - Neutrale Formulierungen (keine Ich-Form, keine direkte Anrede).
+    - Jedes Risiko: 2-3 Sätze + konkrete Maßnahme
+    - Scores aktiv interpretieren (z.B. "Der Sicherheits-Score von X zeigt...")
+    - Branchenspezifische Compliance betonen bei regulierten Branchen
+    - Sachlich, konkret, keine Floskeln
+    - Keine Platzhalter, keine Developer-Sprache
 -->
 
 <section class="section risks">
@@ -164,7 +69,7 @@ Developer: <!--
     </li>
     <li>
       <strong>Überlastung durch zusätzliche Aufgaben.</strong>
-      Wenn KI-Einführung „on top“ zum Tagesgeschäft läuft, werden neue Workflows nicht
+      Wenn KI-Einführung „on top" zum Tagesgeschäft läuft, werden neue Workflows nicht
       dauerhaft etabliert. Hilfreich sind kleine, gut planbare Piloten mit klar
       begrenztem Umfang sowie die bewusste Entlastung an anderer Stelle, damit Zeit
       für Experimente und Lernphasen entsteht.
@@ -231,7 +136,7 @@ Developer: <!--
       <strong>Unklare Nachvollziehbarkeit von Entscheidungen.</strong>
       Wenn nicht dokumentiert ist, welche Rolle KI in der Vorbereitung von Angeboten,
       Reports oder Entscheidungen spielt, wird es im Streitfall schwierig, Entscheidungswege
-      zu rekonstruieren. Eine kurze interne Dokumentation zu „Wo unterstützt KI?“ senkt
+      zu rekonstruieren. Eine kurze interne Dokumentation zu „Wo unterstützt KI?" senkt
       dieses Risiko deutlich.
     </li>
   </ul>
@@ -268,6 +173,10 @@ Developer: <!--
   </ul>
 
   <h3>5. Risiko-Matrix – Überblick über zentrale Risiken</h3>
+  <p>
+    Die folgende Übersicht zeigt die wichtigsten Risikofelder nach Eintrittswahrscheinlichkeit
+    und Auswirkungsstärke, um die Priorisierung von Gegenmaßnahmen zu erleichtern.
+  </p>
   <table class="table">
     <thead>
       <tr>
@@ -306,6 +215,13 @@ Developer: <!--
         <td>niedrig bis mittel</td>
         <td>mittel</td>
         <td>Fallback-Szenarien, Konsolidierung der Tool-Landschaft, klare Vereinbarungen mit Dienstleistern.</td>
+      </tr>
+      <tr>
+        <td>KI-spezifisch: Halluzinationen</td>
+        <td>Fehlerhafte Informationen in Kundendokumenten, Reputationsschaden</td>
+        <td>mittel bis hoch</td>
+        <td>hoch</td>
+        <td>Vier-Augen-Prinzip, Faktenprüfung, klare Qualitätsrichtlinien für KI-Output.</td>
       </tr>
     </tbody>
   </table>

--- a/prompts/de/roadmap_12m.md
+++ b/prompts/de/roadmap_12m.md
@@ -1,58 +1,34 @@
 Developer:
-<!-- roadmap_12m.md – v6.0 PLATIN+ (branch-aware, size-aware, governance-integrated, min 900 chars)
-     Antworte ausschließlich mit validem HTML.
-     KEIN <html>, <head> oder <body>; KEINE Markdown-Fences im OUTPUT.
+<!-- roadmap_12m.md – v7.0 PLATIN+ STREAMLINED
+     Ziel: 4 Quartale mit je 200-250 Wörtern (= 900-1100 Wörter gesamt).
+     Antworte ausschließlich mit validem HTML. Keine Markdown-Fences.
 
-     ZIEL:
-       - Erzeuge eine strategische, branchenspezifische 12-Monats-Roadmap für {{HAUPTLEISTUNG}}.
-       - Nutze aktiv den CONTEXT_BLOCK (Workflows, Pain Points, Tools, Daten).
-       - Size-aware Umsetzung für solo/team/kmu.
-       - Jede Phase (Quartal) enthält: Ziel, Deliverables, Rollen, KPI, Governance/Sicherheit.
-       - 4 Quartale (Q1–Q4) mit klarer Progression.
+     STRUKTUR (4 Quartale):
+       Q1 (Monate 1-3): Grundlagen & Quick Wins
+       Q2 (Monate 4-6): Pilotierung & Integration
+       Q3 (Monate 7-9): Ausbau & Skalierung
+       Q4 (Monate 10-12): Optimierung & Strategie 2.0
+
+     Pro Quartal PFLICHT:
+       - Ziel (1-2 Sätze)
+       - Deliverables (4+ Bullets)
+       - Rollen (size-aware)
+       - KPI (2-3 messbare Kennzahlen)
+       - Governance/Sicherheit (1-2 Bullets)
 
      VARIABLEN:
-       {{BRANCHE_LABEL}}
-       {{UNTERNEHMENSGROESSE_LABEL}}
-       {{HAUPTLEISTUNG}}
-       COMPANY_SIZE ∈ {"solo","team","kmu"}
+       {{BRANCHE_LABEL}}, {{UNTERNEHMENSGROESSE_LABEL}}, {{HAUPTLEISTUNG}}, COMPANY_SIZE
 
-     SIZE-AWARE:
-       SOLO:
-         - Fokus: persönliche Entwicklung, Angebotsausbau, eigene Automatisierung.
-         - Keine Teams, keine Abteilungen, keine "Bereiche".
-         - Governance = persönliche Routinen, Selbst-Checks, Dokumentation.
-       TEAM:
-         - Fokus: Rollen, Team-Koordination, gemeinsame Prozesse, Wissenstransfer.
-         - Governance = Team-Reviews, gemeinsame Standards, KI-Owner.
-       KMU:
-         - Fokus: Fachbereiche, Governance, Skalierung, Pilotflächen.
-         - Governance = Richtlinien, Audit-Prozesse, Compliance-Framework.
+     SIZE-AWARE (COMPANY_SIZE):
+       solo: persönliche Entwicklung, eigene Automatisierung, keine Teams/Bereiche
+       team: Rollen, Team-Koordination, gemeinsame Prozesse
+       kmu: Fachbereiche, Governance, Skalierung, Pilotflächen
 
-     BRANCHEN-AWARE (verbindlich):
-       - Verwende typische Workflows, Datenarten, Tools & Pain Points aus CONTEXT_BLOCK.
-       - Marketing/Kreativ: Content-Pipelines, Kampagnenmanagement, Asset-Verwaltung.
-       - Beratung/Dienstleistung: Wissensmanagement, Angebotserstellung, Dokumentation.
-       - Finanzen/Versicherung: Compliance, Datenvalidierung, Risikoanalyse.
-       - Gesundheit/Pflege: sensible Daten, Qualitätssicherung, Freigabeprozesse.
-       - IT/Software: Code-Assistenz, Automatisierung, Testing & Deployment, CI/CD-Integration.
-       - Industrie/Produktion: Sensor-/Prozessdaten, Qualitätskontrollen, Wartung.
-       - E-Commerce/Handel: Produktdaten, Feed-Management, Textautomatisierung.
-
-     PFLICHTSTRUKTUR (ALLE 4 Quartale, JEDES mit allen Elementen):
-       Pro Quartal MUSS enthalten sein:
-       1. Ziel (1-2 Sätze)
-       2. Deliverables (mindestens 4 Bulletpoints)
-       3. Rollen & Verantwortlichkeiten (size-aware)
-       4. KPI (2-3 messbare Kennzahlen)
-       5. Governance/Sicherheit (mindestens 1 Bullet zu Qualität/Compliance)
-
-     MINDESTLÄNGE: 900 Zeichen (ohne HTML-Tags) – unterschreite diese NIEMALS!
-
-     VERBOTEN:
-       - "TODO", "Freitextfeld", generische Formulierungen ohne Substanz.
-       - Rohvariablen im sichtbaren Output.
-       - Bei SOLO: keine "Abteilungen", "Teams", "Bereiche" (nur persönliche Formulierungen).
-       - Phasen ohne konkrete, branchenspezifische Deliverables.
+     REGELN:
+       - Branchenspezifische Workflows aus CONTEXT_BLOCK nutzen
+       - Governance-Elemente in jedem Quartal
+       - Sachlich, konkret, keine Floskeln
+       - Keine Platzhalter, keine Developer-Sprache
 -->
 
 <section class="section roadmap-12m">

--- a/prompts/de/roadmap_90d.md
+++ b/prompts/de/roadmap_90d.md
@@ -1,43 +1,34 @@
 Developer:
-<!-- roadmap_90d.md – v5.0 GOLD STANDARD+ (branch-aware, size-aware, context-integrated)
-     Antworte ausschließlich mit validem HTML.
-     KEIN <html>, <head> oder <body>; KEINE Markdown-Fences im OUTPUT.
+<!-- roadmap_90d.md – v6.0 PLATIN+ STREAMLINED
+     Ziel: 6 Phasen mit je 80-100 Wörtern (= 500-700 Wörter gesamt).
+     Antworte ausschließlich mit validem HTML. Keine Markdown-Fences.
 
-     ZIEL:
-       - Erzeuge eine strategische, branchenspezifische 90-Tage-Roadmap für {{HAUPTLEISTUNG}}.
-       - Nutze aktiv den CONTEXT_BLOCK (Workflows, Pain Points, Tools, Daten).
-       - Size-aware Umsetzung für solo/team/kmu.
-       - Jede Phase enthält: Ziel, Deliverables, Rollen, KPI.
-       - Maximal 13 Wochen (6 Phasen).
+     STRUKTUR (6 Phasen):
+       Phase 1: Woche 1-2 – Zielbild & Prioritäten
+       Phase 2: Woche 3-4 – Datenqualität & Workflow-Grundlagen
+       Phase 3: Woche 5-6 – Quick-Wins & erste Wirkung
+       Phase 4: Woche 7-8 – Qualitätsstandards
+       Phase 5: Woche 9-10 – Monitoring & Iteration
+       Phase 6: Woche 11-13 – Konsolidierung & Skalierungsvorbereitung
+
+     Pro Phase PFLICHT:
+       - Ziel (1-2 Sätze)
+       - Deliverables (3-4 Bullets)
+       - Rollen (size-aware)
+       - KPI (1-2 messbare Kennzahlen)
 
      VARIABLEN:
-       {{BRANCHE_LABEL}}
-       {{UNTERNEHMENSGROESSE_LABEL}}
-       {{HAUPTLEISTUNG}}
-       COMPANY_SIZE ∈ {"solo","team","kmu"}
+       {{BRANCHE_LABEL}}, {{UNTERNEHMENSGROESSE_LABEL}}, {{HAUPTLEISTUNG}}, COMPANY_SIZE
 
-     SIZE-AWARE:
-       SOLO:
-         - Fokus: persönliche Routinen, einfache Templates, klare Regeln, schnelle Wirkung.
-         - Keine Teams, keine Abteilungen.
-       TEAM:
-         - Fokus: Rollen, Abstimmung, gemeinsame Standards, dokumentierte Workflows.
-       KMU:
-         - Fokus: Fachbereiche, Governance, Prozessharmonisierung, Pilotflächen.
+     SIZE-AWARE (COMPANY_SIZE):
+       solo: persönliche Routinen, eigene Dokumentation, keine Teams
+       team: Rollen, gemeinsame Standards, Abstimmung
+       kmu: Fachbereiche, Governance, Pilotflächen
 
-     BRANCHEN-AWARE (verbindlich):
-       - Verwende typische Workflows, Datenarten, Tools & Pain Points aus CONTEXT_BLOCK.
-       - Marketing/Kreativ: Content, Kampagnen, Asset-Qualität.
-       - Beratung/Dienstleistung: Wissensarbeit, Angebotsprozesse, Dokumentation.
-       - Finanzen/Versicherung: Compliance, Datengenauigkeit, Risikoprüfung.
-       - Gesundheit/Pflege: sensible Daten, Qualität & Freigabeprozesse.
-       - IT/Software: Automatisierung, Code-Assistenz, Testing.
-       - Industrie/Produktion: Sensor-/Prozessdaten, Qualitätskontrollen.
-       - E-Commerce/Handel: Produktdaten, Feeds, Textprozesse.
-
-     VERBOTEN:
-       - „Platzhalter", „TODO", „Freitextfeld", generische Formulierungen ohne Substanz.
-       - Rohvariablen im sichtbaren Output.
+     REGELN:
+       - Branchenspezifische Workflows aus CONTEXT_BLOCK nutzen
+       - Sachlich, konkret, keine Floskeln
+       - Keine Platzhalter, keine Developer-Sprache
 -->
 
 <section class="section roadmap-90d">

--- a/services/report_validator.py
+++ b/services/report_validator.py
@@ -399,6 +399,34 @@ def validate_report(sections: Dict[str, Any], briefing: Dict[str, Any]) -> bool:
 
 
 def filter_size_inappropriate_content(content: str, unternehmensgroesse: str) -> str:
+    """
+    PLATIN+ Post-Filter: Ersetzt size-inappropriate Begriffe im Content.
+
+    Für Solo-Profile werden Begriffe wie "Abteilung" durch "Bereich" ersetzt,
+    sofern sie sich nicht auf Kunden-Strukturen beziehen.
+    """
+    if not content or not isinstance(content, str):
+        return content
+
+    size_raw = unternehmensgroesse.lower() if unternehmensgroesse else ""
+
+    # Solo-spezifische Ersetzungen
+    if "solo" in size_raw or "1" in size_raw or "freiberuf" in size_raw:
+        # Ersetze "Abteilung" durch "Bereich" (nur wenn nicht im Kunden-Kontext)
+        # Vorsicht: Nicht ersetzen bei "Kundenabteilung", "auf Kundenseite"
+        import re
+
+        # Patterns für solo-unpassende Begriffe (nur wenn nicht Kunden-bezogen)
+        replacements = [
+            # "Abteilung" → "Aufgabenbereich" (wenn nicht Kunden-bezogen)
+            (r'(?<![Kk]unden)([Aa])bteilung(?!en\s+(?:auf|bei|der|des)\s+[Kk]unden)', r'\1ufgabenbereich'),
+            # "Abteilungen" → "Aufgabenbereiche" (wenn nicht Kunden-bezogen)
+            (r'(?<![Kk]unden)([Aa])bteilungen(?!\s+(?:auf|bei|der|des)\s+[Kk]unden)', r'\1ufgabenbereiche'),
+        ]
+
+        for pattern, replacement in replacements:
+            content = re.sub(pattern, replacement, content)
+
     return content
 
 

--- a/tests/test_platin_word_lengths.py
+++ b/tests/test_platin_word_lengths.py
@@ -1,0 +1,262 @@
+# -*- coding: utf-8 -*-
+"""
+PLATIN+ Quality Tests - Word Length Validation
+===============================================
+
+Tests zur Sicherstellung der PLATIN+ Mindest-Wortlängen für kritische Sections.
+
+PLATIN+ Mindestlängen (WÖRTER):
+- foerderpotenzial: 900 Wörter
+- risks: 800 Wörter
+- recommendations: 800 Wörter
+- roadmap_12m: 900 Wörter
+"""
+from __future__ import annotations
+
+import os
+import re
+import json
+import glob
+import pytest
+from typing import Dict, Any
+
+# Set test environment before imports
+os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
+os.environ.setdefault("JWT_SECRET", "test-secret-key-for-testing-only")
+os.environ.setdefault("OPENAI_API_KEY", "test-api-key")
+
+
+class TestPlatinMinWordLengths:
+    """Tests für PLATIN+ Mindest-Wortlängen."""
+
+    # PLATIN+ Mindestlängen in WÖRTERN
+    PLATIN_MIN_WORDS = {
+        "foerderpotenzial": 900,
+        "risks": 800,
+        "recommendations": 800,
+        "roadmap_12m": 900,
+    }
+
+    def count_words(self, html_content: str) -> int:
+        """Zählt Wörter im HTML-Content (ohne Tags)."""
+        # HTML-Tags entfernen
+        text_only = re.sub(r"<[^>]+>", "", html_content).strip()
+        # Wörter zählen
+        words = text_only.split()
+        return len(words)
+
+    def test_report_validator_has_correct_min_lengths(self):
+        """Prüft, dass report_validator.py die korrekten PLATIN+ Mindestlängen definiert."""
+        from services.report_validator import ReportValidator
+
+        for section, expected_min in self.PLATIN_MIN_WORDS.items():
+            actual_min = ReportValidator.MIN_SECTION_LENGTH_WORDS.get(section, 0)
+            assert actual_min >= expected_min, (
+                f"Section '{section}': MIN_SECTION_LENGTH_WORDS ist {actual_min}, "
+                f"erwartet mindestens {expected_min} Wörter"
+            )
+
+    def test_fallback_foerderpotenzial_word_count(self):
+        """Prüft, dass der Förderpotenzial-Fallback mindestens 900 Wörter hat."""
+        from gpt_analyze import _get_fallback_content
+
+        briefing = {
+            "BRANCHE_LABEL": "Beratung & Dienstleistungen",
+            "UNTERNEHMENSGROESSE_LABEL": "1 (Solo)",
+            "HAUPTLEISTUNG": "KI-gestützte Assessments",
+            "BUNDESLAND_LABEL": "Berlin",
+            "CAPEX_REALISTISCH_EUR": "5000",
+            "OPEX_REALISTISCH_EUR": "200",
+            "EINSPARUNG_MONAT_EUR": "500",
+            "PAYBACK_MONTHS": "10",
+            "ROI_12M": "60",
+        }
+        scores = {"governance": 70, "sicherheit": 65}
+
+        content = _get_fallback_content("foerderpotenzial", briefing, scores)
+        word_count = self.count_words(content)
+
+        assert word_count >= 900, (
+            f"Förderpotenzial Fallback hat nur {word_count} Wörter, "
+            f"erwartet mindestens 900"
+        )
+
+    def test_fallback_risks_word_count(self):
+        """Prüft, dass der Risks-Fallback mindestens 800 Wörter hat."""
+        from gpt_analyze import _get_fallback_content
+
+        briefing = {
+            "BRANCHE_LABEL": "Beratung & Dienstleistungen",
+            "UNTERNEHMENSGROESSE_LABEL": "1 (Solo)",
+            "HAUPTLEISTUNG": "KI-gestützte Assessments",
+        }
+        scores = {"governance": 70, "sicherheit": 65}
+
+        content = _get_fallback_content("risks", briefing, scores)
+        word_count = self.count_words(content)
+
+        assert word_count >= 800, (
+            f"Risks Fallback hat nur {word_count} Wörter, erwartet mindestens 800"
+        )
+
+    def test_fallback_recommendations_word_count(self):
+        """Prüft, dass der Recommendations-Fallback mindestens 800 Wörter hat."""
+        from gpt_analyze import _get_fallback_content
+
+        briefing = {
+            "BRANCHE_LABEL": "Beratung & Dienstleistungen",
+            "UNTERNEHMENSGROESSE_LABEL": "1 (Solo)",
+            "HAUPTLEISTUNG": "KI-gestützte Assessments",
+            "BUNDESLAND_LABEL": "Berlin",
+        }
+        scores = {}
+
+        content = _get_fallback_content("recommendations", briefing, scores)
+        word_count = self.count_words(content)
+
+        assert word_count >= 800, (
+            f"Recommendations Fallback hat nur {word_count} Wörter, "
+            f"erwartet mindestens 800"
+        )
+
+    def test_fallback_size_aware_solo(self):
+        """Prüft, dass Solo-Fallbacks keine Team/Abteilungs-Begriffe enthalten."""
+        from gpt_analyze import _get_fallback_content
+
+        briefing = {
+            "BRANCHE_LABEL": "Beratung",
+            "UNTERNEHMENSGROESSE_LABEL": "1 (Solo)",
+            "HAUPTLEISTUNG": "KI-Beratung",
+            "BUNDESLAND_LABEL": "Berlin",
+            "CAPEX_REALISTISCH_EUR": "5000",
+            "OPEX_REALISTISCH_EUR": "200",
+            "EINSPARUNG_MONAT_EUR": "500",
+            "PAYBACK_MONTHS": "10",
+            "ROI_12M": "60",
+        }
+        scores = {"governance": 70, "sicherheit": 65}
+
+        forbidden_terms = ["Abteilung", "HR-Abteilung", "IT-Abteilung", "PMO-Team"]
+
+        for section in ["foerderpotenzial", "risks", "recommendations"]:
+            content = _get_fallback_content(section, briefing, scores)
+            for term in forbidden_terms:
+                # Erlaubt in Kunden-Kontext
+                if "Kunden" not in term:
+                    assert term not in content, (
+                        f"Section '{section}' enthält '{term}' für Solo-Profil"
+                    )
+
+
+class TestPlatinPromptStructure:
+    """Tests für PLATIN+ Prompt-Struktur."""
+
+    def test_foerderpotenzial_has_4_sections(self):
+        """Prüft, dass foerderpotenzial.md 4 Hauptabschnitte definiert."""
+        with open("prompts/de/foerderpotenzial.md") as f:
+            content = f.read()
+
+        # Prüfe auf H3-Struktur
+        h3_count = content.count("<h3>")
+        assert h3_count >= 4, (
+            f"foerderpotenzial.md hat nur {h3_count} H3-Abschnitte, erwartet 4"
+        )
+
+    def test_risks_has_5_sections(self):
+        """Prüft, dass risks.md 5 Hauptabschnitte definiert."""
+        with open("prompts/de/risks.md") as f:
+            content = f.read()
+
+        h3_count = content.count("<h3>")
+        assert h3_count >= 5, (
+            f"risks.md hat nur {h3_count} H3-Abschnitte, erwartet 5"
+        )
+
+    def test_recommendations_has_priority_table(self):
+        """Prüft, dass recommendations.md eine Prioritäten-Tabelle enthält."""
+        with open("prompts/de/recommendations.md") as f:
+            content = f.read()
+
+        assert "<table" in content, "recommendations.md muss eine Prioritäten-Tabelle enthalten"
+        assert "Priorität" in content or "priority" in content.lower(), (
+            "recommendations.md muss eine Prioritäten-Spalte haben"
+        )
+
+
+class TestPlatinTestProfiles:
+    """Tests für PLATIN+ Test-Profile."""
+
+    REQUIRED_FIELDS = [
+        "profile_id",
+        "description",
+        "lang",
+        "BRANCHE_LABEL",
+        "UNTERNEHMENSGROESSE_LABEL",
+        "HAUPTLEISTUNG",
+        "answers",
+    ]
+
+    def test_all_profiles_have_required_fields(self):
+        """Prüft, dass alle Test-Profile die erforderlichen Felder haben."""
+        profiles = glob.glob("data/test_profiles_gold/*.json")
+        assert len(profiles) > 0, "Keine Test-Profile gefunden"
+
+        for path in profiles:
+            with open(path) as f:
+                data = json.load(f)
+
+            missing = [f for f in self.REQUIRED_FIELDS if f not in data]
+            assert not missing, (
+                f"Profil {path} fehlen Felder: {missing}"
+            )
+
+    def test_solo_profiles_have_solo_label(self):
+        """Prüft, dass Solo-Profile korrekt als Solo gekennzeichnet sind."""
+        profiles = glob.glob("data/test_profiles_gold/*.json")
+
+        for path in profiles:
+            with open(path) as f:
+                data = json.load(f)
+
+            if "solo" in path.lower():
+                size_label = data.get("UNTERNEHMENSGROESSE_LABEL", "")
+                assert "Solo" in size_label or "1" in size_label, (
+                    f"Solo-Profil {path} hat falsches UNTERNEHMENSGROESSE_LABEL: {size_label}"
+                )
+
+
+class TestSizeFilter:
+    """Tests für den Size-Filter in report_validator.py."""
+
+    def test_filter_replaces_abteilung_for_solo(self):
+        """Prüft, dass 'Abteilung' für Solo-Profile ersetzt wird."""
+        from services.report_validator import filter_size_inappropriate_content
+
+        content = "Die HR-Abteilung sollte involviert werden."
+        filtered = filter_size_inappropriate_content(content, "solo")
+
+        # "Abteilung" sollte ersetzt worden sein
+        assert "Abteilung" not in filtered or "Kundenab" in filtered, (
+            "Abteilung wurde nicht gefiltert für Solo-Profil"
+        )
+
+    def test_filter_keeps_customer_abteilung(self):
+        """Prüft, dass Kunden-Abteilungen nicht ersetzt werden."""
+        from services.report_validator import filter_size_inappropriate_content
+
+        content = "Die Kundenabteilung beim Auftraggeber ist involviert."
+        filtered = filter_size_inappropriate_content(content, "solo")
+
+        # "Kundenabteilung" sollte erhalten bleiben
+        assert "Kundenabteilung" in filtered, (
+            "Kundenabteilung wurde fälschlicherweise gefiltert"
+        )
+
+    def test_filter_no_change_for_kmu(self):
+        """Prüft, dass für KMU keine Ersetzungen stattfinden."""
+        from services.report_validator import filter_size_inappropriate_content
+
+        content = "Die IT-Abteilung sollte involviert werden."
+        filtered = filter_size_inappropriate_content(content, "kmu")
+
+        assert filtered == content, "KMU-Content sollte unverändert bleiben"


### PR DESCRIPTION
PLATIN+ Refactoring:

A. Prompts entlasten (Meta-Overhead reduziert):
   - foerderpotenzial.md: v8.0 PLATIN+ STREAMLINED
   - risks.md: v6.0 PLATIN+ STREAMLINED
   - recommendations.md: v8.0 PLATIN+ STREAMLINED
   - roadmap_90d.md: v6.0 PLATIN+ STREAMLINED
   - roadmap_12m.md: v7.0 PLATIN+ STREAMLINED

B. Platin-Fallbacks ausgebaut (gpt_analyze.py):
   - NEU: foerderpotenzial Fallback mit 900+ Wörtern
   - NEU: risks Fallback mit 800+ Wörtern
   - NEU: recommendations Fallback mit 800+ Wörtern
   - Alle Fallbacks size-aware (solo/team/kmu)

C. Size-Mismatch "Abteilung" geschlossen:
   - filter_size_inappropriate_content() für Solo-Profile
   - Ersetzt "Abteilung" → "Aufgabenbereich" (wenn nicht Kunden-bezogen)

D. GitHub Action + Tests:
   - .github/workflows/platin-validation.yml
   - tests/test_platin_word_lengths.py
   - Validiert Mindest-Wortlängen und Prompt-Struktur