### PR TITLE
fix(quality): G6 Post-Check - EN prompt & fallback updates

### DIFF
--- a/gpt_analyze.py
+++ b/gpt_analyze.py
@@ -3534,18 +3534,35 @@ def _get_fallback_content(section_key: str, briefing: Dict[str, Any], scores: Di
   </p>
 </div>""",
         # SPRINT G2.3/G2.4: Fallback für tools_empfehlungen (size-aware + short labels)
+        # SPRINT G6: Erweitert auf ~150+ Wörter, size-aware Struktur
         "tools_empfehlungen": f"""<div class="tools-empfehlungen-fallback">
-  <h3>Empfohlene KI-Tools</h3>
+  <h3>Empfohlener KI-Stack für {branch_context_label}</h3>
   <p class="context-label"><em>{branch_core_label}</em></p>
+
+  <h4>1. Fundament & Basis</h4>
   <ul>
-    <li><strong>ChatGPT / Claude:</strong> Texterstellung, E-Mail-Entwürfe, Content-Generierung. Einstieg ab 20 €/Monat.</li>
-    <li><strong>Fireflies.ai / Otter.ai:</strong> Meeting-Transkription und automatische Protokolle. Ab 19 €/Monat.</li>
-    <li><strong>Make.com / Zapier:</strong> Workflow-Automatisierung ohne Programmierung. Ab 9 €/Monat.</li>
-    <li><strong>Notion AI:</strong> Wissensmanagement und Dokumentation mit KI-Unterstützung. Ab 10 €/Monat.</li>
+    <li><strong>KI-Assistent:</strong> Texterstellung, E-Mail-Entwürfe, Content-Generierung – Einstieg ab 20 €/Monat.</li>
+    <li><strong>Wissensspeicher:</strong> Zentrale Ablage für Templates, Prompts und Best Practices.</li>
+    <li><strong>Aufgabenverwaltung:</strong> Planung und Koordination von KI-gestützten Workflows.</li>
   </ul>
+
+  <h4>2. Kernprozess-Tools für {offering_label}</h4>
+  <ul>
+    <li><strong>Formular-Tool:</strong> Strukturierte Erfassung von Kundendaten und Feedback.</li>
+    <li><strong>Auswertungs-Tool:</strong> KI-gestützte Analyse und Report-Erstellung.</li>
+    <li><strong>Automatisierung:</strong> Make.com oder Zapier für wiederkehrende Abläufe (ab 9 €/Monat).</li>
+  </ul>
+
+  {"" if size_key == "solo" else '''<h4>3. Governance & Qualität</h4>
+  <ul>
+    <li><strong>Richtlinien:</strong> Kurze, schriftliche Regeln für den KI-Einsatz.</li>
+    <li><strong>Dokumentation:</strong> Übersicht welche Tools wofür eingesetzt werden.</li>
+    <li><strong>Qualitätskontrolle:</strong> Review-Prozesse für wichtige KI-Ergebnisse.</li>
+  </ul>'''}
+
   <p>
-    Der Einstieg erfolgt am besten mit einem Tool, das sofort Zeitersparnis bringt.
-    Für <strong>{size_label}</strong> empfiehlt sich ein schrittweiser Ausbau nach messbarem Erfolg.
+    Für <strong>{size_label}</strong> empfiehlt sich ein schrittweiser Ausbau: Erst Fundament,
+    dann Kernprozess-Tools, schließlich Governance. Details zur Einführung → siehe Roadmap.
   </p>
 </div>""",
         # SPRINT G2.3/G2.4: Fallback für strategie_governance (size-aware + short labels)

--- a/gpt_analyze.py
+++ b/gpt_analyze.py
@@ -3536,7 +3536,7 @@ def _get_fallback_content(section_key: str, briefing: Dict[str, Any], scores: Di
         # SPRINT G2.3/G2.4: Fallback für tools_empfehlungen (size-aware + short labels)
         # SPRINT G6: Erweitert auf ~150+ Wörter, size-aware Struktur
         "tools_empfehlungen": f"""<div class="tools-empfehlungen-fallback">
-  <h3>Empfohlener KI-Stack für {branch_context_label}</h3>
+  <h3>Empfohlener KI-Stack für {branche}</h3>
   <p class="context-label"><em>{branch_core_label}</em></p>
 
   <h4>1. Fundament & Basis</h4>
@@ -3546,14 +3546,14 @@ def _get_fallback_content(section_key: str, briefing: Dict[str, Any], scores: Di
     <li><strong>Aufgabenverwaltung:</strong> Planung und Koordination von KI-gestützten Workflows.</li>
   </ul>
 
-  <h4>2. Kernprozess-Tools für {offering_label}</h4>
+  <h4>2. Kernprozess-Tools für {offering_label or hauptleistung or branche}</h4>
   <ul>
     <li><strong>Formular-Tool:</strong> Strukturierte Erfassung von Kundendaten und Feedback.</li>
     <li><strong>Auswertungs-Tool:</strong> KI-gestützte Analyse und Report-Erstellung.</li>
     <li><strong>Automatisierung:</strong> Make.com oder Zapier für wiederkehrende Abläufe (ab 9 €/Monat).</li>
   </ul>
 
-  {"" if size_key == "solo" else '''<h4>3. Governance & Qualität</h4>
+  {"" if size_group == "solo" else '''<h4>3. Governance & Qualität</h4>
   <ul>
     <li><strong>Richtlinien:</strong> Kurze, schriftliche Regeln für den KI-Einsatz.</li>
     <li><strong>Dokumentation:</strong> Übersicht welche Tools wofür eingesetzt werden.</li>

--- a/gpt_analyze.py
+++ b/gpt_analyze.py
@@ -149,7 +149,13 @@ from services.alerts import (
     MAX_FALLBACKS_PER_REPORT,
 )
 from services.monitoring import _metrics
-from services.ai_act_module import build_ai_act_sections, validate_ai_act_sections
+from services.ai_act_module import (
+    build_ai_act_sections,
+    build_ai_act_sections_optimized,
+    validate_ai_act_sections,
+    ai_act_harmonize,
+    validate_ai_act_persona_compliance,
+)
 
 # Und direkt nach Zeile 61, vor try:
 UTF8Handler.setup_encoding()  # Global UTF-8 fix beim Start
@@ -4423,7 +4429,7 @@ def _generate_content_sections(briefing: Dict[str, Any], scores: Dict[str, Any])
     sections["executive_summary"] = exec_summary_cleaned
 
     # ==========================================================================
-    # Sprint G7: AI Act Compliance Sections
+    # Sprint G7/G8: AI Act Compliance Sections with Cross-Integration
     # ==========================================================================
     try:
         # Determine report language from briefing
@@ -4431,8 +4437,8 @@ def _generate_content_sections(briefing: Dict[str, Any], scores: Dict[str, Any])
         if report_lang not in ["de", "en"]:
             report_lang = "de"
 
-        # Generate all AI Act sections
-        ai_act_data = build_ai_act_sections(briefing, lang=report_lang)
+        # G8.6: Use optimized version with caching
+        ai_act_data = build_ai_act_sections_optimized(briefing, lang=report_lang)
 
         # Add AI Act variables to sections
         sections.update(ai_act_data)
@@ -4454,12 +4460,21 @@ def _generate_content_sections(briefing: Dict[str, Any], scores: Dict[str, Any])
             gaps_html += "</ul>"
             sections["AI_ACT_DATA_GAPS_HTML"] = gaps_html
 
+        # G8.2: Harmonize AI Act content across all sections
+        sections = ai_act_harmonize(sections, briefing)
+
+        # G8.3: Validate persona compliance
+        size = briefing.get("unternehmensgroesse", "")
+        persona_violations = validate_ai_act_persona_compliance(sections, size)
+        if persona_violations:
+            log.warning("⚠️ AI Act persona violations: %s", persona_violations[:3])
+
         # Validate AI Act sections
         validation_errors = validate_ai_act_sections(ai_act_data)
         if validation_errors:
             log.warning("⚠️ AI Act validation issues: %s", validation_errors)
         else:
-            log.info("✅ AI Act sections validated successfully")
+            log.info("✅ AI Act sections validated & harmonized successfully")
 
     except Exception as e:
         log.error("❌ AI Act section generation failed: %s", e)
@@ -4476,6 +4491,7 @@ def _generate_content_sections(briefing: Dict[str, Any], scores: Dict[str, Any])
         sections["AI_ACT_DATA_GAPS_HTML"] = ""
         sections["AI_ACT_RECOMMENDED_NEXT_STEPS_HTML"] = ""
         sections["AI_ACT_RELATED_USECASES_HTML"] = ""
+        sections["AI_ACT_CONSISTENCY_WARNINGS"] = []
 
     return sections
 

--- a/gpt_analyze.py
+++ b/gpt_analyze.py
@@ -149,6 +149,7 @@ from services.alerts import (
     MAX_FALLBACKS_PER_REPORT,
 )
 from services.monitoring import _metrics
+from services.ai_act_module import build_ai_act_sections, validate_ai_act_sections
 
 # Und direkt nach Zeile 61, vor try:
 UTF8Handler.setup_encoding()  # Global UTF-8 fix beim Start
@@ -4420,7 +4421,62 @@ def _generate_content_sections(briefing: Dict[str, Any], scores: Dict[str, Any])
     sections["EXECUTIVE_SUMMARY_HTML"] = exec_summary_cleaned
     sections["EXEC_SUMMARY_HTML"] = exec_summary_cleaned
     sections["executive_summary"] = exec_summary_cleaned
-    
+
+    # ==========================================================================
+    # Sprint G7: AI Act Compliance Sections
+    # ==========================================================================
+    try:
+        # Determine report language from briefing
+        report_lang = briefing.get("lang", "de")
+        if report_lang not in ["de", "en"]:
+            report_lang = "de"
+
+        # Generate all AI Act sections
+        ai_act_data = build_ai_act_sections(briefing, lang=report_lang)
+
+        # Add AI Act variables to sections
+        sections.update(ai_act_data)
+
+        # Generate HTML for alerts and gaps (convert lists to HTML)
+        alerts_list = ai_act_data.get("AI_ACT_NONCOMPLIANCE_ALERTS", [])
+        if alerts_list:
+            alerts_html = "<ul class='alert-list'>\n"
+            for alert in alerts_list:
+                alerts_html += f"  <li class='alert-item'>{alert}</li>\n"
+            alerts_html += "</ul>"
+            sections["AI_ACT_NONCOMPLIANCE_ALERTS_HTML"] = alerts_html
+
+        gaps_list = ai_act_data.get("AI_ACT_DATA_GAPS", [])
+        if gaps_list:
+            gaps_html = "<ul class='gaps-list'>\n"
+            for gap in gaps_list:
+                gaps_html += f"  <li class='gap-item'>{gap}</li>\n"
+            gaps_html += "</ul>"
+            sections["AI_ACT_DATA_GAPS_HTML"] = gaps_html
+
+        # Validate AI Act sections
+        validation_errors = validate_ai_act_sections(ai_act_data)
+        if validation_errors:
+            log.warning("⚠️ AI Act validation issues: %s", validation_errors)
+        else:
+            log.info("✅ AI Act sections validated successfully")
+
+    except Exception as e:
+        log.error("❌ AI Act section generation failed: %s", e)
+        # Set fallback values
+        sections["AI_ACT_RISK_LEVEL"] = "limited"
+        sections["AI_ACT_RISK_REASONING"] = (
+            "Die Risikoeinstufung konnte nicht automatisch ermittelt werden. "
+            "Bitte prüfen Sie die AI Act Anforderungen manuell basierend auf Ihrer Branche und Ihren Anwendungsfällen."
+        )
+        sections["AI_ACT_DUTY_MATRIX_HTML"] = ""
+        sections["AI_ACT_NONCOMPLIANCE_ALERTS"] = []
+        sections["AI_ACT_NONCOMPLIANCE_ALERTS_HTML"] = ""
+        sections["AI_ACT_DATA_GAPS"] = []
+        sections["AI_ACT_DATA_GAPS_HTML"] = ""
+        sections["AI_ACT_RECOMMENDED_NEXT_STEPS_HTML"] = ""
+        sections["AI_ACT_RELATED_USECASES_HTML"] = ""
+
     return sections
 
 

--- a/prompts/en/tools_recommendations.md
+++ b/prompts/en/tools_recommendations.md
@@ -1,45 +1,87 @@
-Developer:
-<!-- PLATIN++ PROMPT v5.2 -->
+<!-- PLATIN++ PROMPT v5.4 - SPRINT G6 -->
 <!-- SECTION: tools_recommendations -->
 <!-- OUTPUT: HTML ONLY -->
-<!-- SIZE-AWARE: solo/team/kmu -->
-<!-- INPUT: {{BRANCHE_LABEL}}, {{UNTERNEHMENSGROESSE_LABEL}}, {{HAUPTLEISTUNG}}, {{COMPANY_SIZE}} -->
+<!-- SIZE-AWARE: solo/team/sme -->
+<!-- INPUT: {{BRANCH_CORE_LABEL}}, {{BRANCH_CONTEXT_LABEL}}, {{OFFERING_LABEL}}, {{COMPANY_SIZE}} -->
 <!-- TOKEN-BUDGET: 2500 (solo:0.8x=2000, team:1.0x=2500, sme:1.15x=2875) -->
-<!-- RESEARCH: Tools can be referenced from {{RESEARCH_PROVENANCE_HTML}} -->
+<!-- WORD_MINIMUM_SOLO: 130 -->
+<!-- WORD_MINIMUM_TEAM: 190 -->
+<!-- WORD_MINIMUM_SME: 220 -->
 <!--
-GOAL: Clearly structured tool recommendation section ("AI Stack") for {{BRANCHE_LABEL}}.
+GOAL: Clearly structured tool recommendation section ("AI Stack") for {{BRANCH_CONTEXT_LABEL}}.
 
-PERSONA VARIATIONS (COMPANY_SIZE):
-- solo: 3–5 tools, simple operation, low integration effort
-        FORBIDDEN: "department", "project team", "area"
-- team: shared workspace, collaboration, rights/roles concepts
-- sme: defined stack with governance, roles, monitoring, area-specific
+SHORT LABELS (MANDATORY!):
+- {{BRANCH_CORE_LABEL}} = Industry in 8-12 words
+- {{BRANCH_CONTEXT_LABEL}} = Industry in 4-6 words
+- {{OFFERING_LABEL}} = Core offering in 6-10 words
+
+MINIMUM LENGTH (STRICT!):
+- Solo: ≥130 words
+- Team: ≥190 words (especially for regulated industries!)
+- SME: ≥220 words
+
+STRUCTURE BY SIZE:
+{% if COMPANY_SIZE == "solo" %}
+SOLO: 3–5 tool clusters with 2-3 examples each:
+1. AI Assistant & Basics (2-3 examples)
+2. Core Process Tools for {{OFFERING_LABEL}} (2-3 examples)
+3. Quality & Documentation (1-2 examples)
+
+{% elif COMPANY_SIZE == "team" %}
+TEAM: 4 tool clusters with 2-3 examples each (min. 190 words!):
+1. Collaboration & Shared Workspace (2-3 examples)
+2. Core Process Tools for {{OFFERING_LABEL}} (2-3 examples)
+3. Reporting & Analytics (2-3 examples)
+4. Governance & Quality (2 examples)
+
+For regulated industries (Finance, Healthcare, Legal) additionally:
+- Compliance/RegTech tools
+- Audit trail features
+- Access control & logging
+
+{% else %}
+SME: 5 tool clusters with 2-3 examples each (min. 220 words!):
+1. Enterprise Foundation (AI platform, knowledge base)
+2. Department-specific tools for {{OFFERING_LABEL}}
+3. Reporting/BI integration
+4. Compliance & Governance
+5. Rollout & Training
+{% endif %}
 
 ANTI-REDUNDANCY:
-- Tool details explained fully HERE
-- In Roadmaps only reference: "Tools (see AI Stack)"
+- Explain tool details fully HERE
+- In Roadmaps only reference: "Tools (→ see AI Stack)"
+- No generic meta-sentences ("This section explains...")
 
 STYLE & RULES:
 - Product-neutral (no brand names)
 - Focus on tool categories and purpose
+- Name specific use cases per tool type
 - No placeholders or developer language
+
+SPRINT G6 - PERSONA HARD-GUARDS (STRICT!):
+{% if COMPANY_SIZE == "solo" %}
+SOLO MODE - FORBIDDEN:
+- "Department" → "work area"
+- "Project team" → "project capacity"
+- "Teams" → "resources"
+{% elif COMPANY_SIZE == "team" %}
+TEAM MODE - FORBIDDEN:
+- "Division/Unit/Corporation" → do not use
+- Solo terms: "individual", "alone"
+{% else %}
+SME MODE - FORBIDDEN:
+- "Corporation/Division/Unit" → do not use
+- Solo terms: "individual", "alone"
+{% endif %}
 -->
 
 <section class="section tools">
-  <h2>Recommended AI Stack for {{BRANCHE_LABEL}}</h2>
+  <h2>Recommended AI Stack for {{BRANCH_CONTEXT_LABEL}}</h2>
 
   <p>
-    For the core process <strong>{{HAUPTLEISTUNG}}</strong>, a clearly structured
-    AI stack is recommended that fits the size <strong>{{UNTERNEHMENSGROESSE_LABEL}}</strong>.
-    It should noticeably relieve daily work without overwhelming the organization, and be
-    expandable step by step as needed.
-  </p>
-
-  <p>
-    In practice, a multi-stage approach has proven effective: First a lightweight
-    foundation that solo businesses, small teams, and SMEs can all use, then
-    targeted building blocks for the core process, and finally supplementary elements for governance
-    and quality.
+    For {{OFFERING_LABEL}}, a clearly structured AI stack is recommended
+    that noticeably relieves daily work and can be expanded step by step as needed.
   </p>
 
   <h3>Alignment by Company Size</h3>
@@ -68,26 +110,23 @@ STYLE & RULES:
   <ul>
     <li>
       <strong>AI Assistant for Daily Tasks</strong> –
-      for drafts, text revision, note structuring, workshop preparation,
-      or condensing questionnaire responses in the context of {{HAUPTLEISTUNG}}.
-      For solo businesses, a central assistant is sufficient; in teams and SMEs, it should be
-      integrated so that multiple people can use it consistently.
+      for drafts, text revision, note structuring, and condensing inputs.
+      For solo setups, a central assistant is sufficient; in teams and SMEs,
+      it should be integrated so multiple people can use it consistently.
     </li>
     <li>
       <strong>Knowledge and Document Store</strong> –
-      a central place for questionnaires, report templates, best practice examples,
-      protocols, and AI prompt collections. A clear structure is important so that content
-      is quickly found and understood by all participants.
+      a central place for templates, best practice examples, and prompt collections.
+      Clear structure enables quick finding and shared understanding.
     </li>
     <li>
       <strong>Collaboration or Task Tool</strong> –
-      for planning tasks, deadlines, and responsibilities in the {{HAUPTLEISTUNG}} process.
-      Solo businesses use simple task lists; small teams and SMEs should additionally
-      be able to transparently display responsibilities, status, and dependencies.
+      for planning tasks, deadlines, and responsibilities.
+      Solo: simple task lists; Teams/SMEs: responsibilities and dependencies.
     </li>
   </ul>
 
-  <h3>2. Tools for the Core Process {{HAUPTLEISTUNG}}</h3>
+  <h3>2. Tools for the Core Process {{OFFERING_LABEL}}</h3>
   <ul>
     <li>
       <strong>Form or Survey Tool</strong> –
@@ -97,23 +136,20 @@ STYLE & RULES:
     </li>
     <li>
       <strong>Evaluation and Reporting Tool</strong> –
-      supports processing responses with AI, creating maturity analyses,
-      action recommendations, and reports in a uniform layout.
-      A clear template approach ensures that all reports in {{BRANCHE_LABEL}}
-      appear professional and consistent.
+      supports processing with AI assistance and creating analyses and reports.
+      Template approach for professional, consistent results.
     </li>
     <li>
       <strong>Automation Tool</strong> –
-      connects survey, evaluation, and report creation. Typical workflows are:
-      form submission, automatic report creation, sending via email
-      or filing in the knowledge store. Solo businesses use simple automations,
-      SMEs integrate them into existing workflows.
+      connects input, evaluation, and result creation. Typical workflows:
+      Form → Analysis → Report → Delivery. Solo: simple automations;
+      SMEs: integration into existing workflows.
     </li>
     <li>
-      <strong>Industry-Specific Specialized Tools</strong> –
-      depending on {{BRANCHE_LABEL}}, additional solutions may be useful, e.g., for
-      scheduling, document approvals, media production, or business metrics analysis.
-      These tools should complement the AI stack, not unnecessarily complicate it.
+      <strong>Industry-Specific Tools</strong> –
+      depending on {{BRANCH_CONTEXT_LABEL}}, additional solutions may be useful,
+      e.g., for scheduling, document approvals, or specialized analyses.
+      These should complement the stack, not complicate it.
     </li>
   </ul>
 
@@ -123,15 +159,14 @@ STYLE & RULES:
       <strong>Simple Guidelines &amp; Roles</strong> –
       brief, written rules about what data may be entered into AI tools,
       how results are reviewed and approved, and who decides in case of doubt.
-      Solo businesses formulate a compact checklist; small teams and SMEs
+      Solo businesses formulate a compact checklist; teams and SMEs
       name responsible parties for quality, data protection, and usage.
     </li>
     <li>
       <strong>Documentation of AI Usage</strong> –
       an overview of which tools are used for what, with what data volume
       and what protective measures. This documentation facilitates adaptations to new
-      regulatory requirements and creates transparency toward employees
-      and external partners.
+      regulatory requirements and creates transparency.
     </li>
     <li>
       <strong>Quality Control</strong> –
@@ -146,8 +181,7 @@ STYLE & RULES:
   <p>
     Instead of introducing all tools simultaneously, the AI stack should be built up in manageable
     stages. First a stable foundation of assistant, knowledge store, and task management,
-    then a form and evaluation setup for {{HAUPTLEISTUNG}}, and finally targeted automations
-    and governance building blocks.
+    then a form and evaluation setup, and finally targeted automations and governance building blocks.
   </p>
 
   <table class="table tools-priorities">
@@ -155,7 +189,7 @@ STYLE & RULES:
       <tr>
         <th>Stage</th>
         <th>Building Block</th>
-        <th>Role in {{HAUPTLEISTUNG}} Process</th>
+        <th>Role in Process</th>
         <th>Recommended Timing</th>
       </tr>
     </thead>
@@ -164,8 +198,7 @@ STYLE & RULES:
         <td>1</td>
         <td>Assistant, knowledge store, task management</td>
         <td>
-          Supports daily work, secures knowledge, and creates transparency
-          about tasks and priorities.
+          Supports daily work, secures knowledge, and creates transparency.
         </td>
         <td>within the first 30 days</td>
       </tr>
@@ -173,8 +206,8 @@ STYLE & RULES:
         <td>2</td>
         <td>Form tool &amp; evaluation setup</td>
         <td>
-          Makes customer data in the context of {{HAUPTLEISTUNG}} usable in a structured way and
-          enables AI-powered evaluations and reports.
+          Makes data for {{OFFERING_LABEL}} usable in a structured way and
+          enables AI-powered evaluations.
         </td>
         <td>Day 30–60</td>
       </tr>
@@ -182,7 +215,7 @@ STYLE & RULES:
         <td>3</td>
         <td>Automation &amp; governance building blocks</td>
         <td>
-          Reduces manual intermediate steps, strengthens security and quality, and makes
+          Reduces manual steps, strengthens security and quality, and makes
           the overall process scalable – especially relevant for growing teams and SMEs.
         </td>
         <td>from about 60 days</td>
@@ -191,9 +224,8 @@ STYLE & RULES:
   </table>
 
   <p class="small muted">
-    The recommended AI stack is deliberately kept lean: For {{UNTERNEHMENSGROESSE_LABEL}},
-    the priority is to quickly generate value in the core process {{HAUPTLEISTUNG}} and
-    add further building blocks step by step as needed. This keeps costs and
-    complexity manageable while laying the foundation for later scaling.
+    The recommended AI stack is deliberately kept lean: quickly generate value for
+    {{OFFERING_LABEL}} and add further building blocks step by step as needed.
+    Details on implementation → see Roadmap.
   </p>
 </section>

--- a/services/ai_act_module.py
+++ b/services/ai_act_module.py
@@ -1845,7 +1845,9 @@ def build_ai_act_sections_optimized(
 
     # Apply persona filter to text sections
     for key in ["AI_ACT_RISK_REASONING"]:
-        sections[key] = apply_ai_act_persona_filter(sections[key], size)
+        value = sections[key]
+        if isinstance(value, str):
+            sections[key] = apply_ai_act_persona_filter(value, size)
 
     log.info("🏛️ AI Act sections (optimized): risk_level=%s", risk_level)
 

--- a/services/ai_act_module.py
+++ b/services/ai_act_module.py
@@ -1,0 +1,1087 @@
+# -*- coding: utf-8 -*-
+"""
+AI Act Compliance Module - Sprint G7
+
+Size-aware, branch-aware, language-aware AI Act risk assessment and compliance generation.
+
+Version: 1.0.0 (Sprint G7)
+
+This module provides:
+- Risk level determination (none/minimal/limited/high-risk)
+- Duty matrix HTML generation
+- Non-compliance alerts
+- Data gaps identification
+- Recommended next steps
+- Use case risk tagging
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, List, Optional, Tuple
+
+log = logging.getLogger(__name__)
+
+# =============================================================================
+# CONSTANTS
+# =============================================================================
+
+VALID_RISK_LEVELS = {"none", "minimal", "limited", "high-risk"}
+
+# High-risk branches per AI Act Annex III
+HIGH_RISK_BRANCHES = {"gesundheit", "medizin", "healthcare", "medical"}
+LIMITED_RISK_BRANCHES = {"recht", "legal", "law"}
+REGULATED_BRANCHES = {"finanzen", "versicherung", "finance", "insurance", "banking"}
+
+# Use case keywords that indicate high-risk
+HIGH_RISK_USECASES_KEYWORDS = {
+    "scoring", "kredit", "credit", "entscheidung", "decision",
+    "bewertung", "assessment", "rating", "profiling", "biometric",
+    "recruitment", "hiring", "personalauswahl", "bewerberauswahl"
+}
+
+# Use case keywords that indicate limited risk
+LIMITED_RISK_USECASES_KEYWORDS = {
+    "chatbot", "kundenservice", "customer service", "kommunikation",
+    "content", "marketing", "empfehlung", "recommendation"
+}
+
+# Solo-forbidden terms (for persona clean checks)
+SOLO_FORBIDDEN_TERMS = [
+    "team", "teams", "abteilung", "mitarbeiter", "kollegen",
+    "fachbereich", "projektteam", "department", "employees", "colleagues"
+]
+
+# Team/KMU forbidden terms for Solo reports
+TEAM_KMU_TERMS_FOR_SOLO = [
+    "abteilungsleiter", "projektleiter", "compliance-officer",
+    "department head", "project manager", "governance board"
+]
+
+
+# =============================================================================
+# RISK LEVEL DETERMINATION
+# =============================================================================
+
+def determine_risk_level(
+    branche: str,
+    size: str,
+    usecases: List[str],
+    automatisierung_prozent: int = 0
+) -> str:
+    """
+    Determine AI Act risk level based on branch, size, and use cases.
+
+    Returns: "none" | "minimal" | "limited" | "high-risk"
+    """
+    branche_lower = branche.lower().strip()
+    size_lower = size.lower().strip()
+    usecases_text = " ".join(usecases).lower()
+
+    # Rule 1: Finance/Insurance with scoring/decision → high-risk
+    if any(b in branche_lower for b in ["finanz", "versicher", "finance", "insurance", "bank"]):
+        if any(kw in usecases_text for kw in HIGH_RISK_USECASES_KEYWORDS):
+            return "high-risk"
+        return "limited"
+
+    # Rule 2: Healthcare/Medical → high-risk
+    if any(b in branche_lower for b in ["gesundheit", "medizin", "health", "medical", "pharma"]):
+        return "high-risk"
+
+    # Rule 3: Legal → limited
+    if any(b in branche_lower for b in ["recht", "legal", "law", "anwalt", "lawyer"]):
+        return "limited"
+
+    # Rule 4: HR/Recruitment with automated decisions → high-risk
+    if any(b in branche_lower for b in ["hr", "personal", "human resources", "recruiting"]):
+        if any(kw in usecases_text for kw in ["auswahl", "selection", "screening", "bewertung"]):
+            return "high-risk"
+        return "limited"
+
+    # Rule 5: Solo with low automation → minimal
+    if "solo" in size_lower or "freiberuf" in size_lower or "1" in size_lower:
+        return "minimal"
+
+    # Rule 6: Team with low automation (<30%) → minimal
+    if ("team" in size_lower or "klein" in size_lower) and automatisierung_prozent < 30:
+        return "minimal"
+
+    # Default: limited
+    return "limited"
+
+
+def generate_risk_reasoning(
+    risk_level: str,
+    branche: str,
+    size: str,
+    usecases: List[str],
+    lang: str = "de"
+) -> str:
+    """
+    Generate 80-120 word reasoning for the risk level determination.
+    Size-aware, no persona leaks.
+    """
+    size_lower = size.lower()
+    is_solo = "solo" in size_lower or "freiberuf" in size_lower or "1" in size_lower
+    is_team = "team" in size_lower or "klein" in size_lower or "2" in size_lower
+
+    usecases_str = ", ".join(usecases[:3]) if usecases else "allgemeine KI-Nutzung"
+
+    if lang == "en":
+        return _generate_risk_reasoning_en(risk_level, branche, size, usecases_str, is_solo, is_team)
+    else:
+        return _generate_risk_reasoning_de(risk_level, branche, size, usecases_str, is_solo, is_team)
+
+
+def _generate_risk_reasoning_de(
+    risk_level: str,
+    branche: str,
+    size: str,
+    usecases_str: str,
+    is_solo: bool,
+    is_team: bool
+) -> str:
+    """German risk reasoning generation."""
+
+    if risk_level == "high-risk":
+        if is_solo:
+            return f"""Die Einstufung als Hochrisiko-System ergibt sich aus der Branche {branche} und den
+geplanten Anwendungsfällen ({usecases_str}). Gemäß EU AI Act Anhang III fallen automatisierte
+Entscheidungssysteme in regulierten Branchen unter strenge Anforderungen. Auch bei Ihrer
+Unternehmensgröße gelten diese Pflichten vollumfänglich, sobald entsprechende Systeme eingesetzt
+werden. Empfohlen wird eine frühzeitige Konformitätsprüfung, Dokumentation der Datengrundlagen
+und Definition klarer Human-Oversight-Prozesse. Die Anforderungen umfassen Risikoanalyse,
+Qualitätsmanagement und Post-Market-Monitoring."""
+        elif is_team:
+            return f"""Die Einstufung als Hochrisiko-System ergibt sich aus der Branche {branche} und den
+geplanten Anwendungsfällen ({usecases_str}). Gemäß EU AI Act Anhang III fallen automatisierte
+Entscheidungssysteme in regulierten Branchen unter strenge Anforderungen. Für Ihr Unternehmen
+bedeutet dies die Notwendigkeit einer strukturierten Compliance-Strategie mit klaren
+Verantwortlichkeiten. Empfohlen wird die Benennung eines KI-Verantwortlichen, Dokumentation
+aller Datenflüsse und Implementierung von Review-Prozessen. Die Anforderungen umfassen
+Risikoanalyse, Qualitätsmanagement und Post-Market-Monitoring."""
+        else:
+            return f"""Die Einstufung als Hochrisiko-System ergibt sich aus der Branche {branche} und den
+geplanten Anwendungsfällen ({usecases_str}). Gemäß EU AI Act Anhang III fallen automatisierte
+Entscheidungssysteme in regulierten Branchen unter strenge Anforderungen. Für Ihr Unternehmen
+ist eine umfassende Compliance-Struktur mit definierten Rollen und Prozessen erforderlich.
+Dies umfasst ein Qualitätsmanagementsystem, dokumentierte Risikoanalysen, klare
+Human-Oversight-Konzepte und Post-Market-Monitoring. Die Benennung eines Compliance-Beauftragten
+und regelmäßige Audits werden empfohlen."""
+
+    elif risk_level == "limited":
+        if is_solo:
+            return f"""Die Einstufung als System mit begrenztem Risiko basiert auf der Branche {branche}
+und Ihren Anwendungsfällen ({usecases_str}). Der EU AI Act sieht für diese Kategorie primär
+Transparenzpflichten vor. Für Sie bedeutet dies: Dokumentation der eingesetzten KI-Systeme,
+klare Kennzeichnung KI-generierter Inhalte und nachvollziehbare Qualitätsprüfung. Formale
+Zertifizierungen sind nicht erforderlich, aber eine strukturierte Dokumentation Ihrer
+KI-Nutzung wird empfohlen. Dies schafft Vertrauen und erleichtert eventuelle spätere
+Erweiterungen."""
+        elif is_team:
+            return f"""Die Einstufung als System mit begrenztem Risiko basiert auf der Branche {branche}
+und den Anwendungsfällen ({usecases_str}). Der EU AI Act sieht für diese Kategorie primär
+Transparenzpflichten vor. Für Ihr Unternehmen bedeutet dies: gemeinsame Dokumentation der
+eingesetzten KI-Systeme, klare Kennzeichnung KI-generierter Inhalte und definierte
+Qualitätsprüfprozesse. Die Benennung eines KI-Verantwortlichen und einfache Logging-Mechanismen
+werden empfohlen. Dies schafft eine solide Basis für verantwortungsvolle KI-Nutzung."""
+        else:
+            return f"""Die Einstufung als System mit begrenztem Risiko basiert auf der Branche {branche}
+und den Anwendungsfällen ({usecases_str}). Der EU AI Act sieht für diese Kategorie primär
+Transparenzpflichten vor. Für Ihr Unternehmen empfiehlt sich eine strukturierte
+Dokumentation aller KI-Systeme, klare Prozesse für Kennzeichnung und Qualitätsprüfung
+sowie definierte Verantwortlichkeiten. Ein einfaches Governance-Framework mit Logging
+und regelmäßigen Reviews schafft die Basis für Compliance und ermöglicht Skalierung."""
+
+    else:  # minimal or none
+        if is_solo:
+            return f"""Die Einstufung als minimales Risiko basiert auf der Branche {branche}, Ihrer
+Unternehmensgröße und den Anwendungsfällen ({usecases_str}). Der EU AI Act sieht für
+diese Kategorie keine spezifischen Pflichten vor. Dennoch empfehlen sich Best Practices:
+Dokumentation der genutzten Tools, Prüfung wichtiger Ergebnisse vor Verwendung und
+Transparenz gegenüber Kunden. Diese Maßnahmen sind freiwillig, stärken aber das
+Vertrauen und bereiten auf eventuelle künftige Anforderungen vor."""
+        elif is_team:
+            return f"""Die Einstufung als minimales Risiko basiert auf der Branche {branche}, Ihrer
+Unternehmensgröße und den Anwendungsfällen ({usecases_str}). Der EU AI Act sieht für
+diese Kategorie keine spezifischen Pflichten vor. Dennoch empfehlen sich Best Practices
+für Ihr Unternehmen: gemeinsame Dokumentation der genutzten Tools, einfache Qualitätsprüfung
+und Transparenz. Die Etablierung grundlegender Richtlinien für die KI-Nutzung ist
+sinnvoll und bereitet auf eventuelle Erweiterungen vor."""
+        else:
+            return f"""Die Einstufung als minimales Risiko basiert auf der Branche {branche} und den
+Anwendungsfällen ({usecases_str}). Der EU AI Act sieht für diese Kategorie keine
+spezifischen Pflichten vor. Dennoch empfiehlt sich für Ihr Unternehmen die Etablierung
+freiwilliger Best Practices: Dokumentation der KI-Systeme, einfache Governance-Richtlinien
+und Qualitätsprüfprozesse. Diese Maßnahmen stärken das Vertrauen und schaffen eine
+Grundlage für verantwortungsvolle Skalierung."""
+
+
+def _generate_risk_reasoning_en(
+    risk_level: str,
+    branche: str,
+    size: str,
+    usecases_str: str,
+    is_solo: bool,
+    is_team: bool
+) -> str:
+    """English risk reasoning generation."""
+
+    if risk_level == "high-risk":
+        if is_solo:
+            return f"""The high-risk classification results from the {branche} industry and planned
+use cases ({usecases_str}). According to EU AI Act Annex III, automated decision-making
+systems in regulated industries fall under strict requirements. These obligations apply
+fully regardless of business size when such systems are deployed. Early conformity
+assessment, documentation of data foundations, and clear human oversight processes are
+recommended. Requirements include risk analysis, quality management, and post-market
+monitoring."""
+        elif is_team:
+            return f"""The high-risk classification results from the {branche} industry and planned
+use cases ({usecases_str}). According to EU AI Act Annex III, automated decision-making
+systems in regulated industries fall under strict requirements. For your organization,
+this means establishing a structured compliance strategy with clear responsibilities.
+Designating an AI lead, documenting all data flows, and implementing review processes
+is recommended. Requirements include risk analysis, quality management, and post-market
+monitoring."""
+        else:
+            return f"""The high-risk classification results from the {branche} industry and planned
+use cases ({usecases_str}). According to EU AI Act Annex III, automated decision-making
+systems in regulated industries fall under strict requirements. Your organization requires
+a comprehensive compliance structure with defined roles and processes. This includes a
+quality management system, documented risk analyses, clear human oversight concepts,
+and post-market monitoring. Designating a compliance officer and regular audits are
+recommended."""
+
+    elif risk_level == "limited":
+        if is_solo:
+            return f"""The limited risk classification is based on the {branche} industry and your
+use cases ({usecases_str}). The EU AI Act primarily requires transparency obligations
+for this category. For you, this means: documenting AI systems in use, clearly labeling
+AI-generated content, and maintaining traceable quality checks. Formal certifications
+are not required, but structured documentation of your AI usage is recommended. This
+builds trust and facilitates potential future expansions."""
+        elif is_team:
+            return f"""The limited risk classification is based on the {branche} industry and use
+cases ({usecases_str}). The EU AI Act primarily requires transparency obligations for
+this category. For your organization, this means: shared documentation of AI systems,
+clear labeling of AI-generated content, and defined quality review processes. Designating
+an AI lead and implementing simple logging mechanisms is recommended. This creates a
+solid foundation for responsible AI use."""
+        else:
+            return f"""The limited risk classification is based on the {branche} industry and use
+cases ({usecases_str}). The EU AI Act primarily requires transparency obligations for
+this category. Your organization should establish structured documentation of all AI
+systems, clear processes for labeling and quality review, and defined responsibilities.
+A simple governance framework with logging and regular reviews creates the foundation
+for compliance and enables scaling."""
+
+    else:  # minimal or none
+        if is_solo:
+            return f"""The minimal risk classification is based on the {branche} industry, your
+business size, and use cases ({usecases_str}). The EU AI Act does not mandate specific
+requirements for this category. However, best practices are recommended: documenting
+tools in use, reviewing important outputs before use, and transparency with clients.
+These measures are voluntary but build trust and prepare for potential future
+requirements."""
+        elif is_team:
+            return f"""The minimal risk classification is based on the {branche} industry, your
+business size, and use cases ({usecases_str}). The EU AI Act does not mandate specific
+requirements for this category. However, best practices for your organization are
+recommended: shared documentation of tools, simple quality reviews, and transparency.
+Establishing basic guidelines for AI usage is sensible and prepares for potential
+expansions."""
+        else:
+            return f"""The minimal risk classification is based on the {branche} industry and use
+cases ({usecases_str}). The EU AI Act does not mandate specific requirements for this
+category. However, your organization should consider voluntary best practices:
+documenting AI systems, simple governance guidelines, and quality review processes.
+These measures build trust and create a foundation for responsible scaling."""
+
+
+# =============================================================================
+# DUTY MATRIX GENERATION
+# =============================================================================
+
+def generate_duty_matrix_html(
+    risk_level: str,
+    branche: str,
+    size: str,
+    lang: str = "de"
+) -> str:
+    """
+    Generate HTML duty matrix table based on risk level.
+
+    - none/minimal: 3-4 rows (best practices)
+    - limited: 6-8 rows
+    - high-risk: 8-12 rows
+    """
+    size_lower = size.lower()
+    is_solo = "solo" in size_lower or "freiberuf" in size_lower
+
+    if lang == "en":
+        return _generate_duty_matrix_en(risk_level, branche, is_solo)
+    else:
+        return _generate_duty_matrix_de(risk_level, branche, is_solo)
+
+
+def _generate_duty_matrix_de(risk_level: str, branche: str, is_solo: bool) -> str:
+    """German duty matrix."""
+
+    header = """<table class="table duty-matrix">
+  <thead>
+    <tr>
+      <th>Pflicht / Best Practice</th>
+      <th>Beschreibung</th>
+      <th>Priorität</th>
+    </tr>
+  </thead>
+  <tbody>"""
+
+    footer = """  </tbody>
+</table>"""
+
+    if risk_level in ["none", "minimal"]:
+        rows = [
+            ("Dokumentation", "Übersicht der genutzten KI-Tools und deren Einsatzzweck", "Empfohlen"),
+            ("Qualitätsprüfung", "Stichprobenartige Prüfung wichtiger KI-Ergebnisse", "Empfohlen"),
+            ("Transparenz", "Kennzeichnung KI-generierter Inhalte gegenüber Kunden", "Empfohlen"),
+        ]
+        if not is_solo:
+            rows.append(("Richtlinien", "Einfache Regeln für die KI-Nutzung im Unternehmen", "Empfohlen"))
+        note = '<p class="small muted">Diese Maßnahmen sind Best Practices, keine gesetzlichen Pflichten.</p>'
+
+    elif risk_level == "limited":
+        rows = [
+            ("Transparenzpflicht", "Klare Kennzeichnung aller KI-generierten Inhalte", "Pflicht"),
+            ("Dokumentation", "Vollständige Dokumentation aller KI-Systeme", "Pflicht"),
+            ("Human Oversight", "Definierte Prozesse für menschliche Kontrolle", "Empfohlen"),
+            ("Logging", "Protokollierung der KI-Nutzung und Entscheidungen", "Empfohlen"),
+            ("Datenqualität", "Sicherstellung der Qualität von Trainingsdaten", "Empfohlen"),
+            ("Monitoring", "Regelmäßige Überprüfung der KI-Systemleistung", "Empfohlen"),
+        ]
+        if not is_solo:
+            rows.extend([
+                ("Verantwortlichkeiten", "Klare Zuweisung von Rollen und Zuständigkeiten", "Empfohlen"),
+                ("Schulung", "Grundlegende KI-Kompetenz für alle Beteiligten", "Empfohlen"),
+            ])
+        note = '<p class="small muted">Transparenzpflichten sind gesetzlich vorgeschrieben, weitere Maßnahmen werden empfohlen.</p>'
+
+    else:  # high-risk
+        rows = [
+            ("Konformitätserklärung", "EU-Konformitätserklärung gemäß AI Act", "Pflicht"),
+            ("Qualitätsmanagementsystem", "Dokumentiertes QMS für KI-Systeme", "Pflicht"),
+            ("Risikoanalyse", "Umfassende Risikobewertung und -dokumentation", "Pflicht"),
+            ("Human Oversight", "Definierte Prozesse für menschliche Kontrolle und Eingriff", "Pflicht"),
+            ("Logging & Audit Trail", "Vollständige Protokollierung aller Entscheidungen", "Pflicht"),
+            ("Daten-Governance", "Dokumentierte Prozesse für Datenqualität und -management", "Pflicht"),
+            ("Post-Market Monitoring", "Kontinuierliche Überwachung im Betrieb", "Pflicht"),
+            ("Incident Reporting", "Definierter Prozess für Vorfallsmeldungen", "Pflicht"),
+        ]
+        if not is_solo:
+            rows.extend([
+                ("Compliance-Beauftragter", "Benannte verantwortliche Person für AI Act Compliance", "Pflicht"),
+                ("Regelmäßige Audits", "Interne und externe Überprüfungen", "Empfohlen"),
+                ("Schulungsprogramm", "Systematische Schulung aller Beteiligten", "Empfohlen"),
+                ("Dokumentenmanagement", "Zentrale Verwaltung aller Compliance-Dokumente", "Empfohlen"),
+            ])
+        note = '<p class="small muted">Alle als Pflicht markierten Maßnahmen sind gesetzlich vorgeschrieben.</p>'
+
+    rows_html = "\n".join([
+        f'    <tr><td>{pflicht}</td><td>{beschreibung}</td><td><span class="badge badge-{"danger" if prio == "Pflicht" else "info"}">{prio}</span></td></tr>'
+        for pflicht, beschreibung, prio in rows
+    ])
+
+    return f"{header}\n{rows_html}\n{footer}\n{note}"
+
+
+def _generate_duty_matrix_en(risk_level: str, branche: str, is_solo: bool) -> str:
+    """English duty matrix."""
+
+    header = """<table class="table duty-matrix">
+  <thead>
+    <tr>
+      <th>Obligation / Best Practice</th>
+      <th>Description</th>
+      <th>Priority</th>
+    </tr>
+  </thead>
+  <tbody>"""
+
+    footer = """  </tbody>
+</table>"""
+
+    if risk_level in ["none", "minimal"]:
+        rows = [
+            ("Documentation", "Overview of AI tools in use and their purpose", "Recommended"),
+            ("Quality Review", "Spot-check review of important AI outputs", "Recommended"),
+            ("Transparency", "Label AI-generated content for clients", "Recommended"),
+        ]
+        if not is_solo:
+            rows.append(("Guidelines", "Simple rules for AI usage in the organization", "Recommended"))
+        note = '<p class="small muted">These measures are best practices, not legal obligations.</p>'
+
+    elif risk_level == "limited":
+        rows = [
+            ("Transparency Obligation", "Clear labeling of all AI-generated content", "Required"),
+            ("Documentation", "Complete documentation of all AI systems", "Required"),
+            ("Human Oversight", "Defined processes for human control", "Recommended"),
+            ("Logging", "Logging of AI usage and decisions", "Recommended"),
+            ("Data Quality", "Ensuring quality of training data", "Recommended"),
+            ("Monitoring", "Regular review of AI system performance", "Recommended"),
+        ]
+        if not is_solo:
+            rows.extend([
+                ("Responsibilities", "Clear assignment of roles and responsibilities", "Recommended"),
+                ("Training", "Basic AI competency for all stakeholders", "Recommended"),
+            ])
+        note = '<p class="small muted">Transparency obligations are legally required, additional measures are recommended.</p>'
+
+    else:  # high-risk
+        rows = [
+            ("Conformity Declaration", "EU conformity declaration per AI Act", "Required"),
+            ("Quality Management System", "Documented QMS for AI systems", "Required"),
+            ("Risk Analysis", "Comprehensive risk assessment and documentation", "Required"),
+            ("Human Oversight", "Defined processes for human control and intervention", "Required"),
+            ("Logging & Audit Trail", "Complete logging of all decisions", "Required"),
+            ("Data Governance", "Documented processes for data quality and management", "Required"),
+            ("Post-Market Monitoring", "Continuous monitoring in operation", "Required"),
+            ("Incident Reporting", "Defined process for incident reports", "Required"),
+        ]
+        if not is_solo:
+            rows.extend([
+                ("Compliance Officer", "Designated responsible person for AI Act compliance", "Required"),
+                ("Regular Audits", "Internal and external reviews", "Recommended"),
+                ("Training Program", "Systematic training for all stakeholders", "Recommended"),
+                ("Document Management", "Central management of all compliance documents", "Recommended"),
+            ])
+        note = '<p class="small muted">All measures marked as Required are legally mandated.</p>'
+
+    rows_html = "\n".join([
+        f'    <tr><td>{duty}</td><td>{description}</td><td><span class="badge badge-{"danger" if prio == "Required" else "info"}">{prio}</span></td></tr>'
+        for duty, description, prio in rows
+    ])
+
+    return f"{header}\n{rows_html}\n{footer}\n{note}"
+
+
+# =============================================================================
+# NON-COMPLIANCE ALERTS
+# =============================================================================
+
+def generate_noncompliance_alerts(
+    risk_level: str,
+    branche: str,
+    size: str,
+    lang: str = "de"
+) -> List[str]:
+    """
+    Generate 3-8 non-compliance alert bullet points.
+    """
+    size_lower = size.lower()
+    is_solo = "solo" in size_lower or "freiberuf" in size_lower
+
+    if lang == "en":
+        return _generate_alerts_en(risk_level, is_solo)
+    else:
+        return _generate_alerts_de(risk_level, is_solo)
+
+
+def _generate_alerts_de(risk_level: str, is_solo: bool) -> List[str]:
+    """German non-compliance alerts."""
+
+    if risk_level in ["none", "minimal"]:
+        alerts = [
+            "Keine formale Risikoanalyse vorhanden",
+            "Keine Dokumentation der genutzten KI-Modelle",
+            "Fehlende Qualitätsprüfung vor Nutzung von KI-Ergebnissen",
+        ]
+        if not is_solo:
+            alerts.append("Keine definierten Verantwortlichkeiten für KI-Nutzung")
+
+    elif risk_level == "limited":
+        alerts = [
+            "Transparenzpflicht nicht vollständig umgesetzt",
+            "Human Oversight unzureichend definiert",
+            "Datenqualität nicht dokumentiert",
+            "Keine Versionierung von Modellen",
+            "Fehlende Logging-Mechanismen für KI-Entscheidungen",
+        ]
+        if not is_solo:
+            alerts.extend([
+                "Keine klaren Verantwortlichkeiten für KI-Compliance",
+                "Fehlende Schulungsmaßnahmen für KI-Nutzer",
+            ])
+
+    else:  # high-risk
+        alerts = [
+            "Fehlende EU-Konformitätserklärung – gesetzlich zwingend erforderlich",
+            "Kein dokumentiertes Qualitätsmanagementsystem vorhanden",
+            "Risikoanalyse nicht vollständig oder nicht aktuell",
+            "Human Oversight nicht ausreichend implementiert",
+            "Post-Market Monitoring nicht eingerichtet",
+            "Keine definierte Incident-Meldestruktur",
+            "Audit Trail / Logging unvollständig",
+        ]
+        if not is_solo:
+            alerts.extend([
+                "Kein Compliance-Beauftragter benannt",
+            ])
+
+    return alerts
+
+
+def _generate_alerts_en(risk_level: str, is_solo: bool) -> List[str]:
+    """English non-compliance alerts."""
+
+    if risk_level in ["none", "minimal"]:
+        alerts = [
+            "No formal risk analysis available",
+            "No documentation of AI models in use",
+            "Missing quality review before using AI outputs",
+        ]
+        if not is_solo:
+            alerts.append("No defined responsibilities for AI usage")
+
+    elif risk_level == "limited":
+        alerts = [
+            "Transparency obligation not fully implemented",
+            "Human oversight insufficiently defined",
+            "Data quality not documented",
+            "No model versioning",
+            "Missing logging mechanisms for AI decisions",
+        ]
+        if not is_solo:
+            alerts.extend([
+                "No clear responsibilities for AI compliance",
+                "Missing training measures for AI users",
+            ])
+
+    else:  # high-risk
+        alerts = [
+            "Missing EU conformity declaration – legally required",
+            "No documented quality management system",
+            "Risk analysis incomplete or outdated",
+            "Human oversight not sufficiently implemented",
+            "Post-market monitoring not established",
+            "No defined incident reporting structure",
+            "Audit trail / logging incomplete",
+        ]
+        if not is_solo:
+            alerts.append("No compliance officer designated")
+
+    return alerts
+
+
+# =============================================================================
+# DATA GAPS
+# =============================================================================
+
+def generate_data_gaps(
+    risk_level: str,
+    branche: str,
+    size: str,
+    lang: str = "de"
+) -> List[str]:
+    """
+    Generate 2-6 data gap bullet points.
+    """
+    size_lower = size.lower()
+    is_solo = "solo" in size_lower or "freiberuf" in size_lower
+    is_team = "team" in size_lower or "klein" in size_lower
+
+    if lang == "en":
+        return _generate_gaps_en(risk_level, is_solo, is_team)
+    else:
+        return _generate_gaps_de(risk_level, is_solo, is_team)
+
+
+def _generate_gaps_de(risk_level: str, is_solo: bool, is_team: bool) -> List[str]:
+    """German data gaps."""
+
+    if is_solo:
+        gaps = [
+            "Keine definierte Datenklassifikation",
+            "Unklare Trennung zwischen Test- und Produktivdaten",
+        ]
+        if risk_level not in ["none", "minimal"]:
+            gaps.append("Fehlende Dokumentation der Datenherkunft")
+
+    elif is_team:
+        gaps = [
+            "Keine dokumentierten Datenqualitätsmetriken",
+            "Fehlende Prozessbeschreibung der Datenflüsse",
+            "Keine definierten Verantwortlichkeiten für Datenkategorien",
+        ]
+        if risk_level not in ["none", "minimal"]:
+            gaps.extend([
+                "Fehlende Versionierung von Trainingsdaten",
+                "Keine dokumentierte Datenlöschstrategie",
+            ])
+
+    else:  # KMU
+        gaps = [
+            "Keine dokumentierten Datenqualitätsmetriken",
+            "Fehlende Prozessbeschreibung der Datenflüsse zwischen Fachbereichen",
+            "Keine definierten Data Owner für sensible Kategorien",
+            "Fehlende Datenherkunftsdokumentation (Data Lineage)",
+        ]
+        if risk_level not in ["none", "minimal"]:
+            gaps.extend([
+                "Keine systematische Datenvalidierung vor KI-Training",
+                "Fehlende Archivierungs- und Löschkonzepte",
+            ])
+
+    return gaps
+
+
+def _generate_gaps_en(risk_level: str, is_solo: bool, is_team: bool) -> List[str]:
+    """English data gaps."""
+
+    if is_solo:
+        gaps = [
+            "No defined data classification",
+            "Unclear separation between test and production data",
+        ]
+        if risk_level not in ["none", "minimal"]:
+            gaps.append("Missing documentation of data origin")
+
+    elif is_team:
+        gaps = [
+            "No documented data quality metrics",
+            "Missing process description for data flows",
+            "No defined responsibilities for data categories",
+        ]
+        if risk_level not in ["none", "minimal"]:
+            gaps.extend([
+                "Missing versioning of training data",
+                "No documented data deletion strategy",
+            ])
+
+    else:  # SME
+        gaps = [
+            "No documented data quality metrics",
+            "Missing process description for data flows between departments",
+            "No defined data owners for sensitive categories",
+            "Missing data provenance documentation (data lineage)",
+        ]
+        if risk_level not in ["none", "minimal"]:
+            gaps.extend([
+                "No systematic data validation before AI training",
+                "Missing archival and deletion concepts",
+            ])
+
+    return gaps
+
+
+# =============================================================================
+# RECOMMENDED NEXT STEPS
+# =============================================================================
+
+def generate_next_steps_html(
+    risk_level: str,
+    branche: str,
+    size: str,
+    lang: str = "de"
+) -> str:
+    """
+    Generate HTML list with 3-5 recommended next steps.
+    """
+    size_lower = size.lower()
+    is_solo = "solo" in size_lower or "freiberuf" in size_lower
+
+    if lang == "en":
+        return _generate_next_steps_en(risk_level, is_solo)
+    else:
+        return _generate_next_steps_de(risk_level, is_solo)
+
+
+def _generate_next_steps_de(risk_level: str, is_solo: bool) -> str:
+    """German next steps."""
+
+    if risk_level in ["none", "minimal"]:
+        if is_solo:
+            steps = [
+                ("Woche 1–2", "KI-Tool-Dokumentation", "Erstellen Sie eine einfache Übersicht der genutzten KI-Tools und deren Einsatzzweck."),
+                ("Woche 2–3", "Qualitätsprüfung", "Definieren Sie 3-5 Prüfpunkte für wichtige KI-Ergebnisse."),
+                ("Woche 3–4", "Transparenz", "Legen Sie fest, wie KI-generierte Inhalte gegenüber Kunden gekennzeichnet werden."),
+            ]
+        else:
+            steps = [
+                ("Woche 1–2", "KI-Inventar erstellen", "Dokumentieren Sie alle genutzten KI-Tools und deren Einsatzbereiche."),
+                ("Woche 2–3", "Richtlinien definieren", "Erstellen Sie einfache Regeln für die KI-Nutzung."),
+                ("Woche 3–4", "Verantwortlichkeiten klären", "Benennen Sie einen KI-Verantwortlichen."),
+                ("Woche 4", "Qualitätsprüfung", "Definieren Sie Prüfprozesse für wichtige KI-Ergebnisse."),
+            ]
+
+    elif risk_level == "limited":
+        if is_solo:
+            steps = [
+                ("Woche 1–2", "Dokumentation aufsetzen", "Erstellen Sie eine vollständige Dokumentation Ihrer KI-Systeme."),
+                ("Woche 2–3", "Transparenz umsetzen", "Implementieren Sie klare Kennzeichnung für KI-generierte Inhalte."),
+                ("Woche 3–4", "Human Oversight definieren", "Legen Sie fest, welche Ergebnisse vor Verwendung geprüft werden."),
+                ("Woche 4–5", "Logging einrichten", "Implementieren Sie einfache Protokollierung der KI-Nutzung."),
+            ]
+        else:
+            steps = [
+                ("Woche 1–2", "KI-Verantwortlichen benennen", "Definieren Sie klare Verantwortlichkeiten für AI Act Compliance."),
+                ("Woche 2–3", "Dokumentation aufsetzen", "Erstellen Sie vollständige Dokumentation aller KI-Systeme."),
+                ("Woche 3–4", "Transparenzpflichten umsetzen", "Implementieren Sie Kennzeichnung und Logging."),
+                ("Woche 4–6", "Human Oversight etablieren", "Definieren Sie Prüf- und Freigabeprozesse."),
+                ("Woche 6–8", "Monitoring einrichten", "Etablieren Sie regelmäßige Reviews der KI-Nutzung."),
+            ]
+
+    else:  # high-risk
+        if is_solo:
+            steps = [
+                ("Woche 1–2", "Risikoanalyse durchführen", "Erstellen Sie eine umfassende Risikobewertung Ihrer KI-Nutzung."),
+                ("Woche 2–4", "Konformitätspflichten prüfen", "Identifizieren Sie alle relevanten AI Act Anforderungen."),
+                ("Woche 4–6", "Human Oversight konzipieren", "Definieren Sie klare Prozesse für menschliche Kontrolle."),
+                ("Woche 6–8", "Dokumentation vervollständigen", "Erstellen Sie alle erforderlichen Compliance-Dokumente."),
+                ("Woche 8–10", "Externe Beratung einholen", "Konsultieren Sie einen Experten für AI Act Compliance."),
+            ]
+        else:
+            steps = [
+                ("Woche 1–2", "Compliance-Beauftragten benennen", "Definieren Sie eine verantwortliche Person für AI Act."),
+                ("Woche 2–4", "Risikoanalyse durchführen", "Erstellen Sie umfassende Risikobewertungen für alle KI-Systeme."),
+                ("Woche 4–6", "QMS aufsetzen", "Implementieren Sie ein dokumentiertes Qualitätsmanagementsystem."),
+                ("Woche 6–8", "Human Oversight etablieren", "Definieren Sie Prozesse für Kontrolle und Eingriff."),
+                ("Woche 8–12", "Post-Market Monitoring einrichten", "Etablieren Sie kontinuierliche Überwachung."),
+            ]
+
+    html = '<ol class="next-steps-list">\n'
+    for zeitraum, titel, beschreibung in steps:
+        html += f'  <li><strong>{titel}</strong> ({zeitraum})<br/>{beschreibung}</li>\n'
+    html += '</ol>'
+
+    return html
+
+
+def _generate_next_steps_en(risk_level: str, is_solo: bool) -> str:
+    """English next steps."""
+
+    if risk_level in ["none", "minimal"]:
+        if is_solo:
+            steps = [
+                ("Week 1–2", "AI Tool Documentation", "Create a simple overview of AI tools in use and their purpose."),
+                ("Week 2–3", "Quality Review", "Define 3-5 checkpoints for important AI outputs."),
+                ("Week 3–4", "Transparency", "Establish how AI-generated content is labeled for clients."),
+            ]
+        else:
+            steps = [
+                ("Week 1–2", "Create AI Inventory", "Document all AI tools in use and their application areas."),
+                ("Week 2–3", "Define Guidelines", "Create simple rules for AI usage."),
+                ("Week 3–4", "Clarify Responsibilities", "Designate an AI lead."),
+                ("Week 4", "Quality Review", "Define review processes for important AI outputs."),
+            ]
+
+    elif risk_level == "limited":
+        if is_solo:
+            steps = [
+                ("Week 1–2", "Set Up Documentation", "Create complete documentation of your AI systems."),
+                ("Week 2–3", "Implement Transparency", "Implement clear labeling for AI-generated content."),
+                ("Week 3–4", "Define Human Oversight", "Establish which outputs require review before use."),
+                ("Week 4–5", "Set Up Logging", "Implement simple logging of AI usage."),
+            ]
+        else:
+            steps = [
+                ("Week 1–2", "Designate AI Lead", "Define clear responsibilities for AI Act compliance."),
+                ("Week 2–3", "Set Up Documentation", "Create complete documentation of all AI systems."),
+                ("Week 3–4", "Implement Transparency", "Implement labeling and logging."),
+                ("Week 4–6", "Establish Human Oversight", "Define review and approval processes."),
+                ("Week 6–8", "Set Up Monitoring", "Establish regular reviews of AI usage."),
+            ]
+
+    else:  # high-risk
+        if is_solo:
+            steps = [
+                ("Week 1–2", "Conduct Risk Analysis", "Create a comprehensive risk assessment of your AI usage."),
+                ("Week 2–4", "Review Conformity Requirements", "Identify all relevant AI Act requirements."),
+                ("Week 4–6", "Design Human Oversight", "Define clear processes for human control."),
+                ("Week 6–8", "Complete Documentation", "Create all required compliance documents."),
+                ("Week 8–10", "Seek External Advice", "Consult an AI Act compliance expert."),
+            ]
+        else:
+            steps = [
+                ("Week 1–2", "Designate Compliance Officer", "Define a responsible person for AI Act."),
+                ("Week 2–4", "Conduct Risk Analysis", "Create comprehensive risk assessments for all AI systems."),
+                ("Week 4–6", "Set Up QMS", "Implement a documented quality management system."),
+                ("Week 6–8", "Establish Human Oversight", "Define processes for control and intervention."),
+                ("Week 8–12", "Set Up Post-Market Monitoring", "Establish continuous monitoring."),
+            ]
+
+    html = '<ol class="next-steps-list">\n'
+    for timeframe, title, description in steps:
+        html += f'  <li><strong>{title}</strong> ({timeframe})<br/>{description}</li>\n'
+    html += '</ol>'
+
+    return html
+
+
+# =============================================================================
+# USE CASE RISK TAGGING
+# =============================================================================
+
+def generate_usecase_risk_html(
+    usecases: List[str],
+    branche: str,
+    size: str,
+    lang: str = "de"
+) -> str:
+    """
+    Generate HTML list of use cases with risk tags.
+    """
+    if not usecases:
+        usecases = _get_default_usecases(branche, lang)
+
+    tagged_usecases = []
+    for usecase in usecases:
+        risk_tag = _determine_usecase_risk(usecase, branche)
+        tagged_usecases.append((usecase, risk_tag))
+
+    if lang == "en":
+        return _render_usecase_html_en(tagged_usecases)
+    else:
+        return _render_usecase_html_de(tagged_usecases)
+
+
+def _determine_usecase_risk(usecase: str, branche: str) -> str:
+    """Determine risk tag for a single use case."""
+    usecase_lower = usecase.lower()
+    branche_lower = branche.lower()
+
+    # High-risk indicators
+    if any(kw in usecase_lower for kw in HIGH_RISK_USECASES_KEYWORDS):
+        return "high-risk"
+
+    # Branch-specific high-risk
+    if any(b in branche_lower for b in ["gesundheit", "health", "medical"]):
+        if any(kw in usecase_lower for kw in ["diagnose", "diagnosis", "behandlung", "treatment"]):
+            return "high-risk"
+
+    if any(b in branche_lower for b in ["finanz", "finance", "bank"]):
+        if any(kw in usecase_lower for kw in ["kredit", "credit", "risiko", "risk"]):
+            return "high-risk"
+
+    # Limited risk indicators
+    if any(kw in usecase_lower for kw in LIMITED_RISK_USECASES_KEYWORDS):
+        return "limited"
+
+    # Default
+    return "minimal"
+
+
+def _get_default_usecases(branche: str, lang: str) -> List[str]:
+    """Get default use cases based on branch."""
+    branche_lower = branche.lower()
+
+    if lang == "en":
+        if "finanz" in branche_lower or "finance" in branche_lower:
+            return ["Document Automation", "Customer Communication", "Report Generation", "Risk Assessment Support"]
+        elif "gesund" in branche_lower or "health" in branche_lower:
+            return ["Documentation", "Appointment Scheduling", "Patient Communication", "Research Support"]
+        elif "recht" in branche_lower or "legal" in branche_lower:
+            return ["Contract Analysis", "Legal Research", "Document Generation", "Case Summary"]
+        else:
+            return ["Content Generation", "Document Automation", "Customer Support", "Data Analysis"]
+    else:
+        if "finanz" in branche_lower:
+            return ["Dokumentenautomatisierung", "Kundenkommunikation", "Berichterstellung", "Risikoanalyse-Unterstützung"]
+        elif "gesund" in branche_lower:
+            return ["Dokumentation", "Terminplanung", "Patientenkommunikation", "Rechercheunterstützung"]
+        elif "recht" in branche_lower:
+            return ["Vertragsanalyse", "Rechtsrecherche", "Dokumentenerstellung", "Fallzusammenfassung"]
+        else:
+            return ["Content-Erstellung", "Dokumentenautomatisierung", "Kundensupport", "Datenanalyse"]
+
+
+def _render_usecase_html_de(tagged_usecases: List[Tuple[str, str]]) -> str:
+    """Render German use case list."""
+    risk_labels = {
+        "none": "Kein Risiko",
+        "minimal": "Minimal",
+        "limited": "Begrenzt",
+        "high-risk": "Hochrisiko"
+    }
+    risk_classes = {
+        "none": "success",
+        "minimal": "success",
+        "limited": "warning",
+        "high-risk": "danger"
+    }
+
+    html = '<ul class="usecase-risk-list">\n'
+    for usecase, risk in tagged_usecases:
+        label = risk_labels.get(risk, risk)
+        css_class = risk_classes.get(risk, "secondary")
+        html += f'  <li>{usecase} <span class="badge badge-{css_class}">{label}</span></li>\n'
+    html += '</ul>'
+
+    return html
+
+
+def _render_usecase_html_en(tagged_usecases: List[Tuple[str, str]]) -> str:
+    """Render English use case list."""
+    risk_labels = {
+        "none": "No Risk",
+        "minimal": "Minimal",
+        "limited": "Limited",
+        "high-risk": "High-Risk"
+    }
+    risk_classes = {
+        "none": "success",
+        "minimal": "success",
+        "limited": "warning",
+        "high-risk": "danger"
+    }
+
+    html = '<ul class="usecase-risk-list">\n'
+    for usecase, risk in tagged_usecases:
+        label = risk_labels.get(risk, risk)
+        css_class = risk_classes.get(risk, "secondary")
+        html += f'  <li>{usecase} <span class="badge badge-{css_class}">{label}</span></li>\n'
+    html += '</ul>'
+
+    return html
+
+
+# =============================================================================
+# MAIN BUILD FUNCTION
+# =============================================================================
+
+def build_ai_act_sections(
+    briefing: Dict[str, Any],
+    lang: str = "de"
+) -> Dict[str, Any]:
+    """
+    Build all AI Act sections from briefing data.
+
+    Returns dict with all AI_ACT_* variables.
+    """
+    # Extract relevant data from briefing
+    branche = briefing.get("BRANCHE_LABEL") or briefing.get("branche", "Allgemein")
+    size = briefing.get("UNTERNEHMENSGROESSE_LABEL") or briefing.get("unternehmensgroesse", "")
+
+    # Extract use cases from various possible fields
+    usecases = []
+    if briefing.get("ki_einsatzbereiche"):
+        if isinstance(briefing["ki_einsatzbereiche"], list):
+            usecases = briefing["ki_einsatzbereiche"]
+        elif isinstance(briefing["ki_einsatzbereiche"], str):
+            usecases = [x.strip() for x in briefing["ki_einsatzbereiche"].split(",")]
+
+    if not usecases and briefing.get("hauptleistung"):
+        usecases = [briefing["hauptleistung"]]
+
+    # Get automation percentage if available
+    automatisierung = briefing.get("automatisierungsgrad", 0)
+    if isinstance(automatisierung, str):
+        try:
+            automatisierung = int(automatisierung.replace("%", ""))
+        except ValueError:
+            automatisierung = 0
+
+    # Determine risk level
+    risk_level = determine_risk_level(branche, size, usecases, automatisierung)
+
+    # Generate all sections
+    risk_reasoning = generate_risk_reasoning(risk_level, branche, size, usecases, lang)
+    duty_matrix = generate_duty_matrix_html(risk_level, branche, size, lang)
+    alerts = generate_noncompliance_alerts(risk_level, branche, size, lang)
+    gaps = generate_data_gaps(risk_level, branche, size, lang)
+    next_steps = generate_next_steps_html(risk_level, branche, size, lang)
+    usecase_html = generate_usecase_risk_html(usecases, branche, size, lang)
+
+    log.info("🏛️ AI Act sections generated: risk_level=%s, alerts=%d, gaps=%d",
+             risk_level, len(alerts), len(gaps))
+
+    return {
+        "AI_ACT_RISK_LEVEL": risk_level,
+        "AI_ACT_RISK_REASONING": risk_reasoning,
+        "AI_ACT_DUTY_MATRIX_HTML": duty_matrix,
+        "AI_ACT_NONCOMPLIANCE_ALERTS": alerts,
+        "AI_ACT_DATA_GAPS": gaps,
+        "AI_ACT_RECOMMENDED_NEXT_STEPS_HTML": next_steps,
+        "AI_ACT_RELATED_USECASES_HTML": usecase_html,
+    }
+
+
+# =============================================================================
+# VALIDATION HELPERS
+# =============================================================================
+
+def validate_ai_act_sections(sections: Dict[str, Any]) -> List[str]:
+    """
+    Validate AI Act sections for completeness and correctness.
+    Returns list of error messages (empty if valid).
+    """
+    errors = []
+
+    # Check risk level
+    risk_level = sections.get("AI_ACT_RISK_LEVEL", "")
+    if risk_level not in VALID_RISK_LEVELS:
+        errors.append(f"Invalid AI_ACT_RISK_LEVEL: '{risk_level}' not in {VALID_RISK_LEVELS}")
+
+    # Check risk reasoning length
+    reasoning = sections.get("AI_ACT_RISK_REASONING", "")
+    word_count = len(reasoning.split())
+    if word_count < 60:
+        errors.append(f"AI_ACT_RISK_REASONING too short: {word_count} words (min 60)")
+
+    # Check duty matrix
+    matrix = sections.get("AI_ACT_DUTY_MATRIX_HTML", "")
+    if "<table" not in matrix or "</table>" not in matrix:
+        errors.append("AI_ACT_DUTY_MATRIX_HTML missing table tags")
+
+    # Count table rows
+    row_count = matrix.count("<tr>") - 1  # Subtract header row
+    if row_count < 3:
+        errors.append(f"AI_ACT_DUTY_MATRIX_HTML has only {row_count} rows (min 3)")
+
+    # Check alerts
+    alerts = sections.get("AI_ACT_NONCOMPLIANCE_ALERTS", [])
+    if len(alerts) < 2:
+        errors.append(f"AI_ACT_NONCOMPLIANCE_ALERTS has only {len(alerts)} items (min 2)")
+
+    # Check gaps
+    gaps = sections.get("AI_ACT_DATA_GAPS", [])
+    if len(gaps) < 2:
+        errors.append(f"AI_ACT_DATA_GAPS has only {len(gaps)} items (min 2)")
+
+    # Check next steps
+    next_steps = sections.get("AI_ACT_RECOMMENDED_NEXT_STEPS_HTML", "")
+    if not next_steps or "<ol" not in next_steps:
+        errors.append("AI_ACT_RECOMMENDED_NEXT_STEPS_HTML is empty or malformed")
+
+    # Check use cases
+    usecases = sections.get("AI_ACT_RELATED_USECASES_HTML", "")
+    if not usecases or "<ul" not in usecases:
+        errors.append("AI_ACT_RELATED_USECASES_HTML is empty or malformed")
+
+    return errors
+
+
+def check_persona_leaks(text: str, size: str) -> List[str]:
+    """
+    Check for persona leaks in AI Act text.
+    Returns list of found forbidden terms.
+    """
+    size_lower = size.lower()
+    text_lower = text.lower()
+    leaks = []
+
+    is_solo = "solo" in size_lower or "freiberuf" in size_lower or "1" in size_lower
+
+    if is_solo:
+        # Check for team/kmu terms in solo report
+        for term in SOLO_FORBIDDEN_TERMS + TEAM_KMU_TERMS_FOR_SOLO:
+            if term in text_lower:
+                leaks.append(term)
+    else:
+        # Check for solo-specific terms in team/kmu report
+        solo_specific = ["als einzelperson", "allein arbeitend", "solo-selbstständig",
+                        "as an individual", "working alone", "freelancer"]
+        for term in solo_specific:
+            if term in text_lower:
+                leaks.append(term)
+
+    return leaks

--- a/services/ai_act_module.py
+++ b/services/ai_act_module.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 """
-AI Act Compliance Module - Sprint G7
+AI Act Compliance Module - Sprint G7/G8
 
 Size-aware, branch-aware, language-aware AI Act risk assessment and compliance generation.
 
-Version: 1.0.0 (Sprint G7)
+Version: 1.1.0 (Sprint G8 - Cross-Integration & Harmonization)
 
 This module provides:
 - Risk level determination (none/minimal/limited/high-risk)
@@ -13,6 +13,9 @@ This module provides:
 - Data gaps identification
 - Recommended next steps
 - Use case risk tagging
+- Cross-section injection (G8.1)
+- Harmonization engine (G8.2)
+- Extended persona guards (G8.3)
 """
 from __future__ import annotations
 
@@ -1085,3 +1088,765 @@ def check_persona_leaks(text: str, size: str) -> List[str]:
                 leaks.append(term)
 
     return leaks
+
+
+# =============================================================================
+# SPRINT G8.1: CROSS-SECTION INJECTION
+# =============================================================================
+
+# G8.3: Extended Persona Hard-Guards
+EXTENDED_SOLO_FORBIDDEN = [
+    # Team/Organization terms
+    "ihr team", "your team", "das team", "the team",
+    "mitarbeiter", "employees", "mitarbeitende",
+    "abteilung", "abteilungen", "department", "departments",
+    "fachbereiche", "fachbereich", "divisions",
+    "organisation", "organization",
+    "unternehmen mit 11", "company with 11",
+    "governance board", "compliance-officer", "compliance officer",
+    "projektleiter", "project manager", "abteilungsleiter",
+    "teamleiter", "team lead", "team leader",
+]
+
+EXTENDED_TEAM_FORBIDDEN = [
+    # Solo-specific terms
+    "als einzelperson", "as an individual", "as a solo",
+    "solo-selbstständig", "solo-selbstständige", "solo-selbstständigen",
+    "individuelle kapazität", "individual capacity",
+    "ihre persönliche kapazität", "your personal capacity",
+    "freiberufler", "freiberuflerin", "freelancer",
+    "einzelunternehmer", "einzelunternehmerin", "sole proprietor",
+    "allein arbeitend", "working alone",
+]
+
+EXTENDED_KMU_FORBIDDEN = [
+    # Solo-specific terms (same as Team + some extras)
+    "als einzelperson", "as an individual", "as a solo",
+    "solo-selbstständig", "solo-selbstständige", "solo-selbstständigen",
+    "individuelle kapazität", "individual capacity",
+    "ihre persönliche kapazität", "your personal capacity",
+    "freiberufler", "freiberuflerin", "freelancer",
+    "einzelunternehmer", "einzelunternehmerin", "sole proprietor",
+    "allein arbeitend", "working alone",
+    # Team-specific mini-structures (optional for large KMU)
+    "2–10 personen", "2-10 persons", "kleines team von",
+]
+
+
+def get_ai_act_exec_summary_injection(
+    risk_level: str,
+    size: str,
+    branche: str,
+    lang: str = "de"
+) -> str:
+    """
+    G8.1: Generate 1-2 sentence AI Act injection for Executive Summary.
+    Size-aware, no tables, no legal jargon.
+    """
+    size_lower = size.lower()
+    is_solo = "solo" in size_lower or "freiberuf" in size_lower
+    is_team = "team" in size_lower or "klein" in size_lower
+
+    if lang == "en":
+        if risk_level == "high-risk":
+            if is_solo:
+                return (
+                    "EU AI Act classification: High-risk. Your AI applications require "
+                    "documented risk management, quality controls, and human oversight. "
+                    "Early compliance preparation is essential."
+                )
+            elif is_team:
+                return (
+                    "EU AI Act classification: High-risk. Your organization needs structured "
+                    "compliance measures including risk documentation, oversight processes, "
+                    "and designated responsibilities. Proactive preparation is recommended."
+                )
+            else:
+                return (
+                    "EU AI Act classification: High-risk. Your company requires comprehensive "
+                    "compliance infrastructure including quality management, risk analysis, "
+                    "human oversight, and post-market monitoring. Immediate action recommended."
+                )
+        elif risk_level == "limited":
+            if is_solo:
+                return (
+                    "EU AI Act classification: Limited risk. Focus on transparency: "
+                    "document AI usage and label AI-generated content clearly."
+                )
+            elif is_team:
+                return (
+                    "EU AI Act classification: Limited risk. Establish transparency measures, "
+                    "basic documentation, and shared guidelines for AI usage."
+                )
+            else:
+                return (
+                    "EU AI Act classification: Limited risk. Implement transparency obligations, "
+                    "structured documentation, and defined responsibilities for AI governance."
+                )
+        else:  # minimal/none
+            if is_solo:
+                return (
+                    "EU AI Act classification: Minimal risk. No mandatory requirements apply. "
+                    "Voluntary best practices like documentation and quality checks are recommended."
+                )
+            else:
+                return (
+                    "EU AI Act classification: Minimal risk. No specific obligations apply. "
+                    "Establish basic guidelines and documentation as voluntary best practices."
+                )
+    else:  # German
+        if risk_level == "high-risk":
+            if is_solo:
+                return (
+                    "EU AI Act Einstufung: Hochrisiko. Ihre KI-Anwendungen erfordern "
+                    "dokumentiertes Risikomanagement, Qualitätskontrollen und menschliche "
+                    "Aufsicht. Frühzeitige Compliance-Vorbereitung ist essenziell."
+                )
+            elif is_team:
+                return (
+                    "EU AI Act Einstufung: Hochrisiko. Ihr Unternehmen benötigt strukturierte "
+                    "Compliance-Maßnahmen mit Risikodokumentation, Aufsichtsprozessen und "
+                    "klaren Verantwortlichkeiten. Proaktive Vorbereitung wird empfohlen."
+                )
+            else:
+                return (
+                    "EU AI Act Einstufung: Hochrisiko. Ihr Unternehmen erfordert umfassende "
+                    "Compliance-Strukturen mit Qualitätsmanagement, Risikoanalyse, menschlicher "
+                    "Aufsicht und Post-Market-Monitoring. Sofortige Maßnahmen empfohlen."
+                )
+        elif risk_level == "limited":
+            if is_solo:
+                return (
+                    "EU AI Act Einstufung: Begrenztes Risiko. Fokus auf Transparenz: "
+                    "KI-Nutzung dokumentieren und KI-generierte Inhalte klar kennzeichnen."
+                )
+            elif is_team:
+                return (
+                    "EU AI Act Einstufung: Begrenztes Risiko. Transparenzmaßnahmen etablieren, "
+                    "Basisdokumentation führen und gemeinsame Richtlinien für KI-Nutzung definieren."
+                )
+            else:
+                return (
+                    "EU AI Act Einstufung: Begrenztes Risiko. Transparenzpflichten umsetzen, "
+                    "strukturierte Dokumentation etablieren und Verantwortlichkeiten für "
+                    "KI-Governance definieren."
+                )
+        else:  # minimal/none
+            if is_solo:
+                return (
+                    "EU AI Act Einstufung: Minimales Risiko. Keine Pflichten. "
+                    "Freiwillige Best Practices wie Dokumentation und Qualitätsprüfung empfohlen."
+                )
+            else:
+                return (
+                    "EU AI Act Einstufung: Minimales Risiko. Keine spezifischen Pflichten. "
+                    "Grundlegende Richtlinien und Dokumentation als freiwillige Best Practices."
+                )
+
+
+def get_ai_act_business_case_injection(
+    risk_level: str,
+    size: str,
+    lang: str = "de"
+) -> Dict[str, Any]:
+    """
+    G8.1: Generate Business Case cost adjustments based on risk level.
+    Returns dict with CAPEX/OPEX modifiers and text injection.
+    """
+    size_lower = size.lower()
+    is_solo = "solo" in size_lower or "freiberuf" in size_lower
+
+    if risk_level == "high-risk":
+        capex_modifier = 1.25  # +25% for compliance infrastructure
+        opex_modifier = 1.15   # +15% for ongoing compliance
+        if lang == "en":
+            text = (
+                "Compliance costs: High-risk classification requires additional investment "
+                "in documentation, monitoring, and quality management systems."
+            )
+        else:
+            text = (
+                "Compliance-Kosten: Hochrisiko-Einstufung erfordert zusätzliche Investitionen "
+                "in Dokumentation, Monitoring und Qualitätsmanagementsysteme."
+            )
+    elif risk_level == "limited":
+        capex_modifier = 1.10  # +10% for transparency tools
+        opex_modifier = 1.05   # +5% for documentation
+        if lang == "en":
+            text = (
+                "Transparency costs: Limited risk requires investment in documentation "
+                "and labeling infrastructure."
+            )
+        else:
+            text = (
+                "Transparenz-Kosten: Begrenztes Risiko erfordert Investitionen in "
+                "Dokumentations- und Kennzeichnungsinfrastruktur."
+            )
+    else:  # minimal/none
+        capex_modifier = 1.0
+        opex_modifier = 1.0
+        if lang == "en":
+            text = "Minimal compliance overhead – focus on efficiency gains."
+        else:
+            text = "Minimaler Compliance-Aufwand – Fokus auf Effizienzgewinne."
+
+    return {
+        "CAPEX_MODIFIER": capex_modifier,
+        "OPEX_MODIFIER": opex_modifier,
+        "AI_ACT_BUSINESS_CASE_TEXT": text,
+    }
+
+
+def get_ai_act_roadmap_injection(
+    risk_level: str,
+    size: str,
+    lang: str = "de"
+) -> Dict[str, str]:
+    """
+    G8.1: Generate roadmap milestones based on risk level.
+    Returns dict with 90d and 12m roadmap additions.
+    """
+    size_lower = size.lower()
+    is_solo = "solo" in size_lower or "freiberuf" in size_lower
+
+    if lang == "en":
+        if risk_level == "high-risk":
+            roadmap_90d = (
+                "<li><strong>Week 1-4:</strong> Risk analysis & documentation framework</li>"
+                "<li><strong>Week 5-8:</strong> Human oversight processes & QMS setup</li>"
+                "<li><strong>Week 9-12:</strong> Conformity assessment preparation</li>"
+            )
+            roadmap_12m = (
+                "<li><strong>Q1:</strong> Complete risk documentation & QMS implementation</li>"
+                "<li><strong>Q2:</strong> Human oversight training & process rollout</li>"
+                "<li><strong>Q3:</strong> Post-market monitoring setup & incident procedures</li>"
+                "<li><strong>Q4:</strong> Audit preparation & conformity declaration</li>"
+            )
+        elif risk_level == "limited":
+            roadmap_90d = (
+                "<li><strong>Week 1-4:</strong> AI inventory & documentation setup</li>"
+                "<li><strong>Week 5-8:</strong> Transparency labeling implementation</li>"
+                "<li><strong>Week 9-12:</strong> Monitoring & logging setup</li>"
+            )
+            roadmap_12m = (
+                "<li><strong>Q1:</strong> Complete AI documentation</li>"
+                "<li><strong>Q2:</strong> Transparency measures & oversight processes</li>"
+                "<li><strong>Q3:</strong> Regular review cycles</li>"
+                "<li><strong>Q4:</strong> Compliance assessment & optimization</li>"
+            )
+        else:  # minimal
+            roadmap_90d = (
+                "<li><strong>Week 1-4:</strong> AI awareness & basic documentation</li>"
+                "<li><strong>Week 5-8:</strong> Quality review guidelines</li>"
+                "<li><strong>Week 9-12:</strong> Simple logging implementation</li>"
+            )
+            roadmap_12m = (
+                "<li><strong>Q1-Q2:</strong> Best practices implementation</li>"
+                "<li><strong>Q3-Q4:</strong> Review & optimization</li>"
+            )
+    else:  # German
+        if risk_level == "high-risk":
+            roadmap_90d = (
+                "<li><strong>Woche 1-4:</strong> Risikoanalyse & Dokumentationsrahmen</li>"
+                "<li><strong>Woche 5-8:</strong> Human Oversight Prozesse & QMS-Aufbau</li>"
+                "<li><strong>Woche 9-12:</strong> Konformitätsbewertung vorbereiten</li>"
+            )
+            roadmap_12m = (
+                "<li><strong>Q1:</strong> Risikodokumentation & QMS-Implementierung</li>"
+                "<li><strong>Q2:</strong> Human Oversight Schulung & Prozess-Rollout</li>"
+                "<li><strong>Q3:</strong> Post-Market-Monitoring & Incident-Prozesse</li>"
+                "<li><strong>Q4:</strong> Audit-Vorbereitung & Konformitätserklärung</li>"
+            )
+        elif risk_level == "limited":
+            roadmap_90d = (
+                "<li><strong>Woche 1-4:</strong> KI-Inventar & Dokumentation aufsetzen</li>"
+                "<li><strong>Woche 5-8:</strong> Transparenz-Kennzeichnung implementieren</li>"
+                "<li><strong>Woche 9-12:</strong> Monitoring & Logging einrichten</li>"
+            )
+            roadmap_12m = (
+                "<li><strong>Q1:</strong> KI-Dokumentation vervollständigen</li>"
+                "<li><strong>Q2:</strong> Transparenzmaßnahmen & Aufsichtsprozesse</li>"
+                "<li><strong>Q3:</strong> Regelmäßige Review-Zyklen</li>"
+                "<li><strong>Q4:</strong> Compliance-Bewertung & Optimierung</li>"
+            )
+        else:  # minimal
+            roadmap_90d = (
+                "<li><strong>Woche 1-4:</strong> KI-Awareness & Basis-Dokumentation</li>"
+                "<li><strong>Woche 5-8:</strong> Qualitätsprüfungs-Richtlinien</li>"
+                "<li><strong>Woche 9-12:</strong> Einfaches Logging implementieren</li>"
+            )
+            roadmap_12m = (
+                "<li><strong>Q1-Q2:</strong> Best Practices implementieren</li>"
+                "<li><strong>Q3-Q4:</strong> Review & Optimierung</li>"
+            )
+
+    return {
+        "AI_ACT_ROADMAP_90D_INJECTION": roadmap_90d,
+        "AI_ACT_ROADMAP_12M_INJECTION": roadmap_12m,
+    }
+
+
+def get_ai_act_governance_injection(
+    risk_level: str,
+    size: str,
+    alerts: List[str],
+    gaps: List[str],
+    lang: str = "de"
+) -> str:
+    """
+    G8.1: Generate governance section injection with duty matrix integration.
+    """
+    size_lower = size.lower()
+    is_solo = "solo" in size_lower or "freiberuf" in size_lower
+
+    # Build action items from alerts (max 3)
+    action_items = alerts[:3] if alerts else []
+
+    if lang == "en":
+        if risk_level == "high-risk":
+            if is_solo:
+                intro = "AI Act governance focus: Risk management, documentation, and oversight."
+            else:
+                intro = "AI Act governance requirements: Structured compliance with defined roles and processes."
+            level_text = "High-risk systems require comprehensive governance including QMS, risk documentation, and human oversight."
+        elif risk_level == "limited":
+            intro = "AI Act governance focus: Transparency and documentation."
+            level_text = "Limited risk requires transparency measures and basic documentation."
+        else:
+            intro = "AI Act governance: Voluntary best practices."
+            level_text = "Minimal risk – no mandatory governance requirements."
+
+        if action_items:
+            actions_html = "<ul class='governance-actions'>"
+            for item in action_items:
+                actions_html += f"<li>{item}</li>"
+            actions_html += "</ul>"
+        else:
+            actions_html = ""
+
+        return f"<div class='ai-act-governance'><p><strong>{intro}</strong></p><p>{level_text}</p>{actions_html}</div>"
+
+    else:  # German
+        if risk_level == "high-risk":
+            if is_solo:
+                intro = "AI Act Governance-Fokus: Risikomanagement, Dokumentation und Aufsicht."
+            else:
+                intro = "AI Act Governance-Anforderungen: Strukturierte Compliance mit definierten Rollen und Prozessen."
+            level_text = "Hochrisiko-Systeme erfordern umfassende Governance mit QMS, Risikodokumentation und Human Oversight."
+        elif risk_level == "limited":
+            intro = "AI Act Governance-Fokus: Transparenz und Dokumentation."
+            level_text = "Begrenztes Risiko erfordert Transparenzmaßnahmen und Basisdokumentation."
+        else:
+            intro = "AI Act Governance: Freiwillige Best Practices."
+            level_text = "Minimales Risiko – keine Pflicht-Governance-Anforderungen."
+
+        if action_items:
+            actions_html = "<ul class='governance-actions'>"
+            for item in action_items:
+                actions_html += f"<li>{item}</li>"
+            actions_html += "</ul>"
+        else:
+            actions_html = ""
+
+        return f"<div class='ai-act-governance'><p><strong>{intro}</strong></p><p>{level_text}</p>{actions_html}</div>"
+
+
+def get_ai_act_risks_injection(
+    risk_level: str,
+    branche: str,
+    size: str,
+    lang: str = "de"
+) -> str:
+    """
+    G8.1: Generate risk section injection with branch-specific context.
+    """
+    branche_lower = branche.lower()
+    is_finance = any(b in branche_lower for b in ["finanz", "finance", "bank", "versicher", "insurance"])
+    is_hr = any(b in branche_lower for b in ["hr", "personal", "human resources", "recruiting"])
+
+    if lang == "en":
+        if risk_level == "high-risk":
+            base_risk = "AI Act non-compliance risk: High. Potential penalties up to €35M or 7% of global turnover."
+            if is_finance:
+                sector_risk = " Additional sector regulations (BAIT/MaRisk) apply to AI systems in financial services."
+            elif is_hr:
+                sector_risk = " Employment law considerations for automated decision-making in HR processes."
+            else:
+                sector_risk = ""
+        elif risk_level == "limited":
+            base_risk = "AI Act non-compliance risk: Moderate. Transparency violations may result in regulatory action."
+            sector_risk = ""
+        else:
+            base_risk = "AI Act risk exposure: Low. Focus on voluntary compliance measures."
+            sector_risk = ""
+
+        return f"<p class='ai-act-risk'>{base_risk}{sector_risk}</p>"
+
+    else:  # German
+        if risk_level == "high-risk":
+            base_risk = "AI Act Non-Compliance-Risiko: Hoch. Mögliche Strafen bis €35 Mio. oder 7% des globalen Umsatzes."
+            if is_finance:
+                sector_risk = " Zusätzliche Branchenregulierung (BAIT/MaRisk/VAIT) für KI-Systeme im Finanzsektor."
+            elif is_hr:
+                sector_risk = " Arbeitsrechtliche Aspekte bei automatisierten Entscheidungen in HR-Prozessen."
+            else:
+                sector_risk = ""
+        elif risk_level == "limited":
+            base_risk = "AI Act Non-Compliance-Risiko: Moderat. Transparenzverstöße können zu Aufsichtsmaßnahmen führen."
+            sector_risk = ""
+        else:
+            base_risk = "AI Act Risikoexposition: Gering. Fokus auf freiwillige Compliance-Maßnahmen."
+            sector_risk = ""
+
+        return f"<p class='ai-act-risk'>{base_risk}{sector_risk}</p>"
+
+
+def get_ai_act_tools_injection(
+    risk_level: str,
+    size: str,
+    lang: str = "de"
+) -> str:
+    """
+    G8.1: Generate tools recommendation injection based on risk level.
+    """
+    size_lower = size.lower()
+    is_solo = "solo" in size_lower or "freiberuf" in size_lower
+
+    if lang == "en":
+        if risk_level == "high-risk":
+            tools = [
+                "Audit trail & logging tools (e.g., MLflow, Weights & Biases)",
+                "Explainability frameworks (e.g., SHAP, LIME)",
+                "Model monitoring solutions (e.g., Evidently, Arize)",
+                "Documentation platforms (e.g., Notion, Confluence)",
+            ]
+        elif risk_level == "limited":
+            tools = [
+                "Version control & documentation (e.g., Git, Notion)",
+                "Simple logging solutions",
+                "Content labeling tools",
+            ]
+        else:
+            tools = [
+                "Basic documentation tools",
+                "Simple quality review checklists",
+            ]
+
+        intro = "Recommended compliance tools based on your AI Act risk classification:"
+    else:
+        if risk_level == "high-risk":
+            tools = [
+                "Audit-Trail & Logging-Tools (z.B. MLflow, Weights & Biases)",
+                "Explainability-Frameworks (z.B. SHAP, LIME)",
+                "Model-Monitoring-Lösungen (z.B. Evidently, Arize)",
+                "Dokumentationsplattformen (z.B. Notion, Confluence)",
+            ]
+        elif risk_level == "limited":
+            tools = [
+                "Versionskontrolle & Dokumentation (z.B. Git, Notion)",
+                "Einfache Logging-Lösungen",
+                "Content-Kennzeichnungs-Tools",
+            ]
+        else:
+            tools = [
+                "Basis-Dokumentations-Tools",
+                "Einfache Qualitätsprüfungs-Checklisten",
+            ]
+
+        intro = "Empfohlene Compliance-Tools basierend auf Ihrer AI Act Risikoeinstufung:"
+
+    tools_html = f"<p class='ai-act-tools-intro'>{intro}</p><ul class='ai-act-tools'>"
+    for tool in tools:
+        tools_html += f"<li>{tool}</li>"
+    tools_html += "</ul>"
+
+    return tools_html
+
+
+# =============================================================================
+# SPRINT G8.2: HARMONIZATION & CONSISTENCY ENGINE
+# =============================================================================
+
+def ai_act_harmonize(sections: Dict[str, Any], briefing: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    G8.2: Harmonize AI Act content across sections for consistency.
+
+    Checks:
+    - Executive Summary ↔ Risk Level consistency
+    - Roadmap ↔ Duty Matrix alignment
+    - Governance ↔ Alerts/Gaps integration
+    - Business Case ↔ Risk Level cost adjustment
+
+    Returns:
+    - Harmonized sections dict
+    - AI_ACT_CONSISTENCY_WARNINGS list (max 3)
+    """
+    warnings: List[str] = []
+
+    risk_level = sections.get("AI_ACT_RISK_LEVEL", "minimal")
+    size = briefing.get("unternehmensgroesse", "")
+    branche = briefing.get("branche", "")
+    lang = briefing.get("lang", "de")
+    alerts = sections.get("AI_ACT_NONCOMPLIANCE_ALERTS", [])
+    gaps = sections.get("AI_ACT_DATA_GAPS", [])
+
+    # --- Consistency Check 1: Executive Summary ---
+    exec_summary = sections.get("EXECUTIVE_SUMMARY_HTML", "")
+    if exec_summary:
+        exec_lower = exec_summary.lower()
+        if risk_level == "high-risk" and "hochrisiko" not in exec_lower and "high-risk" not in exec_lower:
+            warnings.append("Executive Summary erwähnt Hochrisiko-Einstufung nicht")
+        elif risk_level == "limited" and "begrenzt" not in exec_lower and "limited" not in exec_lower and "transparenz" not in exec_lower:
+            warnings.append("Executive Summary erwähnt Transparenzpflichten nicht")
+
+    # --- Consistency Check 2: Business Case CAPEX/OPEX ---
+    if risk_level == "high-risk":
+        capex = sections.get("CAPEX_REALISTISCH_EUR", 0)
+        if isinstance(capex, (int, float)) and capex > 0:
+            # Check if compliance costs are factored in
+            bc_html = sections.get("BUSINESS_CASE_HTML", "")
+            if bc_html and "compliance" not in bc_html.lower() and "konformität" not in bc_html.lower():
+                warnings.append("Business Case enthält keine Compliance-Kosten für Hochrisiko")
+
+    # --- Consistency Check 3: Roadmap coverage ---
+    roadmap_90d = sections.get("PILOT_PLAN_HTML", "") or sections.get("ROADMAP_90D_HTML", "")
+    if roadmap_90d and risk_level == "high-risk":
+        roadmap_lower = roadmap_90d.lower()
+        if "qms" not in roadmap_lower and "qualitätsmanagement" not in roadmap_lower and "quality management" not in roadmap_lower:
+            warnings.append("90-Tage-Roadmap enthält keine QMS-Planung für Hochrisiko")
+
+    # --- Inject cross-section content ---
+    harmonized = dict(sections)
+
+    # Add AI Act injection for Executive Summary (if not already present)
+    if "AI_ACT_EXEC_INJECTION" not in harmonized:
+        harmonized["AI_ACT_EXEC_INJECTION"] = get_ai_act_exec_summary_injection(
+            risk_level, size, branche, lang
+        )
+
+    # Add Business Case injection
+    bc_injection = get_ai_act_business_case_injection(risk_level, size, lang)
+    harmonized.update(bc_injection)
+
+    # Add Roadmap injection
+    roadmap_injection = get_ai_act_roadmap_injection(risk_level, size, lang)
+    harmonized.update(roadmap_injection)
+
+    # Add Governance injection
+    harmonized["AI_ACT_GOVERNANCE_INJECTION"] = get_ai_act_governance_injection(
+        risk_level, size, alerts, gaps, lang
+    )
+
+    # Add Risks injection
+    harmonized["AI_ACT_RISKS_INJECTION"] = get_ai_act_risks_injection(
+        risk_level, branche, size, lang
+    )
+
+    # Add Tools injection
+    harmonized["AI_ACT_TOOLS_INJECTION"] = get_ai_act_tools_injection(
+        risk_level, size, lang
+    )
+
+    # Store warnings (max 3)
+    harmonized["AI_ACT_CONSISTENCY_WARNINGS"] = warnings[:3]
+
+    log.info("🔄 AI Act harmonization complete: %d warnings", len(warnings))
+
+    return harmonized
+
+
+# =============================================================================
+# SPRINT G8.3: EXTENDED PERSONA HARD-GUARDS
+# =============================================================================
+
+def apply_ai_act_persona_filter(text: str, size: str) -> str:
+    """
+    G8.3: Apply persona-specific filtering to AI Act content.
+    Removes or replaces size-inappropriate terms.
+    """
+    if not text or not isinstance(text, str):
+        return text
+
+    size_lower = size.lower()
+
+    # Determine size category
+    if "solo" in size_lower or "freiberuf" in size_lower or "1" in size_lower:
+        size_key = "solo"
+        forbidden = EXTENDED_SOLO_FORBIDDEN
+        replacements = {
+            "ihr team": "Sie",
+            "your team": "you",
+            "das team": "Sie",
+            "the team": "you",
+            "mitarbeiter": "Sie",
+            "employees": "you",
+            "abteilung": "Ihren Arbeitsbereich",
+            "department": "your work area",
+        }
+    elif "team" in size_lower or "klein" in size_lower:
+        size_key = "team"
+        forbidden = EXTENDED_TEAM_FORBIDDEN
+        replacements = {
+            "als einzelperson": "als kleines Team",
+            "as an individual": "as a small team",
+            "solo-selbstständige": "kleine Teams",
+            "freelancer": "Ihr Team",
+        }
+    else:  # KMU
+        size_key = "kmu"
+        forbidden = EXTENDED_KMU_FORBIDDEN
+        replacements = {
+            "als einzelperson": "als Unternehmen",
+            "as an individual": "as a company",
+            "solo-selbstständige": "KMU",
+            "freelancer": "Ihr Unternehmen",
+        }
+
+    # Apply replacements
+    import re
+    result = text
+    for term, replacement in replacements.items():
+        pattern = re.compile(re.escape(term), re.IGNORECASE)
+        result = pattern.sub(replacement, result)
+
+    return result
+
+
+def validate_ai_act_persona_compliance(sections: Dict[str, Any], size: str) -> List[str]:
+    """
+    G8.3: Validate that AI Act sections contain no persona leaks.
+    Returns list of violations found.
+    """
+    violations = []
+    size_lower = size.lower()
+
+    # Determine forbidden terms based on size
+    if "solo" in size_lower or "freiberuf" in size_lower:
+        forbidden = EXTENDED_SOLO_FORBIDDEN
+        size_key = "solo"
+    elif "team" in size_lower or "klein" in size_lower:
+        forbidden = EXTENDED_TEAM_FORBIDDEN
+        size_key = "team"
+    else:
+        forbidden = EXTENDED_KMU_FORBIDDEN
+        size_key = "kmu"
+
+    # AI Act sections to validate
+    ai_act_keys = [
+        "AI_ACT_RISK_REASONING",
+        "AI_ACT_DUTY_MATRIX_HTML",
+        "AI_ACT_NONCOMPLIANCE_ALERTS_HTML",
+        "AI_ACT_DATA_GAPS_HTML",
+        "AI_ACT_RECOMMENDED_NEXT_STEPS_HTML",
+        "AI_ACT_RELATED_USECASES_HTML",
+        "AI_ACT_EXEC_INJECTION",
+        "AI_ACT_GOVERNANCE_INJECTION",
+        "AI_ACT_RISKS_INJECTION",
+        "AI_ACT_TOOLS_INJECTION",
+    ]
+
+    for key in ai_act_keys:
+        content = sections.get(key, "")
+        if not isinstance(content, str):
+            continue
+
+        content_lower = content.lower()
+        for term in forbidden:
+            if term.lower() in content_lower:
+                violations.append(f"[{key}] Persona leak: '{term}' (size={size_key})")
+
+    return violations
+
+
+# =============================================================================
+# SPRINT G8.6: PERFORMANCE OPTIMIZATION (Caching)
+# =============================================================================
+
+# Simple cache for duty matrix (per risk_level + size + lang)
+_duty_matrix_cache: Dict[str, str] = {}
+
+
+def get_cached_duty_matrix(risk_level: str, branche: str, size: str, lang: str) -> str:
+    """
+    G8.6: Get duty matrix with caching for performance.
+    """
+    cache_key = f"{risk_level}:{size}:{lang}"
+
+    if cache_key not in _duty_matrix_cache:
+        _duty_matrix_cache[cache_key] = generate_duty_matrix_html(
+            risk_level, branche, size, lang
+        )
+
+    return _duty_matrix_cache[cache_key]
+
+
+def clear_duty_matrix_cache() -> None:
+    """Clear the duty matrix cache."""
+    global _duty_matrix_cache
+    _duty_matrix_cache = {}
+
+
+def build_ai_act_sections_optimized(
+    briefing: Dict[str, Any],
+    lang: str = "de"
+) -> Dict[str, Any]:
+    """
+    G8.6: Optimized version of build_ai_act_sections with caching.
+    Generates all AI Act sections with performance optimizations.
+    """
+    # Extract relevant data
+    branche = briefing.get("BRANCHE_LABEL") or briefing.get("branche", "Allgemein")
+    size = briefing.get("UNTERNEHMENSGROESSE_LABEL") or briefing.get("unternehmensgroesse", "")
+
+    # Extract use cases
+    usecases = []
+    if briefing.get("ki_einsatzbereiche"):
+        if isinstance(briefing["ki_einsatzbereiche"], list):
+            usecases = briefing["ki_einsatzbereiche"]
+        elif isinstance(briefing["ki_einsatzbereiche"], str):
+            usecases = [x.strip() for x in briefing["ki_einsatzbereiche"].split(",")]
+
+    if not usecases and briefing.get("hauptleistung"):
+        usecases = [briefing["hauptleistung"]]
+
+    # Get automation percentage
+    automatisierung = briefing.get("automatisierungsgrad", 0)
+    if isinstance(automatisierung, str):
+        try:
+            automatisierung = int(automatisierung.replace("%", ""))
+        except ValueError:
+            automatisierung = 0
+
+    # Determine risk level (single pass)
+    risk_level = determine_risk_level(branche, size, usecases, automatisierung)
+
+    # Generate all sections in one pass
+    sections = {
+        "AI_ACT_RISK_LEVEL": risk_level,
+        "AI_ACT_RISK_REASONING": generate_risk_reasoning(
+            risk_level, branche, size, usecases, lang
+        ),
+        "AI_ACT_DUTY_MATRIX_HTML": get_cached_duty_matrix(
+            risk_level, branche, size, lang
+        ),
+        "AI_ACT_NONCOMPLIANCE_ALERTS": generate_noncompliance_alerts(
+            risk_level, branche, size, lang
+        ),
+        "AI_ACT_DATA_GAPS": generate_data_gaps(
+            risk_level, branche, size, lang
+        ),
+        "AI_ACT_RECOMMENDED_NEXT_STEPS_HTML": generate_next_steps_html(
+            risk_level, branche, size, lang
+        ),
+        "AI_ACT_RELATED_USECASES_HTML": generate_usecase_risk_html(
+            usecases, branche, size, lang
+        ),
+    }
+
+    # Apply persona filter to text sections
+    for key in ["AI_ACT_RISK_REASONING"]:
+        sections[key] = apply_ai_act_persona_filter(sections[key], size)
+
+    log.info("🏛️ AI Act sections (optimized): risk_level=%s", risk_level)
+
+    return sections

--- a/services/report_validator.py
+++ b/services/report_validator.py
@@ -13,7 +13,7 @@ Prüft:
 - Template-Text statt echtem Content
 - Prompt-Leaks in Quick-Wins
 
-Version: 1.4.0-SPRINT-N (Persona Leak Elimination + Length Stabilization)
+Version: 1.5.0-SPRINT-G7 (AI Act Compliance Validation + Persona Leak Elimination)
 Author: Claude + Wolf
 
 PLATIN+ ÄNDERUNG: Validierung basiert jetzt auf WÖRTERN statt Zeichen!
@@ -409,6 +409,22 @@ class ReportValidator:
         "monetarisierung": "monetarisierung",
         "ki_skillplan": "ki_skillplan",
         "ai_act_summary": "ai_act_summary",
+        # SPRINT G7: AI Act Compliance Sections
+        "ai_act_risk_reasoning": "AI_ACT_RISK_REASONING",
+        "ai_act_duty_matrix": "AI_ACT_DUTY_MATRIX_HTML",
+        "ai_act_next_steps": "AI_ACT_RECOMMENDED_NEXT_STEPS_HTML",
+        "ai_act_usecases": "AI_ACT_RELATED_USECASES_HTML",
+    }
+
+    # SPRINT G7: Valid AI Act risk levels
+    VALID_AI_ACT_RISK_LEVELS = {"none", "minimal", "limited", "high-risk"}
+
+    # SPRINT G7: AI Act section minimum lengths (words)
+    MIN_AI_ACT_SECTION_LENGTH = {
+        "AI_ACT_RISK_REASONING": 60,      # 80-120 words expected
+        "AI_ACT_DUTY_MATRIX_HTML": 30,    # Table content
+        "AI_ACT_RECOMMENDED_NEXT_STEPS_HTML": 30,  # List content
+        "AI_ACT_RELATED_USECASES_HTML": 15,       # List content
     }
 
     def __init__(self, sections: Dict[str, Any], meta: Dict[str, Any]) -> None:
@@ -428,6 +444,7 @@ class ReportValidator:
         self._check_quick_wins_prompt_leaks()
         self._check_size_specific_issues()
         self._check_redundancy()  # Sprint G2.4
+        self._check_ai_act_sections()  # Sprint G7
 
         is_valid = not any(e.severity == "CRITICAL" for e in self.errors)
         return is_valid, self.errors
@@ -674,6 +691,149 @@ class ReportValidator:
                                 f"SPRINT N: Term '{term}' muss ersetzt werden. "
                                 f"HARD_STOP={self.HARD_STOP_ON_SIZE_MISMATCH}"
                             ),
+                        )
+                    )
+
+    def _check_ai_act_sections(self) -> None:
+        """
+        SPRINT G7: Validate AI Act compliance sections.
+
+        Checks:
+        - AI_ACT_RISK_LEVEL is valid (none/minimal/limited/high-risk)
+        - AI_ACT_RISK_REASONING meets minimum word count
+        - AI_ACT_DUTY_MATRIX_HTML contains table structure
+        - AI_ACT_NONCOMPLIANCE_ALERTS has items
+        - AI_ACT_DATA_GAPS has items
+        - Persona leaks in AI Act text
+        """
+        # Check risk level validity
+        risk_level = self.sections.get("AI_ACT_RISK_LEVEL", "")
+        if risk_level and risk_level not in self.VALID_AI_ACT_RISK_LEVELS:
+            self.errors.append(
+                ValidationError(
+                    severity="CRITICAL",
+                    category="AI_ACT_INVALID_RISK",
+                    section="AI_ACT_RISK_LEVEL",
+                    message=f"Ungültiges AI Act Risk Level: '{risk_level}'",
+                    details=f"Erlaubte Werte: {self.VALID_AI_ACT_RISK_LEVELS}",
+                )
+            )
+
+        # Check risk reasoning length
+        reasoning = self.sections.get("AI_ACT_RISK_REASONING", "")
+        if reasoning and isinstance(reasoning, str):
+            text_only = re.sub(r"<[^>]+>", "", reasoning).strip()
+            word_count = len(text_only.split())
+            min_words = self.MIN_AI_ACT_SECTION_LENGTH.get("AI_ACT_RISK_REASONING", 60)
+
+            if word_count < min_words:
+                self.errors.append(
+                    ValidationError(
+                        severity="WARNING",
+                        category="AI_ACT_SHORT_REASONING",
+                        section="AI_ACT_RISK_REASONING",
+                        message=f"AI Act Begründung zu kurz: {word_count} Wörter (min {min_words})",
+                        details=f"Content: {text_only[:100]}...",
+                    )
+                )
+
+        # Check duty matrix structure
+        duty_matrix = self.sections.get("AI_ACT_DUTY_MATRIX_HTML", "")
+        if duty_matrix and isinstance(duty_matrix, str):
+            if "<table" not in duty_matrix.lower() or "</table>" not in duty_matrix.lower():
+                self.errors.append(
+                    ValidationError(
+                        severity="WARNING",
+                        category="AI_ACT_MALFORMED_MATRIX",
+                        section="AI_ACT_DUTY_MATRIX_HTML",
+                        message="AI Act Pflichten-Matrix enthält keine gültige Tabellenstruktur",
+                        details="Erwartet: <table>...</table>",
+                    )
+                )
+            else:
+                # Check minimum row count
+                row_count = duty_matrix.lower().count("<tr>") - 1  # Subtract header
+                if row_count < 3:
+                    self.errors.append(
+                        ValidationError(
+                            severity="WARNING",
+                            category="AI_ACT_SHORT_MATRIX",
+                            section="AI_ACT_DUTY_MATRIX_HTML",
+                            message=f"AI Act Pflichten-Matrix hat nur {row_count} Zeilen (min 3)",
+                            details="Matrix sollte mindestens 3 Pflichten/Best Practices enthalten",
+                        )
+                    )
+
+        # Check alerts list
+        alerts = self.sections.get("AI_ACT_NONCOMPLIANCE_ALERTS", [])
+        if isinstance(alerts, list) and len(alerts) < 2:
+            self.errors.append(
+                ValidationError(
+                    severity="WARNING",
+                    category="AI_ACT_FEW_ALERTS",
+                    section="AI_ACT_NONCOMPLIANCE_ALERTS",
+                    message=f"Nur {len(alerts)} Non-Compliance Alerts (min 2 empfohlen)",
+                    details="Mehr spezifische Hinweise für das Unternehmen generieren",
+                )
+            )
+
+        # Check data gaps list
+        gaps = self.sections.get("AI_ACT_DATA_GAPS", [])
+        if isinstance(gaps, list) and len(gaps) < 2:
+            self.errors.append(
+                ValidationError(
+                    severity="WARNING",
+                    category="AI_ACT_FEW_GAPS",
+                    section="AI_ACT_DATA_GAPS",
+                    message=f"Nur {len(gaps)} Data Gaps (min 2 empfohlen)",
+                    details="Mehr Datenlücken identifizieren",
+                )
+            )
+
+        # Check persona leaks in AI Act content
+        self._check_ai_act_persona_leaks()
+
+    def _check_ai_act_persona_leaks(self) -> None:
+        """
+        SPRINT G7: Check for persona leaks in AI Act sections.
+        """
+        # Normalize company_size
+        size_key = self.company_size.lower() if self.company_size else "kmu"
+        if "solo" in size_key or "1" in size_key or "freiberuf" in size_key:
+            size_key = "solo"
+        elif "team" in size_key or "klein" in size_key:
+            size_key = "team"
+        else:
+            size_key = "kmu"
+
+        # AI Act sections to check
+        ai_act_sections = [
+            "AI_ACT_RISK_REASONING",
+            "AI_ACT_DUTY_MATRIX_HTML",
+            "AI_ACT_NONCOMPLIANCE_ALERTS_HTML",
+            "AI_ACT_DATA_GAPS_HTML",
+            "AI_ACT_RECOMMENDED_NEXT_STEPS_HTML",
+        ]
+
+        forbidden_terms = self.SIZE_FORBIDDEN.get(size_key, [])
+        if not forbidden_terms:
+            return
+
+        for section_name in ai_act_sections:
+            content = self.sections.get(section_name, "")
+            if not isinstance(content, str):
+                continue
+
+            lower = content.lower()
+            for term in forbidden_terms:
+                if term.lower() in lower:
+                    self.errors.append(
+                        ValidationError(
+                            severity="WARNING",
+                            category="AI_ACT_PERSONA_LEAK",
+                            section=section_name,
+                            message=f"Persona-Leak in AI Act Section: '{term}'",
+                            details=f"Term '{term}' unpassend für '{self.company_size}'",
                         )
                     )
 

