### PR TITLE
fix(openai): remove unsupported stop parameter from all OpenAI calls

### DIFF
--- a/gpt_analyze.py
+++ b/gpt_analyze.py
@@ -58,7 +58,7 @@ from services.email_templates import render_report_ready_email
 from settings import settings
 from services.coverage_guard import analyze_coverage, build_html_report
 from services.prompt_loader import load_prompt
-from services.prompt_enhancer import PromptEnhancer, get_platin_config, PLATIN_STOP_SEQUENCES
+from services.prompt_enhancer import PromptEnhancer, get_platin_config
 from services.html_sanitizer import sanitize_sections_dict
 from utils.hotfix_gold_standard import apply_hotfix, UTF8Handler
 from utils.encoding_fixer import clean_briefing_data
@@ -847,12 +847,9 @@ def _call_openai(
         else:
             payload["max_tokens"] = int(max_tokens)
 
-        # PDF-SLIMDOWN: Stop-Sequences für kritische Sections hinzufügen
-        # Verhindert zu lange Outputs und Token-Abbrüche
-        if section and get_platin_config(section):
-            # Nur für PLATIN-kritische Sections Stop-Sequences verwenden
-            payload["stop"] = PLATIN_STOP_SEQUENCES
-            log.debug("🛑 Added stop sequences for section=%s", section)
+        # NOTE: stop parameter removed for OpenAI models (gpt-4o-mini, gpt-4.1, etc.)
+        # as it's no longer supported. Stop sequences are still used for Anthropic models
+        # via the anthropic_client.py module.
 
         r = requests.post(
             url,

--- a/services/anthropic_client.py
+++ b/services/anthropic_client.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 import os
 from functools import lru_cache
-from typing import Optional
+from typing import List, Optional
 
 try:
     import anthropic
@@ -13,6 +13,14 @@ except ImportError:  # pragma: no cover
     anthropic = None  # Wir loggen das später sauber weg
 
 log = logging.getLogger(__name__)
+
+# Import PLATIN_STOP_SEQUENCES for Anthropic-specific stop sequence handling
+# OpenAI no longer supports stop parameter for new models, but Anthropic still does
+try:
+    from services.prompt_enhancer import PLATIN_STOP_SEQUENCES, get_platin_config
+except ImportError:  # pragma: no cover
+    PLATIN_STOP_SEQUENCES: List[str] = []
+    get_platin_config = lambda x: None  # noqa: E731
 
 # --- ENV Defaults ----------------------------------------------------------
 
@@ -350,25 +358,37 @@ def call_anthropic(
     max_tok = max_tokens if max_tokens is not None else _get_max_tokens_for_section(section)
     sys = system_prompt or "Du bist ein hilfreicher, präziser KI-Berater."
 
+    # Stop-Sequences für PLATIN-kritische Sections (Anthropic still supports this)
+    # OpenAI no longer supports stop parameter for new models (gpt-4o-mini, gpt-4.1, etc.)
+    stop_seqs = None
+    if section and get_platin_config(section) and PLATIN_STOP_SEQUENCES:
+        stop_seqs = PLATIN_STOP_SEQUENCES
+        log.debug("🛑 Added stop sequences for Anthropic section=%s", section)
+
+    # Build API call kwargs
+    api_kwargs = {
+        "model": model_name,
+        "max_tokens": max_tok,
+        "temperature": temp,
+        "system": sys,
+        "messages": [
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "text",
+                        "text": prompt,
+                    }
+                ],
+            }
+        ],
+    }
+    if stop_seqs:
+        api_kwargs["stop_sequences"] = stop_seqs
+
     # Versuch 1: Mit aufgelöstem Modell
     try:
-        message = client.messages.create(
-            model=model_name,
-            max_tokens=max_tok,
-            temperature=temp,
-            system=sys,
-            messages=[
-                {
-                    "role": "user",
-                    "content": [
-                        {
-                            "type": "text",
-                            "text": prompt,
-                        }
-                    ],
-                }
-            ],
-        )
+        message = client.messages.create(**api_kwargs)
     except anthropic.NotFoundError as exc:
         # Modell nicht gefunden -> Fallback-Versuch
         fallback_model = os.getenv("ANTHROPIC_MODEL_FALLBACK", "claude-3-5-sonnet-latest")
@@ -380,26 +400,11 @@ def call_anthropic(
             str(exc),
             fallback_model
         )
-        
-        # Retry mit Fallback
+
+        # Retry mit Fallback - use same kwargs but with fallback model
+        api_kwargs["model"] = fallback_model
         try:
