### PR TITLE
fix(test-profiles): add required metadata and answers wrapper to all …

### DIFF
--- a/data/test_profiles_gold/kmu_handel_ecommerce_advisory.json
+++ b/data/test_profiles_gold/kmu_handel_ecommerce_advisory.json
@@ -1,125 +1,58 @@
 {
-  "branche": "handel_ecommerce",
-  "unternehmensgroesse": "kmu",
-  "bundesland": "Berlin",
+  "profile_id": "kmu_handel_ecommerce_advisory",
+  "description": "KMU im Handel/E-Commerce Bereich mit Fokus auf Produktdatenqualität und Conversion-Optimierung",
+  "lang": "de",
+  "BRANCHE_LABEL": "Handel & E-Commerce",
+  "UNTERNEHMENSGROESSE_LABEL": "11-50 (KMU)",
+  "HAUPTLEISTUNG": "Beratung für mittelständische Online-Händler und Omnichannel-Einzelhändler zu Produktdatenqualität, Conversion-Optimierung, KI-gestützten Kampagnenstrategien, Automatisierung von Produkttexten sowie Analyse und Optimierung digitaler Vertriebskanäle.",
 
-  "hauptleistung": "Beratung für mittelständische Online-Händler und Omnichannel-Einzelhändler zu Produktdatenqualität, Conversion-Optimierung, KI-gestützten Kampagnenstrategien, Automatisierung von Produkttexten sowie Analyse und Optimierung digitaler Vertriebskanäle.",
-
-  "zielgruppen": [
-    "B2B",
-    "B2C",
-    "E-Commerce-Unternehmen",
-    "Omnichannel-Einzelhandel"
-  ],
-
-  "jahresumsatz": "1-5m",
-  "it_infrastruktur": "cloud_hybrid",
-  "interne_ki_kompetenzen": "grundkenntnisse",
-
-  "datenquellen": [
-    "CRM",
-    "Shop-System",
-    "Web-Analytics",
-    "Produktdaten",
-    "Social Media Insights"
-  ],
-
-  "digitalisierungsgrad": "hoch",
-  "prozesse_papierlos": "teilweise",
-  "automatisierungsgrad": "mittel",
-
-  "ki_einsatz": [
-    "marketing_automation",
-    "content_generation",
-    "datenanalyse",
-    "customer_journey_optimierung"
-  ],
-
-  "ki_kompetenz": "fortgeschritten",
-
-  "ki_ziele": [
-    "effizienz",
-    "skalierung",
-    "conversion_optimierung",
-    "datenqualitaet"
-  ],
-
-  "ki_projekte": "Geplant sind automatisierte Produkttextgenerierung, KI-gestützte Kampagnenoptimierung (Meta/Google Ads), Predictive Analytics für Nachfrageprognosen sowie ein Recommendation-System für personalisierte Shop-Erlebnisse. Weitere interne Projekte betreffen automatisierte Reportings und semantische Analysen großer Produktkataloge.",
-
-  "anwendungsfaelle": [
-    "produkttexte",
-    "kampagnenoptimierung",
-    "recommendation_engine",
-    "preisoptimierung",
-    "chatbots_kundenservice",
-    "fraud_detection_light"
-  ],
-
-  "zeitersparnis_prioritaet": "Besonders priorisiert ist die Reduzierung manueller Produktdatenpflege, die Automatisierung der Content-Erstellung und die Beschleunigung datengetriebener Entscheidungen. Teams verbringen aktuell zu viel Zeit mit redundanten Aufgaben wie Kategorisierung, Keyword-Mapping und QA-Schleifen für Produktkarten.",
-
-  "pilot_bereich": "marketing",
-
-  "geschaeftsmodell_evolution": "Das Geschäftsmodell soll stärker auf wiederkehrende Beratungsprodukte, automatisierte Audits und KI-basierte Toolkits erweitert werden – insbesondere White-Label-Analytics-Dashboards und automatisierte Optimierungsroutinen für Händler.",
-
-  "vision_3_jahre": "Das Unternehmen möchte sich zu einem führenden KI-Enablement-Partner im deutschsprachigen E-Commerce entwickeln und skalierbare Lösungen anbieten, die Händlern schnelle Produktivitätsgewinne ermöglichen. Ziel ist ein modularer KI-Baukasten für Produktdaten, Conversion-Optimierung und Omni-Retail-Intelligence.",
-
-  "strategische_ziele": "Marktdurchdringung im E-Commerce-Segment erhöhen, Beratungsprodukte industrialisieren, KI-Enablement als Kernleistung skalieren, datengetriebene Entscheidungsmodelle für Händler entwickeln und Qualitätsstandards für Produktdaten definieren.",
-
-  "massnahmen_komplexitaet": "mittel",
-
-  "roadmap_vorhanden": "nein",
-  "governance_richtlinien": "in_planung",
-  "change_management": "punktuell",
-  "zeitbudget": "10h_woche",
-
-  "vorhandene_tools": [
-    "google_workspace",
-    "shopware",
-    "hubspot",
-    "zapier",
-    "semrush",
-    "meta_ads_tools"
-  ],
-
-  "regulierte_branche": [
-    "keine_regulierung"
-  ],
-
-  "trainings_interessen": [
-    "prompting_expert",
-    "automatisierung",
-    "ki_in_marketing",
-    "datenqualitaet",
-    "strategische_ki_nutzung"
-  ],
-
-  "vision_prioritaet": "hoch",
-
-  "datenschutzbeauftragter": "extern",
-  "technische_massnahmen": "standardisiert",
-  "folgenabschaetzung": "nicht_erforderlich",
-  "meldewege": "teilweise_definiert",
-  "loeschregeln": "teilweise_implementiert",
-
-  "ai_act_kenntnis": "grundkenntnisse",
-
-  "ki_hemmnisse": [
-    "datenqualitaet",
-    "ressourcen",
-    "tool_ueberangebot",
-    "fehlende_zeit",
-    "unklare_verantwortlichkeiten"
-  ],
-
-  "bisherige_foerdermittel": "keine",
-  "interesse_foerderung": "ja",
-  "erfahrung_beratung": "viel",
-  "investitionsbudget": "20-50k",
-
-  "marktposition": "etabliert",
-  "benchmark_wettbewerb": "ueberdurchschnittlich",
-  "innovationsprozess": "regelmaessig",
-  "risikofreude": "75",
-
-  "datenschutz": true
+  "answers": {
+    "branche": "handel_ecommerce",
+    "unternehmensgroesse": "kmu",
+    "bundesland": "Berlin",
+    "hauptleistung": "Beratung für mittelständische Online-Händler und Omnichannel-Einzelhändler zu Produktdatenqualität, Conversion-Optimierung, KI-gestützten Kampagnenstrategien, Automatisierung von Produkttexten sowie Analyse und Optimierung digitaler Vertriebskanäle.",
+    "zielgruppen": ["B2B", "B2C", "E-Commerce-Unternehmen", "Omnichannel-Einzelhandel"],
+    "jahresumsatz": "1-5m",
+    "it_infrastruktur": "cloud_hybrid",
+    "interne_ki_kompetenzen": "grundkenntnisse",
+    "datenquellen": ["CRM", "Shop-System", "Web-Analytics", "Produktdaten", "Social Media Insights"],
+    "digitalisierungsgrad": "hoch",
+    "prozesse_papierlos": "teilweise",
+    "automatisierungsgrad": "mittel",
+    "ki_einsatz": ["marketing_automation", "content_generation", "datenanalyse", "customer_journey_optimierung"],
+    "ki_kompetenz": "fortgeschritten",
+    "ki_ziele": ["effizienz", "skalierung", "conversion_optimierung", "datenqualitaet"],
+    "ki_projekte": "Geplant sind automatisierte Produkttextgenerierung, KI-gestützte Kampagnenoptimierung (Meta/Google Ads), Predictive Analytics für Nachfrageprognosen sowie ein Recommendation-System für personalisierte Shop-Erlebnisse. Weitere interne Projekte betreffen automatisierte Reportings und semantische Analysen großer Produktkataloge.",
+    "anwendungsfaelle": ["produkttexte", "kampagnenoptimierung", "recommendation_engine", "preisoptimierung", "chatbots_kundenservice", "fraud_detection_light"],
+    "zeitersparnis_prioritaet": "Besonders priorisiert ist die Reduzierung manueller Produktdatenpflege, die Automatisierung der Content-Erstellung und die Beschleunigung datengetriebener Entscheidungen. Teams verbringen aktuell zu viel Zeit mit redundanten Aufgaben wie Kategorisierung, Keyword-Mapping und QA-Schleifen für Produktkarten.",
+    "pilot_bereich": "marketing",
+    "geschaeftsmodell_evolution": "Das Geschäftsmodell soll stärker auf wiederkehrende Beratungsprodukte, automatisierte Audits und KI-basierte Toolkits erweitert werden – insbesondere White-Label-Analytics-Dashboards und automatisierte Optimierungsroutinen für Händler.",
+    "vision_3_jahre": "Das Unternehmen möchte sich zu einem führenden KI-Enablement-Partner im deutschsprachigen E-Commerce entwickeln und skalierbare Lösungen anbieten, die Händlern schnelle Produktivitätsgewinne ermöglichen. Ziel ist ein modularer KI-Baukasten für Produktdaten, Conversion-Optimierung und Omni-Retail-Intelligence.",
+    "strategische_ziele": "Marktdurchdringung im E-Commerce-Segment erhöhen, Beratungsprodukte industrialisieren, KI-Enablement als Kernleistung skalieren, datengetriebene Entscheidungsmodelle für Händler entwickeln und Qualitätsstandards für Produktdaten definieren.",
+    "massnahmen_komplexitaet": "mittel",
+    "roadmap_vorhanden": "nein",
+    "governance_richtlinien": "in_planung",
+    "change_management": "punktuell",
+    "zeitbudget": "10h_woche",
+    "vorhandene_tools": ["google_workspace", "shopware", "hubspot", "zapier", "semrush", "meta_ads_tools"],
+    "regulierte_branche": ["keine_regulierung"],
+    "trainings_interessen": ["prompting_expert", "automatisierung", "ki_in_marketing", "datenqualitaet", "strategische_ki_nutzung"],
+    "vision_prioritaet": "hoch",
+    "datenschutzbeauftragter": "extern",
+    "technische_massnahmen": "standardisiert",
+    "folgenabschaetzung": "nicht_erforderlich",
+    "meldewege": "teilweise_definiert",
+    "loeschregeln": "teilweise_implementiert",
+    "ai_act_kenntnis": "grundkenntnisse",
+    "ki_hemmnisse": ["datenqualitaet", "ressourcen", "tool_ueberangebot", "fehlende_zeit", "unklare_verantwortlichkeiten"],
+    "bisherige_foerdermittel": "keine",
+    "interesse_foerderung": "ja",
+    "erfahrung_beratung": "viel",
+    "investitionsbudget": "20-50k",
+    "marktposition": "etabliert",
+    "benchmark_wettbewerb": "ueberdurchschnittlich",
+    "innovationsprozess": "regelmaessig",
+    "risikofreude": "75",
+    "datenschutz": true
+  }
 }

