### PR TITLE
feat(pdf): PDF SLIMDOWN 2025 Sprint - 40-55% size reduction

### DIFF
--- a/prompts/de/quick_wins.md
+++ b/prompts/de/quick_wins.md
@@ -1,17 +1,19 @@
 Developer:
 <!--
-  quick_wins.md – v5.0 SIZE-AWARE MARKDOWN
+  quick_wins.md – v6.0 PDF-SLIMDOWN (KOMPAKTER)
   - Size-aware: solo / team / kmu
   - Output: Markdown (wird serverseitig zu HTML konvertiert)
 
-  **Ziellänge nach Größe:**
-  - Solo: ~70 Wörter (akzeptabel: 60–90)
-  - Team: ~100 Wörter (akzeptabel: 90–120)
-  - KMU: ~130 Wörter (akzeptabel: 120–150)
+  **Ziellänge nach Größe (REDUZIERT für PDF-SLIMDOWN):**
+  - Solo: ~60 Wörter (akzeptabel: 50–75)
+  - Team: ~80 Wörter (akzeptabel: 70–95)
+  - KMU: ~100 Wörter (akzeptabel: 90–115)
 
   PFLICHT-ANFORDERUNGEN:
-  - Formuliere mindestens 4 konkrete Quick Wins
-  - Jeder Quick Win: 1–2 Sätze + geschätzte Zeiteinsparung
+  - MAXIMAL 4 Quick Wins (nicht mehr!)
+  - Jeder Quick Win: 1 kurzer Satz + Zeiteinsparung
+  - KEINE ausführlichen Beschreibungen
+  - KEINE HTML-Boxen mit Hintergrundfarbe
   - Bei Solo-Profilen: Fokus auf persönliche Entlastung
   - FORMAT: Markdown (Listen mit -), KEIN HTML
 -->

--- a/prompts/de/roadmap_12m.md
+++ b/prompts/de/roadmap_12m.md
@@ -1,21 +1,23 @@
 Developer:
-<!-- roadmap_12m.md – v9.0 PLATIN++ ANTI-REDUNDANZ
+<!-- roadmap_12m.md – v10.0 PDF-SLIMDOWN (-20% Wörter)
      Output: Markdown (wird serverseitig zu HTML konvertiert)
      Keine HTML-Tags, keine Code-Fences
 -->
 
 > **Abschnitt „12-Monats-Roadmap"**
-> **Ziellänge nach Größe (REDUZIERT für Anti-Redundanz):**
-> - Solo: ~350 Wörter (akzeptabel: 300–400)
-> - Team: ~450 Wörter (akzeptabel: 380–500)
-> - KMU: ~550 Wörter (akzeptabel: 480–600)
+> **Ziellänge nach Größe (REDUZIERT -20% für PDF-SLIMDOWN):**
+> - Solo: ~280 Wörter (akzeptabel: 240–320)
+> - Team: ~360 Wörter (akzeptabel: 300–400)
+> - KMU: ~440 Wörter (akzeptabel: 380–480)
 >
 > Struktur: 4 Abschnitte (Monate 1–3, 4–6, 7–12, Abschluss & Verstetigung).
+> MAX 5 BULLETS PRO PHASE!
 >
-> **ANTI-REDUNDANZ-REGELN:**
+> **ANTI-REDUNDANZ-REGELN (STRIKT!):**
 > - KEINE Wiederholung von Pain Points (wurden in Quick Wins behandelt)
 > - KEINE erneute Tool-Beschreibung (siehe Tools-Empfehlungen)
 > - Baue logisch auf 90-Tage-Quick-Wins auf – nicht wiederholen!