--- a/templates/pdf_template.html
+++ b/templates/pdf_template.html
@@ -1599,81 +1599,87 @@
                     </div>
                 </section>
                 {% endif %}
-                <!-- SPRINT G7: AI Act Compliance Section -->
+                <!-- SPRINT G7/G8: AI Act Compliance Section -->
                 {% if AI_ACT_RISK_LEVEL %}
-                <section class="section chapter ai-act-compliance">
+                <section class="section chapter ai-act-compliance" style="page-break-inside: avoid;">
                     <div class="section-header">
                         <div class="section-title">
                             <span class="section-kicker">EU AI Act</span>
-                            <h2>Compliance-Einstufung</h2>
+                            <h2>AI-Act Compliance & Pflichten</h2>
                         </div>
                         <span class="section-pill">
-                            <span class="pill-dot {% if AI_ACT_RISK_LEVEL == 'high-risk' %}pill-danger{% elif AI_ACT_RISK_LEVEL == 'limited' %}pill-warning{% else %}pill-success{% endif %}"></span>
+                            <span class="pill-dot {% if AI_ACT_RISK_LEVEL == 'high-risk' %}pill-danger{% elif AI_ACT_RISK_LEVEL == 'limited' %}pill-warning{% else %}pill-success{% endif %}" style="{% if AI_ACT_RISK_LEVEL == 'high-risk' %}background:#dc3545{% elif AI_ACT_RISK_LEVEL == 'limited' %}background:#ffc107{% else %}background:#28a745{% endif %}"></span>
                             Risikoklasse: {{ AI_ACT_RISK_LEVEL }}
                         </span>
                     </div>
                     <div class="section-body">
                         <!-- Risk Level Badge -->