--- a/data/test_profiles_gold/kmu_industrie_production_advisory.json
+++ b/data/test_profiles_gold/kmu_industrie_production_advisory.json
@@ -1,129 +1,58 @@
 {
-  "branche": "industrie_production",
-  "unternehmensgroesse": "kmu",
-  "bundesland": "Baden-Württemberg",
+  "profile_id": "kmu_industrie_production_advisory",
+  "description": "KMU in der Industrie/Produktion mit Fokus auf Qualitätskontrolle und Fertigungsoptimierung",
+  "lang": "de",
+  "BRANCHE_LABEL": "Industrie & Produktion",
+  "UNTERNEHMENSGROESSE_LABEL": "11-50 (KMU)",
+  "HAUPTLEISTUNG": "Beratung und operative Begleitung von kleinen und mittelständischen Produktionsunternehmen bei der Digitalisierung, der Prozessanalyse, der Optimierung von Fertigungsabläufen, der Einführung KI-gestützter Qualitätskontrolle sowie beim Aufbau datengestützter Entscheidungsprozesse in Planung, Logistik und Fertigungssteuerung.",
 
-  "hauptleistung": "Beratung und operative Begleitung von kleinen und mittelständischen Produktionsunternehmen bei der Digitalisierung, der Prozessanalyse, der Optimierung von Fertigungsabläufen, der Einführung KI-gestützter Qualitätskontrolle sowie beim Aufbau datengestützter Entscheidungsprozesse in Planung, Logistik und Fertigungssteuerung.",
-
-  "zielgruppen": [
-    "B2B",
-    "KMU_Fertigung",
-    "Zulieferindustrie",
-    "Maschinenbau"
-  ],
-
-  "jahresumsatz": "1-5m",
-
-  "it_infrastruktur": "onprem_cloudmix",
-
-  "interne_ki_kompetenzen": "grundkenntnisse",
-
-  "datenquellen": [
-    "ERP",
-    "MES",
-    "Qualitätsdaten",
-    "Maschinendaten",
-    "Sensorik",
-    "Excel_Reports"
-  ],
-
-  "digitalisierungsgrad": "mittel",
-  "prozesse_papierlos": "teilweise",
-  "automatisierungsgrad": "mittel",
-
-  "ki_einsatz": [
-    "datenanalyse",
-    "qualitaetskontrolle",
-    "prozessoptimierung",
-    "predictive_maintenance"
-  ],
-
-  "ki_kompetenz": "mittel",
-
-  "ki_ziele": [
-    "effizienz",
-    "fehlerreduktion",
-    "standardisierung",
-    "optimierung",
-    "transparenz"
-  ],
-
-  "ki_projekte": "Aktuell werden erste PoCs zu KI-gestützter Anomalieerkennung in Qualitätsdaten, automatisierter Prüfbericht-Generierung, Produktionsprognosen für Engpassstationen und der Einsatz eines KI-gestützten Wissenssystems für Störungsmeldungen vorbereitet. Weitere Projekte betreffen die automatische Auswertung von Maschinenzustandsdaten zur Reduzierung ungeplanter Stillstände.",
-
-  "anwendungsfaelle": [
-    "qualitaetskontrolle",
-    "automatische_dokumentation",
-    "prozessanalyse",
-    "schichtplanung",
-    "engpassprognosen",
-    "maschine_sensordaten_analyse"
-  ],
-
-  "zeitersparnis_prioritaet": "Großer Bedarf besteht bei der Pflege technischer Dokumentationen, der manuellen Analyse von Qualitätsdaten, der Erstellung von Produktionsreportings sowie bei der Koordination zwischen Fertigungssteuerung, Logistik und QS. Besonders aufwendig sind wiederkehrende Auswertungen, Schichtabgleiche und manuelle Prüfprozesse.",
-
-  "pilot_bereich": "produktion",
-
-  "geschaeftsmodell_evolution": "Ausbau von wiederkehrenden Beratungsmodulen, Entwicklung eines KI-basierten Fertigungs-Dashboards für KMU, Aufbau eines Standard-Analyse-Kits für Maschinen- und Qualitätsdaten sowie Erweiterung um Schulungs- und Befähigungsprogramme für Produktionsmitarbeitende.",
-
-  "vision_3_jahre": "Das Unternehmen möchte als führender KI-Enablement-Partner für industrielle KMU in der DACH-Region etabliert sein und modulare Lösungen für Qualitätskontrolle, Fertigungsoptimierung und datenbasierte Planung anbieten. Ziel ist es, Predictive-Intelligence-Ansätze so zu operationalisieren, dass KMU sie ohne eigene Data-Science-Teams nutzen können.",
-
-  "strategische_ziele": "Steigerung der Beratungsproduktivität durch KI, Ausbau der Dienstleistungspakete, stärkere Standardisierung der Analyseprozesse, Aufbau industrieller Best-Practice-Bibliotheken, Positionierung als Innovationspartner für Maschinenbau und Zulieferer.",
-
-  "massnahmen_komplexitaet": "mittel",
-
-  "roadmap_vorhanden": "nein",
-  "governance_richtlinien": "in_planung",
-  "change_management": "punktuell",
-  "zeitbudget": "10h_woche",
-
-  "vorhandene_tools": [
-    "microsoft365",
-    "teams",
-    "sap_business_one",
-    "mes_systeme",
-    "powerbi",
-    "confluence",
-    "jira"
-  ],
-
-  "regulierte_branche": [
-    "keine_regulierung"
-  ],
-
-  "trainings_interessen": [
-    "automatisierung",
-    "datenkompetenz",
-    "ki_in_produktion",
-    "prozessdigitalisierung",
-    "prompting_expert"
-  ],
-
-  "vision_prioritaet": "hoch",
-
-  "datenschutzbeauftragter": "extern",
-  "technische_massnahmen": "standardisiert",
-  "folgenabschaetzung": "nicht_erforderlich",
-  "meldewege": "teilweise_definiert",
-  "loeschregeln": "teilweise_implementiert",
-
-  "ai_act_kenntnis": "grundkenntnisse",
-
-  "ki_hemmnisse": [
-    "datenqualitaet",
-    "veraltete_systeme",
-    "silos",
-    "ressourcenknappheit"
-  ],
-
-  "bisherige_foerdermittel": "keine",
-  "interesse_foerderung": "ja",
-  "erfahrung_beratung": "moderat",
-  "investitionsbudget": "20-50k",
-
-  "marktposition": "etabliert",
-  "benchmark_wettbewerb": "durchschnittlich",
-  "innovationsprozess": "punktuell",
-  "risikofreude": "60",
-
-  "datenschutz": true
+  "answers": {
+    "branche": "industrie_production",
+    "unternehmensgroesse": "kmu",
+    "bundesland": "Baden-Württemberg",
+    "hauptleistung": "Beratung und operative Begleitung von kleinen und mittelständischen Produktionsunternehmen bei der Digitalisierung, der Prozessanalyse, der Optimierung von Fertigungsabläufen, der Einführung KI-gestützter Qualitätskontrolle sowie beim Aufbau datengestützter Entscheidungsprozesse in Planung, Logistik und Fertigungssteuerung.",
+    "zielgruppen": ["B2B", "KMU_Fertigung", "Zulieferindustrie", "Maschinenbau"],
+    "jahresumsatz": "1-5m",
+    "it_infrastruktur": "onprem_cloudmix",
+    "interne_ki_kompetenzen": "grundkenntnisse",
+    "datenquellen": ["ERP", "MES", "Qualitätsdaten", "Maschinendaten", "Sensorik", "Excel_Reports"],
+    "digitalisierungsgrad": "mittel",
+    "prozesse_papierlos": "teilweise",
+    "automatisierungsgrad": "mittel",
+    "ki_einsatz": ["datenanalyse", "qualitaetskontrolle", "prozessoptimierung", "predictive_maintenance"],
+    "ki_kompetenz": "mittel",
+    "ki_ziele": ["effizienz", "fehlerreduktion", "standardisierung", "optimierung", "transparenz"],
+    "ki_projekte": "Aktuell werden erste PoCs zu KI-gestützter Anomalieerkennung in Qualitätsdaten, automatisierter Prüfbericht-Generierung, Produktionsprognosen für Engpassstationen und der Einsatz eines KI-gestützten Wissenssystems für Störungsmeldungen vorbereitet. Weitere Projekte betreffen die automatische Auswertung von Maschinenzustandsdaten zur Reduzierung ungeplanter Stillstände.",
+    "anwendungsfaelle": ["qualitaetskontrolle", "automatische_dokumentation", "prozessanalyse", "schichtplanung", "engpassprognosen", "maschine_sensordaten_analyse"],
+    "zeitersparnis_prioritaet": "Großer Bedarf besteht bei der Pflege technischer Dokumentationen, der manuellen Analyse von Qualitätsdaten, der Erstellung von Produktionsreportings sowie bei der Koordination zwischen Fertigungssteuerung, Logistik und QS. Besonders aufwendig sind wiederkehrende Auswertungen, Schichtabgleiche und manuelle Prüfprozesse.",
+    "pilot_bereich": "produktion",
+    "geschaeftsmodell_evolution": "Ausbau von wiederkehrenden Beratungsmodulen, Entwicklung eines KI-basierten Fertigungs-Dashboards für KMU, Aufbau eines Standard-Analyse-Kits für Maschinen- und Qualitätsdaten sowie Erweiterung um Schulungs- und Befähigungsprogramme für Produktionsmitarbeitende.",
+    "vision_3_jahre": "Das Unternehmen möchte als führender KI-Enablement-Partner für industrielle KMU in der DACH-Region etabliert sein und modulare Lösungen für Qualitätskontrolle, Fertigungsoptimierung und datenbasierte Planung anbieten. Ziel ist es, Predictive-Intelligence-Ansätze so zu operationalisieren, dass KMU sie ohne eigene Data-Science-Teams nutzen können.",
+    "strategische_ziele": "Steigerung der Beratungsproduktivität durch KI, Ausbau der Dienstleistungspakete, stärkere Standardisierung der Analyseprozesse, Aufbau industrieller Best-Practice-Bibliotheken, Positionierung als Innovationspartner für Maschinenbau und Zulieferer.",
+    "massnahmen_komplexitaet": "mittel",
+    "roadmap_vorhanden": "nein",
+    "governance_richtlinien": "in_planung",
+    "change_management": "punktuell",
+    "zeitbudget": "10h_woche",
+    "vorhandene_tools": ["microsoft365", "teams", "sap_business_one", "mes_systeme", "powerbi", "confluence", "jira"],
+    "regulierte_branche": ["keine_regulierung"],
+    "trainings_interessen": ["automatisierung", "datenkompetenz", "ki_in_produktion", "prozessdigitalisierung", "prompting_expert"],
+    "vision_prioritaet": "hoch",
+    "datenschutzbeauftragter": "extern",
+    "technische_massnahmen": "standardisiert",
+    "folgenabschaetzung": "nicht_erforderlich",
+    "meldewege": "teilweise_definiert",
+    "loeschregeln": "teilweise_implementiert",
+    "ai_act_kenntnis": "grundkenntnisse",
+    "ki_hemmnisse": ["datenqualitaet", "veraltete_systeme", "silos", "ressourcenknappheit"],
+    "bisherige_foerdermittel": "keine",
+    "interesse_foerderung": "ja",
+    "erfahrung_beratung": "moderat",
+    "investitionsbudget": "20-50k",
+    "marktposition": "etabliert",
+    "benchmark_wettbewerb": "durchschnittlich",
+    "innovationsprozess": "punktuell",
+    "risikofreude": "60",
+    "datenschutz": true
+  }
 }