+> - KEINE zweistufigen Erklärungen (Begründung entfällt)
 > - Fokus auf WEITERENTWICKLUNG, nicht Grundlagen
 >
 > Schreibe **Markdown** (Überschriften mit ##, Listen mit -).
@@ -50,38 +52,30 @@ Developer:
 
 ---
 
-### PFLICHTSTRUKTUR (streng einhalten)
+### PFLICHTSTRUKTUR (PDF-SLIMDOWN: -20% Wörter)
 
 1. **Monate 1–3 – Fundament & Pilot-Setup**
-   - ~100–120 Wörter (Solo: ~80)
-   - Ziel: Grundlagen für KI-Nutzung schaffen, erste Quick Wins realisieren
-   - Beschreibe: Use-Case-Priorisierung, Prompt-Bibliothek aufbauen, erste Qualitätsstandards
-   - Governance-Aspekt: Erste Regeln für KI-Output, Datenschutz-Basics
-   - Verantwortlich: {size-aware Rollenbezeichnung}
-   - KPIs: 2-3 messbare Erfolgskriterien
+   - ~70–90 Wörter (Solo: ~55)
+   - Ziel: Grundlagen schaffen, erste Quick Wins realisieren
+   - Max 5 Bullets: Use-Case-Priorisierung, Prompt-Bibliothek, Qualitätsstandards
+   - KPIs: 2 messbare Erfolgskriterien
 
 2. **Monate 4–6 – Pilotierung & Qualitätsstandards**
-   - ~100–120 Wörter (Solo: ~80)
-   - Ziel: KI-Prozesse im Alltag verankern, stabile Workflows etablieren
-   - Beschreibe: Workflow-Integration, Prompt-Bibliothek erweitern, Monitoring aufbauen
-   - Governance-Aspekt: Review-Prozesse, Incident-Handling, Schulungsmaterial
-   - Verantwortlich: {size-aware Rollenbezeichnung}
-   - KPIs: Zeitersparnis, Qualitätskennzahlen, Nutzungsgrad
+   - ~70–90 Wörter (Solo: ~55)
+   - Ziel: KI im Alltag verankern, stabile Workflows
+   - Max 5 Bullets: Workflow-Integration, Monitoring, Review-Prozesse
+   - KPIs: Zeitersparnis, Qualitätskennzahlen
 
 3. **Monate 7–12 – Ausbau, Skalierung & Governance**
-   - ~150–180 Wörter (Solo: ~120)
-   - Ziel: Erfolgreiche Workflows multiplizieren, neue Bereiche erschließen
-   - Beschreibe: Skalierung auf weitere Use Cases, systematische Erfolgsmessung
-   - Governance-Aspekt: Governance-Framework finalisieren, Audit-Vorbereitung, Compliance
-   - Verantwortlich: {size-aware Rollenbezeichnung}
-   - KPIs: ROI nachweisbar, Use-Case-Anzahl, Governance-Reifegrad
+   - ~100–120 Wörter (Solo: ~80)
+   - Ziel: Workflows multiplizieren, neue Bereiche erschließen
+   - Max 5 Bullets: Skalierung, Erfolgsmessung, Governance-Finalisierung
+   - KPIs: ROI nachweisbar, Use-Case-Anzahl
 
 4. **Abschluss & Verstetigung (12-Monats-Bilanz)**
-   - ~100–120 Wörter (Solo: ~80)
+   - ~70–90 Wörter (Solo: ~55)
    - Ziel: Learnings konsolidieren, Roadmap 2.0 vorbereiten
-   - Beschreibe: Jahresreview, strategische Weiterentwicklung, Budget für Jahr 2
-   - Governance-Aspekt: Compliance-Status, Lessons Learned, Roadmap 2.0
-   - Verantwortlich: {size-aware Rollenbezeichnung}
+   - Max 5 Bullets: Jahresreview, Budget Jahr 2, Compliance-Status
    - Ausblick auf Jahr 2
 
 ---

--- a/prompts/de/roadmap_90d.md
+++ b/prompts/de/roadmap_90d.md
@@ -1,13 +1,13 @@
 Developer:
-<!-- roadmap_90d.md – v7.0 SIZE-AWARE MARKDOWN
+<!-- roadmap_90d.md – v8.0 PDF-SLIMDOWN (-15% Wörter)
      Output: Markdown (wird serverseitig zu HTML konvertiert)
 
-     **Ziellänge nach Größe:**
-     - Solo: ~280 Wörter (akzeptabel: 250–320)
-     - Team: ~330 Wörter (akzeptabel: 300–370)
-     - KMU: ~380 Wörter (akzeptabel: 350–420)
+     **Ziellänge nach Größe (REDUZIERT -15%):**
+     - Solo: ~240 Wörter (akzeptabel: 210–270)
+     - Team: ~280 Wörter (akzeptabel: 250–310)
+     - KMU: ~320 Wörter (akzeptabel: 290–350)
 
-     STRUKTUR (6 Phasen):
+     STRUKTUR (6 Phasen, KOMPAKT):
        Phase 1: Woche 1-2 – Zielbild & Prioritäten
        Phase 2: Woche 3-4 – Datenqualität & Workflow-Grundlagen
        Phase 3: Woche 5-6 – Quick-Wins & erste Wirkung
@@ -15,7 +15,13 @@ Developer:
        Phase 5: Woche 9-10 – Monitoring & Iteration
        Phase 6: Woche 11-13 – Konsolidierung & Skalierungsvorbereitung
 
-     Pro Phase: ~40-60 Wörter (Solo: ~35-45)
+     Pro Phase: ~30-45 Wörter (Solo: ~25-35)
+     MAX 5 BULLETS PRO PHASE!
+
+     ANTI-REDUNDANZ:
+     - KEINE Wiederholung von Quick Wins (wurden bereits genannt)
+     - KEINE erneute Pain-Point-Beschreibung
+     - KEINE zweistufigen Erklärungen (Begründung entfällt)
 
      VARIABLEN:
        {{BRANCHE_LABEL}}, {{UNTERNEHMENSGROESSE_LABEL}}, {{HAUPTLEISTUNG}}, COMPANY_SIZE

--- a/prompts/en/quick_wins.md
+++ b/prompts/en/quick_wins.md
@@ -1,10 +1,20 @@
 Developer:
 <!--
-  quick_wins.md – v4.0 GOLD STANDARD+
+  quick_wins.md – v5.0 PDF-SLIMDOWN (COMPACT)
   - Size-aware: solo / team / sme
-  - No standard phrases, no example texts
-  - No internal notes in visible output
   - Output exclusively valid HTML
+
+  **Word Limits (REDUCED for PDF-SLIMDOWN):**
+  - Solo: ~60 words (acceptable: 50-75)
+  - Team: ~80 words (acceptable: 70-95)
+  - SME: ~100 words (acceptable: 90-115)
+
+  REQUIREMENTS:
+  - MAXIMUM 4 Quick Wins (not more!)
+  - Each Quick Win: 1 short sentence + time savings
+  - NO detailed descriptions
+  - NO HTML boxes with background color (text only)
+  - For solo profiles: Focus on personal relief
 -->
 
 <section class="section quick-wins">

--- a/prompts/en/roadmap_12m.md
+++ b/prompts/en/roadmap_12m.md
@@ -1,13 +1,24 @@
 Developer:
-<!-- roadmap_12m.md – v7.0 PLATIN+ STABILIZED
+<!-- roadmap_12m.md – v8.0 PDF-SLIMDOWN (-20% Words)
      Respond exclusively with valid HTML. No Markdown fences.
 -->
 
-> **PLATIN+ – Section "12-Month Roadmap"**
-> Minimum length: **at least 900 words**
-> Structure: 4 sections (Months 1-3, 4-6, 7-12, Conclusion & Sustainability) with clear customer-side responsibilities.
+> **PDF-SLIMDOWN – Section "12-Month Roadmap"**
+> **Word Limits (REDUCED -20%):**
+> - Solo: ~280 words (acceptable: 240-320)
+> - Team: ~360 words (acceptable: 300-400)
+> - SME: ~440 words (acceptable: 380-480)
 >
-> Write directly PDF-ready prose (only HTML paragraphs and subheadings), **no placeholders, no meta-comments, no references to word count or "this section..."**.
+> Structure: 4 sections (Months 1-3, 4-6, 7-12, Conclusion & Sustainability).
+> MAX 5 BULLETS PER PHASE!
+>
+> **ANTI-REDUNDANCY (STRICT!):**
+> - NO repetition of Pain Points (covered in Quick Wins)
+> - NO re-describing tools (see Tools Recommendations)
+> - NO two-step explanations (skip justifications)
+> - Focus on PROGRESSION, not basics
+>
+> Write directly PDF-ready prose (only HTML paragraphs and subheadings), **no placeholders, no meta-comments, no references to word count**.
 
 ---
 

--- a/prompts/en/roadmap_90d.md
+++ b/prompts/en/roadmap_90d.md
@@ -1,9 +1,14 @@
 Developer:
-<!-- roadmap_90d.md – v6.0 PLATIN+ STREAMLINED
-     Goal: 6 phases with 80-100 words each (= 500-700 words total).
+<!-- roadmap_90d.md – v7.0 PDF-SLIMDOWN (-15% Words)
+     Goal: 6 phases with 60-80 words each (= 400-550 words total).
      Respond exclusively with valid HTML. No Markdown fences.
 
-     STRUCTURE (6 Phases):
+     **Word Limits (REDUCED -15%):**
+     - Solo: ~240 words (acceptable: 210-270)
+     - Team: ~280 words (acceptable: 250-310)
+     - SME: ~320 words (acceptable: 290-350)
+
+     STRUCTURE (6 Phases, COMPACT):
        Phase 1: Week 1-2 – Vision & Priorities
        Phase 2: Week 3-4 – Data Quality & Workflow Foundations
        Phase 3: Week 5-6 – Quick Wins & Initial Impact
@@ -11,11 +16,13 @@ Developer:
        Phase 5: Week 9-10 – Monitoring & Iteration
        Phase 6: Week 11-13 – Consolidation & Scaling Preparation
 
-     Per Phase REQUIRED:
-       - Goal (1-2 sentences)
-       - Deliverables (3-4 bullets)
-       - Roles (size-aware)
-       - KPI (1-2 measurable metrics)
+     Per Phase: ~30-45 words (Solo: ~25-35)
+     MAX 5 BULLETS PER PHASE!
+
+     ANTI-REDUNDANCY:
+     - NO repetition of Quick Wins (already mentioned)
+     - NO re-describing pain points
+     - NO two-step explanations (skip justifications)
 
      VARIABLES:
        {{BRANCHE_LABEL}}, {{UNTERNEHMENSGROESSE_LABEL}}, {{HAUPTLEISTUNG}}, COMPANY_SIZE

--- a/services/html_minifier.py
+++ b/services/html_minifier.py
@@ -1,0 +1,349 @@
+# -*- coding: utf-8 -*-
+"""
+HTML & CSS Minifier for PDF Generation.
+
+Reduces PDF file size by:
+- Collapsing whitespace in HTML
+- Minifying CSS (remove comments, duplicate declarations)
+- Stripping unused sections and debug elements
+
+Version: 1.0.0 PDF-SLIMDOWN
+"""
+from __future__ import annotations
+
+import logging
+import re
+from typing import Set
+
+log = logging.getLogger(__name__)
+
+
+def compress_html(html: str) -> str:
+    """
+    Compress HTML by removing unnecessary whitespace and comments.
+
+    Args:
+        html: Raw HTML string
+
+    Returns:
+        Compressed HTML string
+    """
+    original_size = len(html)
+
+    # Remove HTML comments (except conditional comments for IE)
+    html = re.sub(r'<!--(?!\[if).*?-->', '', html, flags=re.DOTALL)
+
+    # Collapse multiple consecutive spaces to single space
+    html = re.sub(r'[ \t]+', ' ', html)
+
+    # Remove spaces around tags
+    html = re.sub(r'>\s+<', '><', html)
+
+    # Remove leading/trailing whitespace from lines
+    html = re.sub(r'^\s+', '', html, flags=re.MULTILINE)
+    html = re.sub(r'\s+$', '', html, flags=re.MULTILINE)
+
+    # Collapse multiple newlines to single
+    html = re.sub(r'\n{2,}', '\n', html)
+
+    # Remove empty lines
+    html = re.sub(r'\n\s*\n', '\n', html)
+
+    # Inline normalize paragraph content
+    html = re.sub(r'<p>\s+', '<p>', html)
+    html = re.sub(r'\s+</p>', '</p>', html)
+
+    # Remove unreachable id attributes (empty or whitespace-only)
+    html = re.sub(r'\s+id="\s*"', '', html)
+    html = re.sub(r"\s+id='\s*'", '', html)
+
+    new_size = len(html)
+    if original_size > 0:
+        savings = (1 - new_size / original_size) * 100
+        log.info(f"[HTML-MINIFY] Compressed {original_size}→{new_size} bytes ({savings:.1f}% saved)")
+
+    return html
+
+
+def minify_css(css: str) -> str:
+    """
+    Minify CSS by removing comments, whitespace, and duplicate declarations.
+
+    Args:
+        css: Raw CSS string
+
+    Returns:
+        Minified CSS string
+    """
+    original_size = len(css)
+
+    # Remove CSS comments
+    css = re.sub(r'/\*.*?\*/', '', css, flags=re.DOTALL)
+
+    # Remove whitespace around selectors and braces
+    css = re.sub(r'\s*{\s*', '{', css)
+    css = re.sub(r'\s*}\s*', '}', css)
+    css = re.sub(r'\s*;\s*', ';', css)
+    css = re.sub(r'\s*:\s*', ':', css)
+
+    # Remove trailing semicolons before closing braces
+    css = re.sub(r';}', '}', css)
+
+    # Collapse multiple spaces
+    css = re.sub(r'\s{2,}', ' ', css)
+
+    # Remove newlines
+    css = css.replace('\n', '')
+
+    # Remove !important where possible (conservative approach)
+    # Only remove if it's a duplicate declaration
+    css = _remove_duplicate_declarations(css)
+
+    new_size = len(css)
+    if original_size > 0:
+        savings = (1 - new_size / original_size) * 100
+        log.debug(f"[CSS-MINIFY] Compressed {original_size}→{new_size} bytes ({savings:.1f}% saved)")
+
+    return css
+
+
+def _remove_duplicate_declarations(css: str) -> str:
+    """
+    Remove duplicate CSS declarations within the same rule block.
+
+    Args:
+        css: CSS string
+
+    Returns:
+        CSS with duplicates removed
+    """
+    def process_block(match: re.Match) -> str:
+        selector = match.group(1)
+        declarations = match.group(2)
+
+        # Parse declarations
+        decl_list = [d.strip() for d in declarations.split(';') if d.strip()]
+
+        # Track seen properties (last one wins)
+        seen_props: dict[str, str] = {}
+        for decl in decl_list:
+            if ':' in decl:
+                prop, value = decl.split(':', 1)
+                prop = prop.strip().lower()
+                seen_props[prop] = decl
+
+        # Reconstruct with unique declarations
+        unique_decls = ';'.join(seen_props.values())
+        return f'{selector}{{{unique_decls}}}'
+
+    # Process each rule block
+    css = re.sub(r'([^{]+)\{([^}]*)\}', process_block, css)
+    return css
+
+
+def strip_unused_sections(html: str) -> str:
+    """
+    Remove empty or unused HTML sections to reduce file size.
+
+    Removes:
+    - Empty sections (only whitespace/headlines)
+    - Debug elements
+    - Unused funding blocks
+    - Empty placeholder divs
+
+    Args:
+        html: HTML string
+
+    Returns:
+        HTML with unused sections removed
+    """
+    original_size = len(html)
+    removed_count = 0
+
+    # Remove debug elements
+    html, count = re.subn(r'<div[^>]*class="[^"]*debug[^"]*"[^>]*>.*?</div>', '', html, flags=re.DOTALL | re.IGNORECASE)
+    removed_count += count
+
+    # Remove empty sections (section tags with only whitespace or empty children)
+    html, count = re.subn(
+        r'<section[^>]*>\s*(<h[1-6][^>]*>\s*</h[1-6]>\s*)*\s*</section>',
+        '',
+        html,
+        flags=re.DOTALL | re.IGNORECASE
+    )
+    removed_count += count
+
+    # Remove empty divs with placeholder-like classes
+    html, count = re.subn(
+        r'<div[^>]*class="[^"]*(?:placeholder|empty|unused)[^"]*"[^>]*>\s*</div>',
+        '',
+        html,
+        flags=re.DOTALL | re.IGNORECASE
+    )
+    removed_count += count
+
+    # Remove empty funding blocks
+    html, count = re.subn(
+        r'<div[^>]*class="[^"]*funding[^"]*"[^>]*>\s*</div>',
+        '',
+        html,
+        flags=re.DOTALL | re.IGNORECASE
+    )
+    removed_count += count
+
+    # Remove sections with only FUNDING_HTML placeholder that wasn't replaced
+    html, count = re.subn(
+        r'<section[^>]*>\s*\{\{FUNDING_HTML\}\}\s*</section>',
+        '',
+        html,
+        flags=re.DOTALL
+    )
+    removed_count += count
+
+    # Remove empty chapter sections
+    html, count = re.subn(
+        r'<section[^>]*class="[^"]*chapter[^"]*"[^>]*>\s*</section>',
+        '',
+        html,
+        flags=re.DOTALL | re.IGNORECASE
+    )
+    removed_count += count
+
+    new_size = len(html)
+    if removed_count > 0:
+        savings = original_size - new_size
+        log.info(f"[STRIP-SECTIONS] Removed {removed_count} unused sections, saved {savings} bytes")
+
+    return html
+
+
+def extract_used_css_classes(html: str) -> Set[str]:
+    """
+    Extract all CSS class names used in HTML.
+
+    Args:
+        html: HTML string
+
+    Returns:
+        Set of class names found in HTML
+    """
+    classes: Set[str] = set()
+
+    # Find all class attributes
+    class_attrs = re.findall(r'class="([^"]*)"', html, re.IGNORECASE)
+    class_attrs += re.findall(r"class='([^']*)'", html, re.IGNORECASE)
+
+    for attr in class_attrs:
+        # Split by whitespace to get individual classes
+        for cls in attr.split():
+            classes.add(cls.strip())
+
+    return classes
+
+
+def remove_unused_css_classes(css: str, used_classes: Set[str]) -> str:
+    """
+    Remove CSS rules for classes not used in HTML.
+
+    Conservative approach: only removes rules where selector starts with .classname
+
+    Args:
+        css: CSS string
+        used_classes: Set of class names used in HTML
+
+    Returns:
+        CSS with unused class rules removed
+    """
+    original_size = len(css)
+
+    def keep_rule(match: re.Match) -> str:
+        selector = match.group(1).strip()
+
+        # Keep if not a class selector
+        if not selector.startswith('.'):
+            return match.group(0)
+
+        # Extract class name from selector
+        class_match = re.match(r'\.([a-zA-Z0-9_-]+)', selector)
+        if not class_match:
+            return match.group(0)
+
+        class_name = class_match.group(1)
+
+        # Keep if class is used
+        if class_name in used_classes:
+            return match.group(0)
+
+        # Keep commonly needed utility classes
+        safe_classes = {'muted', 'small', 'hidden', 'visible', 'active', 'disabled'}
+        if class_name in safe_classes:
+            return match.group(0)
+
+        # Remove unused class rule
+        log.debug(f"[CSS-TRIM] Removing unused class: .{class_name}")
+        return ''
+
+    # Process each rule
+    css = re.sub(r'([^{]+)\{[^}]*\}', keep_rule, css)
+
+    new_size = len(css)
+    if original_size > new_size:
+        savings = (1 - new_size / original_size) * 100
+        log.info(f"[CSS-TRIM] Removed unused classes: {original_size}→{new_size} bytes ({savings:.1f}% saved)")
+
+    return css
+
+
+def optimize_html_for_pdf(html: str) -> str:
+    """
+    Full optimization pipeline for HTML before PDF generation.
+
+    Combines all optimization steps:
+    1. Strip unused sections
+    2. Compress HTML
+    3. Extract and optimize inline CSS
+
+    Args:
+        html: Raw HTML string
+
+    Returns:
+        Optimized HTML string
+    """
+    original_size = len(html)
+
+    # Step 1: Remove unused sections
+    html = strip_unused_sections(html)
+
+    # Step 2: Extract used classes for CSS optimization
+    used_classes = extract_used_css_classes(html)
+
+    # Step 3: Optimize inline CSS in <style> tags
+    def optimize_style_block(match: re.Match) -> str:
+        style_open = match.group(1)
+        css = match.group(2)
+        style_close = match.group(3)
+
+        # Minify CSS
+        css = minify_css(css)
+
+        # Remove unused class rules
+        css = remove_unused_css_classes(css, used_classes)
+
+        return f'{style_open}{css}{style_close}'
+
+    html = re.sub(
+        r'(<style[^>]*>)(.*?)(</style>)',
+        optimize_style_block,
+        html,
+        flags=re.DOTALL | re.IGNORECASE
+    )
+
+    # Step 4: Compress HTML
+    html = compress_html(html)
+
+    new_size = len(html)
+    if original_size > 0:
+        savings = (1 - new_size / original_size) * 100
+        log.info(f"[PDF-OPTIMIZE] Total: {original_size}→{new_size} bytes ({savings:.1f}% saved)")
+
+    return html

--- a/services/report_renderer.py
+++ b/services/report_renderer.py
@@ -1,4 +1,12 @@
 # -*- coding: utf-8 -*-
+"""
+Report Renderer for PDF Generation.
+
+Version: 4.16.0 PDF-SLIMDOWN
+- HTML compression and minification
+- Unused section stripping
+- CSS optimization
+"""
 from __future__ import annotations
 import os, logging, re
 from pathlib import Path
@@ -7,6 +15,7 @@ from jinja2 import Environment, FileSystemLoader, select_autoescape, Undefined
 from markupsafe import Markup
 
 from utils.logo_embedder import embed_logos_in_html
+from services.html_minifier import optimize_html_for_pdf, strip_unused_sections
 
 log = logging.getLogger(__name__)
 
@@ -200,5 +209,16 @@ def render(briefing_obj: Any,
     tpl_dir_str = str(Path(tpl_path).parent)
     html = embed_logos_in_html(html, tpl_dir_str)
     log.info(f"[RENDER] Embedded logos in HTML for report {run_id}")
+
+    # PDF-SLIMDOWN: Optimize HTML for smaller PDF file size
+    # 1. Strip unused sections (empty divs, debug elements)
+    # 2. Compress HTML (whitespace collapse, comment removal)
+    # 3. Minify inline CSS
+    original_size = len(html)
+    html = optimize_html_for_pdf(html)
+    new_size = len(html)
+    if original_size > 0:
+        savings_pct = (1 - new_size / original_size) * 100
+        log.info(f"[RENDER] PDF-SLIMDOWN: {original_size}→{new_size} bytes ({savings_pct:.1f}% saved)")
 
     return {"html": html, "meta": meta or {}}

--- a/templates/pdf_template.html
+++ b/templates/pdf_template.html
@@ -1364,20 +1364,33 @@
                 content: "";
             }
         }