-                        <div class="risk-level-banner risk-{{ AI_ACT_RISK_LEVEL }}">
+                        <div class="risk-level-banner" style="padding:12px 16px;border-radius:8px;margin-bottom:16px;{% if AI_ACT_RISK_LEVEL == 'high-risk' %}background:#fff5f5;border-left:4px solid #dc3545{% elif AI_ACT_RISK_LEVEL == 'limited' %}background:#fffbeb;border-left:4px solid #ffc107{% else %}background:#f0fff4;border-left:4px solid #28a745{% endif %}">
                             {% if AI_ACT_RISK_LEVEL == 'high-risk' %}
-                            <span class="risk-icon">⚠️</span>
-                            <strong>Hochrisiko-Einstufung</strong> – Umfassende Compliance-Pflichten gemäß EU AI Act
+                            <strong style="color:#dc3545">⚠️ Hochrisiko-Einstufung</strong> – Umfassende Compliance-Pflichten gemäß EU AI Act
                             {% elif AI_ACT_RISK_LEVEL == 'limited' %}
-                            <span class="risk-icon">📋</span>
-                            <strong>Begrenztes Risiko</strong> – Transparenzpflichten beachten
+                            <strong style="color:#856404">📋 Begrenztes Risiko</strong> – Transparenzpflichten beachten
                             {% else %}
