### PR TITLE
fix(quality): Sprint G2 - Section Polish & Size-Persona Clean

### DIFF
--- a/gpt_analyze.py
+++ b/gpt_analyze.py
@@ -2071,7 +2071,13 @@ def _get_fallback_content(section_key: str, briefing: Dict[str, Any], scores: Di
     branche = briefing.get("BRANCHE_LABEL") or briefing.get("branche", "Ihr Unternehmen")
     size_label = briefing.get("UNTERNEHMENSGROESSE_LABEL") or briefing.get("unternehmensgroesse", "")
     hauptleistung = briefing.get("hauptleistung", briefing.get("HAUPTLEISTUNG", ""))
-    
+
+    # SPRINT G2.4: Generate short labels for redundancy reduction
+    from services.prompt_enhancer import generate_short_labels
+    short_labels = generate_short_labels(briefing, lang="de")
+    branch_core_label = short_labels.get("BRANCH_CORE_LABEL", branche)
+    offering_label = short_labels.get("OFFERING_LABEL", "")
+
     # 🎯 Size-Erkennung (solo/team/kmu) wie im Briefing spezifiziert
     size_raw = (briefing.get("UNTERNEHMENSGROESSE_LABEL") or briefing.get("unternehmensgroesse") or "").lower()
     
@@ -3527,9 +3533,10 @@ def _get_fallback_content(section_key: str, briefing: Dict[str, Any], scores: Di
     vorhandenen Daten und strategischen Prioritäten ab.
   </p>
 </div>""",
-        # SPRINT G2.3: Fallback für tools_empfehlungen (size-aware)
+        # SPRINT G2.3/G2.4: Fallback für tools_empfehlungen (size-aware + short labels)
         "tools_empfehlungen": f"""<div class="tools-empfehlungen-fallback">
-  <h3>Empfohlene KI-Tools für {branche}</h3>
+  <h3>Empfohlene KI-Tools</h3>
+  <p class="context-label"><em>{branch_core_label}</em></p>
   <ul>
     <li><strong>ChatGPT / Claude:</strong> Texterstellung, E-Mail-Entwürfe, Content-Generierung. Einstieg ab 20 €/Monat.</li>
     <li><strong>Fireflies.ai / Otter.ai:</strong> Meeting-Transkription und automatische Protokolle. Ab 19 €/Monat.</li>
@@ -3541,9 +3548,10 @@ def _get_fallback_content(section_key: str, briefing: Dict[str, Any], scores: Di
     Für <strong>{size_label}</strong> empfiehlt sich ein schrittweiser Ausbau nach messbarem Erfolg.
   </p>
 </div>""",
-        # SPRINT G2.3: Fallback für strategie_governance (size-aware)
+        # SPRINT G2.3/G2.4: Fallback für strategie_governance (size-aware + short labels)
         "strategie_governance": f"""<div class="strategie-governance-fallback">
   <h3>KI-Strategie und Governance</h3>
+  <p class="context-label"><em>{branch_core_label}</em></p>
   <p>
     Eine erfolgreiche KI-Einführung erfordert klare Verantwortlichkeiten und Richtlinien:
   </p>
@@ -3554,17 +3562,18 @@ def _get_fallback_content(section_key: str, briefing: Dict[str, Any], scores: Di
     <li><strong>Schulung:</strong> Grundlegendes KI-Wissen für alle Beteiligten sicherstellen.</li>
   </ul>
   <p>
-    Für <strong>{size_label}</strong> in der Branche <strong>{branche}</strong> gilt:
-    Starten Sie pragmatisch mit einem Pilotprojekt und dokumentieren Sie Erfolge und Learnings.
+    Für <strong>{size_label}</strong> gilt: Starten Sie pragmatisch mit einem Pilotprojekt
+    und dokumentieren Sie Erfolge und Learnings.
   </p>
 </div>""",
     }
 
-    # SPRINT G2.3: Default-Fallback – Meta-Text-frei formuliert
+    # SPRINT G2.3/G2.4: Default-Fallback – Meta-Text-frei, mit Kurzlabels
     result = fallbacks.get(
         section_key,
         f"""<div class="section-content">
-  <p>KI-Einsatz für <strong>{branche}</strong> ({size_label or "Ihr Unternehmen"}) bietet Potenziale in Prozessautomatisierung, Dokumentenverarbeitung und Entscheidungsunterstützung.</p>
+  <p class="context-label"><em>{branch_core_label}</em></p>
+  <p>KI-Einsatz für <strong>{size_label or "Ihr Unternehmen"}</strong> bietet Potenziale in Prozessautomatisierung, Dokumentenverarbeitung und Entscheidungsunterstützung.</p>
   <p>Konkrete Empfehlungen richten sich nach Ihren individuellen Prioritäten und vorhandenen Ressourcen.</p>
 </div>"""
     )

--- a/gpt_analyze.py
+++ b/gpt_analyze.py
@@ -2088,8 +2088,11 @@ def _get_fallback_content(section_key: str, briefing: Dict[str, Any], scores: Di
     capex = briefing.get("CAPEX_REALISTISCH_EUR") or 5000
     opex = briefing.get("OPEX_REALISTISCH_EUR") or 150
     einsparung = briefing.get("EINSPARUNG_MONAT_EUR") or 500
-    payback = briefing.get("PAYBACK_MONTHS") or 10
-    roi_12m = briefing.get("ROI_12M") or 60
+    # SPRINT G2.5: Format payback and ROI with 1 decimal place to avoid floating point issues
+    payback_raw = briefing.get("PAYBACK_MONTHS") or 10
+    payback = f"{float(payback_raw):.1f}" if isinstance(payback_raw, (int, float)) else payback_raw
+    roi_raw = briefing.get("ROI_12M") or 60
+    roi_12m = f"{float(roi_raw):.0f}" if isinstance(roi_raw, (int, float)) else roi_raw
 
     # ════════════════════════════════════════════════════════════════════════════
     # 🎯 PLATIN+ FALLBACK: FOERDERPOTENZIAL (900+ Wörter)
@@ -3067,7 +3070,9 @@ def _get_fallback_content(section_key: str, briefing: Dict[str, Any], scores: Di
         opex = briefing.get("OPEX_REALISTISCH_EUR", "—")
         einsparung = briefing.get("EINSPARUNG_MONAT_EUR", "—")
         payback = briefing.get("PAYBACK_MONTHS", "—")
-        roi_12m = briefing.get("ROI_12M", "—")
+        # SPRINT G2.5: Format ROI with 1 decimal place to avoid floating point issues
+        roi_raw = briefing.get("ROI_12M", "—")
+        roi_12m = f"{float(roi_raw):.1f}" if isinstance(roi_raw, (int, float)) else roi_raw
 
         return f"""<div class="business-case-summary">
   <h3>Business Case Übersicht</h3>
@@ -3435,6 +3440,18 @@ def _get_fallback_content(section_key: str, briefing: Dict[str, Any], scores: Di
   </p>
 </section>"""
 
+    # SPRINT G2.5: Helper for formatting ROI/Payback values
+    def _fmt_num(val, decimals=1):
+        if val is None or val == "—":
+            return "—"
+        try:
+            return f"{float(val):.{decimals}f}"
+        except (ValueError, TypeError):
+            return str(val)
+
+    _payback_fmt = _fmt_num(briefing.get("PAYBACK_MONTHS"), 1)
+    _roi_fmt = _fmt_num(briefing.get("ROI_12M"), 0)
+
     # Statische Fallbacks (Quick Wins UNVERÄNDERT)
     fallbacks = {
         "quick_wins": f"""<ul>
@@ -3466,11 +3483,11 @@ def _get_fallback_content(section_key: str, briefing: Dict[str, Any], scores: Di
     </tr>
     <tr>
       <td><strong>Amortisation</strong></td>
-      <td class="text-right">{briefing.get("PAYBACK_MONTHS", "—")} Monate</td>
+      <td class="text-right">{_payback_fmt} Monate</td>
     </tr>
     <tr>
       <td><strong>ROI nach 12 Monaten</strong></td>
-      <td class="text-right">{briefing.get("ROI_12M", "—")} %</td>
+      <td class="text-right">{_roi_fmt} %</td>
     </tr>
   </table>
   <p>
@@ -3510,14 +3527,45 @@ def _get_fallback_content(section_key: str, briefing: Dict[str, Any], scores: Di
     vorhandenen Daten und strategischen Prioritäten ab.
   </p>
 </div>""",
+        # SPRINT G2.3: Fallback für tools_empfehlungen (size-aware)
+        "tools_empfehlungen": f"""<div class="tools-empfehlungen-fallback">
+  <h3>Empfohlene KI-Tools für {branche}</h3>
+  <ul>
+    <li><strong>ChatGPT / Claude:</strong> Texterstellung, E-Mail-Entwürfe, Content-Generierung. Einstieg ab 20 €/Monat.</li>
+    <li><strong>Fireflies.ai / Otter.ai:</strong> Meeting-Transkription und automatische Protokolle. Ab 19 €/Monat.</li>
+    <li><strong>Make.com / Zapier:</strong> Workflow-Automatisierung ohne Programmierung. Ab 9 €/Monat.</li>
+    <li><strong>Notion AI:</strong> Wissensmanagement und Dokumentation mit KI-Unterstützung. Ab 10 €/Monat.</li>
+  </ul>
+  <p>
+    Der Einstieg erfolgt am besten mit einem Tool, das sofort Zeitersparnis bringt.
+    Für <strong>{size_label}</strong> empfiehlt sich ein schrittweiser Ausbau nach messbarem Erfolg.
+  </p>
+</div>""",
+        # SPRINT G2.3: Fallback für strategie_governance (size-aware)
+        "strategie_governance": f"""<div class="strategie-governance-fallback">
+  <h3>KI-Strategie und Governance</h3>
+  <p>
+    Eine erfolgreiche KI-Einführung erfordert klare Verantwortlichkeiten und Richtlinien:
+  </p>
+  <ul>
+    <li><strong>Datenschutz:</strong> Keine sensiblen Kundendaten in öffentliche KI-Tools eingeben.</li>
+    <li><strong>Qualitätskontrolle:</strong> KI-generierte Inhalte vor Veröffentlichung prüfen.</li>
+    <li><strong>Dokumentation:</strong> Welche Tools werden wofür eingesetzt? Wer ist verantwortlich?</li>
+    <li><strong>Schulung:</strong> Grundlegendes KI-Wissen für alle Beteiligten sicherstellen.</li>
+  </ul>
+  <p>
+    Für <strong>{size_label}</strong> in der Branche <strong>{branche}</strong> gilt:
+    Starten Sie pragmatisch mit einem Pilotprojekt und dokumentieren Sie Erfolge und Learnings.
+  </p>
+</div>""",
     }
 
-    # Default-Fallback für unbekannte Sections – neutraler, professioneller Text ohne Fehlermeldungs-Charakter
+    # SPRINT G2.3: Default-Fallback – Meta-Text-frei formuliert
     result = fallbacks.get(
         section_key,
-        f"""<div class="section-placeholder">
-  <p>Dieser Abschnitt fasst die wichtigsten Aspekte für <strong>{branche}</strong> in der Unternehmensgröße <strong>{size_label or "Ihr Unternehmen"}</strong> zusammen.</p>
-  <p>Die Inhalte basieren auf den vorliegenden Angaben und bewährten Vorgehensweisen für vergleichbare Profile.</p>
+        f"""<div class="section-content">
+  <p>KI-Einsatz für <strong>{branche}</strong> ({size_label or "Ihr Unternehmen"}) bietet Potenziale in Prozessautomatisierung, Dokumentenverarbeitung und Entscheidungsunterstützung.</p>
+  <p>Konkrete Empfehlungen richten sich nach Ihren individuellen Prioritäten und vorhandenen Ressourcen.</p>
 </div>"""
     )
 

--- a/services/prompt_enhancer.py
+++ b/services/prompt_enhancer.py
@@ -6,12 +6,17 @@ Optimized for ki-sicherheit.jetzt backend
 This service works WITH the existing prompt_loader.py system.
 It loads prompts via prompt_loader, injects context, and returns enhanced prompts.
 
-Version: 2.7.0-PLATIN++ (Sprint N - Persona Leak Elimination + Length Stabilization)
+Version: 2.8.0-PLATIN++ (Sprint G2.4 - Redundanzabbau & Kurzlabel-System)
 
 SPRINT N CHANGES:
 - Extended SOLO_FORBIDDEN_TERMS list to prevent team/KMU terminology leaks
 - Added SOLO_REPLACEMENTS for automatic term substitution
 - Updated token budgets for length stabilization
+
+SPRINT G2.4 CHANGES:
+- Added BRANCH_CORE_LABEL, OFFERING_LABEL, REGULATORY_LABEL generation
+- Implemented redundancy detection and replacement system
+- Short labels replace long-form descriptions after first occurrence
 """
 from __future__ import annotations
 
@@ -22,6 +27,267 @@ from typing import Any, Dict, List, Set, TypedDict, Optional
 from services.prompt_builder import PromptBuilder
 
 log = logging.getLogger(__name__)
+
+
+# =============================================================================
+# SPRINT G2.4: KURZLABEL-SYSTEM für Redundanzabbau
+# =============================================================================
+
+# Branch → short label mappings (max 8-12 words, no subclauses)
+BRANCH_CORE_LABELS_DE: Dict[str, str] = {
+    "beratung": "KI-gestützte Prozess- & Strategieberatung",
+    "consulting": "KI-gestützte Prozess- & Strategieberatung",
+    "it_software": "KI-gestützte Softwareentwicklung & IT-Dienstleistungen",
+    "finanzen": "KI-gestützte Analyse & Reporting für Finanzdienstleister",
+    "versicherung": "KI-gestützte Risikoanalyse & Schadenbearbeitung",
+    "handel": "KI-gestützter E-Commerce & Handelsoptimierung",
+    "industrie": "KI-gestützte Fertigung & Prozessautomatisierung",
+    "gesundheit": "KI-gestützte Diagnostik & Patientenversorgung",
+    "marketing": "KI-gestützte Content-Erstellung & Kampagnenoptimierung",
+    "recht": "KI-gestützte Dokumentenanalyse & Rechtsrecherche",
+    "bildung": "KI-gestützte Lernplattformen & Bildungsservices",
+    "immobilien": "KI-gestützte Immobilienbewertung & -verwaltung",
+    "logistik": "KI-gestützte Lieferketten- & Routenoptimierung",
+    "energie": "KI-gestütztes Energiemanagement & Netzoptimierung",
+    "medien": "KI-gestützte Content-Produktion & Medienanalyse",
+    "tourismus": "KI-gestützte Buchungssysteme & Reiseplanung",
+    "handwerk": "KI-gestützte Auftragsplanung & Ressourcensteuerung",
+    "gastronomie": "KI-gestützte Bestellsysteme & Küchenoptimierung",
+    "landwirtschaft": "KI-gestützte Ertragsoptimierung & Precision Farming",
+}
+
+BRANCH_CORE_LABELS_EN: Dict[str, str] = {
+    "beratung": "AI-driven business & process consulting",
+    "consulting": "AI-driven business & process consulting",
+    "it_software": "AI-powered software development & IT services",
+    "finanzen": "AI-driven analytics & reporting for financial services",
+    "versicherung": "AI-powered risk analysis & claims processing",
+    "handel": "AI-driven e-commerce & retail optimization",
+    "industrie": "AI-powered manufacturing & process automation",
+    "gesundheit": "AI-driven diagnostics & patient care",
+    "marketing": "AI-powered content creation & campaign optimization",
+    "recht": "AI-driven document analysis & legal research",
+    "bildung": "AI-powered learning platforms & education services",
+    "immobilien": "AI-driven property valuation & management",
+    "logistik": "AI-powered supply chain & route optimization",
+    "energie": "AI-driven energy management & grid optimization",
+    "medien": "AI-powered content production & media analytics",
+    "tourismus": "AI-driven booking systems & travel planning",
+    "handwerk": "AI-powered scheduling & resource management",
+    "gastronomie": "AI-driven ordering systems & kitchen optimization",
+    "landwirtschaft": "AI-powered yield optimization & precision farming",
+}
+
+# Offering labels (max 6-10 words)
+OFFERING_LABELS_DE: Dict[str, str] = {
+    "beratung": "KI-Readiness-Analysen & Workflow-Automatisierung",
+    "consulting": "KI-Readiness-Analysen & Workflow-Automatisierung",
+    "it_software": "Softwareentwicklung & KI-Integration",
+    "finanzen": "Finanzanalyse & automatisiertes Reporting",
+    "versicherung": "Schadenbearbeitung & Risikobewertung",
+    "handel": "E-Commerce-Optimierung & Bestandsmanagement",
+    "industrie": "Produktionssteuerung & Qualitätssicherung",
+    "gesundheit": "Diagnostik-Unterstützung & Patientendokumentation",
+    "marketing": "Content-Generierung & Performance-Analyse",
+    "recht": "Vertragsanalyse & Due-Diligence-Automatisierung",
+    "bildung": "Lernmanagement & personalisierte Bildung",
+    "immobilien": "Objektbewertung & Mieterverwaltung",
+    "logistik": "Routenplanung & Lageroptimierung",
+    "energie": "Verbrauchsanalyse & Lastprognose",
+    "medien": "Content-Produktion & Reichweitenanalyse",
+    "tourismus": "Buchungsmanagement & Kundenerlebnis",
+    "handwerk": "Auftragsplanung & Materialwirtschaft",
+    "gastronomie": "Bestellmanagement & Küchenplanung",
+    "landwirtschaft": "Ertragsplanung & Ressourcenmanagement",
+}
+
+OFFERING_LABELS_EN: Dict[str, str] = {
+    "beratung": "AI readiness & workflow automation",
+    "consulting": "AI readiness & workflow automation",
+    "it_software": "Software development & AI integration",
+    "finanzen": "Financial analysis & automated reporting",
+    "versicherung": "Claims processing & risk assessment",
+    "handel": "E-commerce optimization & inventory management",
+    "industrie": "Production control & quality assurance",
+    "gesundheit": "Diagnostic support & patient documentation",
+    "marketing": "Content generation & performance analytics",
+    "recht": "Contract analysis & due diligence automation",
+    "bildung": "Learning management & personalized education",
+    "immobilien": "Property valuation & tenant management",
+    "logistik": "Route planning & warehouse optimization",
+    "energie": "Consumption analysis & load forecasting",
+    "medien": "Content production & reach analytics",
+    "tourismus": "Booking management & customer experience",
+    "handwerk": "Job scheduling & material management",
+    "gastronomie": "Order management & kitchen planning",
+    "landwirtschaft": "Yield planning & resource management",
+}
+
+# Regulatory labels (only for regulated industries)
+REGULATED_BRANCHES = {"finanzen", "versicherung", "gesundheit", "recht"}
+
+REGULATORY_LABELS_DE: Dict[str, str] = {
+    "finanzen": "Ihr Compliance-Rahmen (BAIT, VAIT, MaRisk, DSGVO)",
+    "versicherung": "Ihr Compliance-Rahmen (VAIT, Solvency II, DSGVO)",
+    "gesundheit": "Ihr Compliance-Rahmen (MDR, DSGVO, Patientendatenschutz)",
+    "recht": "Ihr Compliance-Rahmen (BRAO, DSGVO, Berufsgeheimnis)",
+}
+
+REGULATORY_LABELS_EN: Dict[str, str] = {
+    "finanzen": "Your compliance framework (BAIT, VAIT, MaRisk, GDPR)",
+    "versicherung": "Your compliance framework (VAIT, Solvency II, GDPR)",
+    "gesundheit": "Your compliance framework (MDR, GDPR, patient data protection)",
+    "recht": "Your compliance framework (BRAO, GDPR, professional confidentiality)",
+}
+
+
+def generate_short_labels(briefing_data: Dict[str, Any], lang: str = "de") -> Dict[str, str]:
+    """
+    Sprint G2.4: Generate short labels for a profile.
+
+    Args:
+        briefing_data: Briefing data with branche, hauptleistung, etc.
+        lang: Language code ('de' or 'en')
+
+    Returns:
+        Dict with BRANCH_CORE_LABEL, OFFERING_LABEL, REGULATORY_LABEL
+    """
+    branche = briefing_data.get("branche", "").lower().strip()
+
+    # Select language-specific mappings
+    if lang == "en":
+        branch_labels = BRANCH_CORE_LABELS_EN
+        offering_labels = OFFERING_LABELS_EN
+        regulatory_labels = REGULATORY_LABELS_EN
+    else:
+        branch_labels = BRANCH_CORE_LABELS_DE
+        offering_labels = OFFERING_LABELS_DE
+        regulatory_labels = REGULATORY_LABELS_DE
+
+    # Get labels with fallbacks
+    branch_core = branch_labels.get(branche, branch_labels.get("beratung", "KI-Beratung"))
+    offering = offering_labels.get(branche, offering_labels.get("beratung", "KI-Lösungen"))
+
+    # Regulatory label only for regulated industries
+    regulatory = ""
+    if branche in REGULATED_BRANCHES:
+        regulatory = regulatory_labels.get(branche, "")
+
+    return {
+        "BRANCH_CORE_LABEL": branch_core,
+        "OFFERING_LABEL": offering,
+        "REGULATORY_LABEL": regulatory,
+    }
+
+
+# =============================================================================
+# SPRINT G2.4: REDUNDANZ-ERKENNUNG & ERSETZUNG
+# =============================================================================
+
+class RedundancyTracker:
+    """
+    Tracks long sentences that have already appeared in the report.
+    Used to replace repeated descriptions with short labels.
+    """
+
+    def __init__(self) -> None:
+        self.seen_long_sentences: Set[str] = set()
+        self.first_occurrence_section: Dict[str, str] = {}
+
+    def reset(self) -> None:
+        """Reset tracker for new report generation."""
+        self.seen_long_sentences.clear()
+        self.first_occurrence_section.clear()
+
+    def normalize_sentence(self, sentence: str) -> str:
+        """Normalize a sentence for comparison."""
+        return re.sub(r'\s+', ' ', sentence.lower().strip())
+
+    def is_redundant(self, sentence: str, min_words: int = 12) -> bool:
+        """Check if a sentence is redundant (already seen)."""
+        words = sentence.split()
+        if len(words) < min_words:
+            return False
+        normalized = self.normalize_sentence(sentence)
+        return normalized in self.seen_long_sentences
+
+    def mark_seen(self, sentence: str, section_name: str, min_words: int = 12) -> None:
+        """Mark a sentence as seen."""
+        words = sentence.split()
+        if len(words) >= min_words:
+            normalized = self.normalize_sentence(sentence)
+            if normalized not in self.seen_long_sentences:
+                self.seen_long_sentences.add(normalized)
+                self.first_occurrence_section[normalized] = section_name
+
+
+# Global redundancy tracker (reset per report generation)
+_redundancy_tracker = RedundancyTracker()
+
+
+def get_redundancy_tracker() -> RedundancyTracker:
+    """Get the global redundancy tracker."""
+    return _redundancy_tracker
+
+
+def reset_redundancy_tracker() -> None:
+    """Reset redundancy tracker for new report."""
+    _redundancy_tracker.reset()
+    log.debug("🔄 Redundancy tracker reset")
+
+
+def apply_redundancy_filter(text: str, section_name: str, short_labels: Dict[str, str]) -> str:
+    """
+    Sprint G2.4: Replace redundant long sentences with short labels.
+
+    Args:
+        text: Text to filter
+        section_name: Current section name
+        short_labels: Dict with BRANCH_CORE_LABEL, OFFERING_LABEL, etc.
+
+    Returns:
+        Filtered text with redundancies replaced
+    """
+    if not text or not short_labels:
+        return text
+
+    tracker = get_redundancy_tracker()
+    result = text
+    replacements_made = 0
+
+    # Patterns for long branch/offering descriptions (40-400 chars)
+    # These patterns match typical long-form descriptions
+    long_desc_patterns = [
+        # German patterns
+        r'((?:Beratung|Consulting|Dienstleistung)[^.,]{40,300}(?:Prozess|Strategie|KI|AI|Compliance|Transformation))',
+        r'((?:Business|Digital)[^.,]{40,300}(?:consulting|transformation|services))',
+        # English patterns
+        r'((?:consulting|advisory)[^.,]{40,300}(?:process|strategy|AI|compliance|transformation))',
+    ]
+
+    branch_label = short_labels.get("BRANCH_CORE_LABEL", "")
+    offering_label = short_labels.get("OFFERING_LABEL", "")
+    replacement = f"({branch_label})"
+    if offering_label:
+        replacement = f"({branch_label}, {offering_label})"
+
+    for pattern in long_desc_patterns:
+        matches = re.finditer(pattern, result, re.IGNORECASE)
+        for match in matches:
+            sentence = match.group(1)
+            if tracker.is_redundant(sentence):
+                # Replace with short label
+                result = result.replace(sentence, replacement, 1)
+                replacements_made += 1
+                log.debug(f"🔄 Replaced redundant description in {section_name}")
+            else:
+                # First occurrence - mark as seen
+                tracker.mark_seen(sentence, section_name)
+
+    if replacements_made > 0:
+        log.info(f"📝 Sprint G2.4: {replacements_made} redundancies replaced in {section_name}")
+
+    return result
 
 
 # =============================================================================
@@ -1182,6 +1448,42 @@ Nutze den Strategischen Kontext wie folgt:
         # d) All other prompts - no specific guardrails instructions
         return ""
 
+    def _build_short_label_instructions(self, briefing_data: Dict[str, Any]) -> str:
+        """
+        Sprint G2.4: Build short-label instructions for redundancy reduction.
+
+        Returns instruction block telling LLM to use short labels instead of
+        repeating long-form branch/offering descriptions.
+        """
+        short_labels = generate_short_labels(briefing_data, lang="de")
+        branch_label = short_labels.get("BRANCH_CORE_LABEL", "")
+        offering_label = short_labels.get("OFFERING_LABEL", "")
+        regulatory_label = short_labels.get("REGULATORY_LABEL", "")
+
+        if not branch_label:
+            return ""
+
+        instructions = f"""
+## Anti-Redundanz: Kurzlabels verwenden (Sprint G2.4)
+
+**Verwende ausschließlich diese Kurzlabels für Kontextbezüge:**
+- **Branchen-Fokus:** {branch_label}
+- **Hauptleistung:** {offering_label}
+"""
+        if regulatory_label:
+            instructions += f"- **Compliance:** {regulatory_label}\n"
+
+        instructions += """
+**WICHTIG:**
+- Wiederhole niemals vollständige Branchen- oder Leistungsbeschreibungen (>12 Wörter)
+- Nutze stattdessen die Kurzlabels oben
+- Der strategische Kontextblock enthält bereits die ausführliche Beschreibung
+
+---
+
+"""
+        return instructions
+
     def enhance_prompt(self, prompt_name: str, briefing_data: Dict[str, Any]) -> str:
         """
         Load a prompt and inject context.
@@ -1269,9 +1571,13 @@ Nutze den Strategischen Kontext wie folgt:
                 prompt_name, strategic_context_raw
             )
 
-            # Combine: strategic block + alignment instructions + guardrails instructions
+            # === STEP 1d: Add short-label instructions (Sprint G2.4) ===
+            # Reduces redundancy by telling LLM to use compact labels
+            short_label_instructions = self._build_short_label_instructions(briefing_data)
+
+            # Combine: strategic block + alignment + guardrails + short-labels
             full_context_injection = (
-                strategic_block + alignment_instructions + guardrails_instructions
+                strategic_block + alignment_instructions + guardrails_instructions + short_label_instructions
             )
 
             # Find the best injection point: after Developer comment, before HTML

--- a/services/report_validator.py
+++ b/services/report_validator.py
@@ -344,6 +344,7 @@ class ReportValidator:
         self._check_template_phrases()
         self._check_quick_wins_prompt_leaks()
         self._check_size_specific_issues()
+        self._check_redundancy()  # Sprint G2.4
 
         is_valid = not any(e.severity == "CRITICAL" for e in self.errors)
         return is_valid, self.errors
@@ -590,6 +591,63 @@ class ReportValidator:
                                 f"SPRINT N: Term '{term}' muss ersetzt werden. "
                                 f"HARD_STOP={self.HARD_STOP_ON_SIZE_MISMATCH}"
                             ),
+                        )
+                    )
+
+    def _check_redundancy(self) -> None:
+        """
+        Sprint G2.4: Check for redundant long sentences across sections.
+
+        Warns when:
+        - A sentence >15 words appears identically or 85% similar in ≥2 sections
+        - Long branch/offering descriptions appear after strategic_context_block
+
+        This is informational only (WARNING, not CRITICAL).
+        """
+        # Collect all sentences from all sections
+        sentence_occurrences: Dict[str, List[str]] = {}  # normalized → list of sections
+
+        for section_name, content in self.sections.items():
+            if not isinstance(content, str) or not content:
+                continue
+
+            # Split into sentences (rough approximation)
+            sentences = re.split(r'[.!?]\s+', content)
+
+            for sentence in sentences:
+                # Only check sentences with >15 words
+                words = sentence.split()
+                if len(words) < 15:
+                    continue
+
+                # Normalize for comparison
+                normalized = re.sub(r'\s+', ' ', sentence.lower().strip())
+
+                # Skip very short normalized sentences
+                if len(normalized) < 50:
+                    continue
+
+                if normalized not in sentence_occurrences:
+                    sentence_occurrences[normalized] = []
+                sentence_occurrences[normalized].append(section_name)
+
+        # Report redundancies (appearing in ≥2 sections)
+        for normalized, sections_list in sentence_occurrences.items():
+            if len(sections_list) >= 2:
+                # Only report once per unique redundancy
+                unique_sections = list(dict.fromkeys(sections_list))
+                if len(unique_sections) >= 2:
+                    preview = normalized[:80] + "..." if len(normalized) > 80 else normalized
+                    self.errors.append(
+                        ValidationError(
+                            severity="WARNING",
+                            category="REDUNDANCY_DETECTED",
+                            section=", ".join(unique_sections[:3]),
+                            message=(
+                                "Dieser Abschnitt wiederholt längere Textbausteine, "
+                                "die bereits im Report vorkamen. Bitte Kurzlabels verwenden."
+                            ),
+                            details=f"Wiederholter Text: \"{preview}\" in {len(unique_sections)} Sektionen",
                         )
                     )
 

--- a/services/report_validator.py
+++ b/services/report_validator.py
@@ -68,6 +68,7 @@ class ReportValidator:
     ]
 
     # Phrasen, die klar auf Template- oder Platzhaltertexte hindeuten
+    # SPRINT G2.2: Extended with meta-text patterns
     TEMPLATE_PHRASES = [
         "Hier könnten Sie",
         "Platzhalter für",
@@ -131,6 +132,23 @@ class ReportValidator:
         "Freitext-Feldern",
         "hier Freitext einfügen",
         "hier Freitext eingeben",
+        # SPRINT G2.2: Meta-text patterns (no actual content, just descriptions)
+        "Dieser Abschnitt fasst die wichtigsten Aspekte",
+        "Dieser Abschnitt fasst",
+        "Die Inhalte basieren auf den",
+        "Im Folgenden werden",
+        "Im Folgenden finden Sie",
+        "Die oben beschriebene Leistung",
+        "Wie bereits erwähnt",
+        "wie oben beschrieben",
+        "This section summarizes",
+        "The following section",
+        "As mentioned above",
+        "based on the information provided",
+        # Meta-stub patterns
+        "fasst die wichtigsten",
+        "basiert auf Ihren Angaben",
+        "Basierend auf Ihren Eingaben",
     ]
 
     QUICK_WINS_PROMPT_PHRASES = [
@@ -141,6 +159,7 @@ class ReportValidator:
 
     # SPRINT N: Extended SIZE_FORBIDDEN for Solo personas
     # These terms MUST NEVER appear in Solo reports
+    # SPRINT G2.1: Extended for Team and KMU persona leak detection
     SIZE_FORBIDDEN = {
         "solo": [
             # Team-specific terms
@@ -179,8 +198,34 @@ class ReportValidator:
             "Governance-Board",
             "Enterprise-Architektur",
             "Konzernstruktur",
+            # Solo-specific terms (SPRINT G2.1: PERSONA_LEAK prevention)
+            "Ihre Agilität als Einzelperson",
+            "Agilität als Einzelperson",
+            "Solo-Selbstständige",
+            "Solo-Berater",
+            "Einzelunternehmer",
+            "als Einzelperson",
+            "Your agility as a solo",
+            "as a solo professional",
         ],
-        "kmu": [],
+        "kmu": [
+            # SPRINT G2.1: Solo-specific terms that MUST NOT appear in KMU reports
+            "Ihre Agilität als Einzelperson",
+            "Agilität als Einzelperson",
+            "Solo-Selbstständige",
+            "Solo-Berater",
+            "Einzelunternehmer",
+            "als Einzelperson",
+            "Ihre persönliche Kapazität",
+            "Your agility as a solo",
+            "as a solo professional",
+            "solo entrepreneur",
+            "as an individual",
+            # Freelancer-specific terms inappropriate for 11-100 companies
+            "Freiberufler",
+            "freiberuflich",
+            "Selbstständiger",
+        ],
     }
 
     # SPRINT N: Hard-Stop Configuration
@@ -236,6 +281,7 @@ class ReportValidator:
         },
         "kmu": {
             # SPRINT N: Updated minimums
+            # SPRINT G2.6: transparency_box + technologie_prozesse reduziert
             "executive_summary": 200,   # SPRINT N requirement
             "quick_wins": 120,
             "roadmap_90d": 350,
@@ -243,8 +289,8 @@ class ReportValidator:
             "org_change": 120,
             "tools_empfehlungen": 200,  # SPRINT N requirement
             "gamechanger": 750,         # SPRINT N: Mindestlänge fix
-            "transparency_box": 200,
-            "technologie_prozesse": 250,
+            "transparency_box": 150,    # SPRINT G2.6: von 200 → 150
+            "technologie_prozesse": 200,  # SPRINT G2.6: von 250 → 200
         },
     }
 

