### PR TITLE
feat(persona): Sprint N3.1 - Solo Filter Wiring + Exec Summary Templa…

### DIFF
--- a/gpt_analyze.py
+++ b/gpt_analyze.py
@@ -4831,6 +4831,10 @@ def analyze_briefing(db: Session, briefing_id: int, run_id: str) -> tuple[int, s
         })
         sections["RESPONSIBLE_AI_HTML"] = sections["responsible_ai_html"]  # Uppercase alias für Kompatibilität
 
+    # Sprint N3.1: Apply content filter AGAIN to catch RESPONSIBLE_AI_HTML and other late additions
+    log.info(f"[{run_id}] 🔍 Re-applying size-inappropriate content filter for late sections...")
+    sections = filter_all_sections(sections, answers)
+
     # === HARD STOP GATE: Validate report BEFORE rendering ===
     # Derive persona from unternehmensgroesse
     size_raw = (answers.get("unternehmensgroesse", "") or "").lower()

--- a/services/prompt_enhancer.py
+++ b/services/prompt_enhancer.py
@@ -292,6 +292,7 @@ SOLO_PHRASE_REPLACEMENTS: Dict[str, str] = {
 }
 
 # Corporate terms → Solo-appropriate replacements (word-based)
+# NOTE: "abteilung" uses "Aufgabenbereich" to match test expectations
 SOLO_GOVERNANCE_REPLACEMENTS: Dict[str, str] = {
     # Governance terms (case-insensitive replacements)
     "governance framework": "einfache Regeln",
@@ -302,8 +303,8 @@ SOLO_GOVERNANCE_REPLACEMENTS: Dict[str, str] = {
     "steering committee": "regelmäßige Selbstkontrolle",
     "gremium": "Prüfroutine",
     "board": "Prüfroutine",
-    "abteilung": "Arbeitsbereich",
-    "abteilungen": "Arbeitsbereiche",
+    "abteilung": "Aufgabenbereich",
+    "abteilungen": "Aufgabenbereiche",
     "organisationsentwicklung": "Arbeitsweise verbessern",
     "change management": "Veränderung umsetzen",
     "change-management": "Veränderung umsetzen",
@@ -372,10 +373,13 @@ SOLO_FORBIDDEN_TERMS: List[str] = [
 
 def apply_solo_persona_filter(text: str) -> str:
     """
-    Sprint N3: Applies comprehensive Solo persona filtering.
+    Sprint N3/N3.1: Applies comprehensive Solo persona filtering.
 
     Replaces phrases and terms inappropriate for Solo professionals.
     This is the main entry point for Solo text filtering.
+
+    IMPORTANT: Uses word boundaries to avoid replacing within compound words
+    like "Kundenabteilung" (customer department references should be preserved).
 
     Args:
         text: Text to filter
@@ -396,9 +400,24 @@ def apply_solo_persona_filter(text: str) -> str:
             result = pattern.sub(replacement, result)
             replacements_made.append(f"[phrase] {phrase} → {replacement}")
 
-    # 2) Apply word-based replacements (single words/short terms)
+    # 2) Apply word-based replacements with word boundary protection
+    # Sprint N3.1: Protect customer-related compound words (Kundenabteilung, etc.)
     for term, replacement in SOLO_GOVERNANCE_REPLACEMENTS.items():
-        pattern = re.compile(re.escape(term), re.IGNORECASE)
+        # Use negative lookbehind to avoid replacing within compound words
+        # e.g., don't replace "abteilung" in "Kundenabteilung"
+        if term.lower() in ("abteilung", "abteilungen"):
+            # Special handling: preserve customer-related compound words
+            pattern = re.compile(
+                r'(?<![Kk]unden)(?<!\w)' + re.escape(term) + r'(?!\w)',
+                re.IGNORECASE
+            )
+        else:
+            # Standard word boundary matching
+            pattern = re.compile(
+                r'(?<!\w)' + re.escape(term) + r'(?!\w)',
+                re.IGNORECASE
+            )
+
         if pattern.search(result):
             result = pattern.sub(replacement, result)
             replacements_made.append(f"[word] {term} → {replacement}")

--- a/services/prompt_enhancer.py
+++ b/services/prompt_enhancer.py
@@ -223,26 +223,72 @@ Bei Erwähnung: "Tool X nutzen (siehe Quick Wins / Tools-Empfehlungen)"
 # SOLO-PERSONA MODULATION: Vereinfachte Governance-Sprache
 # =============================================================================
 
-# Sprint N3: Phrase-based filtering (applied FIRST, before word-based)
+# Sprint N3/N3.1: Phrase-based filtering (applied FIRST, before word-based)
 # These are multi-word phrases that must be replaced as units
 SOLO_FORBIDDEN_PHRASES: List[str] = [
+    # Team-bezogen
     "team aufbauen",
     "teams aufbauen",
+    "team einbinden",
+    "teams einbinden",
+    "im team",
+    "das team",
+    "ihr team",
+    "unser team",
+    # Mitarbeiter-bezogen
     "mitarbeiter einstellen",
     "mitarbeitende einstellen",
     "personal einstellen",
+    "neue mitarbeiter",
+    "mitarbeiter schulen",
+    # Abteilungs-/Fachbereichs-bezogen
     "fachbereiche einbinden",
     "fachbereich einbinden",
+    "in fachbereichen",
+    "die fachbereiche",
+    "alle fachbereiche",
+    "verschiedene fachbereiche",
+    "abteilungen einbinden",
+    "abteilung einbinden",
+    # Management-/Führungs-bezogen
+    "führungsteam",
+    "management-team",
+    "bereichsleitung",
+    "fachabteilung",
+    "fachabteilungen",
 ]
 
 SOLO_PHRASE_REPLACEMENTS: Dict[str, str] = {
+    # Team-Phrasen → Solo-passend
     "team aufbauen": "Kapazität aufbauen",
     "teams aufbauen": "Kapazitäten erweitern",
+    "team einbinden": "externe Expertise einbinden",
+    "teams einbinden": "Kooperationspartner einbinden",
+    "im team": "gemeinsam mit Partnern",
+    "das team": "Ihre Kapazität",
+    "ihr team": "Ihre Kapazität",
+    "unser team": "unsere Kapazität",
+    # Mitarbeiter-Phrasen → Solo-passend
     "mitarbeiter einstellen": "Ressourcen erweitern",
     "mitarbeitende einstellen": "Ressourcen erweitern",
     "personal einstellen": "externe Unterstützung hinzuziehen",
+    "neue mitarbeiter": "zusätzliche Kapazitäten",
+    "mitarbeiter schulen": "sich weiterbilden",
+    # Fachbereichs-Phrasen → Solo-passend
     "fachbereiche einbinden": "Arbeitsbereiche strukturieren",
     "fachbereich einbinden": "Arbeitsfeld strukturieren",
+    "in fachbereichen": "in Ihren Arbeitsbereichen",
+    "die fachbereiche": "Ihre Arbeitsbereiche",
+    "alle fachbereiche": "alle Ihre Arbeitsbereiche",
+    "verschiedene fachbereiche": "verschiedene Arbeitsbereiche",
+    "abteilungen einbinden": "Arbeitsbereiche strukturieren",
+    "abteilung einbinden": "Arbeitsbereich einbeziehen",
+    # Management/Führung → Solo-passend
+    "führungsteam": "Ihre Entscheidungsfindung",
+    "management-team": "Ihre strategische Planung",
+    "bereichsleitung": "Verantwortungsbereich",
+    "fachabteilung": "Arbeitsfeld",
+    "fachabteilungen": "Arbeitsbereiche",
 }
 
 # Corporate terms → Solo-appropriate replacements (word-based)
@@ -272,10 +318,17 @@ SOLO_GOVERNANCE_REPLACEMENTS: Dict[str, str] = {
     "projektteam": "Projektstruktur",
     "mitarbeiter einstellen": "externe Unterstützung hinzuziehen",
     "mitarbeiter": "Ressourcen",
+    "mitarbeitende": "Beteiligte",
+    "mitarbeitenden": "Beteiligten",
+    "personalentscheidungen": "Ressourcenentscheidungen",
+    "personaldaten": "vertrauliche Daten",
+    "belegschaft": "Kapazität",
     # EN equivalents for Solo
     "department": "work area",
     "departments": "work areas",
     "staff": "resources",
+    "employees": "collaborators",
+    "employee": "collaborator",
 }
 
 # =============================================================================

--- a/services/report_validator.py
+++ b/services/report_validator.py
@@ -559,30 +559,19 @@ def filter_size_inappropriate_content(content: str, unternehmensgroesse: str) ->
     """
     PLATIN+ Post-Filter: Ersetzt size-inappropriate Begriffe im Content.
 
-    Für Solo-Profile werden Begriffe wie "Abteilung" durch "Bereich" ersetzt,
-    sofern sie sich nicht auf Kunden-Strukturen beziehen.
+    Sprint N3.1: Für Solo-Profile wird apply_solo_persona_filter() aufgerufen,
+    das Phrasen wie "Team aufbauen", "Mitarbeiter einstellen", "Fachbereich"
+    durch Solo-passende Alternativen ersetzt.
     """
     if not content or not isinstance(content, str):
         return content
 
     size_raw = unternehmensgroesse.lower() if unternehmensgroesse else ""
 
-    # Solo-spezifische Ersetzungen
+    # Solo-spezifische Ersetzungen via apply_solo_persona_filter
     if "solo" in size_raw or "1" in size_raw or "freiberuf" in size_raw:
-        # Ersetze "Abteilung" durch "Bereich" (nur wenn nicht im Kunden-Kontext)
-        # Vorsicht: Nicht ersetzen bei "Kundenabteilung", "auf Kundenseite"
-        import re
-
-        # Patterns für solo-unpassende Begriffe (nur wenn nicht Kunden-bezogen)
-        replacements = [
-            # "Abteilung" → "Aufgabenbereich" (wenn nicht Kunden-bezogen)
-            (r'(?<![Kk]unden)([Aa])bteilung(?!en\s+(?:auf|bei|der|des)\s+[Kk]unden)', r'\1ufgabenbereich'),
-            # "Abteilungen" → "Aufgabenbereiche" (wenn nicht Kunden-bezogen)
-            (r'(?<![Kk]unden)([Aa])bteilungen(?!\s+(?:auf|bei|der|des)\s+[Kk]unden)', r'\1ufgabenbereiche'),
-        ]
-
-        for pattern, replacement in replacements:
-            content = re.sub(pattern, replacement, content)
+        from services.prompt_enhancer import apply_solo_persona_filter
+        content = apply_solo_persona_filter(content)
 
     return content
 

--- a/templates/pdf_template.html
+++ b/templates/pdf_template.html
@@ -1241,7 +1241,9 @@
                     <div class="section-header">
                         <div class="section-title">
                             <span class="section-kicker">Überblick</span>
+                            {% if size_label != 'Solo-Berater' and size_label != 'Solo-Unternehmer' and size_label != 'Freiberufler' %}
                             <h2>Executive Summary</h2>
+                            {% endif %}
                         </div>
                         <span class="section-pill">
                             <span class="pill-dot"></span>


### PR DESCRIPTION
…te Fix

Sprint N3.1 Implementation:

1. Wire Solo phrase filter into content pipeline:
   - filter_size_inappropriate_content() now calls apply_solo_persona_filter()
   - Added second filter pass after RESPONSIBLE_AI_HTML is added
   - Ensures all sections including late additions are filtered

2. Extended SOLO_PHRASE_REPLACEMENTS with more patterns:
   - Team phrases: "im team", "das team", "ihr team", etc.
   - Department phrases: "in fachbereichen", "alle fachbereiche", etc.
   - Management phrases: "führungsteam", "management-team", etc.

3. Extended SOLO_GOVERNANCE_REPLACEMENTS:
   - Added: mitarbeitende, mitarbeitenden, personalentscheidungen
   - Added: personaldaten, belegschaft, employees, employee

4. PDF template conditional heading:
   - Executive Summary <h2> hidden for Solo profiles
   - Uses size_label check for Solo-Berater/Solo-Unternehmer/Freiberufler

This ensures Solo reports have no persona leaks in:
- WETTBEWERB_BENCHMARK_HTML
- RESPONSIBLE_AI_HTML
- And all other filtered sections