--- a/data/test_profiles_gold/solo_beratung_ki_assessments.json
+++ b/data/test_profiles_gold/solo_beratung_ki_assessments.json
@@ -1,129 +1,58 @@
 {
-  "branche": "beratung",
-  "unternehmensgroesse": "solo",
-  "bundesland": "Berlin",
+  "profile_id": "solo_beratung_ki_assessments",
+  "description": "Solo-Selbstständiger im Beratungsbereich mit Fokus auf KI-Readiness-Analysen",
+  "lang": "de",
+  "BRANCHE_LABEL": "Beratung & Dienstleistungen",
+  "UNTERNEHMENSGROESSE_LABEL": "1 (Solo)",
+  "HAUPTLEISTUNG": "Beratung, Durchführung und Operationalisierung von KI-Readiness-Analysen für Solo-Selbstständige, kleine Unternehmen und Teams. Fokus auf Prozessdiagnose, Potenzialanalysen, KI-gestützte Dokumentations- und Textautomatisierung, Governance-Setup und der Entwicklung von pragmatischen, schnell umsetzbaren KI-Workflows.",
 
-  "hauptleistung": "Beratung, Durchführung und Operationalisierung von KI-Readiness-Analysen für Solo-Selbstständige, kleine Unternehmen und Teams. Fokus auf Prozessdiagnose, Potenzialanalysen, KI-gestützte Dokumentations- und Textautomatisierung, Governance-Setup und der Entwicklung von pragmatischen, schnell umsetzbaren KI-Workflows.",
-
-  "zielgruppen": [
-    "B2B",
-    "beratungen",
-    "soloselbststaendige",
-    "kmu"
-  ],
-
-  "jahresumsatz": "bis_500k",
-
-  "it_infrastruktur": "cloudbasiert",
-
-  "interne_ki_kompetenzen": "fortgeschritten",
-
-  "datenquellen": [
-    "crm",
-    "microsoft365",
-    "notizen",
-    "kundenfeedback",
-    "onlineformulare"
-  ],
-
-  "digitalisierungsgrad": "hoch",
-  "prozesse_papierlos": "ja",
-  "automatisierungsgrad": "mittel",
-
-  "ki_einsatz": [
-    "dokumentenerstellung",
-    "textautomatisierung",
-    "wissenstransfer",
-    "prozessoptimierung",
-    "kundenkommunikation"
-  ],
-
-  "ki_kompetenz": "hoch",
-
-  "ki_ziele": [
-    "effizienz",
-    "beschleunigung",
-    "standardisierung",
-    "qualität",
-    "skalierung"
-  ],
-
-  "ki_projekte": "Bisher wurden KI-gestützte Fragebogen-Analysen, automatisierte Beratungsvorlagen, Chat-basierte Auswertungssysteme, ein Wissens-Hub für Kundengespräche sowie Makro-Workflows für Dokumentation, Reporting und Content-Erstellung aufgebaut. Weitere Projekte betreffen KI-gestützte Kundensegmentierung und eine modulare Analysebibliothek für Assessments.",
-
-  "anwendungsfaelle": [
-    "automatische_dokumentation",
-    "analyseautomation",
-    "kundenkommunikation",
-    "prozessanalyse",
-    "textautomatisierung",
-    "contentproduktion"
-  ],
-
-  "zeitersparnis_prioritaet": "Der größte manuelle Aufwand liegt in der individuellen Auswertung von Kundendaten, der Erstellung maßgeschneiderter Empfehlungen, der Recherche zu Compliance-Themen sowie in der Dokumentation von Workshops, Onboardings und Analyseergebnissen. Zusätzlich binden wiederkehrende Text- und Content-Aufgaben unverhältnismäßig viel Zeit.",
-
-  "pilot_bereich": "beratung",
-
-  "geschaeftsmodell_evolution": "Aufbau eines skalierbaren, KI-gestützten Analyse- und Beratungssystems mit modular buchbaren Leistungspaketen, Automatisierung von Produktionsschritten, Einführung eines Self-Service-Assessment-Tools und Ausbau des Angebots um KI-Microservices für KMU.",
-
-  "vision_3_jahre": "Der Aufbau einer voll skalierbaren KI-Beratung, die jederzeit standardisierte, tiefgreifende Analysen liefern kann – ergänzt durch automatisierte Folgeprozesse, individuelle Handlungsempfehlungen und eine Wissensbasis, die Kundenergebnisse übergreifend optimiert. Ziel ist es, Beratungsqualität unabhängig von der eigenen Kapazität abzusichern und planbar zu skalieren.",
-
-  "strategische_ziele": "Stärkere Produktisierung der Leistungen, klare Positionierung im KI-Readiness-Segment, Ausbau automatisierter Analyseketten, Schaffung datenbasierter Upsell-Pfade, Verbesserung der eigenen Content-Velocity und systematische Strukturierung interner Wissensprozesse.",
-
-  "massnahmen_komplexitaet": "niedrig",
-
-  "roadmap_vorhanden": "nein",
-  "governance_richtlinien": "keine",
-  "change_management": "nein",
-  "zeitbudget": "10h_woche",
-
-  "vorhandene_tools": [
-    "microsoft365",
-    "notion",
-    "chatgpt",
-    "browserplugins",
-    "loom",
-    "canva",
-    "calendly"
-  ],
-
-  "regulierte_branche": [
-    "keine_regulierung"
-  ],
-
-  "trainings_interessen": [
-    "prompting_expert",
-    "effizienz",
-    "contentproduktion",
-    "compliance",
-    "automatisierung"
-  ],
-
-  "vision_prioritaet": "hoch",
-
-  "datenschutzbeauftragter": "nicht_erforderlich",
-  "technische_massnahmen": "standardisiert",
-  "folgenabschaetzung": "nicht_erforderlich",
-  "meldewege": "keine",
-  "loeschregeln": "einfach",
-
-  "ai_act_kenntnis": "fortgeschritten",
-
-  "ki_hemmnisse": [
-    "kundenwissen",
-    "zeit",
-    "standardisierung",
-    "dokumentation"
-  ],
-
-  "bisherige_foerdermittel": "keine",
-  "interesse_foerderung": "ja",
-  "erfahrung_beratung": "hoch",
-  "investitionsbudget": "bis_20k",
-
-  "marktposition": "spezialisiert",
-  "benchmark_wettbewerb": "ueberdurchschnittlich",
-  "innovationsprozess": "kontinuierlich",
-  "risikofreude": "80",
-
-  "datenschutz": true
+  "answers": {
+    "branche": "beratung",
+    "unternehmensgroesse": "solo",
+    "bundesland": "Berlin",
+    "hauptleistung": "Beratung, Durchführung und Operationalisierung von KI-Readiness-Analysen für Solo-Selbstständige, kleine Unternehmen und Teams. Fokus auf Prozessdiagnose, Potenzialanalysen, KI-gestützte Dokumentations- und Textautomatisierung, Governance-Setup und der Entwicklung von pragmatischen, schnell umsetzbaren KI-Workflows.",
+    "zielgruppen": ["B2B", "beratungen", "soloselbststaendige", "kmu"],
+    "jahresumsatz": "bis_500k",
+    "it_infrastruktur": "cloudbasiert",
+    "interne_ki_kompetenzen": "fortgeschritten",
+    "datenquellen": ["crm", "microsoft365", "notizen", "kundenfeedback", "onlineformulare"],
+    "digitalisierungsgrad": "hoch",
+    "prozesse_papierlos": "ja",
+    "automatisierungsgrad": "mittel",
+    "ki_einsatz": ["dokumentenerstellung", "textautomatisierung", "wissenstransfer", "prozessoptimierung", "kundenkommunikation"],
+    "ki_kompetenz": "hoch",
+    "ki_ziele": ["effizienz", "beschleunigung", "standardisierung", "qualität", "skalierung"],
+    "ki_projekte": "Bisher wurden KI-gestützte Fragebogen-Analysen, automatisierte Beratungsvorlagen, Chat-basierte Auswertungssysteme, ein Wissens-Hub für Kundengespräche sowie Makro-Workflows für Dokumentation, Reporting und Content-Erstellung aufgebaut. Weitere Projekte betreffen KI-gestützte Kundensegmentierung und eine modulare Analysebibliothek für Assessments.",
+    "anwendungsfaelle": ["automatische_dokumentation", "analyseautomation", "kundenkommunikation", "prozessanalyse", "textautomatisierung", "contentproduktion"],
+    "zeitersparnis_prioritaet": "Der größte manuelle Aufwand liegt in der individuellen Auswertung von Kundendaten, der Erstellung maßgeschneiderter Empfehlungen, der Recherche zu Compliance-Themen sowie in der Dokumentation von Workshops, Onboardings und Analyseergebnissen. Zusätzlich binden wiederkehrende Text- und Content-Aufgaben unverhältnismäßig viel Zeit.",
+    "pilot_bereich": "beratung",
+    "geschaeftsmodell_evolution": "Aufbau eines skalierbaren, KI-gestützten Analyse- und Beratungssystems mit modular buchbaren Leistungspaketen, Automatisierung von Produktionsschritten, Einführung eines Self-Service-Assessment-Tools und Ausbau des Angebots um KI-Microservices für KMU.",
+    "vision_3_jahre": "Der Aufbau einer voll skalierbaren KI-Beratung, die jederzeit standardisierte, tiefgreifende Analysen liefern kann – ergänzt durch automatisierte Folgeprozesse, individuelle Handlungsempfehlungen und eine Wissensbasis, die Kundenergebnisse übergreifend optimiert. Ziel ist es, Beratungsqualität unabhängig von der eigenen Kapazität abzusichern und planbar zu skalieren.",
+    "strategische_ziele": "Stärkere Produktisierung der Leistungen, klare Positionierung im KI-Readiness-Segment, Ausbau automatisierter Analyseketten, Schaffung datenbasierter Upsell-Pfade, Verbesserung der eigenen Content-Velocity und systematische Strukturierung interner Wissensprozesse.",
+    "massnahmen_komplexitaet": "niedrig",
+    "roadmap_vorhanden": "nein",
+    "governance_richtlinien": "keine",
+    "change_management": "nein",
+    "zeitbudget": "10h_woche",
+    "vorhandene_tools": ["microsoft365", "notion", "chatgpt", "browserplugins", "loom", "canva", "calendly"],
+    "regulierte_branche": ["keine_regulierung"],
+    "trainings_interessen": ["prompting_expert", "effizienz", "contentproduktion", "compliance", "automatisierung"],
+    "vision_prioritaet": "hoch",
+    "datenschutzbeauftragter": "nicht_erforderlich",
+    "technische_massnahmen": "standardisiert",
+    "folgenabschaetzung": "nicht_erforderlich",
+    "meldewege": "keine",
+    "loeschregeln": "einfach",
+    "ai_act_kenntnis": "fortgeschritten",
+    "ki_hemmnisse": ["kundenwissen", "zeit", "standardisierung", "dokumentation"],
+    "bisherige_foerdermittel": "keine",
+    "interesse_foerderung": "ja",
+    "erfahrung_beratung": "hoch",
+    "investitionsbudget": "bis_20k",
+    "marktposition": "spezialisiert",
+    "benchmark_wettbewerb": "ueberdurchschnittlich",
+    "innovationsprozess": "kontinuierlich",
+    "risikofreude": "80",
+    "datenschutz": true
+  }
 }

