### PR TITLE
feat(prompts): add 4 new prompt families with full integration

### DIFF
--- a/gpt_analyze.py
+++ b/gpt_analyze.py
@@ -3263,6 +3263,11 @@ def _generate_content_section(section_name: str, briefing: Dict[str, Any], score
         "monetarisierung": "monetarisierung",
         "ki_skillplan": "ki_skillplan",
         "templates_start": "templates_start",
+        # Neue Sektionen (Sprint 2025 - Phase 2)
+        "roi_tracking": "roi_tracking",
+        "ai_policy_mini": "ai_policy_mini",
+        "kickoff_vorlage": "kickoff_vorlage",
+        "prompt_framework": "prompt_framework",
     }
     
     prompt_key = prompt_map.get(section_name)
@@ -3644,6 +3649,11 @@ def _generate_content_sections(briefing: Dict[str, Any], scores: Dict[str, Any])
         ("monetarisierung", "MONETARISIERUNG_HTML"),
         ("ki_skillplan", "KI_SKILLPLAN_HTML"),
         ("templates_start", "TEMPLATES_START_HTML"),
+        # Neue Sektionen (Sprint 2025 - Phase 2)
+        ("roi_tracking", "ROI_TRACKING_HTML"),
+        ("ai_policy_mini", "AI_POLICY_MINI_HTML"),
+        ("kickoff_vorlage", "KICKOFF_VORLAGE_HTML"),
+        ("prompt_framework", "PROMPT_FRAMEWORK_HTML"),
     ]
 
     max_workers = int(os.getenv("GPT_PARALLEL_WORKERS", "10"))

--- a/prompts/de/ai_policy_mini.md
+++ b/prompts/de/ai_policy_mini.md
@@ -1,0 +1,55 @@
+# AI Mini-Policy – Kompakte Regeln für den KI-Alltag
+
+<!-- persona:solo -->
+<!-- Solo: 5 einfache Regeln, sofort anwendbar, keine Bürokratie -->
+<!-- persona:team -->
+<!-- Team: Klare Rollen (Ersteller, Prüfer), Übergabe-Regeln -->
+<!-- persona:kmu -->
+<!-- KMU: Strukturierte Policy, Verantwortlichkeiten, Dokumentationspflichten -->
+
+## Grundprinzip
+
+Diese Mini-Policy definiert klare Spielregeln für den täglichen KI-Einsatz – ohne bürokratischen Overhead.
+
+---
+
+## Die 7 Grundregeln
+
+### 1. Datennutzung
+**Was darf KI?** Interne, nicht-personenbezogene Daten verarbeiten.
+**Was darf KI nicht?** Kundendaten, Personaldaten oder vertrauliche Dokumente ohne Freigabe nutzen.
+
+### 2. Review-Pflicht
+**Regel:** Jede KI-Ausgabe wird vor Weitergabe an Dritte von einem Menschen geprüft.
+**Ausnahme:** Rein interne Entwürfe zur eigenen Weiterbearbeitung.
+
+### 3. Transparenz
+**Regel:** Bei kundenrelevanten Inhalten kennzeichnen, wenn KI unterstützt hat.
+**Beispiel:** „Erstellt mit KI-Unterstützung, geprüft von [Name]."
+
+### 4. Keine automatisierten Entscheidungen
+**Regel:** KI liefert Vorschläge – Menschen entscheiden.
+**Gilt für:** Personalthemen, Verträge, Finanzen, Kundenzusagen.
+
+### 5. Tool-Freigabe
+**Regel:** Nur freigegebene KI-Tools nutzen (z.B. ChatGPT Enterprise, Claude, interne Systeme).
+**Verboten:** Unbekannte Tools mit Firmendaten füttern.
+
+### 6. Lernkultur
+**Regel:** Fehler dokumentieren, daraus lernen, Prozesse anpassen.
+**Keine Schuldzuweisungen** – KI-Nutzung ist Lernprozess.
+
+### 7. Aktualisierung
+**Regel:** Diese Policy wird quartalsweise überprüft und bei Bedarf angepasst.
+
+---
+
+## Schnell-Check vor jedem KI-Einsatz
+
+- [ ] Daten geeignet? (keine sensiblen Personendaten)
+- [ ] Tool freigegeben?
+- [ ] Ergebnis geprüft?
+- [ ] Transparenz gewährleistet?
+
+---
+*Diese Mini-Policy ersetzt keine Rechtsberatung. Bei Unsicherheiten: Rücksprache halten.*