-        /* Enhanced Table Styles for Print */
+        /* PDF-SLIMDOWN: Enhanced Table Styles for Print */
         table {
             border-collapse: collapse;
             width: 100%;
             break-inside: avoid;
         }
         th, td {
-            padding: 8px 10px;
-            border-bottom: 1px solid var(--rule);
+            padding: 6px 8px;
+            border: 1px solid var(--rule);
+            word-wrap: break-word;
+            overflow-wrap: break-word;
         }
         th {
-            font-weight: 700;
+            font-weight: 600;
             text-align: left;
+            padding: 6px 8px;
         }
+        /* Zebra stripes - very weak (3% opacity) */
+        tr:nth-child(even) td {
+            background: rgba(148, 163, 184, 0.03);
+        }
+        /* PDF-SLIMDOWN: Consolidated Font Sizes (only 14/16/18/24px) */
+        .section-body { font-size: 14px; }
+        .card { font-size: 14px; }
+        .kpi-card { font-size: 14px; }
+        .quick-win-card { font-size: 14px; }
+        .roadmap-phase { font-size: 14px; }
     </style>
 </head>
 <body>
@@ -1771,82 +1784,34 @@ monolithischen Abo-Ökosystem. Im Alltag bewährt haben sich u.&nbsp;a.:</p>
 </section>
 <section class="annex-section annex-glossar chapter">
   <h2>Glossar – zentrale KI-Begriffe</h2>
