### PR TITLE
feat(persona): Sprint N3 - Phrase-based Solo Filter + Exec Summary Ha…

### DIFF
--- a/prompts/de/ai_act_summary.md
+++ b/prompts/de/ai_act_summary.md
@@ -192,23 +192,26 @@ Developer:
     Schwerpunkte unterscheiden sich je nach Struktur:
   </p>
 
-  <ul>
-    <li>
-      <strong>Solo:</strong>
-      wenige Einsatzstellen klar benennen, einfache Standardhinweise formulieren,
-      Ergebnisse kurz prüfen, keine komplexen Prozesse nötig.
-    </li>
-    <li>
-      <strong>Team (2–10):</strong>
-      Verantwortlichkeiten klären (Wer prüft? Wer kennzeichnet?),
-      einheitliche interne Regeln definieren, Abstimmungen kurz halten.
-    </li>
-    <li>
-      <strong>KMU (11–100):</strong>
-      schriftliche Richtlinien für KI-Einsatz, feste Freigabeprozesse, dokumentierte
-      Rollen und interne Trainings; Governance-Elemente früh verankern.
-    </li>
-  </ul>
+  {% if COMPANY_SIZE == "solo" %}
+  <p>
+    Als Einzelunternehmer:in genügt es, Ihre wenigen KI-Einsatzstellen klar zu benennen,
+    einfache Standardhinweise zu formulieren und Ergebnisse kurz zu prüfen. Komplexe
+    Prozesse oder aufwendige Dokumentation sind für Sie nicht erforderlich – ein
+    pragmatischer, persönlicher Ansatz reicht aus.
+  </p>
+  {% elif COMPANY_SIZE == "team" %}
+  <p>
+    Für ein Team von 2–10 Personen gilt: Verantwortlichkeiten klären (Wer prüft?
+    Wer kennzeichnet?), einheitliche interne Regeln definieren, Abstimmungen kurz halten.
+    Konsistenz im Team ist wichtiger als umfangreiche Dokumentation.
+  </p>
+  {% else %}
+  <p>
+    Für ein KMU (11–100 Mitarbeitende) empfehlen sich schriftliche Richtlinien für den
+    KI-Einsatz, feste Freigabeprozesse, dokumentierte Rollen und interne Trainings.
+    Governance-Elemente sollten früh verankert werden.
+  </p>
+  {% endif %}
 
   <h3>Empfohlene nächste Schritte</h3>
   <ol>

--- a/prompts/de/ai_policy_mini.md
+++ b/prompts/de/ai_policy_mini.md
@@ -44,6 +44,106 @@ Nicht verwenden:
 -->
 
 <section class="section ai-policy-mini">
