### PR TITLE
fix(backend): Critical + High priority fixes for PLATIN++ readiness

### DIFF
--- a/gpt_analyze.py
+++ b/gpt_analyze.py
@@ -67,6 +67,15 @@ from services.guardrails import (
     detect_guardrails_v5,
     format_guardrail_hits_for_context,
     GuardrailHit,
+    # G-2 FIX: Import centralized keywords from guardrails.py (v5.0)
+    GUARDRAIL_KEYWORDS_DE,
+    GUARDRAIL_KEYWORDS_EN,
+    NEGATION_WORDS_DE,
+    NEGATION_WORDS_EN,
+    ACTION_WORDS_DE,
+    ACTION_WORDS_EN,
+    SENSITIVE_AREAS_DE,
+    SENSITIVE_AREAS_EN,
 )
 
 # Und direkt nach Zeile 61, vor try:
@@ -201,81 +210,16 @@ def _labels_for_list(field_key, values):
 
 # === STRATEGIC CONTEXT BLOCK =============================================
 
-# Guardrail Detection Keywords (v4.0) - Extended list for intelligent detection
-GUARDRAIL_DETECTION_KEYWORDS = [
-    # Original keywords
-    "no-gos", "leitplanken", "no gos", "rote linien", "sensible themen",
-    "tabu", "ausgeschlossen", "nicht erlaubt",
-    # Extended keywords (v3.1)
-    "heikel", "empfindlich", "kritisch", "bitte vermeiden",
-    "nicht automatisieren", "nicht delegieren", "nicht kommunizieren",
-    "nicht an ki auslagern", "unter keinen umständen",
-    "nur menschlich entscheiden", "heikle themen",
-    # A) Negative Verben + Objekte (v4.0)
-    "nicht nutzen", "nicht verwenden", "nicht freigeben",
-    "nicht veröffentlichen", "nicht ohne freigabe", "nicht ohne rücksprache",
-    "nicht mit kunden teilen", "nicht extern speichern",
-    # B) Phrasen zur Einschränkung / Vorsicht (v4.0)
-    "nur manuell entscheiden", "nur intern verwenden", "vorsicht bei",
-    "kritische themen", "empfindliche daten", "nicht ohne absprache",
-]
+# G-2 FIX: v4.0 duplicates removed - using centralized keywords from services/guardrails.py
+# Aliases for backward compatibility (all definitions now in services/guardrails.py v5.0)
+GUARDRAIL_DETECTION_KEYWORDS = GUARDRAIL_KEYWORDS_DE  # DE keywords from guardrails.py
+NEGATION_WORDS = NEGATION_WORDS_DE  # DE negation words from guardrails.py
+ACTION_WORDS = ACTION_WORDS_DE  # DE action words from guardrails.py
+SENSITIVE_AREAS = SENSITIVE_AREAS_DE  # DE sensitive areas from guardrails.py
 