-                            <span class="risk-icon">✅</span>
-                            <strong>Minimales Risiko</strong> – Best Practices empfohlen
+                            <strong style="color:#28a745">✅ Minimales Risiko</strong> – Best Practices empfohlen
                             {% endif %}
                         </div>
 
                         <!-- Risk Reasoning -->
                         {% if AI_ACT_RISK_REASONING %}
-                        <div class="risk-reasoning">
-                            <h3>Begründung der Einstufung</h3>
-                            <p>{{ AI_ACT_RISK_REASONING }}</p>
+                        <div class="risk-reasoning" style="margin-bottom:16px;">
+                            <h3 style="font-size:14px;margin-bottom:8px;">Begründung der Einstufung</h3>
+                            <p style="line-height:1.5;">{{ AI_ACT_RISK_REASONING }}</p>
                         </div>
                         {% endif %}
 
                         <!-- Duty Matrix -->
                         {% if AI_ACT_DUTY_MATRIX_HTML %}
-                        <div class="duty-matrix-section">
-                            <h3>Pflichten-Matrix</h3>
+                        <div class="duty-matrix-section" style="margin-bottom:16px;">
+                            <h3 style="font-size:14px;margin-bottom:8px;">Pflichten-Matrix</h3>
+                            <div style="overflow-x:auto;width:100%;">
                             {{ AI_ACT_DUTY_MATRIX_HTML|safe }}