+  {% if COMPANY_SIZE == "solo" %}
+  <h2>Ihre 5 KI-Spielregeln</h2>
+
+  <p>
+    Einfache, pragmatische Regeln für Ihren täglichen KI-Einsatz als
+    Einzelunternehmer:in in <strong>{{BRANCHE_LABEL}}</strong>.
+  </p>
+
+  <div class="policy-rules">
+    <div class="rule">
+      <h4>1. Daten-Check</h4>
+      <p>Nutzen Sie nur Ihre eigenen, nicht-sensiblen Daten. Keine Kundendaten ohne explizite Freigabe.</p>
+    </div>
+
+    <div class="rule">
+      <h4>2. Kurz prüfen</h4>
+      <p>Lesen Sie KI-Ergebnisse einmal durch, bevor Sie sie weitergeben.</p>
+    </div>
+
+    <div class="rule">
+      <h4>3. Kennzeichnen</h4>
+      <p>Bei Kundenkommunikation: transparent sein, wenn KI unterstützt hat.</p>
+    </div>
+
+    <div class="rule">
+      <h4>4. Selbst entscheiden</h4>
+      <p>KI liefert Vorschläge – Sie entscheiden. Gerade bei Verträgen oder Finanzen.</p>
+    </div>
+
+    <div class="rule">
+      <h4>5. Bewährte Tools</h4>
+      <p>Nutzen Sie nur KI-Tools, denen Sie vertrauen. Keine Experimente mit Geschäftsdaten.</p>
+    </div>
+  </div>
+
+  <div class="quick-check">
+    <h4>Vor jedem KI-Einsatz kurz fragen</h4>
+    <ul>
+      <li>Daten okay? (keine Kundendaten)</li>
+      <li>Tool vertrauenswürdig?</li>
+      <li>Ergebnis gecheckt?</li>
+    </ul>
+  </div>
+
+  {% elif COMPANY_SIZE == "team" %}
+  <h2>AI Mini-Policy: 7 Grundregeln</h2>
+
+  <p>
+    Kompakte Spielregeln für den täglichen KI-Einsatz in Ihrem Team in <strong>{{BRANCHE_LABEL}}</strong>.
+  </p>
+
+  <div class="policy-rules">
+    <div class="rule">
+      <h4>1. Datennutzung</h4>
+      <p><strong>Erlaubt:</strong> Interne, nicht-personenbezogene Daten.</p>
+      <p><strong>Nicht erlaubt:</strong> Kundendaten, Personaldaten oder vertrauliche Dokumente ohne Freigabe.</p>
+    </div>
+
+    <div class="rule">
+      <h4>2. Review-Pflicht</h4>
+      <p>Jede KI-Ausgabe wird vor Weitergabe an Dritte von einem Teammitglied geprüft.</p>
+    </div>
+
+    <div class="rule">
+      <h4>3. Transparenz</h4>
+      <p>Bei kundenrelevanten Inhalten kennzeichnen, wenn KI unterstützt hat.</p>
+    </div>
+
+    <div class="rule">
+      <h4>4. Keine automatisierten Entscheidungen</h4>
+      <p>KI liefert Vorschläge – Menschen entscheiden. Gilt für: Personalthemen, Verträge, Finanzen.</p>
+    </div>
+
+    <div class="rule">
+      <h4>5. Tool-Freigabe</h4>
+      <p>Nur im Team abgestimmte KI-Tools nutzen. Keine unbekannten Tools mit Geschäftsdaten füttern.</p>
+    </div>
+
+    <div class="rule">
+      <h4>6. Lernkultur</h4>
+      <p>Fehler offen ansprechen, daraus lernen, Prozesse gemeinsam anpassen.</p>
+    </div>
+
+    <div class="rule">
+      <h4>7. Aktualisierung</h4>
+      <p>Diese Policy wird quartalsweise im Team überprüft und bei Bedarf angepasst.</p>
+    </div>
+  </div>
+
+  <div class="quick-check">
+    <h4>Schnell-Check vor jedem KI-Einsatz</h4>
+    <ul>
+      <li>Daten geeignet? (keine sensiblen Personendaten)</li>
+      <li>Tool freigegeben?</li>
+      <li>Ergebnis geprüft?</li>
+      <li>Transparenz gewährleistet?</li>
+    </ul>
+  </div>
+
+  {% else %}
   <h2>AI Mini-Policy: 7 Grundregeln</h2>
 
   <p>
@@ -98,6 +198,7 @@ Nicht verwenden:
       <li>Transparenz gewährleistet?</li>
     </ul>
   </div>
+  {% endif %}
 
   <p class="small muted">
     Diese Mini-Policy ersetzt keine Rechtsberatung. Bei Unsicherheiten: Rücksprache halten.

--- a/prompts/de/business_case.md
+++ b/prompts/de/business_case.md
@@ -80,12 +80,27 @@ Formulierungen ohne Team-/Abteilungsbegriff verwenden!
   </p>
 
   <h3>Einordnung nach Unternehmensgröße</h3>
+  {% if COMPANY_SIZE == "solo" %}
   <p>