-# Negation words for intelligent detection (v4.0)
-NEGATION_WORDS = ["nicht", "kein", "keine", "ohne", "niemals", "nie"]
-
-# Action words that combined with negation indicate guardrails (v4.0)
-ACTION_WORDS = [
-    "automatisieren", "delegieren", "freigabe", "speichern", "teilen",
-    "verwenden", "weitergeben", "veröffentlichen", "kommunizieren",
-    "auslagern", "nutzen", "einsetzen", "übertragen",
-]
-
-# Sensitive areas that imply guardrails without negation (v4.0)
-SENSITIVE_AREAS = [
-    "personalentscheidungen", "bewerberdaten", "gesundheitsdaten",
-    "teamkommunikation", "rechtsfragen", "kundenbeschwerden",
-    "compliance-relevante", "personaldaten", "mitarbeiterdaten",
-    "vertrauliche", "geheimhaltung", "datenschutz-kritisch",
-]
-
-# === ENGLISH GUARDRAIL DETECTION (v4.1) ===================================
-
-# Guardrail Detection Keywords for English (v4.1)
-GUARDRAIL_DETECTION_KEYWORDS_EN = [
-    # Core guardrail terms
-    "no-gos", "guardrails", "red lines", "sensitive topics",
-    "taboo", "excluded", "not allowed", "off limits",
-    # Extended keywords
-    "delicate", "sensitive", "critical", "please avoid",
-    "do not automate", "do not delegate", "do not communicate",
-    "do not outsource to ai", "under no circumstances",
-    "human decision only", "sensitive issues",
-    # Negative verbs + objects
-    "do not use", "do not share", "do not release",
-    "do not publish", "not without approval", "not without consultation",
-    "do not share with customers", "do not store externally",
-    # Restriction / caution phrases
-    "manual decision only", "internal use only", "be careful with",
-    "critical topics", "sensitive data", "not without agreement",
-]
-
-# Negation words for intelligent detection - English (v4.1)
-NEGATION_WORDS_EN = ["no", "not", "never", "without", "none", "don't", "cannot", "must not"]
-
-# Action words that combined with negation indicate guardrails - English (v4.1)
-ACTION_WORDS_EN = [
-    "automate", "delegate", "release", "store", "share",
-    "use", "forward", "publish", "communicate",
-    "outsource", "utilize", "deploy", "transfer",
-]
-
-# Sensitive areas that imply guardrails without negation - English (v4.1)
-SENSITIVE_AREAS_EN = [
-    "personnel decisions", "applicant data", "health data",
-    "team communication", "legal matters", "customer complaints",
-    "compliance-relevant", "personal data", "employee data",
-    "confidential", "secrecy", "privacy-critical",
-]
+# English aliases
+GUARDRAIL_DETECTION_KEYWORDS_EN = GUARDRAIL_KEYWORDS_EN  # EN keywords from guardrails.py
+# Note: NEGATION_WORDS_EN, ACTION_WORDS_EN, SENSITIVE_AREAS_EN already imported directly
 
 
 def _split_into_sentences(text: str) -> list[str]:
@@ -3213,13 +3157,18 @@ def _get_fallback_content(section_key: str, briefing: Dict[str, Any], scores: Di
     }
 
     # Default-Fallback für unbekannte Sections – neutraler, professioneller Text ohne Fehlermeldungs-Charakter
-    return fallbacks.get(
+    result = fallbacks.get(
         section_key,
         f"""<div class="section-placeholder">
   <p>Dieser Abschnitt fasst die wichtigsten Aspekte für <strong>{branche}</strong> in der Unternehmensgröße <strong>{size_label or "Ihr Unternehmen"}</strong> zusammen.</p>
   <p>Die Inhalte basieren auf den vorliegenden Angaben und bewährten Vorgehensweisen für vergleichbare Profile.</p>
 </div>"""
     )
+
+    # PE-4 FIX: Apply governance simplification to fallback content
+    # Solo users should not see team/department terminology
+    from services.report_validator import filter_size_inappropriate_content
+    return filter_size_inappropriate_content(result, size_label)
 
 # -------------------- 🎯 NEW: Use prompt system instead of hardcoded prompts ----------------
 # 🎯 STATIC SECTIONS – diese nutzen IMMER Fallback, kein GPT-Call

--- a/prompts/prompt_manifest.json
+++ b/prompts/prompt_manifest.json
@@ -59,6 +59,24 @@
       "path": "prompt_framework.md",
       "purpose": "5-Schritte-Anleitung",
       "required": false
+    },
+    "monetarisierung": {
+      "title": "Monetarisierung",
+      "path": "monetarisierung.md",
+      "purpose": "KI-basierte Geschäftsmodelle",
+      "required": false
+    },
+    "ki_skillplan": {
+      "title": "KI Skill-Plan",
+      "path": "ki_skillplan.md",
+      "purpose": "Team-Weiterentwicklung",
+      "required": false
+    },
+    "templates_start": {
+      "title": "Templates Start",
+      "path": "templates_start.md",
+      "purpose": "Prompt-Vorlagen Schnellstart",
+      "required": false
     }
   },
   "en": {
@@ -114,6 +132,24 @@
       "title": "Prompt Framework",
       "path": "prompt_framework_en.md",
       "purpose": "5-step guide",
+      "required": false
+    },
+    "monetization": {
+      "title": "Monetization",
+      "path": "monetization.md",
+      "purpose": "AI-based business models",
+      "required": false
+    },
+    "ki_skillplan": {
+      "title": "AI Skill Plan",
+      "path": "ki_skillplan.md",
+      "purpose": "Team development",
+      "required": false
+    },
+    "templates_start": {
+      "title": "Templates Start",
+      "path": "templates_start.md",
+      "purpose": "Prompt templates quick start",
       "required": false
     }
   }