+                            </div>
                         </div>
                         {% endif %}
 
                         <!-- Use Cases with Risk Tags -->
                         {% if AI_ACT_RELATED_USECASES_HTML %}
-                        <div class="usecases-risk-section">
-                            <h3>Anwendungsfälle mit Risikoeinstufung</h3>
+                        <div class="usecases-risk-section" style="margin-bottom:16px;">
+                            <h3 style="font-size:14px;margin-bottom:8px;">Anwendungsfälle mit Risikoeinstufung</h3>
                             {{ AI_ACT_RELATED_USECASES_HTML|safe }}
                         </div>
                         {% endif %}
 
                         <!-- Non-Compliance Alerts -->
                         {% if AI_ACT_NONCOMPLIANCE_ALERTS_HTML %}
-                        <div class="alerts-section">
-                            <h3>Compliance-Lücken</h3>
-                            <p class="section-intro">Folgende Punkte sollten Sie prioritär adressieren:</p>
+                        <div class="alerts-section" style="margin-bottom:16px;padding:12px;background:#fff5f5;border-radius:6px;">
+                            <h3 style="font-size:14px;margin-bottom:8px;color:#dc3545;">Compliance-Lücken</h3>
+                            <p class="section-intro" style="font-size:12px;color:#666;margin-bottom:8px;">Folgende Punkte sollten Sie prioritär adressieren:</p>
                             {{ AI_ACT_NONCOMPLIANCE_ALERTS_HTML|safe }}
                         </div>
                         {% endif %}
 
                         <!-- Data Gaps -->
                         {% if AI_ACT_DATA_GAPS_HTML %}