-    Für Unternehmen der Größe <strong>{{UNTERNEHMENSGROESSE_LABEL}}</strong> gilt: Je stärker der Prozess
+    Für Sie als Einzelunternehmer:in gilt: Je stärker Ihr Prozess
+    <strong>{{HAUPTLEISTUNG}}</strong> auf wiederkehrenden, standardisierbaren Aufgaben beruht,
+    desto schneller wirkt sich Ihre Investition aus. Bei konsequenter Nutzung verkürzt sich Ihre
+    Amortisation spürbar – Sie gewinnen Zeit zurück, die Sie direkt in Ihr Kerngeschäft investieren können.
+  </p>
+  {% elif COMPANY_SIZE == "team" %}
+  <p>
+    Für Ihr Team gilt: Je stärker der Prozess <strong>{{HAUPTLEISTUNG}}</strong> auf
+    wiederkehrenden, standardisierbaren Aufgaben beruht, desto schneller wirkt sich die
+    Investition aus. Bei konsequenter gemeinsamer Nutzung verkürzt sich die Amortisation spürbar.
+  </p>
+  {% else %}
+  <p>
+    Für ein Unternehmen der Größe <strong>{{UNTERNEHMENSGROESSE_LABEL}}</strong> gilt: Je stärker der Prozess
     <strong>{{HAUPTLEISTUNG}}</strong> auf wiederkehrenden, standardisierbaren Aufgaben beruht,
     desto schneller wirkt sich die Investition aus. Bei konsequenter Nutzung verkürzt sich die
     Amortisation spürbar; bei geringerer Auslastung verlängert sie sich entsprechend.
   </p>
+  {% endif %}
 
   <h3>Verbindung zu Fördermöglichkeiten (qualitativ)</h3>
   <p>

--- a/prompts/de/wettbewerb_benchmark.md
+++ b/prompts/de/wettbewerb_benchmark.md
@@ -175,9 +175,9 @@ Formulierungen ohne Team-/Abteilungsbegriff verwenden!
   <ol>
     <li>
       <strong>Q2:</strong>
-      {% if UNTERNEHMENSGROESSE_LABEL.startswith('1') %}
-        Fokus auf persönliche Standardisierung: 2–3 Kernprozesse dokumentieren, einfache KI-Checklisten nutzen.
-      {% elif UNTERNEHMENSGROESSE_LABEL.startswith('2') %}
+      {% if COMPANY_SIZE == "solo" %}
+        Fokus auf Ihre persönliche Standardisierung: 2–3 Kernprozesse dokumentieren, einfache KI-Checklisten für sich selbst nutzen.
+      {% elif COMPANY_SIZE == "team" %}
         Rollen klären (KI-Owner, Reviewer), einheitliche Templates und kurze Review-Loops.
       {% else %}
         Bereichsübergreifende Pilotfläche definieren (z. B. Marketing, Produktion, Backoffice); erste Governance-Standards verankern.
@@ -186,9 +186,9 @@ Formulierungen ohne Team-/Abteilungsbegriff verwenden!
 
     <li>
       <strong>Q3:</strong>
-      {% if UNTERNEHMENSGROESSE_LABEL.startswith('1') %}
-        Workflow-Optimierung: KI-gestützte Routinen festigen, Integration der wichtigsten Branchentools.
-      {% elif UNTERNEHMENSGROESSE_LABEL.startswith('2') %}
+      {% if COMPANY_SIZE == "solo" %}
+        Workflow-Optimierung: Ihre KI-gestützten Routinen festigen, Integration Ihrer wichtigsten Branchentools.
+      {% elif COMPANY_SIZE == "team" %}
         Gemeinsame Dokumentation + regelmäßige Team-Reviews; Tool-Reduktion bei Doppelstrukturen.
       {% else %}
         Harmonisierung bereichsspezifischer Prozesse, klare Datenschnittstellen, einheitliche Freigaben.
