### PR TITLE
feat(g15.1): polish solo report – artefact removal, persona guard, ro…

### DIFF
--- a/prompts/de/roadmap_90d.md
+++ b/prompts/de/roadmap_90d.md
@@ -114,6 +114,24 @@ GUARDRAILS: Berücksichtige Leitplanken aus strategischem Kontext.
     <li><strong>Klarheit:</strong> Fundierte Basis für Entscheidung über weitere Investitionen</li>
   </ul>
 
+  <h3>KPI-Tracking & Review für Ihren Alltag</h3>
+  <p>
+    Planen Sie wöchentlich einen festen 30-Minuten-Slot für Ihr persönliches KI-Review ein.
+    Führen Sie ein einfaches KPI-Board (z. B. Notion, Excel oder handschriftlich): Notieren Sie
+    pro Woche die Anzahl KI-gestützter Aufgaben, geschätzte Zeitersparnis und Qualitätsbewertung
+    (1–5 Sterne). Nach 90 Tagen haben Sie belastbare Daten für Ihre eigene Investitionsentscheidung.
+    Nutzen Sie die generierten Reports als Referenz, um Fortschritte sichtbar zu machen.
+  </p>
+
+  <h3>Content & Marketing-Systematik</h3>
+  <p>
+    Konzentrieren Sie sich auf 1–2 Kanäle, die zu {{OFFERING_LABEL}} passen (z. B. LinkedIn, Newsletter).
+    Etablieren Sie eine feste Content-Routine: Einmal pro Woche einen kurzen Beitrag mit KI-Unterstützung
+    erstellen. Nutzen Sie Ihre eigenen KI-Readiness-Reports als Marketing-Asset – sie zeigen Kompetenz
+    und bieten echten Mehrwert für potenzielle Kunden. So verbinden Sie Ihre KI-Einführung direkt
+    mit Ihrer Sichtbarkeit als Expert:in in {{BRANCH_CONTEXT_LABEL}}.
+  </p>
+
   {% elif COMPANY_SIZE == "team" %}
   <h3>Phase 0: Setup (Woche 1–2)</h3>
   <p><strong>Ziel:</strong> Teamweite Arbeitsfähigkeit mit KI herstellen.</p>

--- a/services/prompt_enhancer.py
+++ b/services/prompt_enhancer.py
@@ -611,6 +611,9 @@ SOLO_PHRASE_REPLACEMENTS: Dict[str, str] = {
     "bereichsleitung": "Verantwortungsbereich",
     "fachabteilung": "Arbeitsfeld",
     "fachabteilungen": "Arbeitsbereiche",
+    # SPRINT G15.1-B: Bereichsleiter persona leak fix for Solo
+    "bereichsleiter:innen": "verantwortliche Ansprechpersonen im Unternehmen",
+    "bereichsleiter": "verantwortliche Ansprechpartner:innen im Unternehmen",
 }
 
 # Corporate terms → Solo-appropriate replacements (word-based)
@@ -646,6 +649,9 @@ SOLO_GOVERNANCE_REPLACEMENTS: Dict[str, str] = {
     "personalentscheidungen": "Ressourcenentscheidungen",
     "personaldaten": "vertrauliche Daten",
     "belegschaft": "Kapazität",
+    # SPRINT G15.1-B: Bereichsleiter persona leak fix
+    "bereichsleiter:innen": "verantwortliche Ansprechpersonen",
+    "bereichsleiter": "Ansprechpartner:innen",
     # EN equivalents for Solo
     "department": "work area",
     "departments": "work areas",
@@ -737,6 +743,13 @@ def apply_solo_persona_filter(text: str) -> str:
             # but catch all other cases including "IT-Abteilung", "HR-Abteilung", etc.
             pattern = re.compile(
                 r'(?<![Kk]unden)(' + re.escape(term) + r')',
+                re.IGNORECASE
+            )
+        elif term.lower() in ("board", "gremium"):
+            # SPRINT G15.1-A: Use word boundaries for short terms that could match
+            # inside other words (e.g., "board" in "Onboarding")
+            pattern = re.compile(
+                r'\b' + re.escape(term) + r'\b',
                 re.IGNORECASE
             )
         else:

--- a/services/report_validator.py
+++ b/services/report_validator.py
@@ -336,6 +336,16 @@ class ReportValidator:
         },
     }
 
