### PR TITLE
feat(funding-en): add EU core funding for non-German EN reports (Phas…

### DIFF
--- a/data/funding/funding_eu_core_en.json
+++ b/data/funding/funding_eu_core_en.json
@@ -1,0 +1,104 @@
+{
+  "scope": "EU_CORE",
+  "language": "en",
+  "last_updated": "2025-01",
+  "description": "EU-wide core funding programmes for AI and digitalisation projects, applicable to organisations in EU member states and associated countries",
+  "programmes": [
+    {
+      "id": "horizon_europe",
+      "name_en": "Horizon Europe",
+      "summary_en": "The EU's flagship R&D and innovation programme supporting companies, universities and research organisations. Covers AI, data, digitalisation, deep-tech, and sustainability projects across multiple thematic clusters.",
+      "funding_type_en": "Grant / Co-funding",
+      "funding_rate_en": "Up to 70-100% (depending on call, action type, and participant role)",
+      "max_amount_en": "Typically from €500k up to €10m+ per project (varies by call)",
+      "target_groups_en": ["Startups", "SMEs", "Large enterprises", "Research organisations", "Universities"],
+      "ai_relevance_en": "High",
+      "notes_en": "Requires consortium of multiple partners from different EU countries in most calls. Single-beneficiary options exist for specific instruments.",
+      "priority": 1
+    },
+    {
+      "id": "digital_europe",
+      "name_en": "Digital Europe Programme (DIGITAL)",
+      "summary_en": "Supports deployment and uptake of digital technologies including AI, advanced digital skills, high-performance computing, cybersecurity, and data spaces across the EU.",
+      "funding_type_en": "Grant / Co-funding",
+      "funding_rate_en": "Up to 50-75% (varies by action type)",
+      "max_amount_en": "Typically up to several million euros per project",
+      "target_groups_en": ["SMEs", "Public sector", "Tech consortia", "Digital Innovation Hubs"],
+      "ai_relevance_en": "High",
+      "notes_en": "Focus on deployment rather than research. Often requires cross-border collaboration.",
+      "priority": 1
+    },
+    {
+      "id": "eic_accelerator",
+      "name_en": "EIC Accelerator",
+      "summary_en": "Part of the European Innovation Council, providing equity and grants for high-risk, high-impact innovation projects. Particularly suited for AI-driven business models and deep-tech scale-ups.",
+      "funding_type_en": "Grant + Equity (blended finance)",
+      "funding_rate_en": "Up to €2.5m grant component + equity investment up to ~€15m",
+      "max_amount_en": "Up to €17.5m total (grant + equity)",
+      "target_groups_en": ["Deep-tech startups", "Scale-ups", "High-growth SMEs"],
+      "ai_relevance_en": "Very high",
+      "notes_en": "Highly competitive. Single-company applications. Requires strong business case and market potential.",
+      "priority": 1
+    },
+    {
+      "id": "eic_pathfinder",
+      "name_en": "EIC Pathfinder",
+      "summary_en": "Supports early-stage development of breakthrough technologies through collaborative research. Ideal for ambitious AI research with transformative potential.",
+      "funding_type_en": "Grant",
+      "funding_rate_en": "Up to 100%",
+      "max_amount_en": "Up to €3-4m per project",
+      "target_groups_en": ["Research organisations", "Universities", "Deep-tech startups", "SMEs"],
+      "ai_relevance_en": "High",
+      "notes_en": "Focus on visionary research. Consortium required for Open calls; single applicants possible for Challenges.",
+      "priority": 2
+    },
+    {
+      "id": "esf_plus_digital_skills",
+      "name_en": "ESF+ Digital Skills Initiatives",
+      "summary_en": "The European Social Fund Plus supports training, upskilling, and reskilling in digital and AI-related competencies across EU member states.",
+      "funding_type_en": "Grant / Co-funding",
+      "funding_rate_en": "Varies by country and programme (typically 50-85%)",
+      "max_amount_en": "Typically up to several hundred thousand euros per project",
+      "target_groups_en": ["SMEs", "Education providers", "Public sector", "Training organisations"],
+      "ai_relevance_en": "Medium",
+      "notes_en": "Implemented through national/regional programmes. Contact national ESF managing authority for specific calls.",
+      "priority": 2
+    },
+    {
+      "id": "innovfin_eib",
+      "name_en": "InnovFin / EIB Innovation Finance",
+      "summary_en": "European Investment Bank instruments providing loans, guarantees, and equity for innovative companies, including AI and digital technology ventures.",
+      "funding_type_en": "Loan / Guarantee / Equity",
+      "funding_rate_en": "Favourable interest rates and terms",
+      "max_amount_en": "From €25k (via intermediaries) to €50m+ (direct)",
+      "target_groups_en": ["Innovative SMEs", "Mid-caps", "Large enterprises"],
+      "ai_relevance_en": "Medium",
+      "notes_en": "Access typically through local financial intermediaries. Direct EIB financing for larger amounts.",
+      "priority": 3
+    },
+    {
+      "id": "eurostars",
+      "name_en": "Eurostars",
+      "summary_en": "Joint programme supporting international collaborative R&D projects led by innovative SMEs. Covers all technology areas including AI and digitalisation.",
+      "funding_type_en": "Grant",
+      "funding_rate_en": "Up to 50-70% (varies by national funding body)",
+      "max_amount_en": "Typically €500k-€2m total project cost",
+      "target_groups_en": ["Innovative SMEs", "Research partners"],
+      "ai_relevance_en": "Medium-High",
+      "notes_en": "Requires partners from at least 2 Eurostars countries. SME must lead the consortium.",
+      "priority": 2
+    },
+    {
+      "id": "interreg",
+      "name_en": "Interreg (European Territorial Cooperation)",
+      "summary_en": "Supports cross-border, transnational and interregional cooperation projects, including digital transformation and smart specialisation initiatives.",
+      "funding_type_en": "Grant / Co-funding",
+      "funding_rate_en": "Up to 70-85% (depending on programme and region)",
+      "max_amount_en": "Varies widely by programme (typically €200k-€5m)",
+      "target_groups_en": ["SMEs", "Public authorities", "Research organisations", "Regional clusters"],
+      "ai_relevance_en": "Medium",
+      "notes_en": "Multiple programmes covering different geographic areas. Partners from multiple regions/countries required.",
+      "priority": 3
+    }
+  ]
+}

--- a/gpt_analyze.py
+++ b/gpt_analyze.py
@@ -4169,23 +4169,18 @@ def analyze_briefing(db: Session, briefing_id: int, run_id: str) -> tuple[int, s
 
     # 🎯 KERN-FÖRDERMATRIX 2025/2026: Statischer, size-aware Kern immer einfügen
     # v4.16.0: Enable funding for EN reports when country is DE/Germany
+    # v4.17.0: Phase 2 - Enable EU core funding for EN reports with non-German countries
     report_lang = sections.get("LANG", "de")
     report_country = (answers.get("country") or "").upper()
 
-    # Check if this is an EN report for Germany (enable funding)
+    # Check if this is an EN report for Germany (enable DE funding)
     is_en_germany = (
         report_lang == "en" and
         report_country in ("DE", "GERMANY", "DEUTSCHLAND", "")  # Empty = default to DE
     )
 
-    if report_lang == "en" and not is_en_germany:
-        # EN report for non-German country: Skip funding
-        log.info("[%s] 🌐 Skipping funding section for English report (country=%s)", run_id, report_country)
-        sections["FOERDERPROGRAMME_HTML"] = ""
-        sections["FOERDERPOTENZIAL_HTML"] = ""
-        sections["FUNDING_HTML"] = ""
-    elif report_lang == "en" and is_en_germany:
-        # EN report for Germany: Enable funding with dedicated EN service
+    if report_lang == "en" and is_en_germany:
+        # Phase 1: EN report for Germany - Enable German funding with dedicated EN service
         log.info("[%s] 🌐 Enabling German funding for English report", run_id)
         from services.funding_service_en import get_funding_for_germany_en, render_funding_html_en
         try:
@@ -4199,19 +4194,50 @@ def analyze_briefing(db: Session, briefing_id: int, run_id: str) -> tuple[int, s
                 sections["FOERDERPOTENZIAL_HTML"] = ""  # Potential section handled by prompt
                 sections["FUNDING_HTML"] = funding_html
                 sections["FUNDING_PROGRAMMES"] = funding_result.programmes  # For Jinja2 template
-                log.info("[%s] ✅ EN funding: %d programmes loaded", run_id, funding_result.programme_count)
+                sections["FUNDING_SCOPE"] = "DE"  # For template title logic
+                log.info("[%s] ✅ EN funding (DE): %d programmes loaded", run_id, funding_result.programme_count)
             else:
-                log.info("[%s] ⚠️ EN funding: No matching programmes found", run_id)
+                log.info("[%s] ⚠️ EN funding (DE): No matching programmes found", run_id)
                 sections["FOERDERPROGRAMME_HTML"] = ""
                 sections["FOERDERPOTENZIAL_HTML"] = ""
                 sections["FUNDING_HTML"] = ""
                 sections["FUNDING_PROGRAMMES"] = []
+                sections["FUNDING_SCOPE"] = ""
         except Exception as e:
             log.warning("[%s] ⚠️ EN funding service error: %s", run_id, e)
             sections["FOERDERPROGRAMME_HTML"] = ""
             sections["FOERDERPOTENZIAL_HTML"] = ""
             sections["FUNDING_HTML"] = ""
             sections["FUNDING_PROGRAMMES"] = []
+            sections["FUNDING_SCOPE"] = ""
+    elif report_lang == "en":
+        # Phase 2: EN report for non-German country - Enable EU core funding
+        log.info("[%s] 🌐 Enabling EU core funding for English report (country=%s)", run_id, report_country)
+        from services.funding_service_en import get_funding_eu_core_en, render_funding_eu_core_html_en
+        try:
+            eu_result = get_funding_eu_core_en(answers)
+            if eu_result.has_programmes:
+                funding_html = render_funding_eu_core_html_en(eu_result, limit=4)
+                sections["FOERDERPROGRAMME_HTML"] = funding_html
+                sections["FOERDERPOTENZIAL_HTML"] = ""
+                sections["FUNDING_HTML"] = funding_html
+                sections["FUNDING_PROGRAMMES_EU_CORE"] = eu_result.programmes  # For Jinja2 template
+                sections["FUNDING_SCOPE"] = "EU_CORE"  # For template title logic
+                log.info("[%s] ✅ EN funding (EU): %d programmes loaded", run_id, eu_result.programme_count)
+            else:
+                log.info("[%s] ⚠️ EN funding (EU): No matching programmes found", run_id)
+                sections["FOERDERPROGRAMME_HTML"] = ""
+                sections["FOERDERPOTENZIAL_HTML"] = ""
+                sections["FUNDING_HTML"] = ""
+                sections["FUNDING_PROGRAMMES_EU_CORE"] = []
+                sections["FUNDING_SCOPE"] = ""
+        except Exception as e:
+            log.warning("[%s] ⚠️ EU core funding service error: %s", run_id, e)
+            sections["FOERDERPROGRAMME_HTML"] = ""
+            sections["FOERDERPOTENZIAL_HTML"] = ""
+            sections["FUNDING_HTML"] = ""
+            sections["FUNDING_PROGRAMMES_EU_CORE"] = []
+            sections["FUNDING_SCOPE"] = ""
     else:
         from services.extra_sections import build_core_funding_table_html
         core_funding_html = build_core_funding_table_html(sections)

--- a/prompts/en/funding_eu_core.md
+++ b/prompts/en/funding_eu_core.md
@@ -1,0 +1,129 @@
+Developer:
+<!-- funding_eu_core.md – v1.0 EU Core Funding for non-German EN reports
+     Target: English-speaking users with companies in EU countries (excluding Germany).
+     Output: Valid HTML only. No Markdown fences.
+
+     STRUCTURE (3 sections):
+       H3 1. EU Core Programmes Overview (Jinja2 loop)
+       H3 2. What This Means for Your Business
+       H3 3. Next Steps
+
+     VARIABLES:
+       - FUNDING_PROGRAMMES_EU_CORE: List of EU programme dicts from funding_service_en.py
+       - {{BRANCHE_LABEL}}, {{UNTERNEHMENSGROESSE_LABEL}}, {{HAUPTLEISTUNG}}
+       - If FUNDING_PROGRAMMES_EU_CORE is empty: provide generic guidance.
+
+     TARGET GROUP LOGIC:
+       startup: EIC Accelerator, EIC Pathfinder, Horizon Europe
+       sme: Digital Europe, Horizon Europe, Eurostars
+       large: Horizon Europe, Digital Europe, InnovFin
+       research: Horizon Europe, EIC Pathfinder
+       public: Digital Europe, ESF+, Interreg
+
+     STYLE:
+       - Professional, factual, cautious language
+       - No guaranteed amounts or rates ("typically", "up to", "varies")
+       - Clear that details vary by call/year
+       - No placeholder text, no "content being created"
+-->
+
+<section class="section funding eu-core">
+  <h2>EU Funding Opportunities</h2>
+
+  <p>
+    The European Union offers several funding programmes that support AI adoption,
+    digitalisation, and innovation across member states. These programmes are
+    generally open to organisations based in EU member states and, in some cases,
+    associated countries.
+  </p>
+
+  <p>
+    For a <strong>{{UNTERNEHMENSGROESSE_LABEL}}</strong> in the
+    <strong>{{BRANCHE_LABEL}}</strong> sector, the following EU-wide programmes
+    may be relevant for your AI initiative:
+  </p>
+
+  <h3>Relevant EU Core Programmes</h3>
+
+  {% if FUNDING_PROGRAMMES_EU_CORE %}
+  <div class="funding-programmes eu-core">
+    {% for p in FUNDING_PROGRAMMES_EU_CORE %}
+    <div class="funding-programme">
+      <h4>{{ p.name_en }}</h4>
+      {% if p.summary_en %}
+      <p class="summary">{{ p.summary_en }}</p>
+      {% endif %}
+      <ul class="details">
+        {% if p.funding_type_en %}<li><strong>Funding type:</strong> {{ p.funding_type_en }}</li>{% endif %}
+        {% if p.funding_rate_en %}<li><strong>Typical co-funding rate:</strong> {{ p.funding_rate_en }}</li>{% endif %}
+        {% if p.max_amount_en %}<li><strong>Typical amount:</strong> {{ p.max_amount_en }}</li>{% endif %}
+        {% if p.target_groups_en %}<li><strong>Target groups:</strong> {{ p.target_groups_en | join(', ') }}</li>{% endif %}
+        {% if p.ai_relevance_en %}<li><strong>AI relevance:</strong> {{ p.ai_relevance_en }}</li>{% endif %}
+      </ul>
+      {% if p.notes_en %}
+      <p class="notes"><em>{{ p.notes_en }}</em></p>
+      {% endif %}
+    </div>
+    {% endfor %}
+  </div>
+  {% else %}
+  <p>
+    At this point, there are no specific EU core programmes we can confidently
+    recommend based on your profile. We suggest consulting your national
+    innovation agency or the EU Funding &amp; Tenders Portal for current
+    opportunities in your sector.
+  </p>
+  {% endif %}
+
+  <h3>What This Means for Your Business</h3>
+  <p>
+    EU funding programmes can significantly reduce the financial risk of AI and
+    digitalisation projects. Depending on the programme and your organisation type,
+    co-funding rates typically range from <strong>50% to 100%</strong> of eligible costs.
+  </p>
+  <ul>
+    <li>
+      <strong>Startups &amp; scale-ups:</strong> The EIC Accelerator offers both
+      grants and equity investment for high-impact innovation projects.
+    </li>
+    <li>
+      <strong>SMEs:</strong> Horizon Europe, Digital Europe, and Eurostars provide
+      collaborative funding opportunities, often requiring consortium partnerships.
+    </li>
+    <li>
+      <strong>Research collaborations:</strong> Partnering with universities or
+      research institutes can open access to additional funding streams.
+    </li>
+  </ul>
+  <p>
+    Note that most EU programmes require a clearly defined project scope,
+    measurable objectives, and often cross-border collaboration.
+  </p>
+
+  <h3>Next Steps</h3>
+  <ul>
+    <li>
+      Review the programmes above and identify 1-2 that align with your project
+      scope and organisation profile.
+    </li>
+    <li>
+      Visit the <a href="https://ec.europa.eu/info/funding-tenders/opportunities/portal/" target="_blank">EU Funding &amp; Tenders Portal</a>
+      to check current calls and deadlines.
+    </li>
+    <li>
+      Contact your national contact point (NCP) for guidance on eligibility
+      and application procedures in your country.
+    </li>
+    <li>
+      Consider potential consortium partners if the programme requires
+      cross-border collaboration.
+    </li>
+  </ul>
+
+  <p class="small muted">
+    Note: EU funding programmes have specific eligibility criteria, deadlines,
+    and call-based requirements that vary by year and work programme. The
+    information above provides general guidance based on current programmes
+    and should be verified against official documentation before applying.
+  </p>
+</section>

--- a/services/funding_service_en.py
+++ b/services/funding_service_en.py
@@ -1,8 +1,9 @@
 """
-Funding Service EN - English funding recommendations for Germany-based companies.
+Funding Service EN - English funding recommendations for EN reports.
 
-This module provides English-language funding program recommendations
-for users with companies based in Germany (lang="en", country="DE").
+This module provides English-language funding program recommendations:
+- Phase 1: German programmes for users with companies based in Germany (lang="en", country="DE")
+- Phase 2: EU core programmes for users in other EU countries (lang="en", country != "DE")
 """
 
 import json
@@ -16,10 +17,30 @@ logger = logging.getLogger(__name__)
 
 @dataclass
 class FundingResult:
-    """Result of funding program matching for EN reports."""
+    """Result of funding program matching for EN reports (Germany)."""
 
     programmes: List[Dict[str, Any]] = field(default_factory=list)
     country: str = "DE"
+    language: str = "en"
+    error: Optional[str] = None
+
+    @property
+    def has_programmes(self) -> bool:
+        """Check if any programmes were found."""
+        return len(self.programmes) > 0
+
+    @property
+    def programme_count(self) -> int:
+        """Return number of matched programmes."""
+        return len(self.programmes)
+
+
+@dataclass
+class FundingResultEUCore:
+    """Result of EU core funding program matching for EN reports (non-German countries)."""
+
+    programmes: List[Dict[str, Any]] = field(default_factory=list)
+    country: str = "EU"
     language: str = "en"
     error: Optional[str] = None
 
@@ -266,5 +287,257 @@ def render_funding_html_en(result: FundingResult, limit: int = 5) -> str:
         html_parts.append("</div>")
 
     html_parts.append("</div>")
+
+    return "\n".join(html_parts)
+
+
+# =============================================================================
+# Phase 2: EU Core Funding (for non-German EN reports)
+# =============================================================================
+
+
+def _load_eu_core_funding_data() -> Dict[str, Any]:
+    """Load funding_eu_core_en.json data file."""
+    funding_file = Path(__file__).parent.parent / "data" / "funding" / "funding_eu_core_en.json"
+
+    if not funding_file.exists():
+        logger.warning(f"EU core funding data file not found: {funding_file}")
+        return {"programmes": []}
+
+    try:
+        with open(funding_file, "r", encoding="utf-8") as f:
+            data: Dict[str, Any] = json.load(f)
+            return data
+    except json.JSONDecodeError as e:
+        logger.error(f"Error parsing EU core funding data: {e}")
+        return {"programmes": []}
+    except Exception as e:
+        logger.error(f"Error loading EU core funding data: {e}")
+        return {"programmes": []}
+
+
+def _normalize_target_group(answers: Dict[str, Any]) -> str:
+    """
+    Normalize company profile to EU target group category.
+
+    Returns: 'startup', 'sme', 'large', 'research', or 'public'
+    """
+    company_size = _normalize_company_size(answers)
+
+    # Check for research/academic indicators
+    branche = str(answers.get("branche", answers.get("industry", ""))).lower()
+    if any(kw in branche for kw in ("research", "university", "forschung", "hochschule", "academic")):
+        return "research"
+
+    # Check for public sector
+    if any(kw in branche for kw in ("public", "government", "öffentlich", "behörde", "verwaltung")):
+        return "public"
+
+    # Map company size to EU target groups
+    if company_size == "solo":
+        return "startup"
+    elif company_size == "team":
+        return "sme"  # Small teams typically qualify as SME
+    else:
+        # Check employee count for large enterprise threshold
+        employees = answers.get("mitarbeiter", answers.get("employees", 0))
+        try:
+            emp_count = int(employees) if employees else 0
+        except (ValueError, TypeError):
+            emp_count = 0
+
+        if emp_count > 250:
+            return "large"
+        return "sme"
+
+
+def _match_eu_core_programmes(
+    programmes: List[Dict[str, Any]],
+    target_group: str,
+    ai_focus: bool = True,
+) -> List[Dict[str, Any]]:
+    """
+    Filter and sort EU core programmes based on profile.
+
+    Args:
+        programmes: List of EU funding programmes from JSON
+        target_group: Normalized target group ('startup', 'sme', 'large', 'research', 'public')
+        ai_focus: Whether to prioritize AI-relevant programmes
+
+    Returns:
+        Sorted list of matching programmes
+    """
+    matched: List[Dict[str, Any]] = []
+
+    # Map our target groups to JSON target_groups_en values
+    target_map = {
+        "startup": ["Startups", "Deep-tech startups", "Scale-ups", "High-growth SMEs", "SMEs", "Innovative SMEs"],
+        "sme": ["SMEs", "Innovative SMEs", "Startups", "Scale-ups", "High-growth SMEs", "Mid-caps"],
+        "large": ["Large enterprises", "Mid-caps", "SMEs"],
+        "research": ["Research organisations", "Universities", "Research partners"],
+        "public": ["Public sector", "Public authorities"],
+    }
+
+    allowed_targets = target_map.get(target_group, ["SMEs"])
+
+    for prog in programmes:
+        prog_targets = prog.get("target_groups_en", [])
+
+        # Check if any of our allowed targets match the programme's target groups
+        if not any(t in prog_targets for t in allowed_targets):
+            continue
+
+        matched.append(prog)
+
+    # Sort by priority and AI relevance
+    def sort_key(p: Dict[str, Any]) -> tuple:
+        priority = p.get("priority", 99)
+        relevance_order = {"Very high": 0, "High": 1, "Medium-High": 2, "Medium": 3, "Low": 4}
+        relevance = relevance_order.get(p.get("ai_relevance_en", "Medium"), 3)
+
+        # Boost AI-relevant programmes if ai_focus is True
+        if ai_focus and relevance <= 1:
+            priority -= 1
+
+        return (priority, relevance)
+
+    matched.sort(key=sort_key)
+
+    return matched
+
+
+def get_funding_eu_core_en(answers: Dict[str, Any]) -> FundingResultEUCore:
+    """
+    Get EU core funding recommendations for non-German EN reports.
+
+    This function:
+    1. Loads funding_eu_core_en.json
+    2. Matches programmes based on company type and AI relevance
+    3. Returns FundingResultEUCore with EN-language strings
+
+    Args:
+        answers: Dictionary containing user answers with keys like:
+            - unternehmensgroesse / company_size
+            - branche / industry
+            - mitarbeiter / employees
+            - country
+
+    Returns:
+        FundingResultEUCore with matched programmes and metadata
+    """
+    try:
+        # Get country from answers
+        country = str(answers.get("country", "EU")).upper()
+
+        # Load EU core funding data
+        data = _load_eu_core_funding_data()
+        programmes = data.get("programmes", [])
+
+        if not programmes:
+            logger.warning("No EU core funding programmes found in data file")
+            return FundingResultEUCore(
+                programmes=[],
+                country=country,
+                language="en",
+                error="No EU funding programmes available",
+            )
+
+        # Determine target group
+        target_group = _normalize_target_group(answers)
+
+        # Check if project has AI focus (default True for this service)
+        ai_focus = True
+
+        # Match programmes
+        matched = _match_eu_core_programmes(
+            programmes=programmes,
+            target_group=target_group,
+            ai_focus=ai_focus,
+        )
+
+        logger.info(
+            f"EU Core funding match: target={target_group}, country={country}, "
+            f"found={len(matched)} programmes"
+        )
+
+        return FundingResultEUCore(
+            programmes=matched,
+            country=country,
+            language="en",
+            error=None,
+        )
+
+    except Exception as e:
+        logger.error(f"Error in get_funding_eu_core_en: {e}")
+        return FundingResultEUCore(
+            programmes=[],
+            country=str(answers.get("country", "EU")).upper(),
+            language="en",
+            error=str(e),
+        )
+
+
+def render_funding_eu_core_html_en(result: FundingResultEUCore, limit: int = 4) -> str:
+    """
+    Render EU core funding programmes as HTML for EN reports.
+
+    Args:
+        result: FundingResultEUCore from get_funding_eu_core_en()
+        limit: Maximum number of programmes to render (default 4)
+
+    Returns:
+        HTML string for embedding in report
+    """
+    if not result.has_programmes:
+        return ""
+
+    programmes = result.programmes[:limit]
+    html_parts: List[str] = ['<div class="funding-programmes eu-core">']
+
+    for prog in programmes:
+        name = prog.get("name_en", "Unknown Programme")
+        summary = prog.get("summary_en", "")
+        funding_type = prog.get("funding_type_en", "")
+        funding_rate = prog.get("funding_rate_en", "")
+        max_amount = prog.get("max_amount_en", "")
+        target_groups = prog.get("target_groups_en", [])
+        ai_relevance = prog.get("ai_relevance_en", "")
+        notes = prog.get("notes_en", "")
+
+        html_parts.append('<div class="funding-programme">')
+        html_parts.append(f'  <h4>{name}</h4>')
+
+        if summary:
+            html_parts.append(f'  <p class="summary">{summary}</p>')
+
+        html_parts.append('  <ul class="details">')
+        if funding_type:
+            html_parts.append(f"    <li><strong>Funding type:</strong> {funding_type}</li>")
+        if funding_rate:
+            html_parts.append(f"    <li><strong>Typical co-funding rate:</strong> {funding_rate}</li>")
+        if max_amount:
+            html_parts.append(f"    <li><strong>Typical amount:</strong> {max_amount}</li>")
+        if target_groups:
+            targets_str = ", ".join(target_groups)
+            html_parts.append(f"    <li><strong>Target groups:</strong> {targets_str}</li>")
+        if ai_relevance:
+            html_parts.append(f"    <li><strong>AI relevance:</strong> {ai_relevance}</li>")
+        html_parts.append("  </ul>")
+
+        if notes:
+            html_parts.append(f'  <p class="notes"><em>{notes}</em></p>')
+
+        html_parts.append("</div>")
+
+    html_parts.append("</div>")
+
+    # Add disclaimer
+    html_parts.append('<p class="funding-disclaimer small muted">')
+    html_parts.append(
+        "Note: EU funding programmes have varying deadlines, eligibility criteria, and call-specific "
+        "requirements. The information above provides general guidance. Please consult official "
+        "programme documentation and national contact points for current opportunities."
+    )
+    html_parts.append("</p>")
 
     return "\n".join(html_parts)

--- a/templates/pdf_template_en.html
+++ b/templates/pdf_template_en.html
@@ -1697,23 +1697,33 @@
                 <section class="chapter">
                     {{RECOMMENDATIONS_HTML}}
                 </section>
-                <!-- FUNDING SECTION - Enabled for EN reports with country=Germany -->
-                {% if FOERDERPOTENZIAL_HTML or FUNDING_HTML %}
+                <!-- FUNDING SECTION - Enabled for EN reports (DE funding or EU core funding) -->
+                {% if FUNDING_HTML %}
                 <section class="section chapter">
                     <div class="section-header">
                         <div class="section-title">
                             <span class="section-kicker">Financial Support</span>
+                            {% if FUNDING_SCOPE == "DE" %}
                             <h2>Funding Opportunities (Germany)</h2>
+                            {% elif FUNDING_SCOPE == "EU_CORE" %}
+                            <h2>EU Funding Opportunities</h2>
+                            {% else %}
+                            <h2>Funding Opportunities</h2>
+                            {% endif %}
                         </div>
                         <span class="section-pill">
                             <span class="pill-dot"></span>
+                            {% if FUNDING_SCOPE == "DE" %}
                             German grant programs for your profile
+                            {% elif FUNDING_SCOPE == "EU_CORE" %}
+                            EU-wide programmes for AI &amp; digitalisation
+                            {% else %}
+                            Relevant funding programmes
+                            {% endif %}
                         </span>
                     </div>
                     <div class="section-body">
-                        {% if FUNDING_HTML %}
                         {{FUNDING_HTML}}
-                        {% endif %}
                         {% if FOERDERPOTENZIAL_HTML %}
                         {{FOERDERPOTENZIAL_HTML}}
                         {% endif %}


### PR DESCRIPTION
…e 2)

- Create data/funding/funding_eu_core_en.json with EU programmes (Horizon Europe, Digital Europe, EIC Accelerator, ESF+, etc.)
- Add FundingResultEUCore, get_funding_eu_core_en(), render_funding_eu_core_html_en() to services/funding_service_en.py
- Update gpt_analyze.py routing:
  - EN + Germany = German funding (Phase 1)
  - EN + other countries = EU core funding (Phase 2)
  - DE reports remain unchanged
- Create prompts/en/funding_eu_core.md with Jinja2 template
- Update pdf_template_en.html with FUNDING_SCOPE logic for dynamic titles