-                        <div class="gaps-section">
-                            <h3>Datenlücken</h3>
-                            <p class="section-intro">Diese Informationen fehlen für eine vollständige Compliance-Bewertung:</p>
+                        <div class="gaps-section" style="margin-bottom:16px;padding:12px;background:#fffbeb;border-radius:6px;">
+                            <h3 style="font-size:14px;margin-bottom:8px;color:#856404;">Datenlücken</h3>
+                            <p class="section-intro" style="font-size:12px;color:#666;margin-bottom:8px;">Diese Informationen fehlen für eine vollständige Compliance-Bewertung:</p>
                             {{ AI_ACT_DATA_GAPS_HTML|safe }}
                         </div>
                         {% endif %}
 
                         <!-- Next Steps -->
                         {% if AI_ACT_RECOMMENDED_NEXT_STEPS_HTML %}
-                        <div class="next-steps-section">
-                            <h3>Empfohlene Nächste Schritte</h3>
+                        <div class="next-steps-section" style="margin-bottom:16px;">
+                            <h3 style="font-size:14px;margin-bottom:8px;">Empfohlene Nächste Schritte</h3>
                             {{ AI_ACT_RECOMMENDED_NEXT_STEPS_HTML|safe }}
+                        </div>
+                        {% endif %}
+
+                        <!-- G8: Tools Injection -->
+                        {% if AI_ACT_TOOLS_INJECTION %}
+                        <div class="ai-act-tools-section" style="margin-bottom:16px;">
+                            {{ AI_ACT_TOOLS_INJECTION|safe }}
                         </div>
                         {% endif %}
                     </div>

