### PR TITLE
feat(prompts): integrate neue Sektionen monetarisierung, ki_skillplan…

### DIFF
--- a/gpt_analyze.py
+++ b/gpt_analyze.py
@@ -3259,6 +3259,10 @@ def _generate_content_section(section_name: str, briefing: Dict[str, Any], score
         "foerderpotenzial": "foerderpotenzial",
         "transparency_box": "transparency_box",
         "ki_aktivitaeten_ziele": "ki_aktivitaeten_ziele",
+        # Neue Sektionen (Sprint 2025)
+        "monetarisierung": "monetarisierung",
+        "ki_skillplan": "ki_skillplan",
+        "templates_start": "templates_start",
     }
     
     prompt_key = prompt_map.get(section_name)
@@ -3636,6 +3640,10 @@ def _generate_content_sections(briefing: Dict[str, Any], scores: Dict[str, Any])
         ("foerderpotenzial", "FOERDERPOTENZIAL_HTML"),
         ("transparency_box", "TRANSPARENCY_BOX_HTML"),
         ("ki_aktivitaeten_ziele", "KI_AKTIVITAETEN_ZIELE_HTML"),
+        # Neue Sektionen (Sprint 2025)
+        ("monetarisierung", "MONETARISIERUNG_HTML"),
+        ("ki_skillplan", "KI_SKILLPLAN_HTML"),
+        ("templates_start", "TEMPLATES_START_HTML"),
     ]
 
     max_workers = int(os.getenv("GPT_PARALLEL_WORKERS", "10"))

--- a/services/prompt_enhancer.py
+++ b/services/prompt_enhancer.py
@@ -899,6 +899,10 @@ Nutze den Strategischen Kontext wie folgt:
             "compliance",               # Compliance needs branch-specific regulations
             "change_management",        # Change management varies by size
             "executive_summary",        # Summary should reflect branch/size
+            # Neue Sektionen (Sprint 2025) - persona-aware
+            "monetarisierung",          # Pricing-Modelle anpassbar an Solo/Team/KMU
+            "ki_skillplan",             # Skill-Entwicklung nach Unternehmensgröße
+            "templates_start",          # Templates für Solo/Team/KMU unterschiedlich
         }
 
         try:

--- a/templates/pdf_template.html
+++ b/templates/pdf_template.html
@@ -1755,6 +1755,58 @@
                 <section class="chapter">
                     {{FOERDERPOTENZIAL_HTML}}
                 </section>
+                <!-- NEUE SEKTIONEN: Monetarisierung, Skill-Plan, Templates -->
+                {% if MONETARISIERUNG_HTML %}
+                <section class="section chapter">
+                    <div class="section-header">
+                        <div class="section-title">
+                            <span class="section-kicker">Wertschöpfung</span>
+                            <h2>Monetarisierung & Angebotslogik</h2>
+                        </div>
+                        <span class="section-pill">
+                            <span class="pill-dot"></span>
+                            Pricing-Modelle für KI-Services
+                        </span>
+                    </div>
+                    <div class="section-body">
+                        {{ MONETARISIERUNG_HTML|safe }}
+                    </div>
+                </section>
+                {% endif %}
+                {% if KI_SKILLPLAN_HTML %}
+                <section class="section chapter">
+                    <div class="section-header">
+                        <div class="section-title">
+                            <span class="section-kicker">Kompetenzaufbau</span>
+                            <h2>KI-Skill-Fahrplan 2025</h2>
+                        </div>
+                        <span class="section-pill">
+                            <span class="pill-dot"></span>
+                            Vom Einsteiger zum Experten
+                        </span>
+                    </div>
+                    <div class="section-body">
+                        {{ KI_SKILLPLAN_HTML|safe }}
+                    </div>
+                </section>
+                {% endif %}
+                {% if TEMPLATES_START_HTML %}
+                <section class="section chapter">
+                    <div class="section-header">
+                        <div class="section-title">
+                            <span class="section-kicker">Sofort loslegen</span>
+                            <h2>Starter-Templates</h2>
+                        </div>
+                        <span class="section-pill">
+                            <span class="pill-dot"></span>
+                            Copy-Paste-Vorlagen für den Start
+                        </span>
+                    </div>
+                    <div class="section-body">
+                        {{ TEMPLATES_START_HTML|safe }}
+                    </div>
+                </section>
+                {% endif %}
                 <!-- FEEDBACK SECTION -->
                 <div class="feedback-section">
                     <h2>Ihr Feedback ist uns wichtig!</h2>

--- a/templates/pdf_template_en.html
+++ b/templates/pdf_template_en.html
@@ -1743,6 +1743,58 @@
                     </div>
                 </section>
                 {% endif %}
+                <!-- NEW SECTIONS: Monetization, Skill Plan, Templates -->
+                {% if MONETARISIERUNG_HTML %}
+                <section class="section chapter">
+                    <div class="section-header">
+                        <div class="section-title">
+                            <span class="section-kicker">Value Creation</span>
+                            <h2>Monetization & Service Models</h2>
+                        </div>
+                        <span class="section-pill">
+                            <span class="pill-dot"></span>
+                            Pricing Models for AI Services
+                        </span>
+                    </div>
+                    <div class="section-body">
+                        {{ MONETARISIERUNG_HTML|safe }}
+                    </div>
+                </section>
+                {% endif %}
+                {% if KI_SKILLPLAN_HTML %}
+                <section class="section chapter">
+                    <div class="section-header">
+                        <div class="section-title">
+                            <span class="section-kicker">Skill Development</span>
+                            <h2>AI Skill Roadmap 2025</h2>
+                        </div>
+                        <span class="section-pill">
+                            <span class="pill-dot"></span>
+                            From Beginner to Expert
+                        </span>
+                    </div>
+                    <div class="section-body">
+                        {{ KI_SKILLPLAN_HTML|safe }}
+                    </div>
+                </section>
+                {% endif %}
+                {% if TEMPLATES_START_HTML %}
+                <section class="section chapter">
+                    <div class="section-header">
+                        <div class="section-title">
+                            <span class="section-kicker">Get Started</span>
+                            <h2>Starter Templates</h2>
+                        </div>
+                        <span class="section-pill">
+                            <span class="pill-dot"></span>
+                            Copy-Paste Templates for Quick Start
+                        </span>
+                    </div>
+                    <div class="section-body">
+                        {{ TEMPLATES_START_HTML|safe }}
+                    </div>
+                </section>
+                {% endif %}
 <!-- FEEDBACK SECTION -->
                 <div class="feedback-section">
                     <h2>Your Feedback Matters!</h2>


### PR DESCRIPTION
…, templates_start

Integration der drei neuen Sektionen aus Sprint 2025:

1. gpt_analyze.py:
   - prompt_map erweitert um monetarisierung, ki_skillplan, templates_start
   - parallel_sections erweitert um MONETARISIERUNG_HTML, KI_SKILLPLAN_HTML, TEMPLATES_START_HTML

2. prompt_enhancer.py:
   - PROMPTS_WITH_BRANCH_SIZE_CONTEXT um neue Sektionen erweitert
   - Persona-aware Logik (Solo/Team/KMU) für neue Sektionen aktiviert

3. PDF Templates (DE & EN):
   - Neue Chapter-Sections für Monetarisierung, KI-Skill-Fahrplan, Starter-Templates
   - Conditional Rendering mit {% if SECTION_HTML %}
   - Konsistente section-header/section-body Struktur

Die Prompts selbst enthalten bereits SIZE-AWARE Kommentare für automatische Persona-Anpassung (Solo/Team/KMU).