### PR TITLE
refactor(validator): cleanup prompts and tune validation rules

### DIFF
--- a/prompts/de/data_readiness.md
+++ b/prompts/de/data_readiness.md
@@ -8,7 +8,7 @@ Developer: <!-- data_readiness.md – v3.0 GOLD STANDARD+ (Daten & Systemreife, 
     * Was ist bereits ausreichend für KI-Piloten?
     * Welche Lücken sollten in den nächsten 6–12 Monaten geschlossen werden?
 
-  VERFÜGBARE VARIABLEN (Labels/Freitexte aus dem Fragebogen):
+  VERFÜGBARE VARIABLEN (Labels/Nutzereingaben aus dem Fragebogen):
   - {{BRANCHE_LABEL}}
   - {{UNTERNEHMENSGROESSE_LABEL}}
   - {{HAUPTLEISTUNG}}

--- a/prompts/de/gamechanger.md
+++ b/prompts/de/gamechanger.md
@@ -42,7 +42,7 @@ Developer:
      MINDESTLÄNGE: 800 Zeichen (ohne HTML-Tags) – unterschreite diese NIEMALS!
 
      VERBOTEN:
-       - "TODO", "Freitextfeld", generische Formulierungen ohne Substanz.
+       - "TODO", Template-Marker, generische Formulierungen ohne Substanz.
        - Gamechanger ohne konkreten Bezug zu {{HAUPTLEISTUNG}}.
        - Bei SOLO: keine "Abteilungen", "Teams", "Bereiche".
 -->

--- a/prompts/de/ki_aktivitaeten_ziele.md
+++ b/prompts/de/ki_aktivitaeten_ziele.md
@@ -18,7 +18,7 @@ Developer:
        - Keine generischen, nicht belegten IST-Aussagen.
        - Keine unrealistischen Ziele.
        - Keine Projekte nennen, die nicht in {{KI_PROJEKTE}} oder {{TOOLS_AKTUELL}} stehen.
-       - Keine Platzhaltertexte („Platzhalter“, „Freitextfeld“, „TODO“).
+       - Keine Platzhaltertexte („Platzhalter", „TODO" oder andere Template-Marker).
 
      IST-REGEL:
        - Wenn ALLE drei Variablen leer sind → statt Tabelle: Text "Noch keine KI-Projekte im Einsatz."

--- a/prompts/de/org_change.md
+++ b/prompts/de/org_change.md
@@ -31,7 +31,7 @@ Developer:
      MINDESTLÄNGE: 700 Zeichen (ohne HTML-Tags) – unterschreite diese NIEMALS!
 
      VERBOTEN:
-       - Platzhalterwörter („Platzhalter", „Freitextfeld", „TODO", …)
+       - Platzhalterwörter („Platzhalter", „TODO", Template-Marker, …)
        - Konzernsprache (Division, Unit) bei KMU
        - Teams/Abteilungen in SOLO
        - generische Aussagen ohne klaren Nutzen

--- a/prompts/de/quick_wins.md
+++ b/prompts/de/quick_wins.md
@@ -1,10 +1,16 @@
 Developer:
 <!--
-  quick_wins.md – v4.0 GOLD STANDARD+
+  quick_wins.md – v4.1 GOLD STANDARD+
   - Size-aware: solo / team / kmu
   - Keine Standardfloskeln, keine Beispieltexte
   - Keine internen Hinweise im sichtbaren Output
   - Output ausschließlich valides HTML
+
+  PFLICHT-ANFORDERUNGEN:
+  - Formuliere mindestens 4 konkrete Quick Wins
+  - Jeder Quick Win: 2–3 Sätze Beschreibung + geschätzte Zeiteinsparung
+  - MINDESTLÄNGE: 300 Zeichen (ohne HTML-Tags)
+  - Bei Solo-Profilen: Fokus auf persönliche Entlastung, keine Teams/Abteilungen
 -->
 
 <section class="section quick-wins">

--- a/prompts/de/strategie_governance.md
+++ b/prompts/de/strategie_governance.md
@@ -39,7 +39,7 @@ Developer:
          - Governance = abgestimmte Struktur über mehrere Bereiche.
 
      VERBOTEN IM HTML-OUTPUT:
-       - "Platzhalter", "Freitextfeld", TODO, technische Systemhinweise.
+       - "Platzhalter", "TODO", Template-Marker, technische Systemhinweise.
        - Kein Verweis auf Variablennamen oder Prompt-Anweisungen.
 -->
 

--- a/prompts/de/tools_empfehlungen.md
+++ b/prompts/de/tools_empfehlungen.md
@@ -31,7 +31,7 @@ Developer:
   STIL & REGELN
   - Schreibe konkret, aber produktneutral (keine Produktnamen).
   - Fokus auf Toolkategorien und ihren Zweck im Prozess {{HAUPTLEISTUNG}}.
-  - Keine Wörter wie "Platzhalter", "Content wird erstellt", "TODO", "Freitextfeld".
+  - Keine Wörter wie "Platzhalter", "Content wird erstellt", "TODO" oder andere Template-Marker.
   - Kein Verweis auf den Prompt oder die Variablen im sichtbaren Text.
   - Output muss alleine lesbar sein, ohne weitere Erklärungen.
 -->

--- a/services/html_sanitizer.py
+++ b/services/html_sanitizer.py
@@ -59,6 +59,22 @@ RE_ON_EVENT_ATTR = re.compile(r"(?i)\s+on[a-z]+\s*=\s*(\"[^\"]*\"|'[^']*')")
 # Daten‑/Sicherheitsfilter: Entferne javascript: URIs in href/src
 RE_JS_PROTOCOL = re.compile(r"(?is)(\s(?:href|src)\s*=\s*['\"])\s*javascript:[^'\"]*(['\"])")
 
+def _cleanup_template_phrases(text: str) -> str:
+    """Entfernt versehentlich eingebettete Template-Phrasen aus dem Output.
+
+    Diese können von GPT trotz Anweisungen übernommen werden.
+    """
+    replacements = [
+        ("Freitextfeld", "Textabschnitt"),
+        ("Freitext-Feld", "Textabschnitt"),
+        ("Freitext-Felder", "Textabschnitte"),
+        ("freitextfeld", "Textabschnitt"),
+    ]
+    for old, new in replacements:
+        text = text.replace(old, new)
+    return text
+
+
 def sanitize_section_html(html_content: Optional[str], compress_ws: bool = True) -> str:
     if not html_content:
         return ""
@@ -66,6 +82,9 @@ def sanitize_section_html(html_content: Optional[str], compress_ws: bool = True)
 
     # ZUERST: Behebe UTF-8 Mojibake (Ã¶ → ö)
     s = _fix_utf8_mojibake(s)
+
+    # Post-Processing: Entferne versehentliche Template-Phrasen
+    s = _cleanup_template_phrases(s)
 
     # Entferne Dokument‑Wrapper & kritische Blöcke
     s = RE_DOCTYPES.sub("", s)

--- a/services/report_validator.py
+++ b/services/report_validator.py
@@ -141,7 +141,7 @@ class ReportValidator:
             "Abteilung",
             "HR-Abteilung",
             "IT-Abteilung",
-            "Organisationsberater",
+            # "Organisationsberater" removed - valid for solo organizational consultants
             "Change-Team",
             "Projektmanagement-Office",
         ],
@@ -156,7 +156,7 @@ class ReportValidator:
     MIN_SECTION_LENGTH_WORDS = {
         "executive_summary": 100,      # ~600 Zeichen
         "business_case": 130,          # ~800 Zeichen
-        "quick_wins": 80,              # ~500 Zeichen
+        "quick_wins": 60,              # ~350 Zeichen (pragmatisch für Solo-Profile)
         "roadmap_90d": 120,            # ~700 Zeichen
         "roadmap_12m": 800,            # PLATIN+: Prompt fordert 900, Validator prüft 800 (Sicherheitsmarge)
         "strategie_governance": 130,   # ~800 Zeichen

--- a/tests/test_platin_sections_valid.py
+++ b/tests/test_platin_sections_valid.py
@@ -141,7 +141,7 @@ class TestSizeMismatchDetection:
         "Mitarbeiter einstellen",
         "HR-Abteilung",
         "IT-Abteilung",
-        "Organisationsberater",
+        # "Organisationsberater" removed - valid for solo organizational consultants
         "Change-Team",
     ]
 


### PR DESCRIPTION
Prompt-Cleanup + Validator-Feinjustierung Sprint:

1. Prompt Cleanup:
   - Remove "Freitextfeld" from all DE prompts (6 files)
   - Replace with "Template-Marker" in VERBOTEN sections
   - Update data_readiness.md to use "Nutzereingaben"

2. Quick Wins Validation:
   - Reduce minimum word count from 80 to 60 (pragmatic for Solo)
   - Add PFLICHT-ANFORDERUNGEN to quick_wins.md prompt

3. Size-Mismatch Rule:
   - Remove "Organisationsberater" from SIZE_FORBIDDEN["solo"]
   - Valid term for solo organizational consultants

4. Post-Processing Safety Net:
   - Add _cleanup_template_phrases() to html_sanitizer.py
   - Auto-replaces "Freitextfeld" with "Textabschnitt"
   - Applied during sanitize_section_html()

QA verified: All changes pass validation tests.