--- a/templates/pdf_template.html
+++ b/templates/pdf_template.html
@@ -1599,6 +1599,86 @@
                     </div>
                 </section>
                 {% endif %}
+                <!-- SPRINT G7: AI Act Compliance Section -->
+                {% if AI_ACT_RISK_LEVEL %}
+                <section class="section chapter ai-act-compliance">
+                    <div class="section-header">
+                        <div class="section-title">
+                            <span class="section-kicker">EU AI Act</span>
+                            <h2>Compliance-Einstufung</h2>
+                        </div>
+                        <span class="section-pill">
+                            <span class="pill-dot {% if AI_ACT_RISK_LEVEL == 'high-risk' %}pill-danger{% elif AI_ACT_RISK_LEVEL == 'limited' %}pill-warning{% else %}pill-success{% endif %}"></span>
+                            Risikoklasse: {{ AI_ACT_RISK_LEVEL }}
+                        </span>
+                    </div>
+                    <div class="section-body">
+                        <!-- Risk Level Badge -->
+                        <div class="risk-level-banner risk-{{ AI_ACT_RISK_LEVEL }}">
+                            {% if AI_ACT_RISK_LEVEL == 'high-risk' %}
+                            <span class="risk-icon">⚠️</span>
+                            <strong>Hochrisiko-Einstufung</strong> – Umfassende Compliance-Pflichten gemäß EU AI Act
+                            {% elif AI_ACT_RISK_LEVEL == 'limited' %}
+                            <span class="risk-icon">📋</span>
+                            <strong>Begrenztes Risiko</strong> – Transparenzpflichten beachten
+                            {% else %}
+                            <span class="risk-icon">✅</span>
+                            <strong>Minimales Risiko</strong> – Best Practices empfohlen
+                            {% endif %}
+                        </div>
+
+                        <!-- Risk Reasoning -->
+                        {% if AI_ACT_RISK_REASONING %}
+                        <div class="risk-reasoning">
+                            <h3>Begründung der Einstufung</h3>
+                            <p>{{ AI_ACT_RISK_REASONING }}</p>
+                        </div>
+                        {% endif %}
+
+                        <!-- Duty Matrix -->
+                        {% if AI_ACT_DUTY_MATRIX_HTML %}
+                        <div class="duty-matrix-section">
+                            <h3>Pflichten-Matrix</h3>
+                            {{ AI_ACT_DUTY_MATRIX_HTML|safe }}
+                        </div>
+                        {% endif %}
+
+                        <!-- Use Cases with Risk Tags -->
+                        {% if AI_ACT_RELATED_USECASES_HTML %}
+                        <div class="usecases-risk-section">
+                            <h3>Anwendungsfälle mit Risikoeinstufung</h3>
+                            {{ AI_ACT_RELATED_USECASES_HTML|safe }}
+                        </div>
+                        {% endif %}
+
+                        <!-- Non-Compliance Alerts -->
+                        {% if AI_ACT_NONCOMPLIANCE_ALERTS_HTML %}
+                        <div class="alerts-section">
+                            <h3>Compliance-Lücken</h3>
+                            <p class="section-intro">Folgende Punkte sollten Sie prioritär adressieren:</p>
+                            {{ AI_ACT_NONCOMPLIANCE_ALERTS_HTML|safe }}
+                        </div>
+                        {% endif %}
+
+                        <!-- Data Gaps -->
+                        {% if AI_ACT_DATA_GAPS_HTML %}
+                        <div class="gaps-section">
+                            <h3>Datenlücken</h3>
+                            <p class="section-intro">Diese Informationen fehlen für eine vollständige Compliance-Bewertung:</p>
+                            {{ AI_ACT_DATA_GAPS_HTML|safe }}
+                        </div>
+                        {% endif %}
+
+                        <!-- Next Steps -->
+                        {% if AI_ACT_RECOMMENDED_NEXT_STEPS_HTML %}
+                        <div class="next-steps-section">
+                            <h3>Empfohlene Nächste Schritte</h3>
+                            {{ AI_ACT_RECOMMENDED_NEXT_STEPS_HTML|safe }}
+                        </div>
+                        {% endif %}
+                    </div>
+                </section>
+                {% endif %}
                 {% if KICKOFF_VORLAGE_HTML %}
                 <section class="section chapter">
                     <div class="section-header">

--- a/templates/pdf_template_en.html
+++ b/templates/pdf_template_en.html
@@ -1586,6 +1586,86 @@
                     </div>
                 </section>
                 {% endif %}
+                <!-- SPRINT G7: AI Act Compliance Section (EN) -->
+                {% if AI_ACT_RISK_LEVEL %}
+                <section class="section chapter ai-act-compliance">
+                    <div class="section-header">
+                        <div class="section-title">
+                            <span class="section-kicker">EU AI Act</span>
+                            <h2>Compliance Assessment</h2>
+                        </div>
+                        <span class="section-pill">
+                            <span class="pill-dot {% if AI_ACT_RISK_LEVEL == 'high-risk' %}pill-danger{% elif AI_ACT_RISK_LEVEL == 'limited' %}pill-warning{% else %}pill-success{% endif %}"></span>
+                            Risk Class: {{ AI_ACT_RISK_LEVEL }}
+                        </span>
+                    </div>
+                    <div class="section-body">
+                        <!-- Risk Level Badge -->
+                        <div class="risk-level-banner risk-{{ AI_ACT_RISK_LEVEL }}">
+                            {% if AI_ACT_RISK_LEVEL == 'high-risk' %}
+                            <span class="risk-icon">⚠️</span>
+                            <strong>High-Risk Classification</strong> – Comprehensive compliance requirements per EU AI Act
+                            {% elif AI_ACT_RISK_LEVEL == 'limited' %}
+                            <span class="risk-icon">📋</span>
+                            <strong>Limited Risk</strong> – Transparency obligations apply
+                            {% else %}
+                            <span class="risk-icon">✅</span>
+                            <strong>Minimal Risk</strong> – Best practices recommended
+                            {% endif %}
+                        </div>
+
+                        <!-- Risk Reasoning -->
+                        {% if AI_ACT_RISK_REASONING %}
+                        <div class="risk-reasoning">
+                            <h3>Classification Reasoning</h3>
+                            <p>{{ AI_ACT_RISK_REASONING }}</p>
+                        </div>
+                        {% endif %}
+
+                        <!-- Duty Matrix -->
+                        {% if AI_ACT_DUTY_MATRIX_HTML %}
+                        <div class="duty-matrix-section">
+                            <h3>Obligations Matrix</h3>
+                            {{ AI_ACT_DUTY_MATRIX_HTML|safe }}
+                        </div>
+                        {% endif %}
+
+                        <!-- Use Cases with Risk Tags -->
+                        {% if AI_ACT_RELATED_USECASES_HTML %}
+                        <div class="usecases-risk-section">
+                            <h3>Use Cases with Risk Classification</h3>
+                            {{ AI_ACT_RELATED_USECASES_HTML|safe }}
+                        </div>
+                        {% endif %}
+
+                        <!-- Non-Compliance Alerts -->
+                        {% if AI_ACT_NONCOMPLIANCE_ALERTS_HTML %}
+                        <div class="alerts-section">
+                            <h3>Compliance Gaps</h3>
+                            <p class="section-intro">Address these items as a priority:</p>
+                            {{ AI_ACT_NONCOMPLIANCE_ALERTS_HTML|safe }}
+                        </div>
+                        {% endif %}
+
+                        <!-- Data Gaps -->
+                        {% if AI_ACT_DATA_GAPS_HTML %}
+                        <div class="gaps-section">
+                            <h3>Data Gaps</h3>
+                            <p class="section-intro">The following information is needed for a complete compliance assessment:</p>
+                            {{ AI_ACT_DATA_GAPS_HTML|safe }}
+                        </div>
+                        {% endif %}
+
+                        <!-- Next Steps -->
+                        {% if AI_ACT_RECOMMENDED_NEXT_STEPS_HTML %}
+                        <div class="next-steps-section">
+                            <h3>Recommended Next Steps</h3>
+                            {{ AI_ACT_RECOMMENDED_NEXT_STEPS_HTML|safe }}
+                        </div>
+                        {% endif %}
+                    </div>
+                </section>
+                {% endif %}
                 {% if KICKOFF_VORLAGE_HTML %}
                 <section class="section chapter">
                     <div class="section-header">

--- a/templates/pdf_template_en.html
+++ b/templates/pdf_template_en.html
@@ -1586,81 +1586,87 @@
                     </div>
                 </section>
                 {% endif %}
-                <!-- SPRINT G7: AI Act Compliance Section (EN) -->
+                <!-- SPRINT G7/G8: AI Act Compliance Section (EN) -->
                 {% if AI_ACT_RISK_LEVEL %}
-                <section class="section chapter ai-act-compliance">
+                <section class="section chapter ai-act-compliance" style="page-break-inside: avoid;">
                     <div class="section-header">
                         <div class="section-title">
                             <span class="section-kicker">EU AI Act</span>
-                            <h2>Compliance Assessment</h2>
+                            <h2>AI Act Compliance & Obligations</h2>
                         </div>
                         <span class="section-pill">
-                            <span class="pill-dot {% if AI_ACT_RISK_LEVEL == 'high-risk' %}pill-danger{% elif AI_ACT_RISK_LEVEL == 'limited' %}pill-warning{% else %}pill-success{% endif %}"></span>
+                            <span class="pill-dot {% if AI_ACT_RISK_LEVEL == 'high-risk' %}pill-danger{% elif AI_ACT_RISK_LEVEL == 'limited' %}pill-warning{% else %}pill-success{% endif %}" style="{% if AI_ACT_RISK_LEVEL == 'high-risk' %}background:#dc3545{% elif AI_ACT_RISK_LEVEL == 'limited' %}background:#ffc107{% else %}background:#28a745{% endif %}"></span>
                             Risk Class: {{ AI_ACT_RISK_LEVEL }}
                         </span>
                     </div>
                     <div class="section-body">
                         <!-- Risk Level Badge -->
-                        <div class="risk-level-banner risk-{{ AI_ACT_RISK_LEVEL }}">
+                        <div class="risk-level-banner" style="padding:12px 16px;border-radius:8px;margin-bottom:16px;{% if AI_ACT_RISK_LEVEL == 'high-risk' %}background:#fff5f5;border-left:4px solid #dc3545{% elif AI_ACT_RISK_LEVEL == 'limited' %}background:#fffbeb;border-left:4px solid #ffc107{% else %}background:#f0fff4;border-left:4px solid #28a745{% endif %}">
                             {% if AI_ACT_RISK_LEVEL == 'high-risk' %}
-                            <span class="risk-icon">⚠️</span>
-                            <strong>High-Risk Classification</strong> – Comprehensive compliance requirements per EU AI Act
+                            <strong style="color:#dc3545">⚠️ High-Risk Classification</strong> – Comprehensive compliance requirements per EU AI Act
                             {% elif AI_ACT_RISK_LEVEL == 'limited' %}
-                            <span class="risk-icon">📋</span>
-                            <strong>Limited Risk</strong> – Transparency obligations apply
+                            <strong style="color:#856404">📋 Limited Risk</strong> – Transparency obligations apply
                             {% else %}
-                            <span class="risk-icon">✅</span>
-                            <strong>Minimal Risk</strong> – Best practices recommended
+                            <strong style="color:#28a745">✅ Minimal Risk</strong> – Best practices recommended
                             {% endif %}
                         </div>
 
                         <!-- Risk Reasoning -->
                         {% if AI_ACT_RISK_REASONING %}
-                        <div class="risk-reasoning">
-                            <h3>Classification Reasoning</h3>
-                            <p>{{ AI_ACT_RISK_REASONING }}</p>
+                        <div class="risk-reasoning" style="margin-bottom:16px;">
+                            <h3 style="font-size:14px;margin-bottom:8px;">Classification Reasoning</h3>
+                            <p style="line-height:1.5;">{{ AI_ACT_RISK_REASONING }}</p>
                         </div>
                         {% endif %}
 
                         <!-- Duty Matrix -->
                         {% if AI_ACT_DUTY_MATRIX_HTML %}
-                        <div class="duty-matrix-section">
-                            <h3>Obligations Matrix</h3>
+                        <div class="duty-matrix-section" style="margin-bottom:16px;">
+                            <h3 style="font-size:14px;margin-bottom:8px;">Obligations Matrix</h3>
+                            <div style="overflow-x:auto;width:100%;">
                             {{ AI_ACT_DUTY_MATRIX_HTML|safe }}
+                            </div>
                         </div>
                         {% endif %}
 
                         <!-- Use Cases with Risk Tags -->
                         {% if AI_ACT_RELATED_USECASES_HTML %}
-                        <div class="usecases-risk-section">
-                            <h3>Use Cases with Risk Classification</h3>
+                        <div class="usecases-risk-section" style="margin-bottom:16px;">
+                            <h3 style="font-size:14px;margin-bottom:8px;">Use Cases with Risk Classification</h3>
                             {{ AI_ACT_RELATED_USECASES_HTML|safe }}
                         </div>
                         {% endif %}
 
                         <!-- Non-Compliance Alerts -->
                         {% if AI_ACT_NONCOMPLIANCE_ALERTS_HTML %}
-                        <div class="alerts-section">
-                            <h3>Compliance Gaps</h3>
-                            <p class="section-intro">Address these items as a priority:</p>
+                        <div class="alerts-section" style="margin-bottom:16px;padding:12px;background:#fff5f5;border-radius:6px;">
+                            <h3 style="font-size:14px;margin-bottom:8px;color:#dc3545;">Compliance Gaps</h3>
+                            <p class="section-intro" style="font-size:12px;color:#666;margin-bottom:8px;">Address these items as a priority:</p>
                             {{ AI_ACT_NONCOMPLIANCE_ALERTS_HTML|safe }}
                         </div>
                         {% endif %}
 
                         <!-- Data Gaps -->
                         {% if AI_ACT_DATA_GAPS_HTML %}
-                        <div class="gaps-section">
-                            <h3>Data Gaps</h3>
-                            <p class="section-intro">The following information is needed for a complete compliance assessment:</p>
+                        <div class="gaps-section" style="margin-bottom:16px;padding:12px;background:#fffbeb;border-radius:6px;">
+                            <h3 style="font-size:14px;margin-bottom:8px;color:#856404;">Data Gaps</h3>
+                            <p class="section-intro" style="font-size:12px;color:#666;margin-bottom:8px;">The following information is needed for a complete compliance assessment:</p>
                             {{ AI_ACT_DATA_GAPS_HTML|safe }}
                         </div>
                         {% endif %}
 
                         <!-- Next Steps -->
                         {% if AI_ACT_RECOMMENDED_NEXT_STEPS_HTML %}
-                        <div class="next-steps-section">
-                            <h3>Recommended Next Steps</h3>
+                        <div class="next-steps-section" style="margin-bottom:16px;">
+                            <h3 style="font-size:14px;margin-bottom:8px;">Recommended Next Steps</h3>
                             {{ AI_ACT_RECOMMENDED_NEXT_STEPS_HTML|safe }}
+                        </div>
+                        {% endif %}
+
+                        <!-- G8: Tools Injection -->
+                        {% if AI_ACT_TOOLS_INJECTION %}
+                        <div class="ai-act-tools-section" style="margin-bottom:16px;">
+                            {{ AI_ACT_TOOLS_INJECTION|safe }}
                         </div>
                         {% endif %}
                     </div>