-            message = client.messages.create(
-                model=fallback_model,
-                max_tokens=max_tok,
-                temperature=temp,
-                system=sys,
-                messages=[
-                    {
-                        "role": "user",
-                        "content": [
-                            {
-                                "type": "text",
-                                "text": prompt,
-                            }
-                        ],
-                    }
-                ],
-            )
+            message = client.messages.create(**api_kwargs)
             log.info(
                 "✅ Fallback auf Modell '%s' erfolgreich (Abschnitt '%s')",
                 fallback_model,

--- a/services/anthropic_client.py
+++ b/services/anthropic_client.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 import os
 from functools import lru_cache
-from typing import List, Optional
+from typing import Any, Callable, List, Optional
 
 try:
     import anthropic
@@ -16,11 +16,16 @@ log = logging.getLogger(__name__)
 
 # Import PLATIN_STOP_SEQUENCES for Anthropic-specific stop sequence handling
 # OpenAI no longer supports stop parameter for new models, but Anthropic still does
+_PLATIN_STOP_SEQUENCES: List[str] = []
+_get_platin_config: Callable[[str], Any] = lambda x: None
+
 try:
-    from services.prompt_enhancer import PLATIN_STOP_SEQUENCES, get_platin_config
+    from services.prompt_enhancer import PLATIN_STOP_SEQUENCES as _imported_seqs
+    from services.prompt_enhancer import get_platin_config as _imported_config
+    _PLATIN_STOP_SEQUENCES = _imported_seqs
+    _get_platin_config = _imported_config
 except ImportError:  # pragma: no cover
-    PLATIN_STOP_SEQUENCES: List[str] = []
-    get_platin_config = lambda x: None  # noqa: E731
+    pass  # Use defaults defined above
 
 # --- ENV Defaults ----------------------------------------------------------
 
@@ -360,35 +365,43 @@ def call_anthropic(
 
     # Stop-Sequences für PLATIN-kritische Sections (Anthropic still supports this)
     # OpenAI no longer supports stop parameter for new models (gpt-4o-mini, gpt-4.1, etc.)
-    stop_seqs = None
-    if section and get_platin_config(section) and PLATIN_STOP_SEQUENCES:
-        stop_seqs = PLATIN_STOP_SEQUENCES
+    stop_seqs: Optional[List[str]] = None
+    if section and _get_platin_config(section) and _PLATIN_STOP_SEQUENCES:
+        stop_seqs = _PLATIN_STOP_SEQUENCES
         log.debug("🛑 Added stop sequences for Anthropic section=%s", section)
 
-    # Build API call kwargs
-    api_kwargs = {
-        "model": model_name,
-        "max_tokens": max_tok,
-        "temperature": temp,
-        "system": sys,
-        "messages": [
-            {
-                "role": "user",
-                "content": [
-                    {
-                        "type": "text",
-                        "text": prompt,
-                    }
-                ],
-            }
-        ],
-    }
-    if stop_seqs:
-        api_kwargs["stop_sequences"] = stop_seqs
+    # Build messages list
+    messages: List[Any] = [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "text",
+                    "text": prompt,
+                }
+            ],
+        }
+    ]
 
     # Versuch 1: Mit aufgelöstem Modell
     try:
-        message = client.messages.create(**api_kwargs)
+        if stop_seqs:
+            message = client.messages.create(
+                model=model_name,
+                max_tokens=max_tok,
+                temperature=temp,
+                system=sys,
+                messages=messages,
+                stop_sequences=stop_seqs,
+            )
+        else:
+            message = client.messages.create(
+                model=model_name,
+                max_tokens=max_tok,
+                temperature=temp,
+                system=sys,
+                messages=messages,
+            )
     except anthropic.NotFoundError as exc:
         # Modell nicht gefunden -> Fallback-Versuch
         fallback_model = os.getenv("ANTHROPIC_MODEL_FALLBACK", "claude-3-5-sonnet-latest")
@@ -401,10 +414,25 @@ def call_anthropic(
             fallback_model
         )
 
-        # Retry mit Fallback - use same kwargs but with fallback model
-        api_kwargs["model"] = fallback_model
+        # Retry mit Fallback
         try:
-            message = client.messages.create(**api_kwargs)
+            if stop_seqs:
+                message = client.messages.create(
+                    model=fallback_model,
+                    max_tokens=max_tok,
+                    temperature=temp,
+                    system=sys,
+                    messages=messages,
+                    stop_sequences=stop_seqs,
+                )
+            else:
+                message = client.messages.create(
+                    model=fallback_model,
+                    max_tokens=max_tok,
+                    temperature=temp,
+                    system=sys,
+                    messages=messages,
+                )
             log.info(
                 "✅ Fallback auf Modell '%s' erfolgreich (Abschnitt '%s')",
                 fallback_model,


### PR DESCRIPTION
- Remove stop parameter from _call_openai() in gpt_analyze.py
- New GPT models (gpt-4o-mini, gpt-4.1, etc.) no longer support the stop parameter
- Remove unused PLATIN_STOP_SEQUENCES import from gpt_analyze.py

feat(prompt-engine): separate stop-sequence logic for Anthropic only

- Add stop_sequences support to Anthropic client for PLATIN critical sections
- Import PLATIN_STOP_SEQUENCES and get_platin_config in anthropic_client.py
- Anthropic API still supports stop_sequences parameter
- Refactor API call to use kwargs pattern for cleaner code

This prevents API errors when using newer OpenAI models while maintaining stop sequence functionality for Anthropic models.