+    # SPRINT G15.1-A: Global Artifact Replacements
+    # These artifacts appear due to prompt leakage and must be cleaned globally
+    # Longest-first matching to avoid partial replacements
+    ARTIFACT_REPLACEMENTS = {
+        "OnPrüfroutineing-Mails": "Onboarding-E-Mails",
+        "OnPrüfroutineing-Mail": "Onboarding-E-Mail",
+        "OnPrüfroutineing zukünftiger": "Onboarding zukünftiger",
+        "OnPrüfroutineing": "Onboarding",
+    }
+
     # SPRINT N / G8.2: Hard-Stop Configuration (now ENV-controlled via ValidationConfig)
     # Can be overridden via HARD_STOP_ON_SIZE_MISMATCH env var
     HARD_STOP_ON_SIZE_MISMATCH = (
@@ -1265,6 +1275,7 @@ def filter_size_inappropriate_content(content: str, unternehmensgroesse: str) ->
     Sprint N3.1: Für Solo-Profile wird apply_solo_persona_filter() aufgerufen.
     Sprint G3.1: Für Team/KMU wird apply_size_persona_filter() aufgerufen,
     das Solo-spezifische Phrasen durch Team/KMU-passende Alternativen ersetzt.
+    Sprint G15.1-A: Global artifact cleaning (OnPrüfroutineing etc.) for all sizes.
     """
     import logging
     import re
@@ -1273,6 +1284,22 @@ def filter_size_inappropriate_content(content: str, unternehmensgroesse: str) ->
 
     if not content or not isinstance(content, str):
         return content
+
+    # SPRINT G15.1-A: Global artifact removal (applies to ALL sizes)
+    artifact_replacements_made = []
+    # Sort by length (longest first) to avoid partial matches
+    sorted_artifacts = sorted(
+        ReportValidator.ARTIFACT_REPLACEMENTS.items(),
+        key=lambda x: len(x[0]),
+        reverse=True
+    )
+    for artifact, replacement in sorted_artifacts:
+        if artifact in content:
+            content = content.replace(artifact, replacement)
+            artifact_replacements_made.append(f"{artifact} → {replacement}")
+
+    if artifact_replacements_made:
+        log.info(f"🧹 Artifact-Cleanup: {len(artifact_replacements_made)} Ersetzungen")
 
     size_raw = unternehmensgroesse.lower() if unternehmensgroesse else ""
 

--- a/tests/test_g15_1_solo_polish.py
+++ b/tests/test_g15_1_solo_polish.py
@@ -1,0 +1,304 @@
+# -*- coding: utf-8 -*-
+"""
+Sprint G15.1 Tests: Solo-Polish (OnPrüf-Artefakt, Persona-Leak, Roadmap-Länge)
+
+Tests for the mini-polish sprint targeting Solo report quality improvements:
+- G15.1-A: OnPrüfroutineing artifact removal
+- G15.1-B: Bereichsleiter persona leak fix for Solo
+- G15.1-C: roadmap_90d Solo minimum length
+
+Version: 1.0.0
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Dict, Any
+
+import pytest
+
+
+# =============================================================================
+# TEST G15.1-A: ONPRÜFROUTINEING ARTIFACT REMOVAL
+# =============================================================================
+
+class TestG151A_ArtifactRemoval:
+    """Tests for OnPrüfroutineing artifact cleanup."""
+
+    def test_artifact_replacements_defined(self) -> None:
+        """ARTIFACT_REPLACEMENTS should be defined in ReportValidator."""
+        from services.report_validator import ReportValidator
+
+        assert hasattr(ReportValidator, "ARTIFACT_REPLACEMENTS")
+        artifacts = ReportValidator.ARTIFACT_REPLACEMENTS
+        assert isinstance(artifacts, dict)
+        assert len(artifacts) >= 3  # At least 3 replacement patterns
+
+    def test_artifact_replacements_content(self) -> None:
+        """ARTIFACT_REPLACEMENTS should contain OnPrüfroutineing patterns."""
+        from services.report_validator import ReportValidator
+
+        artifacts = ReportValidator.ARTIFACT_REPLACEMENTS
+        # Check specific artifacts are covered
+        assert "OnPrüfroutineing" in artifacts
+        assert artifacts["OnPrüfroutineing"] == "Onboarding"
+
+    def test_no_onpruefroutineing_in_rendered_report(self) -> None:
+        """
+        Filter should remove OnPrüfroutineing artifacts from content.
+
+        This simulates a rendered report HTML and verifies cleanup.
+        """
+        from services.report_validator import filter_size_inappropriate_content
+
+        # Sample content with artifacts
+        test_html = """
+        <section class="quick-wins">
+            <h3>Quick Wins</h3>
+            <ul>
+                <li>OnPrüfroutineing-Mails für neue Kunden einrichten</li>
+                <li>OnPrüfroutineing zukünftiger Nutzer:innen automatisieren</li>
+                <li>Einfaches OnPrüfroutineing mit KI-Unterstützung</li>
+            </ul>
+        </section>
+        """
+
+        # Filter for Solo (any size should clean artifacts)
+        filtered = filter_size_inappropriate_content(test_html, "solo")
+
+        # Verify no artifacts remain
+        assert "OnPrüfroutineing" not in filtered
+        assert "OnPrüfroutineing-Mails" not in filtered
+
+        # Verify clean replacements are in place
+        assert "Onboarding-E-Mails" in filtered
+        assert "Onboarding zukünftiger" in filtered
+        assert "Onboarding mit KI" in filtered
+
+    def test_artifact_removal_for_all_sizes(self) -> None:
+        """Artifact removal should work for all company sizes."""
+        from services.report_validator import filter_size_inappropriate_content
+
+        test_content = "OnPrüfroutineing-Mails versenden"
+
+        for size in ["solo", "team", "kmu"]:
+            filtered = filter_size_inappropriate_content(test_content, size)
+            assert "OnPrüfroutineing" not in filtered
+            assert "Onboarding" in filtered
+
+
+# =============================================================================
+# TEST G15.1-B: BEREICHSLEITER PERSONA LEAK
+# =============================================================================
+
+class TestG151B_PersonaLeak:
+    """Tests for Bereichsleiter persona leak fix."""
+
+    def test_bereichsleiter_in_solo_forbidden_terms(self) -> None:
+        """Bereichsleiter should be in SOLO_FORBIDDEN_TERMS."""
+        from services.prompt_enhancer import SOLO_FORBIDDEN_TERMS
+
+        assert "bereichsleiter" in SOLO_FORBIDDEN_TERMS
+
+    def test_bereichsleiter_replacement_defined(self) -> None:
+        """Bereichsleiter replacement should be defined."""
+        from services.prompt_enhancer import (
+            SOLO_PHRASE_REPLACEMENTS,
+            SOLO_GOVERNANCE_REPLACEMENTS,
+        )
+
+        # Check phrase replacements
+        has_phrase = any(
+            "bereichsleiter" in k.lower()
+            for k in SOLO_PHRASE_REPLACEMENTS.keys()
+        )
+        # Check governance replacements
+        has_governance = any(
+            "bereichsleiter" in k.lower()
+            for k in SOLO_GOVERNANCE_REPLACEMENTS.keys()
+        )
+
+        assert has_phrase or has_governance, (
+            "Bereichsleiter replacement should be in SOLO_PHRASE_REPLACEMENTS "
+            "or SOLO_GOVERNANCE_REPLACEMENTS"
+        )
+
+    def test_no_bereichsleiter_for_solo_templates(self) -> None:
+        """Solo content filter should replace Bereichsleiter."""
+        from services.prompt_enhancer import apply_solo_persona_filter
+
+        # Test content with Bereichsleiter
+        test_content = """
+        Die Templates richten sich an Bereichsleiter in Unternehmen.
+        Bereichsleiter:innen können diese Vorlagen direkt nutzen.
+        """
+
+        filtered = apply_solo_persona_filter(test_content)
+
+        # Bereichsleiter should be replaced
+        assert "Bereichsleiter" not in filtered
+        assert "bereichsleiter" not in filtered.lower() or "ansprechp" in filtered.lower()
+
+    def test_solo_filter_preserves_context(self) -> None:
+        """Solo filter should preserve surrounding context."""
+        from services.prompt_enhancer import apply_solo_persona_filter
+
+        test_content = "Die Bereichsleiter im Kundenunternehmen nutzen die Vorlagen."
+        filtered = apply_solo_persona_filter(test_content)
+
+        # Should still contain key context words
+        assert "Kundenunternehmen" in filtered or "unternehmen" in filtered.lower()
+        assert "nutzen" in filtered
+        assert "Vorlagen" in filtered
+
+
+# =============================================================================
+# TEST G15.1-C: ROADMAP_90D SOLO MINIMUM LENGTH
+# =============================================================================
+
+class TestG151C_RoadmapLength:
+    """Tests for roadmap_90d Solo minimum word count."""
+
+    def test_roadmap_90d_prompt_exists(self) -> None:
+        """roadmap_90d.md prompt file should exist."""
+        prompt_path = Path("prompts/de/roadmap_90d.md")
+        assert prompt_path.exists(), f"Prompt file not found: {prompt_path}"
+
+    def test_roadmap_90d_solo_content_extended(self) -> None:
+        """Solo section should have KPI-Tracking and Content-Marketing sections."""
+        prompt_path = Path("prompts/de/roadmap_90d.md")
+        content = prompt_path.read_text(encoding="utf-8")
+
+        # Check for new sections
+        assert "KPI-Tracking" in content, "KPI-Tracking section missing"
+        assert "Content & Marketing" in content or "Marketing-Systematik" in content, (
+            "Content-Marketing section missing"
+        )
+
+    def test_roadmap_90d_solo_meets_min_words(self) -> None:
+        """
+        Solo roadmap content should meet minimum word count.
+
+        The validator minimum for solo roadmap_90d is 250 words.
+        """
+        prompt_path = Path("prompts/de/roadmap_90d.md")
+        content = prompt_path.read_text(encoding="utf-8")
+
+        # Extract Solo HTML section (between {% if COMPANY_SIZE == "solo" %} and {% elif)
+        # The actual content starts after the VERBOTEN instructions (after the comment block)
+        solo_match = re.search(
+            r'\{% if COMPANY_SIZE == "solo" %\}\s*\n\s*<h3>(.*?)\{% elif',
+            content,
+            re.DOTALL
+        )
+
+        assert solo_match, "Could not find Solo section in roadmap_90d.md"
+
+        # Prepend the h3 tag back for the HTML content
+        solo_content = "<h3>" + solo_match.group(1)
+
+        # Remove HTML tags for word count
+        text_only = re.sub(r'<[^>]+>', ' ', solo_content)
+        text_only = re.sub(r'\s+', ' ', text_only).strip()
+
+        word_count = len(text_only.split())
+
+        # Solo minimum is 250 words - content should exceed this
+        min_words = 250
+        assert word_count >= min_words, (
+            f"Solo roadmap has {word_count} words, needs at least {min_words}"
+        )
+
+    def test_roadmap_solo_uses_solo_terminology(self) -> None:
+        """Solo roadmap HTML content should not contain Team/KMU terminology."""
+        prompt_path = Path("prompts/de/roadmap_90d.md")
+        content = prompt_path.read_text(encoding="utf-8")
+
+        # Extract Solo HTML section (only the actual HTML, not instructions)
+        solo_match = re.search(
+            r'\{% if COMPANY_SIZE == "solo" %\}\s*\n\s*<h3>(.*?)\{% elif',
+            content,
+            re.DOTALL
+        )
+        assert solo_match, "Could not find Solo section in roadmap_90d.md"
+
+        solo_content = solo_match.group(1).lower()
+
+        # Solo HTML content should not contain these terms
+        # Note: instruction comments may contain forbidden terms for documentation
+        forbidden_in_solo = [
+            "mitarbeiter einstellen",
+            "team aufbauen",
+            "teamstruktur",
+        ]
+
+        for term in forbidden_in_solo:
+            assert term not in solo_content, (
+                f"Forbidden term '{term}' found in Solo roadmap HTML content"
+            )
+
+
+# =============================================================================
+# TEST G15.1-D: INTEGRATION & REPLACER TESTS
+# =============================================================================
+
+class TestG151D_Integration:
+    """Integration tests for G15.1 changes."""
+
+    def test_size_filter_chain_works(self) -> None:
+        """Full filter chain should clean all artifacts and persona leaks."""
+        from services.report_validator import filter_size_inappropriate_content
+
+        # Content with multiple issues
+        test_html = """
+        <section>
+            <p>OnPrüfroutineing-Mails an Bereichsleiter versenden.</p>
+            <p>Das Team sollte die Mitarbeiter informieren.</p>
+        </section>
+        """
+
+        # Filter for Solo
+        filtered = filter_size_inappropriate_content(test_html, "solo")
+
+        # Artifacts should be cleaned
+        assert "OnPrüfroutineing" not in filtered
+
+        # Team terms should be replaced for Solo
+        # Note: exact replacement depends on filter implementation
+        assert "Onboarding" in filtered
+
+    def test_artifact_longest_first_matching(self) -> None:
+        """Artifact replacement should use longest-first matching."""
+        from services.report_validator import ReportValidator
+
+        artifacts = ReportValidator.ARTIFACT_REPLACEMENTS
+
+        # "OnPrüfroutineing-Mails" should be replaced before "OnPrüfroutineing"
+        keys_by_length = sorted(artifacts.keys(), key=len, reverse=True)
+
+        # Longer patterns should come first when sorted
+        if "OnPrüfroutineing-Mails" in artifacts and "OnPrüfroutineing" in artifacts:
+            assert keys_by_length.index("OnPrüfroutineing-Mails") < keys_by_length.index("OnPrüfroutineing")
+
+    def test_all_g151_modules_import(self) -> None:
+        """All modified modules should import without errors."""
+        # report_validator
+        from services.report_validator import (
+            ReportValidator,
+            filter_size_inappropriate_content,
+            filter_all_sections,
+        )
+        assert ReportValidator is not None
+
+        # prompt_enhancer
+        from services.prompt_enhancer import (
+            apply_solo_persona_filter,
+            SOLO_PHRASE_REPLACEMENTS,
+            SOLO_GOVERNANCE_REPLACEMENTS,
+            SOLO_FORBIDDEN_TERMS,
+        )
+        assert apply_solo_persona_filter is not None
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
…admap depth

G15.1-A: OnPrüfroutineing artifact removal
- Add ARTIFACT_REPLACEMENTS to ReportValidator for global cleanup
- Apply artifact replacements in filter_size_inappropriate_content()
- Fix "board" word boundary to avoid matching inside "Onboarding"
- Supports OnPrüfroutineing-Mails, OnPrüfroutineing-Mail, and variants

G15.1-B: Bereichsleiter persona leak fix for Solo
- Add bereichsleiter:innen and bereichsleiter to SOLO_PHRASE_REPLACEMENTS
- Add bereichsleiter replacements to SOLO_GOVERNANCE_REPLACEMENTS
- Maps to neutral customer terminology (Ansprechpersonen/Ansprechpartner)

G15.1-C: roadmap_90d Solo minimum length & substance
- Add "KPI-Tracking & Review für Ihren Alltag" section (~55 words)
- Add "Content & Marketing-Systematik" section (~60 words)
- Solo roadmap now exceeds 250 word minimum requirement

G15.1-D: Tests
- Create tests/test_g15_1_solo_polish.py with 15 tests
- Tests cover artifact removal, persona leak, roadmap length
- All tests pass (15 passed)