-  <p class="section-intro">Kurzüberblick über wichtige Begriffe aus diesem Report. Dient als Nachschlagewerk für Geschäftsführung, Fachabteilungen und IT.</p>
+  <p class="section-intro">Die wichtigsten Begriffe aus diesem Report (max. 12 Einträge, kompakt).</p>
   <dl class="glossary-list">
     <dt>AI Act (EU)</dt>
-    <dd>Europäische Verordnung zu KI-Systemen mit Pflichten je nach Risikoklasse (Transparenz, Datenqualität, Aufsicht, Dokumentation).</dd>
-    <dt>Alignment</dt>
-    <dd>Ausrichtung eines Modells auf gewünschte Ziele/Verhalten (Sicherheit, Ethik, Stil).</dd>
+    <dd>Europäische KI-Verordnung mit Pflichten je nach Risikoklasse.</dd>
     <dt>API</dt>
-    <dd>Programmierschnittstelle zur Anbindung oder Automatisierung von Software.</dd>
-    <dt>Assistive AI</dt>
-    <dd>KI als Unterstützung in Workflows (nicht vollautonom).</dd>
-    <dt>Benchmark</dt>
-    <dd>Vergleichsmaßstab zur Einordnung der eigenen Performance.</dd>
-    <dt>Chatbot</dt>
-    <dd>Dialogsystem auf Basis eines LLMs, z. B. für Support oder interne Auskünfte.</dd>
-    <dt>Context Window</dt>
-    <dd>Menge an Tokens, die ein Modell pro Anfrage verarbeiten kann.</dd>
-    <dt>Copilot</dt>
-    <dd>Assistent, der in bestehende Tools integriert (z. B. M365 Copilot).</dd>
-    <dt>Data Leakage</dt>
-    <dd>Unbeabsichtigte Preisgabe sensibler Daten durch Logs, Trainingsdaten oder Prompting.</dd>
-    <dt>Data Loss Prevention (DLP)</dt>
-    <dd>Techniken/Regeln, die Datenabflüsse verhindern.</dd>
-    <dt>Dataset Governance</dt>
-    <dd>Richtlinien für Herkunft, Qualität und Nutzung von Trainings-/Kontextdaten.</dd>
-    <dt>Embeddings</dt>
-    <dd>Vektordarstellung von Text/Bildern für Suche, RAG u. ä.</dd>
-    <dt>Enterprise Readiness</dt>
-    <dd>Erfüllung von Anforderungen an Sicherheit, Compliance, Betrieb & Support.</dd>
-    <dt>Few-shot Prompting</dt>
-    <dd>Beispiele im Prompt, um das Modell zu steuern.</dd>
+    <dd>Programmierschnittstelle zur Software-Anbindung.</dd>
+    <dt>DSGVO</dt>
+    <dd>Datenschutz-Grundverordnung für personenbezogene Daten.</dd>
     <dt>Fine-Tuning</dt>
     <dd>Nachtrainieren eines Modells auf eigene Daten.</dd>
     <dt>Guardrails</dt>
