### PR TITLE
feat(platin): stabilize LLM config and unify finish_reason logging

### DIFF
--- a/gpt_analyze.py
+++ b/gpt_analyze.py
@@ -269,16 +269,15 @@ def _llm_params_for(section_key: str) -> Dict[str, Any]:
     else:
         temperature = OPENAI_TEMP_DEFAULT
 
-    # Max-Tokens bestimmen (PLATIN-Config: None → 4096 für längere Outputs)
+    # Max-Tokens bestimmen (PLATIN-Config hat explizite Werte für kritische Sections)
     if max_tokens_env is not None:
         try:
             max_tokens = int(max_tokens_env)
         except ValueError:
             max_tokens = OPENAI_MAX_TOKENS_DEFAULT
     elif platin_config:
-        # PLATIN+ kritische Sections: max_tokens=None → 4096 für 800-900 Wörter
-        platin_max = platin_config.get("max_tokens")
-        max_tokens = 4096 if platin_max is None else platin_max
+        # PLATIN+ kritische Sections: Verwende konfigurierte max_tokens (4096)
+        max_tokens = platin_config.get("max_tokens", 4096)
     elif key in {"executive_summary", "exec_summary", "summary"}:
         max_tokens = EXEC_SUMMARY_MAX_TOKENS
     elif key == "gamechanger":
@@ -599,6 +598,7 @@ def _call_openai(
     temperature: Optional[float] = None,
     max_tokens: Optional[int] = None,
     model: Optional[str] = None,
+    section: Optional[str] = None,  # PLATIN+ Logging: Section-Key für Diagnostik
 ) -> Optional[str]:
     if not OPENAI_API_KEY:
         log.error("❌ OPENAI_API_KEY not set")