--- a/data/test_profiles_gold/solo_marketing_content_solo_agency.json
+++ b/data/test_profiles_gold/solo_marketing_content_solo_agency.json
@@ -1,139 +1,58 @@
 {
-  "branche": "marketing",
-  "unternehmensgroesse": "solo",
-  "bundesland": "Berlin",
+  "profile_id": "solo_marketing_content_solo_agency",
+  "description": "Solo-Content-Agentur im Marketing-Bereich mit Fokus auf Content-Produktion und Kampagnen",
+  "lang": "de",
+  "BRANCHE_LABEL": "Marketing & Werbung",
+  "UNTERNEHMENSGROESSE_LABEL": "1 (Solo)",
+  "HAUPTLEISTUNG": "Konzeption, Erstellung und Optimierung von daten- und KI-gestütztem Content für B2B- und B2C-Marken. Schwerpunkte sind Storytelling, Social-Media-Content, Performance-Kampagnen, Shortform-Video, Marken-Positionierung, Landingpages, Newsletter sowie systematische Content-Repurposing-Workflows für kleine Unternehmen, Startups und Einzelunternehmer.",
 
-  "hauptleistung": "Konzeption, Erstellung und Optimierung von daten- und KI-gestütztem Content für B2B- und B2C-Marken. Schwerpunkte sind Storytelling, Social-Media-Content, Performance-Kampagnen, Shortform-Video, Marken-Positionierung, Landingpages, Newsletter sowie systematische Content-Repurposing-Workflows für kleine Unternehmen, Startups und Einzelunternehmer.",
-
-  "zielgruppen": [
-    "b2b",
-    "b2c",
-    "startups",
-    "soloselbststaendige",
-    "kmu"
-  ],
-
-  "jahresumsatz": "bis_500k",
-
-  "it_infrastruktur": "cloudbasiert",
-
-  "interne_ki_kompetenzen": "fortgeschritten",
-
-  "datenquellen": [
-    "socialmedia",
-    "crm",
-    "microsoft365",
-    "notion",
-    "webtracking",
-    "kundenfeedback"
-  ],
-
-  "digitalisierungsgrad": "hoch",
-  "prozesse_papierlos": "ja",
-  "automatisierungsgrad": "mittel",
-
-  "ki_einsatz": [
-    "contentkreation",
-    "short_copy",
-    "research",
-    "kampagnenkonzepte",
-    "analyse",
-    "optimierung",
-    "workflowautomatisierung"
-  ],
-
-  "ki_kompetenz": "hoch",
-
-  "ki_ziele": [
-    "effizienz",
-    "skalierung",
-    "qualitaet",
-    "beschleunigung",
-    "konsistenz",
-    "standardisierung"
-  ],
-
-  "ki_projekte": "Bereits umgesetzt sind automatisierte Research-Briefings, Prompt-Bibliotheken für verschiedene Markenstile, KI-basierte Kampagnenideen, Social-Media-Redaktionspläne, Content-Repurposing-Pipelines, automatisierte Newsletter-Varianten sowie Video- und Script-Personalisierungen. Weitere Vorhaben betreffen datenbasierte Content-Heatmaps und automatisierte Kundenbriefings.",
-
-  "anwendungsfaelle": [
-    "contentproduktion",
-    "textautomatisierung",
-    "research",
-    "socialmedia",
-    "kampagnenoptimierung",
-    "blogartikel",
-    "landingpages",
-    "newsletter"
-  ],
-
-  "zeitersparnis_prioritaet": "Besonders zeitintensiv sind Konzeptarbeit, manuelles A/B-Testing, Formatvarianten für verschiedene Kanäle, wiederkehrende Kundenbriefings, Keyword-Recherche, Newsletter-Erstellung und das Anpassen von Content an unterschiedliche Markenstimmen. Besonders wertvoll wären automatisierte Vorlagen, vorkonfigurierte Rahmen für Storylines, KI-gestützte Qualitätschecks und Redaktionssysteme, die Rohmaterial in markenkonsistente Formate transformieren.",
-
-  "pilot_bereich": "contentproduktion",
-
-  "geschaeftsmodell_evolution": "Stärkere Produktisierung der Agenturleistung (Content-Pakete), Aufbau automatisierter Content-Pipelines, Einführung eines Self-Service-Content-Kits für Kunden, KI-unterstützte Audit-Services sowie Ausbau skalierbarer Kampagnen-Produktion. Ziel ist es, die Abhängigkeit vom eigenen Arbeitsvolumen zu reduzieren und stabile wiederkehrende Umsätze zu schaffen.",
-
-  "vision_3_jahre": "Eine hochskalierbare Content-Agentur, die durch KI-gestützte Templates, modulare Workflows und automatisierte Research-Prozesse extrem hohe Content-Velocity liefern kann. Durch systematische Datenanalyse sollen Content-Patterns sichtbar werden, die direkt in Kampagnen und Markenführung einfließen. Die Agentur arbeitet zunehmend als orchestrierender Creative-Technologist-Hub.",
-
-  "strategische_ziele": "Erhöhung der Output-Geschwindigkeit, besserer Wiedererkennungswert, Entwicklung einer klaren Signature-Style-Library, Ausbau automatisierter Rechercheprozesse, Senkung manueller Tätigkeiten, stärkere datengetriebene Content-Entscheidungen.",
-
-  "massnahmen_komplexitaet": "niedrig",
-
-  "roadmap_vorhanden": "nein",
-  "governance_richtlinien": "keine",
-  "change_management": "nein",
-  "zeitbudget": "10h_woche",
-
-  "vorhandene_tools": [
-    "adobe",
-    "microsoft365",
-    "notion",
-    "chatgpt",
-    "browserplugins",
-    "canva",
-    "capcut",
-    "calendly",
-    "googleworkspace"
-  ],
-
-  "regulierte_branche": [
-    "keine_regulierung"
-  ],
-
-  "trainings_interessen": [
-    "prompting_expert",
-    "contentproduktion",
-    "automatisierung",
-    "effizienz",
-    "seo",
-    "video"
-  ],
-
-  "vision_prioritaet": "hoch",
-
-  "datenschutzbeauftragter": "nicht_erforderlich",
-  "technische_massnahmen": "standardisiert",
-  "folgenabschaetzung": "nicht_erforderlich",
-  "meldewege": "keine",
-  "loeschregeln": "einfach",
-
-  "ai_act_kenntnis": "basis",
-
-  "ki_hemmnisse": [
-    "zeit",
-    "standardisierung",
-    "auftragslage",
-    "dokumentation"
-  ],
-
-  "bisherige_foerdermittel": "keine",
-  "interesse_foerderung": "ja",
-  "erfahrung_beratung": "mittel",
-  "investitionsbudget": "bis_20k",
-
-  "marktposition": "spezialisiert",
-  "benchmark_wettbewerb": "ueberdurchschnittlich",
-  "innovationsprozess": "kontinuierlich",
-  "risikofreude": "75",
-
-  "datenschutz": true
+  "answers": {
+    "branche": "marketing",
+    "unternehmensgroesse": "solo",
+    "bundesland": "Berlin",
+    "hauptleistung": "Konzeption, Erstellung und Optimierung von daten- und KI-gestütztem Content für B2B- und B2C-Marken. Schwerpunkte sind Storytelling, Social-Media-Content, Performance-Kampagnen, Shortform-Video, Marken-Positionierung, Landingpages, Newsletter sowie systematische Content-Repurposing-Workflows für kleine Unternehmen, Startups und Einzelunternehmer.",
+    "zielgruppen": ["b2b", "b2c", "startups", "soloselbststaendige", "kmu"],
+    "jahresumsatz": "bis_500k",
+    "it_infrastruktur": "cloudbasiert",
+    "interne_ki_kompetenzen": "fortgeschritten",
+    "datenquellen": ["socialmedia", "crm", "microsoft365", "notion", "webtracking", "kundenfeedback"],
+    "digitalisierungsgrad": "hoch",
+    "prozesse_papierlos": "ja",
+    "automatisierungsgrad": "mittel",
+    "ki_einsatz": ["contentkreation", "short_copy", "research", "kampagnenkonzepte", "analyse", "optimierung", "workflowautomatisierung"],
+    "ki_kompetenz": "hoch",
+    "ki_ziele": ["effizienz", "skalierung", "qualitaet", "beschleunigung", "konsistenz", "standardisierung"],
+    "ki_projekte": "Bereits umgesetzt sind automatisierte Research-Briefings, Prompt-Bibliotheken für verschiedene Markenstile, KI-basierte Kampagnenideen, Social-Media-Redaktionspläne, Content-Repurposing-Pipelines, automatisierte Newsletter-Varianten sowie Video- und Script-Personalisierungen. Weitere Vorhaben betreffen datenbasierte Content-Heatmaps und automatisierte Kundenbriefings.",
+    "anwendungsfaelle": ["contentproduktion", "textautomatisierung", "research", "socialmedia", "kampagnenoptimierung", "blogartikel", "landingpages", "newsletter"],
+    "zeitersparnis_prioritaet": "Besonders zeitintensiv sind Konzeptarbeit, manuelles A/B-Testing, Formatvarianten für verschiedene Kanäle, wiederkehrende Kundenbriefings, Keyword-Recherche, Newsletter-Erstellung und das Anpassen von Content an unterschiedliche Markenstimmen. Besonders wertvoll wären automatisierte Vorlagen, vorkonfigurierte Rahmen für Storylines, KI-gestützte Qualitätschecks und Redaktionssysteme, die Rohmaterial in markenkonsistente Formate transformieren.",
+    "pilot_bereich": "contentproduktion",
+    "geschaeftsmodell_evolution": "Stärkere Produktisierung der Agenturleistung (Content-Pakete), Aufbau automatisierter Content-Pipelines, Einführung eines Self-Service-Content-Kits für Kunden, KI-unterstützte Audit-Services sowie Ausbau skalierbarer Kampagnen-Produktion. Ziel ist es, die Abhängigkeit vom eigenen Arbeitsvolumen zu reduzieren und stabile wiederkehrende Umsätze zu schaffen.",
+    "vision_3_jahre": "Eine hochskalierbare Content-Agentur, die durch KI-gestützte Templates, modulare Workflows und automatisierte Research-Prozesse extrem hohe Content-Velocity liefern kann. Durch systematische Datenanalyse sollen Content-Patterns sichtbar werden, die direkt in Kampagnen und Markenführung einfließen. Die Agentur arbeitet zunehmend als orchestrierender Creative-Technologist-Hub.",
+    "strategische_ziele": "Erhöhung der Output-Geschwindigkeit, besserer Wiedererkennungswert, Entwicklung einer klaren Signature-Style-Library, Ausbau automatisierter Rechercheprozesse, Senkung manueller Tätigkeiten, stärkere datengetriebene Content-Entscheidungen.",
+    "massnahmen_komplexitaet": "niedrig",
+    "roadmap_vorhanden": "nein",
+    "governance_richtlinien": "keine",
+    "change_management": "nein",
+    "zeitbudget": "10h_woche",
+    "vorhandene_tools": ["adobe", "microsoft365", "notion", "chatgpt", "browserplugins", "canva", "capcut", "calendly", "googleworkspace"],
+    "regulierte_branche": ["keine_regulierung"],
+    "trainings_interessen": ["prompting_expert", "contentproduktion", "automatisierung", "effizienz", "seo", "video"],
+    "vision_prioritaet": "hoch",
+    "datenschutzbeauftragter": "nicht_erforderlich",
+    "technische_massnahmen": "standardisiert",
+    "folgenabschaetzung": "nicht_erforderlich",
+    "meldewege": "keine",
+    "loeschregeln": "einfach",
+    "ai_act_kenntnis": "basis",
+    "ki_hemmnisse": ["zeit", "standardisierung", "auftragslage", "dokumentation"],
+    "bisherige_foerdermittel": "keine",
+    "interesse_foerderung": "ja",
+    "erfahrung_beratung": "mittel",
+    "investitionsbudget": "bis_20k",
+    "marktposition": "spezialisiert",
+    "benchmark_wettbewerb": "ueberdurchschnittlich",
+    "innovationsprozess": "kontinuierlich",
+    "risikofreude": "75",
+    "datenschutz": true
+  }
 }