-    <dd>Prüfschritte (Policies, Tools), die Ausgaben validieren/filtern.</dd>
+    <dd>Prüfschritte, die KI-Ausgaben validieren/filtern.</dd>
     <dt>Halluzination</dt>
-    <dd>Plausibel klingende, aber faktisch falsche Ausgabe eines Modells.</dd>
-    <dt>Inference</dt>
-    <dd>Ausführung eines Modells zur Beantwortung einer Anfrage.</dd>
-    <dt>KB / Wissensbasis</dt>
-    <dd>Kuratierte, versionierte Sammlung relevanter Dokumente.</dd>
-    <dt>Latency</dt>
-    <dd>Antwortzeit eines Systems.</dd>
+    <dd>Plausibel klingende, aber faktisch falsche Modellausgabe.</dd>
     <dt>LLM</dt>
-    <dd>Large Language Model (z. B. GPT-4.1, Claude 3.5, Llama 3.1).</dd>
-    <dt>Maturity Index</dt>
-    <dd>Indikator für den KI-Reifegrad eines Unternehmens.</dd>
-    <dt>Open-Source Modelle</dt>
-    <dd>Frei verfügbare Modelle (z. B. Llama, Mistral) – oft lokal einsetzbar.</dd>
+    <dd>Large Language Model (GPT-4, Claude, Llama).</dd>
     <dt>Prompt</dt>