--- a/prompts/de/kickoff_vorlage.md
+++ b/prompts/de/kickoff_vorlage.md
@@ -1,0 +1,65 @@
+# Kickoff-Vorlage – KI-Projekt starten
+
+<!-- persona:solo -->
+<!-- Solo: Schneller Selbst-Check, 30 Min., fokussiert auf Quick Wins -->
+<!-- persona:team -->
+<!-- Team: Gemeinsamer Workshop, Rollen klären, 60-90 Min. -->
+<!-- persona:kmu -->
+<!-- KMU: Strukturierter Kickoff, Stakeholder einbinden, 2-3 Stunden -->
+
+## Ziel des Kickoffs
+
+Gemeinsames Verständnis schaffen, Ziele definieren, erste Schritte festlegen.
+
+---
+
+## Agenda (anpassbar)
+
+| # | Thema | Dauer | Verantwortlich |
+|---|-------|-------|----------------|
+| 1 | Begrüßung & Ziele | 5-10 Min. | Projektleitung |
+| 2 | Ausgangslage & Pain Points | 15-20 Min. | Alle |
+| 3 | KI-Potenziale identifizieren | 15-20 Min. | Fachbereich |
+| 4 | Datenlage klären | 10-15 Min. | IT / Datenverantwortliche |
+| 5 | Quick Wins definieren | 15-20 Min. | Alle |
+| 6 | Rollen & Verantwortlichkeiten | 10 Min. | Projektleitung |
+| 7 | Nächste Schritte & Timeline | 10 Min. | Projektleitung |
+
+---
+
+## Fragenkatalog zur Vorbereitung
+
+### Zielklärung
+- Was soll durch KI besser/schneller/günstiger werden?
+- Welche Prozesse verursachen aktuell den größten Aufwand?
+- Wie messen wir Erfolg?
+
+### Datenlage
+- Welche Daten liegen bereits digital vor?
+- In welchen Systemen? (CRM, ERP, Excel, Cloud-Speicher)
+- Gibt es Datenschutz-Einschränkungen?
+
+### Ressourcen
+- Wer hat Zeit für das Projekt? (Stunden/Woche)
+- Welches Budget steht zur Verfügung?
+- Welche Tools sind bereits im Einsatz?
+
+### Rollen
+- Wer trifft Entscheidungen?
+- Wer setzt um?
+- Wer prüft Ergebnisse?
+
+---
+
+## Ergebnis-Template
+
+Nach dem Kickoff dokumentieren:
+
+1. **Projektziel:** _______________
+2. **Top 3 Pain Points:** _______________
+3. **Erster Quick Win:** _______________
+4. **Verantwortlich:** _______________
+5. **Nächster Meilenstein:** _______________ (Datum: ___)
+
+---
+*Tipp: Kickoff kurz halten, Ergebnisse sofort dokumentieren, Follow-up planen.*