--- a/data/test_profiles_gold/team_finance_insurance_advisory.json
+++ b/data/test_profiles_gold/team_finance_insurance_advisory.json
@@ -1,139 +1,58 @@
 {
-  "branche": "finanzen",
-  "unternehmensgroesse": "team",
-  "bundesland": "Hessen",
+  "profile_id": "team_finance_insurance_advisory",
+  "description": "Team im Finanz-/Versicherungsbereich mit Fokus auf Compliance und Risikoanalyse",
+  "lang": "de",
+  "BRANCHE_LABEL": "Finanzen & Versicherungen",
+  "UNTERNEHMENSGROESSE_LABEL": "2-10 (Team)",
+  "HAUPTLEISTUNG": "Beratung für Banken, Versicherer, Finanzdienstleister und FinTechs mit Schwerpunkt auf Prozessoptimierung, regulatorischer Compliance (BAIT, VAIT, MaRisk, DSGVO), Datenqualität, Risikoanalyse, Reporting-Automatisierung und Einführung von KI-gestützten Entscheidungs- und Analyseverfahren. Zusätzlich werden Workshops, Audits, Gap-Analysen, Risiko-Scorings sowie Einführung digitaler Beratungsprozesse angeboten.",
 
-  "hauptleistung": "Beratung für Banken, Versicherer, Finanzdienstleister und FinTechs mit Schwerpunkt auf Prozessoptimierung, regulatorischer Compliance (BAIT, VAIT, MaRisk, DSGVO), Datenqualität, Risikoanalyse, Reporting-Automatisierung und Einführung von KI-gestützten Entscheidungs- und Analyseverfahren. Zusätzlich werden Workshops, Audits, Gap-Analysen, Risiko-Scorings sowie Einführung digitaler Beratungsprozesse angeboten.",
-
-  "zielgruppen": [
-    "banken",
-    "versicherungen",
-    "fintech",
-    "vermögensverwalter",
-    "kmu",
-    "b2b"
-  ],
-
-  "jahresumsatz": "bis_500k",
-
-  "it_infrastruktur": "cloudbasiert",
-
-  "interne_ki_kompetenzen": "mittel",
-
-  "datenquellen": [
-    "crm",
-    "excel",
-    "webtracking",
-    "kundenfeedback",
-    "microsoft365",
-    "analytics"
-  ],
-
-  "digitalisierungsgrad": "mittel",
-  "prozesse_papierlos": "ja",
-  "automatisierungsgrad": "gering",
-
-  "ki_einsatz": [
-    "risikoanalyse",
-    "reporting",
-    "contentkreation",
-    "research",
-    "dokumentenzusammenfassung",
-    "prozessevaluierung",
-    "regelwerksanalyse"
-  ],
-
-  "ki_kompetenz": "mittel",
-
-  "ki_ziele": [
-    "qualitaet",
-    "effizienz",
-    "standardisierung",
-    "risikominimierung",
-    "beschleunigung",
-    "compliance"
-  ],
-
-  "ki_projekte": "Bereits umgesetzt sind KI-basierte First-Level-Analysen für MaRisk/BAIT-Fragen, automatisierte Berichtsbausteine für Versicherungen, Pilotprozesse für Dokumentenklassifikation, generative Textbausteine für Kundenkommunikation sowie KI-gestützte Research-Hilfen. Geplant sind regelwerksbasierte Assistenzsysteme, automatisierte Checklisten, Risiko-Szenarien und KI-Dashboards für interne Qualitätssicherung.",
-
-  "anwendungsfaelle": [
-    "berichtswesen",
-    "risikoanalyse",
-    "dokumentenpruefung",
-    "regelwerksauswertung",
-    "workflowoptimierung",
-    "research",
-    "kundenkommunikation"
-  ],
-
-  "zeitersparnis_prioritaet": "Besonders zeitintensiv sind regulatorische Recherchen, strukturierte Risikoanalysen, komplexe Dokumentenprüfungen, Reporting-Anforderungen, Abstimmungsprozesse, manuelle Excel-Auswertungen sowie priorisierte Handlungsempfehlungen. Hoher Nutzen besteht in KI-unterstützten Assistenzsystemen (Regelwerk-Analyse), automatisierten Reports, Standardisierung von Beraterkits und der Beschleunigung von Review-Schleifen.",
-
-  "pilot_bereich": "risikoanalyse",
-
-  "geschaeftsmodell_evolution": "Aufbau skalierbarer digitaler Beratungsprodukte wie Self-Assessment-Tools, Audit-Kits, Automationspakete, Compliance-Monitoring, Risiko-Szenario-Module sowie White-Label-Lösungen für Finanzdienstleister. Langfristig soll der Anteil wiederkehrender Umsätze erhöht und die Beratungsleistung stärker mit KI-gestützten Modellen verbunden werden.",
-
-  "vision_3_jahre": "Eine hochstandardisierte, automatisierte Beratungsunit mit klaren KI-Prozessen für Risikoanalyse, Regelwerksauswertung und Reporting. Die Beratungsleistungen sollen durch digitale Tools ergänzt werden, die Kunden eigenständig nutzen können. Das Unternehmen möchte als spezialisierter Partner für KI-gestützte Compliance und datenbasierte Entscheidungen im Finanzsektor wahrgenommen werden.",
-
-  "strategische_ziele": "Erhöhung der Prozessgeschwindigkeit, Verbesserung der Dokumentationsqualität, Einführung eines KI-Assistenzsystems, Ausbau wiederkehrender Umsätze, Reduktion manueller Prüfschritte, Einführung automatisierter Risiko-Workflows und stärkere interne Standardisierung.",
-
-  "massnahmen_komplexitaet": "mittel",
-
-  "roadmap_vorhanden": "nein",
-  "governance_richtlinien": "keine",
-  "change_management": "teilweise",
-  "zeitbudget": "15h_woche",
-
-  "vorhandene_tools": [
-    "microsoft365",
-    "notion",
-    "excel",
-    "bitrix",
-    "teams",
-    "chatgpt",
-    "browserplugins"
-  ],
-
-  "regulierte_branche": [
-    "finanzen",
-    "versicherung"
-  ],
-
-  "trainings_interessen": [
-    "risikoanalyse",
-    "prompting_expert",
-    "compliance",
-    "automatisierung",
-    "datenqualitaet",
-    "kundenkommunikation"
-  ],
-
-  "vision_prioritaet": "hoch",
-
-  "datenschutzbeauftragter": "intern",
-  "technische_massnahmen": "erweitert",
-  "folgenabschaetzung": "teilweise",
-  "meldewege": "teilweise",
-  "loeschregeln": "ausfuehrlich",
-
-  "ai_act_kenntnis": "fortgeschritten",
-
-  "ki_hemmnisse": [
-    "datenschutz",
-    "regulierung",
-    "kompetenz",
-    "standardisierung",
-    "zeit"
-  ],
-
-  "bisherige_foerdermittel": "keine",
-  "interesse_foerderung": "ja",
-  "erfahrung_beratung": "fortgeschritten",
-  "investitionsbudget": "bis_200k",
-
-  "marktposition": "etabliert",
-  "benchmark_wettbewerb": "ueberdurchschnittlich",
-  "innovationsprozess": "strukturiert",
-  "risikofreude": "50",
-
-  "datenschutz": true
+  "answers": {
+    "branche": "finanzen",
+    "unternehmensgroesse": "team",
+    "bundesland": "Hessen",
+    "hauptleistung": "Beratung für Banken, Versicherer, Finanzdienstleister und FinTechs mit Schwerpunkt auf Prozessoptimierung, regulatorischer Compliance (BAIT, VAIT, MaRisk, DSGVO), Datenqualität, Risikoanalyse, Reporting-Automatisierung und Einführung von KI-gestützten Entscheidungs- und Analyseverfahren. Zusätzlich werden Workshops, Audits, Gap-Analysen, Risiko-Scorings sowie Einführung digitaler Beratungsprozesse angeboten.",
+    "zielgruppen": ["banken", "versicherungen", "fintech", "vermögensverwalter", "kmu", "b2b"],
+    "jahresumsatz": "bis_500k",
+    "it_infrastruktur": "cloudbasiert",
+    "interne_ki_kompetenzen": "mittel",
+    "datenquellen": ["crm", "excel", "webtracking", "kundenfeedback", "microsoft365", "analytics"],
+    "digitalisierungsgrad": "mittel",
+    "prozesse_papierlos": "ja",
+    "automatisierungsgrad": "gering",
+    "ki_einsatz": ["risikoanalyse", "reporting", "contentkreation", "research", "dokumentenzusammenfassung", "prozessevaluierung", "regelwerksanalyse"],
+    "ki_kompetenz": "mittel",
+    "ki_ziele": ["qualitaet", "effizienz", "standardisierung", "risikominimierung", "beschleunigung", "compliance"],
+    "ki_projekte": "Bereits umgesetzt sind KI-basierte First-Level-Analysen für MaRisk/BAIT-Fragen, automatisierte Berichtsbausteine für Versicherungen, Pilotprozesse für Dokumentenklassifikation, generative Textbausteine für Kundenkommunikation sowie KI-gestützte Research-Hilfen. Geplant sind regelwerksbasierte Assistenzsysteme, automatisierte Checklisten, Risiko-Szenarien und KI-Dashboards für interne Qualitätssicherung.",
+    "anwendungsfaelle": ["berichtswesen", "risikoanalyse", "dokumentenpruefung", "regelwerksauswertung", "workflowoptimierung", "research", "kundenkommunikation"],
+    "zeitersparnis_prioritaet": "Besonders zeitintensiv sind regulatorische Recherchen, strukturierte Risikoanalysen, komplexe Dokumentenprüfungen, Reporting-Anforderungen, Abstimmungsprozesse, manuelle Excel-Auswertungen sowie priorisierte Handlungsempfehlungen. Hoher Nutzen besteht in KI-unterstützten Assistenzsystemen (Regelwerk-Analyse), automatisierten Reports, Standardisierung von Beraterkits und der Beschleunigung von Review-Schleifen.",
+    "pilot_bereich": "risikoanalyse",
+    "geschaeftsmodell_evolution": "Aufbau skalierbarer digitaler Beratungsprodukte wie Self-Assessment-Tools, Audit-Kits, Automationspakete, Compliance-Monitoring, Risiko-Szenario-Module sowie White-Label-Lösungen für Finanzdienstleister. Langfristig soll der Anteil wiederkehrender Umsätze erhöht und die Beratungsleistung stärker mit KI-gestützten Modellen verbunden werden.",
+    "vision_3_jahre": "Eine hochstandardisierte, automatisierte Beratungsunit mit klaren KI-Prozessen für Risikoanalyse, Regelwerksauswertung und Reporting. Die Beratungsleistungen sollen durch digitale Tools ergänzt werden, die Kunden eigenständig nutzen können. Das Unternehmen möchte als spezialisierter Partner für KI-gestützte Compliance und datenbasierte Entscheidungen im Finanzsektor wahrgenommen werden.",
+    "strategische_ziele": "Erhöhung der Prozessgeschwindigkeit, Verbesserung der Dokumentationsqualität, Einführung eines KI-Assistenzsystems, Ausbau wiederkehrender Umsätze, Reduktion manueller Prüfschritte, Einführung automatisierter Risiko-Workflows und stärkere interne Standardisierung.",
+    "massnahmen_komplexitaet": "mittel",
+    "roadmap_vorhanden": "nein",
+    "governance_richtlinien": "keine",
+    "change_management": "teilweise",
+    "zeitbudget": "15h_woche",
+    "vorhandene_tools": ["microsoft365", "notion", "excel", "bitrix", "teams", "chatgpt", "browserplugins"],
+    "regulierte_branche": ["finanzen", "versicherung"],
+    "trainings_interessen": ["risikoanalyse", "prompting_expert", "compliance", "automatisierung", "datenqualitaet", "kundenkommunikation"],
+    "vision_prioritaet": "hoch",
+    "datenschutzbeauftragter": "intern",
+    "technische_massnahmen": "erweitert",
+    "folgenabschaetzung": "teilweise",
+    "meldewege": "teilweise",
+    "loeschregeln": "ausfuehrlich",
+    "ai_act_kenntnis": "fortgeschritten",
+    "ki_hemmnisse": ["datenschutz", "regulierung", "kompetenz", "standardisierung", "zeit"],
+    "bisherige_foerdermittel": "keine",
+    "interesse_foerderung": "ja",
+    "erfahrung_beratung": "fortgeschritten",
+    "investitionsbudget": "bis_200k",
+    "marktposition": "etabliert",
+    "benchmark_wettbewerb": "ueberdurchschnittlich",
+    "innovationsprozess": "strukturiert",
+    "risikofreude": "50",
+    "datenschutz": true
+  }
 }