-    <dd>Eingabeinstruktion an ein LLM.</dd>
-    <dt>Prompt Leakage</dt>
-    <dd>Preisgabe sensibler Systeminstruktionen (z. B. durch Rückfragen).</dd>
+    <dd>Eingabeinstruktion an ein KI-Modell.</dd>
     <dt>RAG</dt>
-    <dd>Retrieval-Augmented Generation: Modell nutzt eigene Wissensbasis.</dd>
-    <dt>Red Teaming</dt>
-    <dd>Systematische Tests gegen Missbrauch/Fehler (Sicherheit).</dd>
+    <dd>Retrieval-Augmented Generation – KI mit eigener Wissensbasis.</dd>
     <dt>Responsible AI</dt>
-    <dd>Verantwortungsvolle Entwicklung/Nutzung mit Ethik & Compliance.</dd>
-    <dt>Runtime Cost</dt>
-    <dd>Laufzeit-/Token-Kosten pro Anfrage.</dd>
-    <dt>Service Levels (SLA)</dt>
-    <dd>Vereinbarte Verfügbarkeits-/Performance-Grenzen.</dd>
-    <dt>Shadow-IT</dt>
-    <dd>Nicht genehmigte Tools/Automationen, die Risiken bergen.</dd>
-    <dt>SLA Drift</dt>
-    <dd>Schleichende Verschlechterung gegenüber vereinbarten Werten.</dd>
-    <dt>Tavily / Perplexity</dt>
-    <dd>Recherche-APIs, die Web-Quellen strukturiert aufbereiten.</dd>
+    <dd>Verantwortungsvolle KI-Nutzung mit Ethik & Compliance.</dd>
     <dt>Token</dt>
     <dd>Grundeinheit der Modellverarbeitung (~3-4 Zeichen).</dd>