--- a/prompts/de/prompt_framework.md
+++ b/prompts/de/prompt_framework.md
@@ -1,0 +1,82 @@
+# Prompt-Framework – 5 Schritte zum perfekten Prompt
+
+<!-- persona:solo -->
+<!-- Solo: Schnell anwendbar, 1 Beispiel reicht, keine Theorie -->
+<!-- persona:team -->
+<!-- Team: Gemeinsame Prompt-Bibliothek aufbauen, Best Practices teilen -->
+<!-- persona:kmu -->
+<!-- KMU: Standardisierte Prompts für wiederkehrende Aufgaben, Qualitätssicherung -->
+
+## Das 5-Schritte-Framework
+
+Jeder gute Prompt enthält diese fünf Elemente:
+
+### 1. Kontext
+*Hintergrundinformationen für die KI*
+
+> „Du arbeitest für ein mittelständisches Beratungsunternehmen im DACH-Raum."
+
+### 2. Rolle
+*Welche Expertise soll die KI annehmen?*
+
+> „Agiere als erfahrener Unternehmensberater mit Fokus auf Prozessoptimierung."
+
+### 3. Ziel
+*Was soll erreicht werden?*
+
+> „Erstelle eine Zusammenfassung der wichtigsten Erkenntnisse aus dem Meeting-Protokoll."
+
+### 4. Constraints
+*Einschränkungen und Qualitätskriterien*
+
+> „Maximal 5 Bullet Points. Keine Fachbegriffe ohne Erklärung. Fokus auf umsetzbare Maßnahmen."
+
+### 5. Format
+*Wie soll das Ergebnis aussehen?*
+
+> „Ausgabe als nummerierte Liste mit Prioritätsangabe (hoch/mittel/niedrig)."
+
+---
+
+## Beispiel-Prompt (komplett)
+
+```
+Kontext: Du unterstützt ein 20-köpfiges Team bei der Einführung von KI-Tools.
+
+Rolle: Du bist ein KI-Trainer mit Erfahrung in Change Management.
+
+Ziel: Erstelle einen Schulungsplan für die ersten 4 Wochen.
+
+Constraints:
+- Max. 2 Stunden Schulung pro Woche
+- Fokus auf praktische Übungen
+- Keine Vorkenntnisse voraussetzen
+
+Format: Tabelle mit Woche, Thema, Dauer, Lernziel
+```
+
+---
+
+## Tipps für bessere Prompts
+
+| Problem | Lösung |
+|---------|--------|
+| Ergebnis zu vage | Mehr Kontext + konkretere Constraints |
+| Ergebnis zu lang | Format-Vorgabe (z.B. „max. 200 Wörter") |
+| Falscher Tonfall | Rolle definieren (z.B. „formell", „locker") |
+| Unpassende Beispiele | Branche/Kontext explizit nennen |
+
+---
+
+## Variablen nutzen
+
+Für wiederkehrende Prompts: Platzhalter einbauen.
+
+```
+Erstelle einen [DOKUMENTTYP] für [ZIELGRUPPE]
+zum Thema [THEMA].
+Länge: [LÄNGE]. Tonalität: [TONALITÄT].
+```
+
+---
+*Tipp: Prompts iterativ verbessern. Erste Version → Ergebnis prüfen → Prompt anpassen.*

--- a/prompts/de/roi_tracking.md
+++ b/prompts/de/roi_tracking.md
@@ -1,0 +1,39 @@
+# ROI Tracking – Monatliche Erfolgskontrolle
+
+<!-- persona:solo -->
+<!-- Solo: Kompakte Selbstkontrolle, 3-4 KPIs, keine komplexen Dashboards -->
+<!-- persona:team -->
+<!-- Team: Gemeinsame Fortschrittsmessung, Rollen-basierte Verantwortung -->
+<!-- persona:kmu -->
+<!-- KMU: Strukturiertes Reporting, Abteilungs-übergreifende KPIs, Management-tauglich -->
+
+## Zweck
+
+Dieses Tracking hilft Ihnen, den messbaren Nutzen Ihrer KI-Maßnahmen monatlich zu erfassen. Fokus: Zeitersparnis, Kostenreduktion, Qualitätsverbesserung.
+
+## Empfohlene KPIs
+
+| KPI | Beschreibung | Messmethode | Zielwert |
+|-----|--------------|-------------|----------|
+| **Zeitersparnis (h/Monat)** | Eingesparte Arbeitsstunden durch KI-Automatisierung | Vorher-Nachher-Vergleich | +10-20% |
+| **Fehlerquote** | Reduzierung manueller Fehler | Stichproben-Kontrolle | -30% |
+| **Output-Steigerung** | Mehr Ergebnisse bei gleichem Aufwand | Mengenmessung | +15-25% |
+| **Kostenersparnis (€)** | Direkte Einsparungen durch Automatisierung | Kostenvergleich | Individuell |
+
+## Tracking-Vorlage
+
+| Monat | Zeitersparnis | Fehlerquote | Output | Kosten | Trend | Kommentar |
+|-------|---------------|-------------|--------|--------|-------|-----------|
+| M1 | ___ h | ___% | ___ | ___€ | ↑↓→ | |
+| M2 | ___ h | ___% | ___ | ___€ | ↑↓→ | |
+| M3 | ___ h | ___% | ___ | ___€ | ↑↓→ | |
+
+## Auswertungshinweise
+
+- **Monatlich ausfüllen** – Konsistenz wichtiger als Perfektion
+- **Trends beobachten** – Einzelwerte schwanken, Trends zählen
+- **Learnings dokumentieren** – Was funktioniert? Was nicht?
+- **Anpassungen ableiten** – KI-Einsatz iterativ optimieren
+
+---
+*Tipp: Starten Sie mit 2-3 KPIs und erweitern Sie schrittweise.*

--- a/prompts/en/ai_policy_mini_en.md
+++ b/prompts/en/ai_policy_mini_en.md
@@ -1,0 +1,55 @@
+# AI Mini Policy – Compact Rules for Daily AI Operations
+
+<!-- persona:solo -->
+<!-- Solo: 5 simple rules, immediately applicable, no bureaucracy -->
+<!-- persona:team -->
+<!-- Team: Clear roles (creator, reviewer), handover rules -->
+<!-- persona:kmu -->
+<!-- SME: Structured policy, responsibilities, documentation requirements -->
+
+## Core Principle
+
+This mini policy defines clear ground rules for daily AI usage – without bureaucratic overhead.
+
+---
+
+## The 7 Core Rules
+
+### 1. Data Usage
+**What AI may do:** Process internal, non-personal data.
+**What AI may not do:** Use customer data, HR data, or confidential documents without approval.
+
+### 2. Review Requirement
+**Rule:** Every AI output is reviewed by a human before sharing externally.
+**Exception:** Purely internal drafts for personal refinement.
+
+### 3. Transparency
+**Rule:** For customer-facing content, disclose AI assistance.
+**Example:** "Created with AI support, reviewed by [Name]."
+
+### 4. No Automated Decisions
+**Rule:** AI provides suggestions – humans decide.
+**Applies to:** HR matters, contracts, finances, customer commitments.
+
+### 5. Tool Approval
+**Rule:** Only use approved AI tools (e.g., ChatGPT Enterprise, Claude, internal systems).
+**Prohibited:** Feeding company data into unknown tools.
+
+### 6. Learning Culture
+**Rule:** Document errors, learn from them, adjust processes.
+**No blame games** – AI usage is a learning journey.
+
+### 7. Updates
+**Rule:** This policy is reviewed quarterly and adjusted as needed.
+
+---
+
+## Quick Check Before Every AI Use
+
+- [ ] Data suitable? (no sensitive personal data)
+- [ ] Tool approved?
+- [ ] Output reviewed?
+- [ ] Transparency ensured?
+
+---
+*This mini policy does not replace legal advice. When in doubt: consult.*

--- a/prompts/en/kickoff_template.md
+++ b/prompts/en/kickoff_template.md
@@ -1,0 +1,65 @@
+# Kickoff Template – Starting Your AI Project
+
+<!-- persona:solo -->
+<!-- Solo: Quick self-check, 30 min, focused on quick wins -->
+<!-- persona:team -->
+<!-- Team: Collaborative workshop, clarify roles, 60-90 min -->
+<!-- persona:kmu -->
+<!-- SME: Structured kickoff, stakeholder involvement, 2-3 hours -->
+
+## Kickoff Objective
+
+Create shared understanding, define goals, establish first steps.
+
+---
+
+## Agenda (Adjustable)
+
+| # | Topic | Duration | Responsible |
+|---|-------|----------|-------------|
+| 1 | Welcome & Objectives | 5-10 min | Project Lead |
+| 2 | Current State & Pain Points | 15-20 min | All |
+| 3 | Identify AI Potential | 15-20 min | Domain Experts |
+| 4 | Data Assessment | 10-15 min | IT / Data Owners |
+| 5 | Define Quick Wins | 15-20 min | All |
+| 6 | Roles & Responsibilities | 10 min | Project Lead |
+| 7 | Next Steps & Timeline | 10 min | Project Lead |
+
+---
+
+## Preparation Questionnaire
+
+### Goal Clarification
+- What should AI make better/faster/cheaper?
+- Which processes currently cause the most effort?
+- How do we measure success?
+
+### Data Situation
+- What data is already available digitally?
+- In which systems? (CRM, ERP, Excel, Cloud Storage)
+- Are there data privacy restrictions?
+
+### Resources
+- Who has time for the project? (hours/week)
+- What budget is available?
+- Which tools are already in use?
+
+### Roles
+- Who makes decisions?
+- Who implements?
+- Who reviews results?
+
+---
+
+## Results Template
+
+Document after kickoff:
+
+1. **Project Goal:** _______________
+2. **Top 3 Pain Points:** _______________
+3. **First Quick Win:** _______________
+4. **Responsible:** _______________
+5. **Next Milestone:** _______________ (Date: ___)
+
+---
+*Tip: Keep kickoff short, document results immediately, plan follow-up.*

--- a/prompts/en/prompt_framework_en.md
+++ b/prompts/en/prompt_framework_en.md
@@ -1,0 +1,82 @@
+# Prompt Framework – 5 Steps to the Perfect Prompt
+
+<!-- persona:solo -->
+<!-- Solo: Quickly applicable, 1 example is enough, no theory -->
+<!-- persona:team -->
+<!-- Team: Build shared prompt library, share best practices -->
+<!-- persona:kmu -->
+<!-- SME: Standardized prompts for recurring tasks, quality assurance -->
+
+## The 5-Step Framework
+
+Every good prompt contains these five elements:
+
+### 1. Context
+*Background information for the AI*
+
+> "You work for a mid-sized consulting company in the DACH region."
+
+### 2. Role
+*What expertise should the AI assume?*
+
+> "Act as an experienced business consultant focused on process optimization."
+
+### 3. Goal
+*What should be achieved?*
+
+> "Create a summary of the key insights from the meeting notes."
+
+### 4. Constraints
+*Limitations and quality criteria*
+
+> "Maximum 5 bullet points. No jargon without explanation. Focus on actionable items."
+
+### 5. Format
+*How should the output look?*
+
+> "Output as a numbered list with priority indication (high/medium/low)."
+
+---
+
+## Complete Example Prompt
+
+```
+Context: You support a 20-person team in implementing AI tools.
+
+Role: You are an AI trainer with experience in change management.
+
+Goal: Create a training plan for the first 4 weeks.
+
+Constraints:
+- Max. 2 hours of training per week
+- Focus on practical exercises
+- No prior knowledge required
+
+Format: Table with Week, Topic, Duration, Learning Objective
+```
+
+---
+
+## Tips for Better Prompts
+
+| Problem | Solution |
+|---------|----------|
+| Result too vague | More context + specific constraints |
+| Result too long | Format specification (e.g., "max. 200 words") |
+| Wrong tone | Define role (e.g., "formal", "casual") |
+| Unsuitable examples | Explicitly mention industry/context |
+
+---
+
+## Using Variables
+
+For recurring prompts: Build in placeholders.
+
+```
+Create a [DOCUMENT_TYPE] for [TARGET_AUDIENCE]
+on the topic [TOPIC].
+Length: [LENGTH]. Tone: [TONE].
+```
+
+---
+*Tip: Improve prompts iteratively. First version → Review result → Adjust prompt.*

--- a/prompts/en/roi_tracking_en.md
+++ b/prompts/en/roi_tracking_en.md
@@ -1,0 +1,39 @@
+# ROI Tracking – Monthly AI Impact Measurement
+
+<!-- persona:solo -->
+<!-- Solo: Compact self-monitoring, 3-4 KPIs, no complex dashboards -->
+<!-- persona:team -->
+<!-- Team: Collaborative progress tracking, role-based accountability -->
+<!-- persona:kmu -->
+<!-- SME: Structured reporting, cross-departmental KPIs, management-ready -->
+
+## Purpose
+
+This tracking helps you measure the tangible benefits of your AI initiatives on a monthly basis. Focus: Time savings, cost reduction, quality improvement.
+
+## Recommended KPIs
+
+| KPI | Description | Measurement Method | Target |
+|-----|-------------|-------------------|--------|
+| **Time Saved (h/month)** | Work hours saved through AI automation | Before-after comparison | +10-20% |
+| **Error Rate** | Reduction in manual errors | Sample checks | -30% |
+| **Output Increase** | More results with same effort | Quantity measurement | +15-25% |
+| **Cost Savings (€/$)** | Direct savings from automation | Cost comparison | Individual |
+
+## Tracking Template
+
+| Month | Time Saved | Error Rate | Output | Costs | Trend | Comments |
+|-------|------------|------------|--------|-------|-------|----------|
+| M1 | ___ h | ___% | ___ | ___€ | ↑↓→ | |
+| M2 | ___ h | ___% | ___ | ___€ | ↑↓→ | |
+| M3 | ___ h | ___% | ___ | ___€ | ↑↓→ | |
+
+## Evaluation Guidelines
+
+- **Fill in monthly** – Consistency matters more than perfection
+- **Watch trends** – Individual values fluctuate, trends count
+- **Document learnings** – What works? What doesn't?
+- **Derive adjustments** – Optimize AI usage iteratively
+
+---
+*Tip: Start with 2-3 KPIs and expand gradually.*

--- a/prompts/prompt_manifest.json
+++ b/prompts/prompt_manifest.json
@@ -35,6 +35,30 @@
       "path": "report.md",
       "purpose": "Strukturierte Ausgabe",
       "required": true
+    },
+    "roi_tracking": {
+      "title": "ROI Tracking",
+      "path": "roi_tracking.md",
+      "purpose": "Monatliche Erfolgskontrolle",
+      "required": false
+    },
+    "ai_policy_mini": {
+      "title": "AI Mini-Policy",
+      "path": "ai_policy_mini.md",
+      "purpose": "Kompakte KI-Regeln",
+      "required": false
+    },
+    "kickoff_vorlage": {
+      "title": "Kickoff-Vorlage",
+      "path": "kickoff_vorlage.md",
+      "purpose": "Projektstart-Template",
+      "required": false
+    },
+    "prompt_framework": {
+      "title": "Prompt-Framework",
+      "path": "prompt_framework.md",
+      "purpose": "5-Schritte-Anleitung",
+      "required": false
     }
   },
   "en": {
@@ -67,6 +91,30 @@
       "path": "report.md",
       "purpose": "Structured output",
       "required": true
+    },
+    "roi_tracking": {
+      "title": "ROI Tracking",
+      "path": "roi_tracking_en.md",
+      "purpose": "Monthly success tracking",
+      "required": false
+    },
+    "ai_policy_mini": {
+      "title": "AI Mini Policy",
+      "path": "ai_policy_mini_en.md",
+      "purpose": "Compact AI rules",
+      "required": false
+    },
+    "kickoff_vorlage": {
+      "title": "Kickoff Template",
+      "path": "kickoff_template.md",
+      "purpose": "Project start template",
+      "required": false
+    },
+    "prompt_framework": {
+      "title": "Prompt Framework",
+      "path": "prompt_framework_en.md",
+      "purpose": "5-step guide",
+      "required": false
     }
   }
 }