--- a/data/test_profiles_gold/team_it_software_saas_advisory.json
+++ b/data/test_profiles_gold/team_it_software_saas_advisory.json
@@ -1,140 +1,58 @@
 {
-  "branche": "it_software",
-  "unternehmensgroesse": "team",
-  "bundesland": "Berlin",
+  "profile_id": "team_it_software_saas_advisory",
+  "description": "Team im IT/Software-Bereich mit Fokus auf SaaS-Entwicklung und DevOps",
+  "lang": "de",
+  "BRANCHE_LABEL": "IT & Software",
+  "UNTERNEHMENSGROESSE_LABEL": "2-10 (Team)",
+  "HAUPTLEISTUNG": "Beratung für IT-Unternehmen, SaaS-Anbieter sowie digitale Produktteams mit Fokus auf Systemarchitektur, KI-gestützte Produktentwicklung, API-Integration, Datenqualität, DevOps-Optimierung, technische Audits, Dokumentationsstandards, Sicherheitsprozesse, Workflow-Automatisierung und strategische Skalierung von Software-Produkten. Dazu gehören Architektur-Reviews, Code-Audits, KI-Feature-Implementierung, Migrationsplanung, Trainings und der Aufbau operativer KI-Workflows in Entwicklung und Betrieb.",
 
-  "hauptleistung": "Beratung für IT-Unternehmen, SaaS-Anbieter sowie digitale Produktteams mit Fokus auf Systemarchitektur, KI-gestützte Produktentwicklung, API-Integration, Datenqualität, DevOps-Optimierung, technische Audits, Dokumentationsstandards, Sicherheitsprozesse, Workflow-Automatisierung und strategische Skalierung von Software-Produkten. Dazu gehören Architektur-Reviews, Code-Audits, KI-Feature-Implementierung, Migrationsplanung, Trainings und der Aufbau operativer KI-Workflows in Entwicklung und Betrieb.",
-
-  "zielgruppen": [
-    "it_software",
-    "saas",
-    "startups",
-    "scaleups",
-    "b2b",
-    "produktteams"
-  ],
-
-  "jahresumsatz": "bis_1m",
-
-  "it_infrastruktur": "cloudbasiert",
-
-  "interne_ki_kompetenzen": "mittel",
-
-  "datenquellen": [
-    "crm",
-    "webtracking",
-    "analytics",
-    "logdaten",
-    "microsoft365",
-    "entwicklertools"
-  ],
-
-  "digitalisierungsgrad": "hoch",
-  "prozesse_papierlos": "ja",
-  "automatisierungsgrad": "mittel",
-
-  "ki_einsatz": [
-    "research",
-    "automatisierung",
-    "contentkreation",
-    "dokumentenzusammenfassung",
-    "code_assistenz",
-    "workflowoptimierung",
-    "kundenkommunikation"
-  ],
-
-  "ki_kompetenz": "mittel",
-
-  "ki_ziele": [
-    "beschleunigung",
-    "skalierung",
-    "standardisierung",
-    "effizienz",
-    "qualitaet",
-    "stabilitaet"
-  ],
-
-  "ki_projekte": "Umgesetzt wurden bereits KI-basierte Recherche-Automationen, automatisierte Dokumentationsbausteine, KI-Assistenzfunktionen zur Code-Analyse, interne ChatOps-Automationen, erste Prototypen für KI-gestützte Testfallgenerierung sowie Workflow-Bots für Support und Monitoring. Geplant sind semantische Suchsysteme, KI-Feature-Kits für SaaS-Produkte, standardisierte Trainingsflows, API-basierte Integrationen und End-to-End-Assistenten für Produktteams.",
-
-  "anwendungsfaelle": [
-    "workflowoptimierung",
-    "code_assistenz",
-    "dokumentenpruefung",
-    "supportautomatisierung",
-    "recherche",
-    "content_generation",
-    "prozessanalyse"
-  ],
-
-  "zeitersparnis_prioritaet": "Hohe Zeitverluste entstehen vor allem in technischem Research, wiederkehrenden Architektur-Abstimmungen, Dokumentation, Code-Reviews, Bereitstellung von DevOps-Artefakten, Support-Tickets, Monitoring-Analysen, Priorisierungen und Übergaben. KI-gestützte Automationen bieten Potenzial für Review-Beschleunigung, Qualitätsverbesserung, Testfallgenerierung, Regelsysteme und assistierte Architekturentscheidungen.",
-
-  "pilot_bereich": "workflowoptimierung",
-
-  "geschaeftsmodell_evolution": "Das Unternehmen plant die Entwicklung von KI-gestützten Toolkits, API-Services, Audit-Frameworks, technischen Beratungspaketen und standardisierten Entwicklungsflows, die als modulare Produkte vertrieben werden können. Ziel ist der Aufbau wiederkehrender Umsätze durch KI-basierte SaaS-Add-ons, Automationspakete und technische Assistenten für Entwicklungsteams.",
-
-  "vision_3_jahre": "Eine hochskalierbare technische Beratungseinheit mit tief integrierten KI-Prozessen, automatisierten Analyse-Pipelines, wiederholbaren Architektur-Reviews, KI-gestützten Qualitätschecks und modularen Produkten für DevOps, Entwicklung, Testing und Systemarchitektur. Die Firma möchte als führender Partner für KI-gestützte Produktentwicklung wahrgenommen werden.",
-
-  "strategische_ziele": "Verbesserung der Entwicklungsqualität, Verkürzung von Release-Zyklen, Aufbau eines KI-Assistenzsystems, Standardisierung aller technischen Abläufe, Ausbau wiederkehrender Umsätze, Reduktion manueller Arbeit, mehr Automatisierung in Research, Testing und Dokumentation.",
-
-  "massnahmen_komplexitaet": "mittel",
-
-  "roadmap_vorhanden": "teilweise",
-  "governance_richtlinien": "entwurf",
-  "change_management": "teilweise",
-  "zeitbudget": "15h_woche",
-
-  "vorhandene_tools": [
-    "microsoft365",
-    "notion",
-    "jira",
-    "github",
-    "bitbucket",
-    "vscode",
-    "teams",
-    "browserplugins",
-    "chatgpt"
-  ],
-
-  "regulierte_branche": [
-    "it"
-  ],
-
-  "trainings_interessen": [
-    "prompting_expert",
-    "automatisierung",
-    "code_assistenz",
-    "devops",
-    "datenqualitaet",
-    "kundenkommunikation"
-  ],
-
-  "vision_prioritaet": "hoch",
-
-  "datenschutzbeauftragter": "extern",
-  "technische_massnahmen": "erweitert",
-  "folgenabschaetzung": "nein",
-  "meldewege": "teilweise",
-  "loeschregeln": "teilweise",
-
-  "ai_act_kenntnis": "mittel",
-
-  "ki_hemmnisse": [
-    "standardisierung",
-    "datenschutz",
-    "kompetenz",
-    "integration",
-    "ressourcen"
-  ],
-
-  "bisherige_foerdermittel": "keine",
-  "interesse_foerderung": "ja",
-  "erfahrung_beratung": "fortgeschritten",
-  "investitionsbudget": "bis_200k",
-
-  "marktposition": "etabliert",
-  "benchmark_wettbewerb": "ueberdurchschnittlich",
-  "innovationsprozess": "strukturiert",
-  "risikofreude": "70",
-
-  "datenschutz": true
+  "answers": {
+    "branche": "it_software",
+    "unternehmensgroesse": "team",
+    "bundesland": "Berlin",
+    "hauptleistung": "Beratung für IT-Unternehmen, SaaS-Anbieter sowie digitale Produktteams mit Fokus auf Systemarchitektur, KI-gestützte Produktentwicklung, API-Integration, Datenqualität, DevOps-Optimierung, technische Audits, Dokumentationsstandards, Sicherheitsprozesse, Workflow-Automatisierung und strategische Skalierung von Software-Produkten. Dazu gehören Architektur-Reviews, Code-Audits, KI-Feature-Implementierung, Migrationsplanung, Trainings und der Aufbau operativer KI-Workflows in Entwicklung und Betrieb.",
+    "zielgruppen": ["it_software", "saas", "startups", "scaleups", "b2b", "produktteams"],
+    "jahresumsatz": "bis_1m",
+    "it_infrastruktur": "cloudbasiert",
+    "interne_ki_kompetenzen": "mittel",
+    "datenquellen": ["crm", "webtracking", "analytics", "logdaten", "microsoft365", "entwicklertools"],
+    "digitalisierungsgrad": "hoch",
+    "prozesse_papierlos": "ja",
+    "automatisierungsgrad": "mittel",
+    "ki_einsatz": ["research", "automatisierung", "contentkreation", "dokumentenzusammenfassung", "code_assistenz", "workflowoptimierung", "kundenkommunikation"],
+    "ki_kompetenz": "mittel",
+    "ki_ziele": ["beschleunigung", "skalierung", "standardisierung", "effizienz", "qualitaet", "stabilitaet"],
+    "ki_projekte": "Umgesetzt wurden bereits KI-basierte Recherche-Automationen, automatisierte Dokumentationsbausteine, KI-Assistenzfunktionen zur Code-Analyse, interne ChatOps-Automationen, erste Prototypen für KI-gestützte Testfallgenerierung sowie Workflow-Bots für Support und Monitoring. Geplant sind semantische Suchsysteme, KI-Feature-Kits für SaaS-Produkte, standardisierte Trainingsflows, API-basierte Integrationen und End-to-End-Assistenten für Produktteams.",
+    "anwendungsfaelle": ["workflowoptimierung", "code_assistenz", "dokumentenpruefung", "supportautomatisierung", "recherche", "content_generation", "prozessanalyse"],
+    "zeitersparnis_prioritaet": "Hohe Zeitverluste entstehen vor allem in technischem Research, wiederkehrenden Architektur-Abstimmungen, Dokumentation, Code-Reviews, Bereitstellung von DevOps-Artefakten, Support-Tickets, Monitoring-Analysen, Priorisierungen und Übergaben. KI-gestützte Automationen bieten Potenzial für Review-Beschleunigung, Qualitätsverbesserung, Testfallgenerierung, Regelsysteme und assistierte Architekturentscheidungen.",
+    "pilot_bereich": "workflowoptimierung",
+    "geschaeftsmodell_evolution": "Das Unternehmen plant die Entwicklung von KI-gestützten Toolkits, API-Services, Audit-Frameworks, technischen Beratungspaketen und standardisierten Entwicklungsflows, die als modulare Produkte vertrieben werden können. Ziel ist der Aufbau wiederkehrender Umsätze durch KI-basierte SaaS-Add-ons, Automationspakete und technische Assistenten für Entwicklungsteams.",
+    "vision_3_jahre": "Eine hochskalierbare technische Beratungseinheit mit tief integrierten KI-Prozessen, automatisierten Analyse-Pipelines, wiederholbaren Architektur-Reviews, KI-gestützten Qualitätschecks und modularen Produkten für DevOps, Entwicklung, Testing und Systemarchitektur. Die Firma möchte als führender Partner für KI-gestützte Produktentwicklung wahrgenommen werden.",
+    "strategische_ziele": "Verbesserung der Entwicklungsqualität, Verkürzung von Release-Zyklen, Aufbau eines KI-Assistenzsystems, Standardisierung aller technischen Abläufe, Ausbau wiederkehrender Umsätze, Reduktion manueller Arbeit, mehr Automatisierung in Research, Testing und Dokumentation.",
+    "massnahmen_komplexitaet": "mittel",
+    "roadmap_vorhanden": "teilweise",
+    "governance_richtlinien": "entwurf",
+    "change_management": "teilweise",
+    "zeitbudget": "15h_woche",
+    "vorhandene_tools": ["microsoft365", "notion", "jira", "github", "bitbucket", "vscode", "teams", "browserplugins", "chatgpt"],
+    "regulierte_branche": ["it"],
+    "trainings_interessen": ["prompting_expert", "automatisierung", "code_assistenz", "devops", "datenqualitaet", "kundenkommunikation"],
+    "vision_prioritaet": "hoch",
+    "datenschutzbeauftragter": "extern",
+    "technische_massnahmen": "erweitert",
+    "folgenabschaetzung": "nein",
+    "meldewege": "teilweise",
+    "loeschregeln": "teilweise",
+    "ai_act_kenntnis": "mittel",
+    "ki_hemmnisse": ["standardisierung", "datenschutz", "kompetenz", "integration", "ressourcen"],
+    "bisherige_foerdermittel": "keine",
+    "interesse_foerderung": "ja",
+    "erfahrung_beratung": "fortgeschritten",
+    "investitionsbudget": "bis_200k",
+    "marktposition": "etabliert",
+    "benchmark_wettbewerb": "ueberdurchschnittlich",
+    "innovationsprozess": "strukturiert",
+    "risikofreude": "70",
+    "datenschutz": true
+  }
 }


### PR DESCRIPTION
…gold profiles

All 6 PLATIN++ test profiles now have the correct structure:
- profile_id, description, lang on top level
- BRANCHE_LABEL, UNTERNEHMENSGROESSE_LABEL, HAUPTLEISTUNG on top level
- All answers wrapped in 'answers' field

This fixes the CI test failure in test_all_gold_profiles_have_valid_structure