-    <dt>Toolformer</dt>
-    <dd>Modell nutzt externe Tools/Plugins zur Problemlösung.</dd>
-    <dt>Vector Store</dt>
-    <dd>Datenbank für Embeddings (z. B. FAISS, pgvector).</dd>
+    <dt>Human-in-the-Loop</dt>
+    <dd>Menschliche Kontrolle bei KI-Entscheidungsprozessen.</dd>
   </dl>
-  <p class="small muted">Quelle: kuratiert, Stand {{LAST_UPDATED}}.</p>
+  <p class="small muted">Stand {{LAST_UPDATED}}.</p>
 </section>
                 <!-- Impressum -->
                 <div class="impressum chapter">

--- a/templates/pdf_template_en.html
+++ b/templates/pdf_template_en.html
@@ -1364,20 +1364,33 @@
                 content: "";
             }
         }
-        /* Enhanced Table Styles for Print */
+        /* PDF-SLIMDOWN: Enhanced Table Styles for Print */
         table {
             border-collapse: collapse;
             width: 100%;
             break-inside: avoid;
         }
         th, td {
-            padding: 8px 10px;
-            border-bottom: 1px solid var(--rule);
+            padding: 6px 8px;
+            border: 1px solid var(--rule);
+            word-wrap: break-word;
+            overflow-wrap: break-word;
         }
         th {
-            font-weight: 700;
+            font-weight: 600;
             text-align: left;
+            padding: 6px 8px;
         }
+        /* Zebra stripes - very weak (3% opacity) */
+        tr:nth-child(even) td {
+            background: rgba(148, 163, 184, 0.03);
+        }
+        /* PDF-SLIMDOWN: Consolidated Font Sizes (only 14/16/18/24px) */
+        .section-body { font-size: 14px; }
+        .card { font-size: 14px; }
+        .kpi-card { font-size: 14px; }
+        .quick-win-card { font-size: 14px; }
+        .roadmap-phase { font-size: 14px; }
     </style>
 </head>
 <body>

--- a/utils/logo_embedder.py
+++ b/utils/logo_embedder.py
@@ -5,9 +5,14 @@ Logo Embedder for PDF Generation.
 Embeds logo images as base64 data URIs in HTML to ensure they render
 correctly when the HTML is sent to an external PDF service.
 
+Version: 2.0.0 PDF-SLIMDOWN
+
 Includes optimize_base64_image() for:
-- PNG→WebP conversion (quality 70-80, typically 50-70% size reduction)
+- Lossless WebP conversion (40-60% size reduction)
+- 8-bit color depth reduction
+- PNG channel stripping
 - SVG minification (whitespace removal, attribute compaction)
+- Max logo size enforcement (40-60kB each)
 """
 from __future__ import annotations
 
@@ -20,6 +25,10 @@ from pathlib import Path
 from typing import Dict, Optional, Tuple
 
 log = logging.getLogger(__name__)
+
+# --- Configuration ---
+MAX_LOGO_SIZE_BYTES = 50 * 1024  # 50kB max per logo (target: 40-60kB)
+MAX_LOGO_DIMENSION = 300  # Max width/height for logos in PDF
 
 # --- Image Optimization ---
 
@@ -36,24 +45,30 @@ def optimize_base64_image(
     data: bytes,
     mime_type: str,
     webp_quality: int = 75,
-    max_dimension: Optional[int] = 400
+    max_dimension: Optional[int] = None,
+    lossless: bool = True
 ) -> Tuple[bytes, str]:
     """
     Optimize image data for smaller base64 embedding.
 
-    PNG/JPEG → WebP conversion (50-70% size reduction)
+    PNG/JPEG → Lossless WebP conversion (40-60% size reduction)
     SVG → Minification (whitespace removal)
+    8-bit color depth reduction for smaller files
+    Max size enforcement (40-60kB)
 
     Args:
         data: Raw image bytes
         mime_type: Original MIME type (image/png, image/svg+xml, etc.)