--- a/services/prompt_enhancer.py
+++ b/services/prompt_enhancer.py
@@ -903,6 +903,11 @@ Nutze den Strategischen Kontext wie folgt:
             "monetarisierung",          # Pricing-Modelle anpassbar an Solo/Team/KMU
             "ki_skillplan",             # Skill-Entwicklung nach Unternehmensgröße
             "templates_start",          # Templates für Solo/Team/KMU unterschiedlich
+            # Neue Sektionen (Sprint 2025 - Phase 2) - persona-aware
+            "roi_tracking",             # Erfolgs-Tracking nach Unternehmensgröße
+            "ai_policy_mini",           # Policy-Regeln nach Komplexität
+            "kickoff_vorlage",          # Kickoff-Agenda nach Team-Größe
+            "prompt_framework",         # Prompt-Anleitung nach Erfahrungslevel
         }
 
         try:

--- a/templates/pdf_template.html
+++ b/templates/pdf_template.html
@@ -1807,6 +1807,75 @@
                     </div>
                 </section>
                 {% endif %}
+                <!-- NEUE SEKTIONEN: ROI Tracking, AI Policy, Kickoff, Prompt Framework -->
+                {% if ROI_TRACKING_HTML %}
+                <section class="section chapter">
+                    <div class="section-header">
+                        <div class="section-title">
+                            <span class="section-kicker">Erfolgsmessung</span>
+                            <h2>ROI Tracking</h2>
+                        </div>
+                        <span class="section-pill">
+                            <span class="pill-dot"></span>
+                            Monatliche Erfolgskontrolle
+                        </span>
+                    </div>
+                    <div class="section-body">
+                        {{ ROI_TRACKING_HTML|safe }}
+                    </div>
+                </section>
+                {% endif %}
+                {% if AI_POLICY_MINI_HTML %}
+                <section class="section chapter">
+                    <div class="section-header">
+                        <div class="section-title">
+                            <span class="section-kicker">Governance</span>
+                            <h2>AI Mini-Policy</h2>
+                        </div>
+                        <span class="section-pill">
+                            <span class="pill-dot"></span>
+                            Kompakte KI-Regeln
+                        </span>
+                    </div>
+                    <div class="section-body">
+                        {{ AI_POLICY_MINI_HTML|safe }}
+                    </div>
+                </section>
+                {% endif %}
+                {% if KICKOFF_VORLAGE_HTML %}
+                <section class="section chapter">
+                    <div class="section-header">
+                        <div class="section-title">
+                            <span class="section-kicker">Projektstart</span>
+                            <h2>Kickoff-Vorlage</h2>
+                        </div>
+                        <span class="section-pill">
+                            <span class="pill-dot"></span>
+                            Agenda & Fragenkatalog
+                        </span>
+                    </div>
+                    <div class="section-body">
+                        {{ KICKOFF_VORLAGE_HTML|safe }}
+                    </div>
+                </section>
+                {% endif %}
+                {% if PROMPT_FRAMEWORK_HTML %}
+                <section class="section chapter">
+                    <div class="section-header">
+                        <div class="section-title">
+                            <span class="section-kicker">Anleitung</span>
+                            <h2>Prompt-Framework</h2>
+                        </div>
+                        <span class="section-pill">
+                            <span class="pill-dot"></span>
+                            5-Schritte zum perfekten Prompt
+                        </span>
+                    </div>
+                    <div class="section-body">
+                        {{ PROMPT_FRAMEWORK_HTML|safe }}
+                    </div>
+                </section>
+                {% endif %}
                 <!-- FEEDBACK SECTION -->
                 <div class="feedback-section">
                     <h2>Ihr Feedback ist uns wichtig!</h2>