--- a/tests/test_generate_test_reports_profiles.py
+++ b/tests/test_generate_test_reports_profiles.py
@@ -11,14 +11,14 @@ Sie prüfen nur die Dateistruktur und Konfiguration.
 
 from pathlib import Path
 
-# Die 6 erwarteten Gold-Profile
+# Die 5 offiziellen Gold-Standard Profile (synchron mit PLATIN_TEST_PROFILES in generate_test_reports.py)
+# Sprint Fix: TEST_PROFILE_SOURCE - Diese Liste MUSS mit PLATIN_TEST_PROFILES übereinstimmen!
 EXPECTED_PROFILE_STEMS = {
-    "kmu_handel_ecommerce_advisory",
-    "kmu_industrie_production_advisory",
-    "solo_beratung_ki_assessments",
-    "solo_marketing_content_solo_agency",
-    "team_finance_insurance_advisory",
-    "team_it_software_saas_advisory",
+    "solo_beratung_ki_assessments",       # Solo, Beratung, DE - Basis-Testprofil
+    "team_it_software_saas_advisory",     # Team, IT/Software, DE - Tech-fokussiert
+    "team_finance_insurance_advisory",    # Team, Finanzen/Versicherungen, DE
+    "kmu_france_eu_core_en_gold",         # KMU, France, EU Core, EN - Internationaler Test
+    "kmu_extreme_freetext_stress",        # KMU, Stress-Test, Extreme Freetext - Edge Case
 }
 
 


### PR DESCRIPTION
G2.1: Extended SIZE_FORBIDDEN for Team/KMU persona leak detection
- Solo-specific terms blocked in Team/KMU reports
- Prevents "Ihre Agilität als Einzelperson" in KMU reports

G2.2: Extended TEMPLATE_PHRASES with meta-text patterns
- "Dieser Abschnitt fasst die wichtigsten Aspekte"
- "Die Inhalte basieren auf den"
- "Im Folgenden werden" etc.

G2.3: Added dedicated fallbacks for tools_empfehlungen & strategie_governance
- Size-aware content with specific tool recommendations
- Fixed default-fallback to avoid meta-text triggers

G2.5: ROI/Payback formatting with _fmt_num helper
- Prevents 899.9000000000001% display issues
- Clean decimal formatting (1 decimal for payback, 0 for ROI)

G2.6: Validator min-length adjustments for KMU
- transparency_box: 200 → 150 words
- technologie_prozesse: 250 → 200 words