### PR TITLE
fix(feedback): add explicit type annotation to fix mypy error

### DIFF
--- a/services/feedback.py
+++ b/services/feedback.py
@@ -225,7 +225,7 @@ async def process_feedback(
 
     Returns a result dict with status and optional details.
     """
-    result = {
+    result: Dict[str, Any] = {
         "logged": False,
         "saved_to_db": False,
         "forwarded_to_webhook": False,


### PR DESCRIPTION
The result dict was inferred as Dict[str, bool] by mypy, but feedback_id is assigned an int. Adding explicit Dict[str, Any] type annotation resolves the incompatible types error.