-        webp_quality: WebP quality 0-100 (default 75)
-        max_dimension: Max width/height in pixels (None = no resize)
+        webp_quality: WebP quality 0-100 (default 75, used if lossless fails size limit)
+        max_dimension: Max width/height in pixels (default: MAX_LOGO_DIMENSION)
+        lossless: Use lossless WebP compression (default True)
 
     Returns:
         Tuple of (optimized_bytes, new_mime_type)
     """
     original_size = len(data)
+    if max_dimension is None:
+        max_dimension = MAX_LOGO_DIMENSION
 
     # --- SVG Minification ---
     if mime_type == "image/svg+xml":
@@ -71,8 +86,8 @@ def optimize_base64_image(
             log.warning("[LOGO-OPTIMIZE] SVG minification failed: %s", e)
             return data, mime_type
 
-    # --- PNG/JPEG → WebP ---
-    if PILLOW_AVAILABLE and mime_type in ("image/png", "image/jpeg", "image/jpg"):
+    # --- PNG/JPEG → Lossless WebP with 8-bit color depth ---
+    if PILLOW_AVAILABLE and mime_type in ("image/png", "image/jpeg", "image/jpg", "image/webp"):
         try:
             img = Image.open(io.BytesIO(data))
 
@@ -81,20 +96,51 @@ def optimize_base64_image(
                 img.thumbnail((max_dimension, max_dimension), Image.Resampling.LANCZOS)
                 log.debug("[LOGO-OPTIMIZE] Resized to %dx%d", img.width, img.height)
 
-            # Convert to WebP
+            # Reduce color depth to 8-bit (palette mode) for smaller files
+            # Only for images without critical transparency
+            original_mode = img.mode
+            if img.mode == "RGBA":
+                # Keep RGBA for transparency, but try to quantize
+                img_quantized = img.quantize(colors=256, method=Image.Quantize.MEDIANCUT)
+                img_quantized = img_quantized.convert("RGBA")
+                img = img_quantized
+            elif img.mode in ("RGB", "L"):
+                # Convert to palette mode (8-bit)
+                img = img.quantize(colors=256, method=Image.Quantize.MEDIANCUT)
+                img = img.convert("RGB")
+
+            # Try lossless WebP first
             output = io.BytesIO()
-            # Handle transparency for PNG
-            if img.mode in ("RGBA", "LA", "P"):
-                img.save(output, format="WEBP", quality=webp_quality, lossless=False)
+            if lossless:
+                img.save(output, format="WEBP", lossless=True, quality=100)
             else:
-                img.save(output, format="WEBP", quality=webp_quality)
+                img.save(output, format="WEBP", quality=webp_quality, lossless=False)
 
             optimized_bytes = output.getvalue()
             new_size = len(optimized_bytes)
 
+            # If lossless is too large, fall back to lossy with quality reduction
+            if new_size > MAX_LOGO_SIZE_BYTES and lossless:
+                log.debug("[LOGO-OPTIMIZE] Lossless too large (%d bytes), trying lossy", new_size)
+                output = io.BytesIO()
+                img.save(output, format="WEBP", quality=webp_quality, lossless=False)
+                optimized_bytes = output.getvalue()
+                new_size = len(optimized_bytes)
+
+                # If still too large, reduce quality further
+                if new_size > MAX_LOGO_SIZE_BYTES:
+                    for quality in [60, 50, 40]:
+                        output = io.BytesIO()
+                        img.save(output, format="WEBP", quality=quality, lossless=False)
+                        optimized_bytes = output.getvalue()
+                        new_size = len(optimized_bytes)
+                        if new_size <= MAX_LOGO_SIZE_BYTES:
+                            log.debug("[LOGO-OPTIMIZE] Reduced quality to %d to meet size limit", quality)
+                            break
+
             # Only use WebP if actually smaller
             if new_size < original_size:
-                log.debug("[LOGO-OPTIMIZE] %s → WebP: %d → %d bytes (%.0f%%)",
+                log.debug("[LOGO-OPTIMIZE] %s → WebP: %d → %d bytes (%.0f%% saved)",
                          mime_type, original_size, new_size, (1 - new_size/original_size) * 100)
                 return optimized_bytes, "image/webp"
             else:


### PR DESCRIPTION
TASK 1: HTML Compression (html_minifier.py)
- New compress_html(), minify_css(), strip_unused_sections()
- Remove HTML comments, collapse whitespace, optimize inline CSS
- Remove unused CSS classes and debug elements

TASK 2: Logo Optimization (logo_embedder.py v2.0.0)
- Lossless WebP conversion with 8-bit color depth
- Max logo size enforcement (50kB)
- Quality fallback for oversized logos

TASK 3: Report Renderer Integration (v4.16.0)
- Integrate optimize_html_for_pdf() pipeline
- Log size savings percentage

TASK 4-5: PDF Templates CSS
- Consolidated font sizes (14/16/18/24px only)
- Table borders 1px, padding 6px, word-wrap
- Zebra stripes 3% opacity

TASK 6: Roadmap Prompts (-15%/-20% words)
- roadmap_90d.md v8.0: -15% word limits
- roadmap_12m.md v10.0: -20% word limits
- Max 5 bullets per phase, anti-redundancy rules

TASK 7: Quick Wins Compact
- Max 4 Quick Wins per report
- Reduced word limits (Solo: 60, Team: 80, KMU: 100)
- No background-color HTML boxes

TASK 8: Glossary Reduced
- Reduced from 37 to 12 essential entries
- Shorter descriptions (2-3 lines each)
- No icons