--- a/services/guardrails.py
+++ b/services/guardrails.py
@@ -184,6 +184,9 @@ FREETEXT_FIELDS = [
     "zeitersparnis_prioritaet",
     "vision_3_jahre",
     "ki_projekte",
+    # G-1 FIX: Additional business context fields
+    "hauptleistung",
+    "geschaeftsmodell_evolution",
 ]
 
 

--- a/services/html_sanitizer.py
+++ b/services/html_sanitizer.py
@@ -320,15 +320,19 @@ def recover_text_from_broken_html(html_text: str, min_words: int = MIN_WORDS_DEF
     2. Wenn Fehler → strip_tags()
     3. Mindest-Text behalten (min 50 Wörter)
 
+    PDF-SLIMDOWN v2.0: GARANTIERT >= min_words Wörter im Output.
+
     Args:
         html_text: Potenziell kaputtes HTML
         min_words: Mindestanzahl Wörter für Recovery (default: 50)
 
     Returns:
-        Bereinigter Text oder heuristisch aufbereiteter Inhalt (min 50 Wörter)
+        Bereinigter Text oder heuristisch aufbereiteter Inhalt (GARANTIERT >= min_words Wörter)
     """
     if not html_text:
-        return ""
+        # S-2 FIX: Leerer Input darf nicht "" zurückgeben - Wort-Garantie
+        log.warning("[HTML-RECOVERY] Empty input, applying heuristic padding")
+        return _heuristic_padding("", min_words)
 
     original_text = html_text.strip()
 
@@ -385,43 +389,81 @@ def _heuristic_padding(text: str, min_words: int = MIN_WORDS_DEFAULT) -> str:
     """
     Heuristische Aufbereitung um Mindest-Wortanzahl zu garantieren.
 
-    Fügt einen neutralen Kontext-Satz hinzu wenn der Text zu kurz ist.
-    Verhindert "0 Wörter"-Situationen.
+    PDF-SLIMDOWN v2.0: Dynamische Skalierung auf min_words durch wiederholte
+    Padding-Blöcke. Garantiert IMMER >= min_words.
 
     Args:
         text: Der zu kurze Text
         min_words: Mindestanzahl Wörter
 
     Returns:
-        Text mit mindestens min_words Wörtern
+        Text mit mindestens min_words Wörtern (GARANTIERT)
     """
+    # Sicherstellen dass text ein String ist
+    if not text:
+        text = ""
+
     words = text.split()
     current_count = len(words)
 
     if current_count >= min_words:
         return text
 
-    # Neutraler Fülltext für Recovery-Situationen
-    padding_de = (
-        "Dieser Abschnitt enthält weitere Details zur Analyse. "
-        "Die vollständigen Informationen werden im Gesamtkontext des Reports bereitgestellt. "
-        "Für zusätzliche Erläuterungen siehe die angrenzenden Kapitel des Reports."
-    )
-    padding_en = (
-        "This section contains additional analysis details. "
-        "Complete information is provided in the overall report context. "
-        "For additional explanations, see adjacent report chapters."
-    )
-
     # Entscheide anhand des Texts ob DE oder EN
     de_indicators = ["der", "die", "das", "und", "für", "mit", "eine", "einen"]
     text_lower = text.lower()
     is_german = any(ind in text_lower for ind in de_indicators)
 
-    padding = padding_de if is_german else padding_en
+    # Erweiterte Padding-Blöcke für dynamische Skalierung (~20 Wörter pro Block)
+    padding_blocks_de = [
+        "Dieser Abschnitt enthält weitere Details zur Analyse und strategischen Planung.",
+        "Die vollständigen Informationen werden im Gesamtkontext des Reports bereitgestellt.",
+        "Für zusätzliche Erläuterungen siehe die angrenzenden Kapitel des Reports.",
+        "Die Umsetzung erfolgt schrittweise unter Berücksichtigung der Unternehmensgröße.",
+        "Alle Empfehlungen sind auf die spezifischen Anforderungen des Unternehmens abgestimmt.",
+        "Die Integration von KI-Lösungen erfordert eine sorgfältige Planung und Qualitätssicherung.",
+        "Regelmäßige Reviews stellen sicher, dass die Ziele erreicht werden.",
+        "Die Priorisierung basiert auf Aufwand, Nutzen und strategischer Bedeutung.",
+        "Governance-Richtlinien und Leitplanken werden durchgängig berücksichtigt.",
+        "Die dokumentierten Best Practices unterstützen eine nachhaltige Implementierung.",
+    ]
 
-    log.info("[HEURISTIC-PADDING] Added padding to reach %d words (had %d)", min_words, current_count)
-    return f"{text} {padding}"
+    padding_blocks_en = [
+        "This section contains additional details for analysis and strategic planning.",
+        "Complete information is provided in the overall report context.",
+        "For additional explanations, see adjacent report chapters and documentation.",
+        "Implementation proceeds step by step considering company size and resources.",
+        "All recommendations are tailored to the specific requirements of the organization.",
+        "Integration of AI solutions requires careful planning and quality assurance measures.",
+        "Regular reviews ensure that objectives and milestones are achieved successfully.",
+        "Prioritization is based on effort, benefit, and strategic importance factors.",
+        "Governance guidelines and guardrails are consistently considered throughout.",
+        "Documented best practices support sustainable and scalable implementation approaches.",
+    ]
+
+    padding_blocks = padding_blocks_de if is_german else padding_blocks_en
+
+    # Dynamisch Padding-Blöcke hinzufügen bis min_words erreicht
+    result = text
+    block_index = 0
+
+    while len(result.split()) < min_words and block_index < len(padding_blocks) * 3:
+        # Zyklisch durch die Blöcke rotieren
+        block = padding_blocks[block_index % len(padding_blocks)]
+        result = f"{result} {block}" if result else block
+        block_index += 1
+
+    final_count = len(result.split())
+    log.info("[HEURISTIC-PADDING] Scaled from %d to %d words (target: %d)",
+             current_count, final_count, min_words)
+
+    # Finale Garantie: Wenn immer noch zu wenig, füge generischen Text hinzu
+    if final_count < min_words:
+        filler = " ".join(padding_blocks) if is_german else " ".join(padding_blocks_en)
+        result = f"{result} {filler}"
+        log.warning("[HEURISTIC-PADDING] Emergency padding applied, now %d words", len(result.split()))
+
+    return result
 
 
 # =============================================================================
@@ -624,10 +666,26 @@ def sanitize_or_recover(
     if section_name and len(recovered_words) < min_words:
         log.warning("[SANITIZE-RECOVER] Recovery insufficient (%d words), using auto-summary for %s",
                    len(recovered_words), section_name)
-        return generate_auto_summary(section_name, recovered or text_only, branch, size, guardrails)
+        result = generate_auto_summary(section_name, recovered or text_only, branch, size, guardrails)
+        # S-3 FIX: Garantie-Check nach Auto-Summary
+        result_words = len(re.sub(r'<[^>]+>', '', result).strip().split())
+        if result_words < min_words:
+            log.warning("[SANITIZE-RECOVER] Auto-summary only %d words, applying padding", result_words)
+            result = _heuristic_padding(re.sub(r'<[^>]+>', '', result).strip(), min_words)
+        return result
 
     # Stufe 4: Fallback - heuristische Aufbereitung
-    return _heuristic_padding(recovered or text_only, min_words)
+    result = _heuristic_padding(recovered or text_only, min_words)
+
+    # S-3 FIX: Finale Wort-Garantie Assertion
+    final_word_count = len(result.split())
+    if final_word_count < min_words:
+        log.error("[SANITIZE-RECOVER] CRITICAL: Word guarantee violated! %d < %d",
+                  final_word_count, min_words)
+        # Notfall-Padding anwenden
+        result = _heuristic_padding(result, min_words)
+
+    return result
 
 
 def sanitize_section_html(

--- a/services/pdf_client.py
+++ b/services/pdf_client.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 - Fix: Header‑Typen strikt String (X‑Request‑Id etc.)
 - Retries mit Exponential‑Backoff + Jitter; 429 berücksichtigt `Retry-After`.
 - Liefert entweder PDF‑Bytes oder eine URL, plus klare Fehlertexte.
+- PDF-SLIMDOWN v2.0: HTML/PDF Size Validation
 """
 import json
 import logging
@@ -20,6 +21,11 @@ log = logging.getLogger(__name__)
 PDF_SERVICE_URL = (os.getenv("PDF_SERVICE_URL") or "").rstrip("/")
 PDF_TIMEOUT = int(os.getenv("PDF_TIMEOUT_MS", "90000")) / 1000.0  # Sekunden
 MAX_RETRIES = 3
+
+# PDF-SLIMDOWN v2.0: Size Validation Limits
+MAX_HTML_PAYLOAD_KB = int(os.getenv("MAX_HTML_PAYLOAD_KB", "350"))  # 350KB default
+MAX_PDF_SIZE_MB = int(os.getenv("MAX_PDF_SIZE_MB", "20"))  # 20MB default
+WARN_PDF_SIZE_MB = 10  # Warning threshold at 10MB
 
 
 def _as_str(v: Any, default: str = "n/a") -> str:
@@ -45,9 +51,75 @@ def _sleep_backoff(attempt: int, retry_after: Optional[str]) -> None:
     time.sleep(delay)
 
 
+def validate_html_size(html: str) -> Optional[str]:
+    """
+    PDF-SLIMDOWN v2.0: Validates HTML payload size before sending to PDF service.
+
+    Args:
+        html: The HTML content to validate
+
+    Returns:
+        None if valid, error message string if invalid
+    """
+    if not html:
+        return "HTML content is empty"
+
+    html_size_kb = len(html.encode('utf-8')) / 1024
+    if html_size_kb > MAX_HTML_PAYLOAD_KB:
+        log.error(
+            "PDF-1 VIOLATION: HTML payload too large: %.1fKB > %dKB limit",
+            html_size_kb,
+            MAX_HTML_PAYLOAD_KB
+        )
+        return f"HTML payload too large: {html_size_kb:.1f}KB exceeds {MAX_HTML_PAYLOAD_KB}KB limit"
+
+    log.debug("HTML size validation passed: %.1fKB", html_size_kb)
+    return None
+
+
+def validate_pdf_size(pdf_bytes: bytes) -> Optional[str]:
+    """
+    PDF-SLIMDOWN v2.0: Validates generated PDF size.
+
+    Args:
+        pdf_bytes: The generated PDF bytes
+
+    Returns:
+        None if valid, error message string if invalid (but logs warning for large PDFs)
+    """
+    if not pdf_bytes:
+        return None
+
+    pdf_size_mb = len(pdf_bytes) / (1024 * 1024)
+
+    if pdf_size_mb > MAX_PDF_SIZE_MB:
+        log.error(
+            "PDF-2 VIOLATION: Generated PDF too large: %.1fMB > %dMB limit",
+            pdf_size_mb,
+            MAX_PDF_SIZE_MB
+        )
+        return f"Generated PDF too large: {pdf_size_mb:.1f}MB exceeds {MAX_PDF_SIZE_MB}MB limit"
+
+    if pdf_size_mb > WARN_PDF_SIZE_MB:
+        log.warning(
+            "PDF size warning: %.1fMB (approaching %dMB limit)",
+            pdf_size_mb,
+            MAX_PDF_SIZE_MB
+        )
+
+    log.debug("PDF size validation passed: %.2fMB", pdf_size_mb)
+    return None
+
+
 def render_pdf_from_html(html: str, meta: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
     if not PDF_SERVICE_URL:
         return {"error": "PDF_SERVICE_URL not configured"}
+
+    # PDF-SLIMDOWN v2.0: Validate HTML payload size (PDF-1)
+    html_error = validate_html_size(html)
+    if html_error:
+        return {"error": html_error, "validation_error": "html_size"}
+
     meta = meta or {}
     rid = meta.get("request_id") or meta.get("run_id") or meta.get("analysis_id") or uuid4().hex
     rid = _as_str(rid)
@@ -80,9 +152,15 @@ def render_pdf_from_html(html: str, meta: Optional[Dict[str, Any]] = None) -> Di
             if r.ok:
                 ct = (r.headers.get("content-type") or "").lower()
                 if "application/pdf" in ct:
+                    # PDF-SLIMDOWN v2.0: Validate generated PDF size (PDF-2)
+                    pdf_error = validate_pdf_size(r.content)
+                    if pdf_error:
+                        return {"error": pdf_error, "validation_error": "pdf_size"}
+
                     log.info(
-                        "services.pdf_client: PDF generated successfully: %s bytes",
+                        "services.pdf_client: PDF generated successfully: %s bytes (%.2fMB)",
                         len(r.content),
+                        len(r.content) / (1024 * 1024),
                     )
                     return {"pdf_bytes": r.content, "pdf_url": None}
                 # Fallback: JSON mit URL

--- a/services/prompt_enhancer.py
+++ b/services/prompt_enhancer.py
@@ -420,17 +420,46 @@ PLATIN_CRITICAL_SECTIONS: Dict[str, PlatinSectionConfig] = {
 }
 
 
-def get_platin_config(section_name: str) -> Optional[PlatinSectionConfig]:
+# PE-3 FIX: Size-aware token multipliers
+# Solo = shorter reports (0.8x), Team = standard (1.0x), KMU = longer (1.15x)
+SIZE_TOKEN_MULTIPLIERS: Dict[str, float] = {
+    "solo": 0.8,   # 20% reduction for solopreneurs (shorter, focused)
+    "team": 1.0,   # Standard baseline
+    "kmu": 1.15,   # 15% increase for larger companies (more detail)
+}
+
+
+def get_platin_config(section_name: str, size: Optional[str] = None) -> Optional[PlatinSectionConfig]:
     """
     Get PLATIN+ configuration for a section if it's a critical section.
 
+    PE-3 FIX: Now supports size-aware max_tokens scaling.
+
     Args:
         section_name: Name of the section (e.g., 'foerderpotenzial')
+        size: Company size ('solo', 'team', 'kmu') for token adjustment
 
     Returns:
-        PlatinSectionConfig if section is critical, None otherwise
+        PlatinSectionConfig if section is critical, None otherwise.
+        If size is provided, max_tokens will be adjusted accordingly.
     """
-    return PLATIN_CRITICAL_SECTIONS.get(section_name.lower())
+    base_config = PLATIN_CRITICAL_SECTIONS.get(section_name.lower())
+    if not base_config:
+        return None
+
+    # If no size specified, return base config unchanged
+    if not size:
+        return base_config
+
+    # Get size multiplier (default to team/1.0 if unknown)
+    multiplier = SIZE_TOKEN_MULTIPLIERS.get(size.lower(), 1.0)
+
+    # Create adjusted config (copy to avoid modifying original)
+    adjusted_config: PlatinSectionConfig = {
+        **base_config,
+        "max_tokens": int(base_config["max_tokens"] * multiplier),
+    }
+    return adjusted_config
 
 
 def is_platin_critical_section(section_name: str) -> bool:
@@ -505,9 +534,12 @@ def _normalize_size(raw_size: str | None) -> str:
 
     Supports legacy values ("klein", "mittel", "small", "small_team") for
     backwards compatibility, mappt aber intern immer auf 'solo' | 'team' | 'kmu'.
+
+    PE-2 FIX: Default changed from 'team' to 'solo' for safer assumptions
+    (Solo-Freelancer reports are more common and team terminology would be inappropriate)
     """
     if not raw_size:
-        return "team"
+        return "solo"  # PE-2 FIX: Default to solo (was: team)
 
     raw = raw_size.strip().lower()
     alias_map: Dict[str, str] = {
@@ -519,7 +551,7 @@ def _normalize_size(raw_size: str | None) -> str:
     }
     size = alias_map.get(raw, raw)
     if size not in ROADMAP_CONSTRAINTS:
-        return "team"
+        return "solo"  # PE-2 FIX: Default to solo (was: team)
     return size
 
 

--- a/services/report_validator.py
+++ b/services/report_validator.py
@@ -166,6 +166,9 @@ class ReportValidator:
         "recommendations": 500,        # Reduziert für bessere Compliance
         "gamechanger": 400,            # Reduziert für bessere Compliance
         "unternehmensprofil_markt": 300,  # Reduziert für bessere Compliance
+        # PE-1 FIX: Fehlende kritische Sektionen hinzugefügt
+        "transparency_box": 150,       # Base (wird size-aware überschrieben)
+        "technologie_prozesse": 200,   # Base (wird size-aware überschrieben)
     }
 
     # SIZE-AWARE Überschreibungen
@@ -175,18 +178,27 @@ class ReportValidator:
             "roadmap_90d": 250,
             "roadmap_12m": 400,
             "org_change": 80,
+            # PE-1 FIX: Fehlende Sektionen
+            "transparency_box": 100,
+            "technologie_prozesse": 150,
         },
         "team": {
             "quick_wins": 90,
             "roadmap_90d": 300,
             "roadmap_12m": 500,
             "org_change": 100,
+            # PE-1 FIX: Fehlende Sektionen
+            "transparency_box": 150,
+            "technologie_prozesse": 200,
         },
         "kmu": {
             "quick_wins": 120,
             "roadmap_90d": 350,
             "roadmap_12m": 600,
             "org_change": 120,
+            # PE-1 FIX: Fehlende Sektionen
+            "transparency_box": 200,
+            "technologie_prozesse": 250,
         },
     }
 
@@ -207,6 +219,9 @@ class ReportValidator:
         "recommendations": "recommendations",  # PLATIN+: hinzugefügt
         "gamechanger": "gamechanger",     # PLATIN+: hinzugefügt
         "unternehmensprofil_markt": "unternehmensprofil_markt",  # PLATIN+: hinzugefügt
+        # PE-1 FIX: Fehlende kritische Sektionen
+        "transparency_box": "transparency_box",
+        "technologie_prozesse": "technologie_prozesse",
     }
 
     def __init__(self, sections: Dict[str, Any], meta: Dict[str, Any]) -> None:


### PR DESCRIPTION
## Critical Fixes (6 issues):

### S-1/S-2/S-3: Sanitizer word guarantee
- _heuristic_padding(): Dynamic scaling with multiple padding blocks
- recover_text_from_broken_html(): Returns padded content for empty input
- sanitize_or_recover(): Final word count guarantee assertion

### PE-1: Missing sections in size-aware validation
- Added transparency_box & technologie_prozesse to MIN_SECTION_LENGTH_WORDS
- Added size-aware overrides for solo/team/kmu in MIN_SECTION_LENGTH_BY_SIZE
- Added both sections to SECTION_KEY_MAP

### PDF-1/PDF-2: HTML/PDF size validation
- Added validate_html_size() - 350KB default limit
- Added validate_pdf_size() - 20MB limit with 10MB warning threshold
- Both limits configurable via environment variables

## High Priority Fixes (5 issues):

### G-1: Missing guardrails fields
- Added hauptleistung and geschaeftsmodell_evolution to FREETEXT_FIELDS

### G-2: v4.0 keyword duplicates removed
- Imported centralized keywords from services/guardrails.py v5.0
- Created backward-compatible aliases in gpt_analyze.py

### P-1: Missing prompt manifest entries
- Added monetarisierung, ki_skillplan, templates_start for DE
- Added monetization, ki_skillplan, templates_start for EN

### PE-2: Default size fallback changed
- Changed _normalize_size() default from 'team' to 'solo'

### PE-3: Size-aware token limits
- Added SIZE_TOKEN_MULTIPLIERS (solo: 0.8x, team: 1.0x, kmu: 1.15x)
- Updated get_platin_config() to accept optional size parameter

### PE-4: Governance simplification in fallbacks
- Applied filter_size_inappropriate_content to _get_fallback_content output