@@ -656,19 +656,23 @@ def _call_openai(
             data = r.json()
             content = data["choices"][0]["message"]["content"]
             finish_reason = data["choices"][0].get("finish_reason", "unknown")
+            completion_tokens = data.get("usage", {}).get("completion_tokens", 0)
+            section_label = section or "unknown"
 
-            # PLATIN+ Diagnostik: Log finish_reason für Debugging
+            # PLATIN+ Diagnostik: Einheitliches Log-Format für Railway
             if finish_reason == "length":
                 log.warning(
-                    "⚠️ OpenAI response truncated (finish_reason=length) – "
-                    "max_tokens=%d may be too low for this section",
+                    "⚠️ LLM section=%s finished with reason=length (hit token limit %d) – risk of truncation",
+                    section_label,
                     max_tokens or OPENAI_MAX_TOKENS,
                 )
             else:
-                log.debug(
-                    "✅ OpenAI response complete (finish_reason=%s, tokens=%d)",
+                log.info(
+                    "✅ LLM section=%s finished with reason=%s (tokens=%d, max=%d)",
+                    section_label,
                     finish_reason,
-                    data.get("usage", {}).get("completion_tokens", 0),
+                    completion_tokens,
+                    max_tokens or OPENAI_MAX_TOKENS,
                 )
 
             return str(content)
@@ -729,13 +733,14 @@ def _call_llm_for_section(
             model=model,
         )
 
-    # Fallback: OpenAI wie bisher
+    # Fallback: OpenAI wie bisher (mit section für besseres Logging)
     return _call_openai(
         prompt=prompt,
         system_prompt=system_prompt,
         temperature=temperature,
         max_tokens=max_tokens,
         model=model,
+        section=section_key,
     )
 
 

--- a/services/anthropic_client.py
+++ b/services/anthropic_client.py
@@ -425,26 +425,25 @@ def call_anthropic(
                 parts.append(getattr(block, "text", "") or "")
         text = "".join(parts).strip()
 
-        # PLATIN+ Diagnostik: Log stop_reason für Debugging
+        # PLATIN+ Diagnostik: Einheitliches Log-Format (wie OpenAI) für Railway
         stop_reason = getattr(message, "stop_reason", "unknown")
         usage = getattr(message, "usage", None)
         output_tokens = getattr(usage, "output_tokens", 0) if usage else 0
+        section_label = section or "unknown"
 
         if stop_reason == "max_tokens":
             log.warning(
-                "⚠️ Anthropic response truncated (stop_reason=max_tokens) – "
-                "max_tokens=%d may be too low for section '%s'",
+                "⚠️ LLM section=%s finished with reason=max_tokens (hit token limit %d) – risk of truncation",
+                section_label,
                 max_tok,
-                section,
             )
         else:
-            log.debug(
-                "✅ Anthropic-Antwort für Abschnitt %s (%s Zeichen, %d tokens, stop_reason=%s, Modell %s)",
-                section,
-                len(text),
-                output_tokens,
+            log.info(
+                "✅ LLM section=%s finished with reason=%s (tokens=%d, max=%d)",
+                section_label,
                 stop_reason,
-                model_name,
+                output_tokens,
+                max_tok,
             )
 
         return text or None

--- a/services/prompt_enhancer.py
+++ b/services/prompt_enhancer.py
@@ -27,13 +27,14 @@ log = logging.getLogger(__name__)
 # Für kritische Sektionen gilt: max_tokens = None (kein Limit)
 # =============================================================================
 
-# PLATIN+ Token-Limit-Deaktivierung für kritische Sektionen
-PLATIN_MAX_TOKENS = None  # max_tokens = None für alle kritischen Sektionen
+# PLATIN+ Token-Limit für kritische Sektionen
+# 4096 Tokens ≈ 3000 Wörter – genug Spielraum für 800-900 Wörter Output
+PLATIN_MAX_TOKENS = 4096
 
 
 class PlatinSectionConfig(TypedDict):
     """Configuration for PLATIN+ critical sections."""
-    max_tokens: Optional[int]  # None = no limit (use model default)
+    max_tokens: int  # Token-Limit für LLM-Output (4096 für lange Sections)
     temperature: float
     presence_penalty: float
     frequency_penalty: float
@@ -42,39 +43,46 @@ class PlatinSectionConfig(TypedDict):
 
 PLATIN_CRITICAL_SECTIONS: Dict[str, PlatinSectionConfig] = {
     "foerderpotenzial": {
-        "max_tokens": None,  # Kein Limit - volle Länge erlauben
-        "temperature": 0.4,  # Etwas kreativ aber konsistent
+        "max_tokens": 4096,  # Explizit 4096 für 900+ Wörter
+        "temperature": 0.4,  # Konsistent aber nicht zu trocken
         "presence_penalty": 0.0,  # Keine Bestrafung für Wiederholungen
         "frequency_penalty": 0.0,  # Keine Bestrafung für häufige Wörter
         "min_words": 900,
     },
     "risks": {
-        "max_tokens": None,
+        "max_tokens": 4096,
         "temperature": 0.4,
         "presence_penalty": 0.0,
         "frequency_penalty": 0.0,
         "min_words": 800,
     },
     "recommendations": {
-        "max_tokens": None,
+        "max_tokens": 4096,
         "temperature": 0.4,
         "presence_penalty": 0.0,
         "frequency_penalty": 0.0,
         "min_words": 800,
     },
     "roadmap_12m": {
-        "max_tokens": None,
+        "max_tokens": 4096,
         "temperature": 0.4,
         "presence_penalty": 0.0,
         "frequency_penalty": 0.0,
         "min_words": 900,
     },
     "gamechanger": {
-        "max_tokens": None,
+        "max_tokens": 4096,
         "temperature": 0.5,  # Etwas kreativer für Gamechanger
         "presence_penalty": 0.0,
         "frequency_penalty": 0.0,
         "min_words": 700,
+    },
+    "unternehmensprofil_markt": {
+        "max_tokens": 4096,
+        "temperature": 0.4,
+        "presence_penalty": 0.0,
+        "frequency_penalty": 0.0,
+        "min_words": 500,
     },
 }
 

--- a/tests/test_platin_llm_params.py
+++ b/tests/test_platin_llm_params.py
@@ -1,0 +1,168 @@
+"""
+Tests für PLATIN+ LLM-Parameter-Konfiguration.
+
+Prüft, dass _llm_params_for() die korrekten PLATIN+-Werte zurückgibt
+für kritische Sections (foerderpotenzial, risks, recommendations, etc.).
+"""
+import pytest
+from unittest.mock import patch
+import os
+import sys
+
+# Ensure the parent directory is in the path
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+class TestPlatinCriticalSections:
+    """Test PLATIN+ configuration for critical sections."""
+
+    def test_platin_config_exists_for_all_critical_sections(self):
+        """Verify PLATIN_CRITICAL_SECTIONS contains all expected sections."""
+        from services.prompt_enhancer import PLATIN_CRITICAL_SECTIONS
+
+        expected_sections = [
+            "foerderpotenzial",
+            "risks",
+            "recommendations",
+            "roadmap_12m",
+            "gamechanger",
+            "unternehmensprofil_markt",
+        ]
+
+        for section in expected_sections:
+            assert section in PLATIN_CRITICAL_SECTIONS, f"Missing section: {section}"
+
+    def test_platin_config_has_required_fields(self):
+        """Verify each PLATIN config has all required fields."""
+        from services.prompt_enhancer import PLATIN_CRITICAL_SECTIONS
+
+        required_fields = ["max_tokens", "temperature", "min_words"]
+
+        for section, config in PLATIN_CRITICAL_SECTIONS.items():
+            for field in required_fields:
+                assert field in config, f"Section {section} missing field: {field}"
+
+    def test_platin_max_tokens_is_4096(self):
+        """Verify all PLATIN sections have explicit max_tokens=4096."""
+        from services.prompt_enhancer import PLATIN_CRITICAL_SECTIONS
+
+        for section, config in PLATIN_CRITICAL_SECTIONS.items():
+            assert config["max_tokens"] == 4096, (
+                f"Section {section} should have max_tokens=4096, got {config['max_tokens']}"
+            )
+
+    def test_platin_temperature_is_reasonable(self):
+        """Verify temperature is in valid range (0.3-0.5)."""
+        from services.prompt_enhancer import PLATIN_CRITICAL_SECTIONS
+
+        for section, config in PLATIN_CRITICAL_SECTIONS.items():
+            temp = config["temperature"]
+            assert 0.3 <= temp <= 0.5, (
+                f"Section {section} temperature {temp} not in range [0.3, 0.5]"
+            )
+
+    def test_platin_min_words_thresholds(self):
+        """Verify min_words thresholds are set correctly."""
+        from services.prompt_enhancer import PLATIN_CRITICAL_SECTIONS
+
+        expected_min_words = {
+            "foerderpotenzial": 900,
+            "risks": 800,
+            "recommendations": 800,
+            "roadmap_12m": 900,
+            "gamechanger": 700,
+            "unternehmensprofil_markt": 500,
+        }
+
+        for section, expected in expected_min_words.items():
+            config = PLATIN_CRITICAL_SECTIONS.get(section)
+            assert config is not None, f"Missing section: {section}"
+            assert config["min_words"] == expected, (
+                f"Section {section} min_words should be {expected}, got {config['min_words']}"
+            )
+
+
+class TestGetPlatinConfig:
+    """Test get_platin_config() helper function."""
+
+    def test_get_platin_config_returns_config_for_critical_section(self):
+        """Verify get_platin_config returns config for critical sections."""
+        from services.prompt_enhancer import get_platin_config
+
+        config = get_platin_config("foerderpotenzial")
+        assert config is not None
+        assert config["max_tokens"] == 4096
+        assert config["temperature"] == 0.4
+        assert config["min_words"] == 900
+
+    def test_get_platin_config_returns_none_for_non_critical_section(self):
+        """Verify get_platin_config returns None for non-critical sections."""
+        from services.prompt_enhancer import get_platin_config
+
+        config = get_platin_config("executive_summary")
+        assert config is None
+
+        config = get_platin_config("quick_wins")
+        assert config is None
+
+    def test_get_platin_config_is_case_insensitive(self):
+        """Verify get_platin_config is case-insensitive."""
+        from services.prompt_enhancer import get_platin_config
+
+        config1 = get_platin_config("FOERDERPOTENZIAL")
+        config2 = get_platin_config("Foerderpotenzial")
+        config3 = get_platin_config("foerderpotenzial")
+
+        assert config1 == config2 == config3
+
+
+class TestIsPlatinCriticalSection:
+    """Test is_platin_critical_section() helper function."""
+
+    def test_is_platin_critical_section_true(self):
+        """Verify is_platin_critical_section returns True for critical sections."""
+        from services.prompt_enhancer import is_platin_critical_section
+
+        critical_sections = [
+            "foerderpotenzial",
+            "risks",
+            "recommendations",
+            "roadmap_12m",
+            "gamechanger",
+        ]
+
+        for section in critical_sections:
+            assert is_platin_critical_section(section), f"Should be critical: {section}"
+
+    def test_is_platin_critical_section_false(self):
+        """Verify is_platin_critical_section returns False for non-critical sections."""
+        from services.prompt_enhancer import is_platin_critical_section
+
+        non_critical = ["executive_summary", "quick_wins", "business_case", "data_readiness"]
+
+        for section in non_critical:
+            assert not is_platin_critical_section(section), f"Should not be critical: {section}"
+
+
+class TestGetPlatinMinWords:
+    """Test get_platin_min_words() helper function."""
+
+    def test_get_platin_min_words_returns_correct_value(self):
+        """Verify get_platin_min_words returns correct min_words."""
+        from services.prompt_enhancer import get_platin_min_words
+
+        assert get_platin_min_words("foerderpotenzial") == 900
+        assert get_platin_min_words("risks") == 800
+        assert get_platin_min_words("recommendations") == 800
+        assert get_platin_min_words("roadmap_12m") == 900
+
+    def test_get_platin_min_words_returns_zero_for_non_critical(self):
+        """Verify get_platin_min_words returns 0 for non-critical sections."""
+        from services.prompt_enhancer import get_platin_min_words
+
+        assert get_platin_min_words("executive_summary") == 0
+        assert get_platin_min_words("quick_wins") == 0
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
PLATIN+ Finetuning:
- Set explicit max_tokens=4096 for all critical sections (was None)
- Add unternehmensprofil_markt to PLATIN_CRITICAL_SECTIONS
- Unify logging format for OpenAI/Anthropic finish_reason/stop_reason Format: "LLM section=X finished with reason=Y (tokens=Z, max=N)"
- Add section parameter to _call_openai for better diagnostics
- Add comprehensive tests for PLATIN config (12 test cases)

Log output now shows clearly:
- ✅ LLM section=foerderpotenzial finished with reason=stop (tokens=2345, max=4096)
- ⚠️ LLM section=roadmap_12m finished with reason=length (hit token limit 4096)