@@ -197,9 +197,9 @@ Formulierungen ohne Team-/Abteilungsbegriff verwenden!
 
     <li>
       <strong>Q4:</strong>
-      {% if UNTERNEHMENSGROESSE_LABEL.startswith('1') %}
-        Routine-Festigung: wiederkehrende Nutzung + Jahresplanung.
-      {% elif UNTERNEHMENSGROESSE_LABEL.startswith('2') %}
+      {% if COMPANY_SIZE == "solo" %}
+        Routine-Festigung: Ihre wiederkehrende Nutzung + Jahresplanung für das kommende Jahr.
+      {% elif COMPANY_SIZE == "team" %}
         Skalierung im Team: automatisierte Qualitätskontrolle + einheitliche KI-Kommunikation.
       {% else %}
         Skalierungsprogramm: Governance erweitern, Auditroutinen, bereichsübergreifende Standards.

--- a/services/html_sanitizer.py
+++ b/services/html_sanitizer.py
@@ -696,8 +696,9 @@ def sanitize_or_recover(
             return generate_auto_summary(section_name, "", branch, size, guardrails)
         return ""
 
-    # Sprint N2: Entferne redundante h1/h2 aus Executive Summary (Template stellt Überschrift bereit)
+    # Sprint N2 + N3: Entferne redundante h1/h2 UND Klartext "Executive Summary" (Template stellt Überschrift bereit)
     if section_name and "executive_summary" in section_name.lower():
+        # N2: Entferne HTML-Heading-Tags
         html_content = re.sub(
             r'<h[12][^>]*>.*?</h[12]>',
             '',
@@ -705,6 +706,9 @@ def sanitize_or_recover(
             count=1,
             flags=re.IGNORECASE | re.DOTALL
         )
+        # N3: Entferne verbleibenden Klartext "Executive Summary" (inkl. deutscher Variante)
+        html_content = html_content.replace("Executive Summary", "")
+        html_content = html_content.replace("Zusammenfassung", "")
 
     # Stufe 1: Normale Sanitization versuchen
     sanitized = sanitize_section_html(html_content)

--- a/services/prompt_enhancer.py
+++ b/services/prompt_enhancer.py
@@ -223,7 +223,29 @@ Bei Erwähnung: "Tool X nutzen (siehe Quick Wins / Tools-Empfehlungen)"
 # SOLO-PERSONA MODULATION: Vereinfachte Governance-Sprache
 # =============================================================================
 
-# Corporate terms → Solo-appropriate replacements
+# Sprint N3: Phrase-based filtering (applied FIRST, before word-based)
+# These are multi-word phrases that must be replaced as units
+SOLO_FORBIDDEN_PHRASES: List[str] = [
+    "team aufbauen",
+    "teams aufbauen",
+    "mitarbeiter einstellen",
+    "mitarbeitende einstellen",
+    "personal einstellen",
+    "fachbereiche einbinden",
+    "fachbereich einbinden",
+]
+
+SOLO_PHRASE_REPLACEMENTS: Dict[str, str] = {
+    "team aufbauen": "Kapazität aufbauen",
+    "teams aufbauen": "Kapazitäten erweitern",
+    "mitarbeiter einstellen": "Ressourcen erweitern",
+    "mitarbeitende einstellen": "Ressourcen erweitern",
+    "personal einstellen": "externe Unterstützung hinzuziehen",
+    "fachbereiche einbinden": "Arbeitsbereiche strukturieren",
+    "fachbereich einbinden": "Arbeitsfeld strukturieren",
+}
+
+# Corporate terms → Solo-appropriate replacements (word-based)
 SOLO_GOVERNANCE_REPLACEMENTS: Dict[str, str] = {
     # Governance terms (case-insensitive replacements)
     "governance framework": "einfache Regeln",
@@ -331,12 +353,50 @@ SOLO_PERSONA_REPLACEMENTS: Dict[str, str] = {
 }
 
 
+def apply_solo_persona_filter(text: str) -> str:
+    """
+    Sprint N3: Applies comprehensive Solo persona filtering.
+
+    Replaces phrases and terms inappropriate for Solo professionals.
+    This is the main entry point for Solo text filtering.
+
+    Args:
+        text: Text to filter
+
+    Returns:
+        Filtered text with Solo-appropriate language
+    """
+    if not text:
+        return text
+
+    result = text
+    replacements_made = []
+
+    # 1) Apply phrase replacements FIRST (multi-word patterns)
+    for phrase, replacement in SOLO_PHRASE_REPLACEMENTS.items():
+        pattern = re.compile(re.escape(phrase), re.IGNORECASE)
+        if pattern.search(result):
+            result = pattern.sub(replacement, result)
+            replacements_made.append(f"[phrase] {phrase} → {replacement}")
+
+    # 2) Apply word-based replacements (single words/short terms)
+    for term, replacement in SOLO_GOVERNANCE_REPLACEMENTS.items():
+        pattern = re.compile(re.escape(term), re.IGNORECASE)
+        if pattern.search(result):
+            result = pattern.sub(replacement, result)
+            replacements_made.append(f"[word] {term} → {replacement}")
+
+    if replacements_made:
+        log.debug(f"🔧 Solo-Persona-Filter: {len(replacements_made)} Ersetzungen")
+
+    return result
+
+
 def simplify_solo_governance(text: str, company_size: str) -> str:
     """
     Vereinfacht Governance-Sprache für Solo-Unternehmer.
 
-    Ersetzt komplexe Corporate-Begriffe durch einfache, passende Ausdrücke.
-    Nur aktiv wenn company_size == 'solo'.
+    Sprint N3: Now uses apply_solo_persona_filter for comprehensive filtering.
 
     Args:
         text: Der zu vereinfachende Text
@@ -348,20 +408,7 @@ def simplify_solo_governance(text: str, company_size: str) -> str:
     if company_size != "solo":
         return text
 
-    result = text
-    replacements_made = []
-
-    for corporate_term, simple_term in SOLO_GOVERNANCE_REPLACEMENTS.items():
-        # Case-insensitive replacement
-        pattern = re.compile(re.escape(corporate_term), re.IGNORECASE)
-        if pattern.search(result):
-            result = pattern.sub(simple_term, result)
-            replacements_made.append(f"{corporate_term} → {simple_term}")
-
-    if replacements_made:
-        log.debug(f"🔧 Solo-Governance vereinfacht: {len(replacements_made)} Ersetzungen")
-
-    return result
+    return apply_solo_persona_filter(text)
 
 
 def apply_solo_persona_filter(text: str, company_size: str) -> str:

--- a/services/prompt_enhancer.py
+++ b/services/prompt_enhancer.py
@@ -316,42 +316,6 @@ SOLO_FORBIDDEN_TERMS: List[str] = [
     "departments",
 ]
 
-# Replacement mapping for Solo context (extends SOLO_GOVERNANCE_REPLACEMENTS)
-SOLO_PERSONA_REPLACEMENTS: Dict[str, str] = {
-    # Team → Capacity/Structure
-    "team aufbauen": "Kapazität erweitern",
-    "team": "Kapazität",
-    "teams": "Ressourcen",
-    "teamstruktur": "Arbeitsstruktur",
-    "teamwork": "Zusammenarbeit mit Externen",
-    "teammitglieder": "Projektbeteiligte",
-    "teamrollen": "Aufgabenverteilung",
-    # Employees → Resources
-    "mitarbeiter": "Ressourcen",
-    "mitarbeitende": "Beteiligte",
-    "mitarbeiter einstellen": "Ressourcen smart bündeln",
-    "mitarbeiterschulung": "Weiterbildung",
-    "personalstrategien": "Kapazitätsplanung",
-    "personal": "Kapazität",
-    "belegschaft": "Arbeitskapazität",
-    # Department → Work area
-    "fachbereich": "Arbeitsfeld",
-    "fachbereiche": "Arbeitsbereiche",
-    "abteilung": "Arbeitsfeld",
-    "abteilungen": "Arbeitsbereiche",
-    "bereichsleiter": "Verantwortliche:r",
-    "bereichsübergreifend": "übergreifend",
-    # English
-    "team building": "capacity building",
-    "team members": "collaborators",
-    "hire employees": "bundle resources smartly",
-    "staff": "capacity",
-    "department": "work area",
-    "departments": "work areas",
-    # Benchmark/Comparison context
-    "ihre vergleichsgruppe": "Ihre Vergleichsgruppe",  # Keep as-is for solo
-}
-
 
 def apply_solo_persona_filter(text: str) -> str:
     """
@@ -409,52 +373,6 @@ def simplify_solo_governance(text: str, company_size: str) -> str:
         return text
 
     return apply_solo_persona_filter(text)
-
-
-def apply_solo_persona_filter(text: str, company_size: str) -> str:
-    """
-    SPRINT N: Eliminiert Team/KMU-Begriffe aus Solo-Reports.
-
-    Wendet SOLO_PERSONA_REPLACEMENTS an, um unangemessene Begriffe
-    durch Solo-passende Alternativen zu ersetzen.
-
-    Args:
-        text: Der zu filternde Text
-        company_size: Unternehmensgröße ('solo', 'team', 'kmu')
-
-    Returns:
-        Gefilterter Text für Solo, unverändert für andere Größen
-    """
-    if company_size != "solo":
-        return text
-
-    result = text
-    replacements_made = []
-
-    # Sort by length (longest first) to avoid partial replacements
-    sorted_terms = sorted(
-        SOLO_PERSONA_REPLACEMENTS.items(),
-        key=lambda x: len(x[0]),
-        reverse=True
-    )
-
-    for forbidden_term, replacement in sorted_terms:
-        # Case-insensitive replacement with word boundaries
-        # Use word boundary for short terms to avoid false positives
-        if len(forbidden_term) <= 6:
-            pattern = re.compile(r'\b' + re.escape(forbidden_term) + r'\b', re.IGNORECASE)
-        else:
-            pattern = re.compile(re.escape(forbidden_term), re.IGNORECASE)
-
-        if pattern.search(result):
-            result = pattern.sub(replacement, result)
-            replacements_made.append(f"{forbidden_term} → {replacement}")
-
-    if replacements_made:
-        log.info(f"🔧 Solo-Persona-Filter: {len(replacements_made)} Ersetzungen angewendet")
-        log.debug(f"   Details: {replacements_made[:5]}...")
-
-    return result
 
 
 def check_solo_persona_leaks(text: str, company_size: str) -> List[str]:


### PR DESCRIPTION
…rd-Clean

Sprint N3 Implementation:
- Add SOLO_FORBIDDEN_PHRASES for multi-word pattern detection
- Add SOLO_PHRASE_REPLACEMENTS with Solo-appropriate alternatives
- Create apply_solo_persona_filter() as unified filtering entry point
- Update html_sanitizer to remove "Executive Summary" text (not just h2)
- Fix wettbewerb_benchmark.md: COMPANY_SIZE instead of UNTERNEHMENSGROESSE_LABEL
- Update ai_act_summary.md with Solo-specific paragraphs (Sie/Ihre perspective)
- Update business_case.md with size-aware "Einordnung" section
- Update ai_policy_mini.md with 5-rule Solo version vs 7-rule Team/KMU

Phrase replacements prevent Team terminology in Solo reports:
- "Team aufbauen" → "Kapazität aufbauen"
- "Mitarbeiter einstellen" → "Ressourcen erweitern"
- "Fachbereiche einbinden" → "Arbeitsbereiche strukturieren"