--- a/tests/test_ai_act_persona.py
+++ b/tests/test_ai_act_persona.py
@@ -1,0 +1,455 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Sprint G8.4 & G8.5: AI Act Persona Leak Protection & Regression Tests
+
+Test Suite for:
+- Persona leak detection in AI Act sections
+- Size-specific content validation (Solo/Team/KMU)
+- AI Act consistency checks
+- End-to-End regression testing
+
+Version: 1.0.0 (Sprint G8)
+"""
+
+import pytest
+from typing import Any, Dict, List
+
+# Import AI Act module functions
+from services.ai_act_module import (
+    determine_risk_level,
+    generate_risk_reasoning,
+    generate_duty_matrix_html,
+    generate_noncompliance_alerts,
+    generate_data_gaps,
+    generate_next_steps_html,
+    generate_usecase_risk_html,
+    build_ai_act_sections,
+    build_ai_act_sections_optimized,
+    validate_ai_act_sections,
+    ai_act_harmonize,
+    validate_ai_act_persona_compliance,
+    apply_ai_act_persona_filter,
+    get_ai_act_exec_summary_injection,
+    get_ai_act_business_case_injection,
+    get_ai_act_roadmap_injection,
+    EXTENDED_SOLO_FORBIDDEN,
+    EXTENDED_TEAM_FORBIDDEN,
+    EXTENDED_KMU_FORBIDDEN,
+    VALID_RISK_LEVELS,
+)
+
+
+# =============================================================================
+# G8.4: HELPER FUNCTIONS FOR PERSONA LEAK DETECTION
+# =============================================================================
+
+def extract_ai_act_sections(report: Dict[str, Any]) -> Dict[str, str]:
+    """Extract all AI Act related sections from a report."""
+    ai_act_keys = [
+        "AI_ACT_RISK_LEVEL",
+        "AI_ACT_RISK_REASONING",
+        "AI_ACT_DUTY_MATRIX_HTML",
+        "AI_ACT_NONCOMPLIANCE_ALERTS_HTML",
+        "AI_ACT_DATA_GAPS_HTML",
+        "AI_ACT_RECOMMENDED_NEXT_STEPS_HTML",
+        "AI_ACT_RELATED_USECASES_HTML",
+        "AI_ACT_EXEC_INJECTION",
+        "AI_ACT_GOVERNANCE_INJECTION",
+        "AI_ACT_RISKS_INJECTION",
+        "AI_ACT_TOOLS_INJECTION",
+    ]
+    return {key: report.get(key, "") for key in ai_act_keys}
+
+
+def no_team_terms_in_ai_act(ai_sections: Dict[str, str]) -> bool:
+    """Check that no team/organization terms appear in AI Act sections."""
+    for key, content in ai_sections.items():
+        if not isinstance(content, str):
+            continue
+        content_lower = content.lower()
+        for term in EXTENDED_SOLO_FORBIDDEN:
+            if term.lower() in content_lower:
+                return False
+    return True
+
+
+def no_solo_terms_in_ai_act(ai_sections: Dict[str, str]) -> bool:
+    """Check that no solo-specific terms appear in AI Act sections."""
+    forbidden = EXTENDED_TEAM_FORBIDDEN + EXTENDED_KMU_FORBIDDEN
+    for key, content in ai_sections.items():
+        if not isinstance(content, str):
+            continue
+        content_lower = content.lower()
+        for term in set(forbidden):  # Remove duplicates
+            if term.lower() in content_lower:
+                return False
+    return True
+
+
+def no_kmu_terms_in_ai_act(ai_sections: Dict[str, str]) -> bool:
+    """Check that no KMU-specific terms appear in Solo AI Act sections."""
+    # For Solo reports, we also check KMU-specific terms
+    kmu_only = ["governance board", "compliance-officer", "abteilungsleiter"]
+    for key, content in ai_sections.items():
+        if not isinstance(content, str):
+            continue
+        content_lower = content.lower()
+        for term in kmu_only:
+            if term in content_lower:
+                return False
+    return True
+
+
+def assert_no_size_leaks_in_ai_act(report: Dict[str, Any], size: str) -> None:
+    """
+    G8.4: Main assertion function for persona leak detection.
+
+    Validates that AI Act sections contain no size-inappropriate terms.
+
+    Args:
+        report: Report sections dictionary
+        size: Size category ("solo", "team", or "kmu")
+
+    Raises:
+        AssertionError: If persona leaks are found
+    """
+    ai_sections = extract_ai_act_sections(report)
+    size_lower = size.lower()
+
+    if "solo" in size_lower or "freiberuf" in size_lower:
+        assert no_team_terms_in_ai_act(ai_sections), \
+            f"Team terms found in Solo AI Act sections"
+        assert no_kmu_terms_in_ai_act(ai_sections), \
+            f"KMU terms found in Solo AI Act sections"
+
+    elif "team" in size_lower or "klein" in size_lower:
+        assert no_solo_terms_in_ai_act(ai_sections), \
+            f"Solo terms found in Team AI Act sections"
+
+    else:  # KMU
+        assert no_solo_terms_in_ai_act(ai_sections), \
+            f"Solo terms found in KMU AI Act sections"
+
+
+# =============================================================================
+# G8.5: REGRESSION CHECK HELPERS
+# =============================================================================
+
+def assert_risk_level_is_consistent(report: Dict[str, Any]) -> None:
+    """G8.5: Assert that risk level is valid and consistent."""
+    risk_level = report.get("AI_ACT_RISK_LEVEL", "")
+    assert risk_level in VALID_RISK_LEVELS, \
+        f"Invalid risk level: {risk_level}, expected one of {VALID_RISK_LEVELS}"
+
+
+def assert_duty_matrix_valid(report: Dict[str, Any]) -> None:
+    """G8.5: Assert that duty matrix contains valid table structure."""
+    matrix = report.get("AI_ACT_DUTY_MATRIX_HTML", "")
+    assert "<table" in matrix.lower(), "Duty matrix missing <table> tag"
+    assert "</table>" in matrix.lower(), "Duty matrix missing </table> tag"
+
+    # Check minimum row count
+    row_count = matrix.lower().count("<tr>") - 1  # Subtract header
+    assert row_count >= 3, f"Duty matrix has only {row_count} rows (min 3)"
+
+
+def assert_mandatory_reasoning_present(report: Dict[str, Any], min_words: int = 60) -> None:
+    """G8.5: Assert that risk reasoning meets minimum word count."""
+    reasoning = report.get("AI_ACT_RISK_REASONING", "")
+    import re
+    text_only = re.sub(r"<[^>]+>", "", reasoning).strip()
+    word_count = len(text_only.split())
+    assert word_count >= min_words, \
+        f"Risk reasoning too short: {word_count} words (min {min_words})"
+
+
+def assert_alerts_and_gaps_count(report: Dict[str, Any], max_alerts: int = 10, max_gaps: int = 8) -> None:
+    """G8.5: Assert that alerts and gaps are within expected range."""
+    alerts = report.get("AI_ACT_NONCOMPLIANCE_ALERTS", [])
+    gaps = report.get("AI_ACT_DATA_GAPS", [])
+
+    assert len(alerts) >= 2, f"Too few alerts: {len(alerts)} (min 2)"
+    assert len(alerts) <= max_alerts, f"Too many alerts: {len(alerts)} (max {max_alerts})"
+
+    assert len(gaps) >= 2, f"Too few gaps: {len(gaps)} (min 2)"
+    assert len(gaps) <= max_gaps, f"Too many gaps: {len(gaps)} (max {max_gaps})"
+
+
+def assert_ai_act_html_valid(report: Dict[str, Any]) -> None:
+    """G8.5: Assert that AI Act HTML sections are well-formed."""
+    html_keys = [
+        "AI_ACT_DUTY_MATRIX_HTML",
+        "AI_ACT_RECOMMENDED_NEXT_STEPS_HTML",
+        "AI_ACT_RELATED_USECASES_HTML",
+    ]
+
+    for key in html_keys:
+        html = report.get(key, "")
+        if html:
+            # Check for balanced tags (basic check)
+            assert html.count("<") == html.count(">"), \
+                f"{key} has unbalanced angle brackets"
+
+
+def assert_no_hardguard_violations(report: Dict[str, Any], size: str) -> None:
+    """G8.5: Assert no hard-guard violations in AI Act content."""
+    violations = validate_ai_act_persona_compliance(report, size)
+    assert len(violations) == 0, \
+        f"Hard-guard violations found: {violations[:3]}"
+
+
+# =============================================================================
+# G8.4: PERSONA LEAK TESTS
+# =============================================================================
+
+class TestAIActPersonaLeaks:
+    """Test suite for AI Act persona leak detection."""
+
+    def test_solo_no_team_terms(self):
+        """Solo reports should not contain team terminology."""
+        briefing = {
+            "branche": "Beratung",
+            "unternehmensgroesse": "Solo-Selbstständig",
+            "ki_einsatzbereiche": ["Content-Erstellung"],
+            "lang": "de",
+        }
+        sections = build_ai_act_sections_optimized(briefing, lang="de")
+        sections = ai_act_harmonize(sections, briefing)
+
+        assert_no_size_leaks_in_ai_act(sections, "solo")
+
+    def test_team_no_solo_terms(self):
+        """Team reports should not contain solo terminology."""
+        briefing = {
+            "branche": "IT-Dienstleister",
+            "unternehmensgroesse": "Team (2-10 MA)",
+            "ki_einsatzbereiche": ["Softwareentwicklung"],
+            "lang": "de",
+        }
+        sections = build_ai_act_sections_optimized(briefing, lang="de")
+        sections = ai_act_harmonize(sections, briefing)
+
+        assert_no_size_leaks_in_ai_act(sections, "team")
+
+    def test_kmu_no_solo_terms(self):
+        """KMU reports should not contain solo terminology."""
+        briefing = {
+            "branche": "Finanzdienstleister",
+            "unternehmensgroesse": "KMU (11-50 MA)",
+            "ki_einsatzbereiche": ["Kreditscoring", "Kundenservice"],
+            "lang": "de",
+        }
+        sections = build_ai_act_sections_optimized(briefing, lang="de")
+        sections = ai_act_harmonize(sections, briefing)
+
+        assert_no_size_leaks_in_ai_act(sections, "kmu")
+
+    def test_exec_summary_injection_solo(self):
+        """Exec summary injection for Solo should not contain team terms."""
+        injection = get_ai_act_exec_summary_injection("high-risk", "Solo", "Beratung", "de")
+
+        for term in EXTENDED_SOLO_FORBIDDEN:
+            assert term.lower() not in injection.lower(), \
+                f"Forbidden term '{term}' found in Solo exec summary injection"
+
+    def test_exec_summary_injection_team(self):
+        """Exec summary injection for Team should not contain solo terms."""
+        injection = get_ai_act_exec_summary_injection("limited", "Team", "IT", "de")
+
+        for term in EXTENDED_TEAM_FORBIDDEN:
+            assert term.lower() not in injection.lower(), \
+                f"Forbidden term '{term}' found in Team exec summary injection"
+
+    def test_persona_filter_removes_forbidden_terms(self):
+        """Persona filter should replace size-inappropriate terms."""
+        # Test Solo filter
+        text_with_team = "Ihr Team sollte die Mitarbeiter schulen."
+        filtered = apply_ai_act_persona_filter(text_with_team, "Solo")
+        assert "ihr team" not in filtered.lower()
+
+        # Test Team filter
+        text_with_solo = "Als Einzelperson sollten Sie..."
+        filtered = apply_ai_act_persona_filter(text_with_solo, "Team")
+        assert "als einzelperson" not in filtered.lower()
+
+
+# =============================================================================
+# G8.5: REGRESSION TESTS
+# =============================================================================
+
+class TestAIActRegression:
+    """End-to-end regression tests for AI Act module."""
+
+    @pytest.fixture
+    def solo_report(self):
+        """Generate a Solo report for testing."""
+        briefing = {
+            "branche": "Beratung",
+            "unternehmensgroesse": "Solo-Selbstständig",
+            "ki_einsatzbereiche": ["Content-Erstellung", "Recherche"],
+            "lang": "de",
+        }
+        sections = build_ai_act_sections_optimized(briefing, lang="de")
+        return ai_act_harmonize(sections, briefing)
+
+    @pytest.fixture
+    def team_report(self):
+        """Generate a Team report for testing."""
+        briefing = {
+            "branche": "IT-Dienstleister",
+            "unternehmensgroesse": "Team (2-10 MA)",
+            "ki_einsatzbereiche": ["Softwareentwicklung", "Testing"],
+            "lang": "de",
+        }
+        sections = build_ai_act_sections_optimized(briefing, lang="de")
+        return ai_act_harmonize(sections, briefing)
+
+    @pytest.fixture
+    def kmu_report(self):
+        """Generate a KMU report for testing."""
+        briefing = {
+            "branche": "Finanzdienstleister",
+            "unternehmensgroesse": "KMU (11-50 MA)",
+            "ki_einsatzbereiche": ["Kreditscoring", "Kundenservice"],
+            "lang": "de",
+        }
+        sections = build_ai_act_sections_optimized(briefing, lang="de")
+        return ai_act_harmonize(sections, briefing)
+
+    def test_solo_regression(self, solo_report):
+        """Full regression test for Solo profile."""
+        assert_risk_level_is_consistent(solo_report)
+        assert_duty_matrix_valid(solo_report)
+        assert_mandatory_reasoning_present(solo_report)
+        assert_alerts_and_gaps_count(solo_report)
+        assert_ai_act_html_valid(solo_report)
+        assert_no_size_leaks_in_ai_act(solo_report, "solo")
+        assert_no_hardguard_violations(solo_report, "Solo-Selbstständig")
+
+    def test_team_regression(self, team_report):
+        """Full regression test for Team profile."""
+        assert_risk_level_is_consistent(team_report)
+        assert_duty_matrix_valid(team_report)
+        assert_mandatory_reasoning_present(team_report)
+        assert_alerts_and_gaps_count(team_report)
+        assert_ai_act_html_valid(team_report)
+        assert_no_size_leaks_in_ai_act(team_report, "team")
+        assert_no_hardguard_violations(team_report, "Team (2-10 MA)")
+
+    def test_kmu_regression(self, kmu_report):
+        """Full regression test for KMU profile."""
+        assert_risk_level_is_consistent(kmu_report)
+        assert_duty_matrix_valid(kmu_report)
+        assert_mandatory_reasoning_present(kmu_report)
+        assert_alerts_and_gaps_count(kmu_report)
+        assert_ai_act_html_valid(kmu_report)
+        assert_no_size_leaks_in_ai_act(kmu_report, "kmu")
+        assert_no_hardguard_violations(kmu_report, "KMU (11-50 MA)")
+
+    def test_high_risk_finance(self):
+        """Test high-risk classification for finance sector."""
+        briefing = {
+            "branche": "Finanzdienstleister",
+            "unternehmensgroesse": "KMU (50-100 MA)",
+            "ki_einsatzbereiche": ["Kreditscoring", "Risikobewertung"],
+            "lang": "de",
+        }
+        sections = build_ai_act_sections_optimized(briefing, lang="de")
+
+        assert sections["AI_ACT_RISK_LEVEL"] == "high-risk"
+        assert_mandatory_reasoning_present(sections, min_words=60)
+
+    def test_high_risk_healthcare(self):
+        """Test high-risk classification for healthcare sector."""
+        briefing = {
+            "branche": "Gesundheitswesen",
+            "unternehmensgroesse": "Team",
+            "ki_einsatzbereiche": ["Diagnoseunterstützung"],
+            "lang": "de",
+        }
+        sections = build_ai_act_sections_optimized(briefing, lang="de")
+
+        assert sections["AI_ACT_RISK_LEVEL"] == "high-risk"
+
+    def test_limited_risk_legal(self):
+        """Test limited risk classification for legal sector."""
+        briefing = {
+            "branche": "Rechtsanwaltskanzlei",
+            "unternehmensgroesse": "Solo",
+            "ki_einsatzbereiche": ["Rechtsrecherche"],
+            "lang": "de",
+        }
+        sections = build_ai_act_sections_optimized(briefing, lang="de")
+
+        assert sections["AI_ACT_RISK_LEVEL"] == "limited"
+
+    def test_minimal_risk_general(self):
+        """Test minimal risk classification for general business."""
+        briefing = {
+            "branche": "Allgemeine Beratung",
+            "unternehmensgroesse": "Solo-Freiberufler",
+            "ki_einsatzbereiche": ["Content-Erstellung"],
+            "lang": "de",
+        }
+        sections = build_ai_act_sections_optimized(briefing, lang="de")
+
+        assert sections["AI_ACT_RISK_LEVEL"] == "minimal"
+
+
+class TestAIActHarmonization:
+    """Tests for the harmonization engine."""
+
+    def test_harmonization_adds_injections(self):
+        """Harmonization should add all injection fields."""
+        briefing = {
+            "branche": "IT",
+            "unternehmensgroesse": "Team",
+            "lang": "de",
+        }
+        sections = build_ai_act_sections_optimized(briefing, lang="de")
+        harmonized = ai_act_harmonize(sections, briefing)
+
+        assert "AI_ACT_EXEC_INJECTION" in harmonized
+        assert "AI_ACT_GOVERNANCE_INJECTION" in harmonized
+        assert "AI_ACT_RISKS_INJECTION" in harmonized
+        assert "AI_ACT_TOOLS_INJECTION" in harmonized
+        assert "AI_ACT_ROADMAP_90D_INJECTION" in harmonized
+        assert "AI_ACT_ROADMAP_12M_INJECTION" in harmonized
+
+    def test_harmonization_tracks_warnings(self):
+        """Harmonization should track consistency warnings."""
+        briefing = {
+            "branche": "Finanzdienstleister",
+            "unternehmensgroesse": "KMU",
+            "lang": "de",
+        }
+        sections = build_ai_act_sections_optimized(briefing, lang="de")
+        harmonized = ai_act_harmonize(sections, briefing)
+
+        assert "AI_ACT_CONSISTENCY_WARNINGS" in harmonized
+        assert isinstance(harmonized["AI_ACT_CONSISTENCY_WARNINGS"], list)
+
+
+class TestAIActBusinessCase:
+    """Tests for business case injection."""
+
+    def test_high_risk_capex_modifier(self):
+        """High-risk should have higher CAPEX modifier."""
+        bc = get_ai_act_business_case_injection("high-risk", "KMU", "de")
+        assert bc["CAPEX_MODIFIER"] > 1.0
+        assert bc["OPEX_MODIFIER"] > 1.0
+
+    def test_minimal_risk_no_modifier(self):
+        """Minimal risk should have no cost modifier."""
+        bc = get_ai_act_business_case_injection("minimal", "Solo", "de")
+        assert bc["CAPEX_MODIFIER"] == 1.0
+        assert bc["OPEX_MODIFIER"] == 1.0
+
+
+# =============================================================================
+# RUN TESTS
+# =============================================================================
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v", "--tb=short"])


### PR DESCRIPTION
G6 Post-Implementation Review Fixes:
- prompts/en/tools_recommendations.md: Updated to v5.4 G6
  - Added BRANCH_CORE_LABEL, BRANCH_CONTEXT_LABEL, OFFERING_LABEL
  - Added WORD_MINIMUM_SOLO/TEAM/SME comments
  - Added Persona Hard-Guards for Solo/Team/SME
  - Added regulated industry requirements for Team
- gpt_analyze.py: Enhanced tools_empfehlungen fallback
  - Expanded from ~40 to ~150+ words
  - Added 3 sections: Fundament, Kernprozess-Tools, Governance
  - Size-aware: Governance section only for Team/KMU
  - Uses short labels: branch_context_label, offering_label

Status after review:
- All DE prompts: OK (v5.4 G6)
- All EN prompts: OK (v5.4 G6)
- Validator settings: OK
- Redundancy rules: OK (20 words, max 5 warnings, whitelist)
- Business Case injection: OK