--- a/templates/pdf_template_en.html
+++ b/templates/pdf_template_en.html
@@ -1795,6 +1795,75 @@
                     </div>
                 </section>
                 {% endif %}
+                <!-- NEW SECTIONS: ROI Tracking, AI Mini Policy, Kickoff Template, Prompt Framework -->
+                {% if ROI_TRACKING_HTML %}
+                <section class="section chapter">
+                    <div class="section-header">
+                        <div class="section-title">
+                            <span class="section-kicker">Measurement</span>
+                            <h2>ROI Tracking</h2>
+                        </div>
+                        <span class="section-pill">
+                            <span class="pill-dot"></span>
+                            Monthly KPIs & Success Metrics
+                        </span>
+                    </div>
+                    <div class="section-body">
+                        {{ ROI_TRACKING_HTML|safe }}
+                    </div>
+                </section>
+                {% endif %}
+                {% if AI_POLICY_MINI_HTML %}
+                <section class="section chapter">
+                    <div class="section-header">
+                        <div class="section-title">
+                            <span class="section-kicker">Governance</span>
+                            <h2>AI Mini Policy</h2>
+                        </div>
+                        <span class="section-pill">
+                            <span class="pill-dot"></span>
+                            7 Rules for Daily AI Use
+                        </span>
+                    </div>
+                    <div class="section-body">
+                        {{ AI_POLICY_MINI_HTML|safe }}
+                    </div>
+                </section>
+                {% endif %}
+                {% if KICKOFF_VORLAGE_HTML %}
+                <section class="section chapter">
+                    <div class="section-header">
+                        <div class="section-title">
+                            <span class="section-kicker">Project Start</span>
+                            <h2>Kickoff Template</h2>
+                        </div>
+                        <span class="section-pill">
+                            <span class="pill-dot"></span>
+                            Agenda & Checklist
+                        </span>
+                    </div>
+                    <div class="section-body">
+                        {{ KICKOFF_VORLAGE_HTML|safe }}
+                    </div>
+                </section>
+                {% endif %}
+                {% if PROMPT_FRAMEWORK_HTML %}
+                <section class="section chapter">
+                    <div class="section-header">
+                        <div class="section-title">
+                            <span class="section-kicker">AI Communication</span>
+                            <h2>Prompt Framework</h2>
+                        </div>
+                        <span class="section-pill">
+                            <span class="pill-dot"></span>
+                            5-Step Prompting Guide
+                        </span>
+                    </div>
+                    <div class="section-body">
+                        {{ PROMPT_FRAMEWORK_HTML|safe }}
+                    </div>
+                </section>
+                {% endif %}
 <!-- FEEDBACK SECTION -->
                 <div class="feedback-section">
                     <h2>Your Feedback Matters!</h2>


### PR DESCRIPTION
Add 8 new prompt files (DE + EN):
- roi_tracking: Monthly KPI tracking template
- ai_policy_mini: 7 compact AI usage rules
- kickoff_vorlage: Project kickoff agenda
- prompt_framework: 5-step prompting guide

All prompts include persona tags (Solo/Team/KMU).

Integration:
- gpt_analyze.py: Added to prompt_map and parallel_sections
- prompt_enhancer.py: Added to PROMPTS_WITH_BRANCH_SIZE_CONTEXT
- prompt_manifest.json: Registered all 8 new prompts
- PDF templates (DE + EN): Added conditional section rendering