### PR TITLE
feat(g17.1): implement segment calibration & insight reliability

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -245,3 +245,29 @@ FUNDING_MIN_CASES_PER_PROGRAM=5
 
 # --- Dashboard Insights ---
 DASHBOARD_INSIGHTS_ENABLED=1
+
+# =============================================================================
+# SPRINT G17.1: SEGMENT CALIBRATION & INSIGHT RELIABILITY
+# =============================================================================
+
+# --- G17.1-A: Segment Calibration ---
+# Standard deviations beyond which values are winsorized (outlier dampening)
+INSIGHTS_SEGMENT_OUTLIER_STD=2.5
+# Minimum sample size to include segment (warning threshold)
+INSIGHTS_SEGMENT_SAMPLE_WARNING=5
+# Minimum standard deviation threshold for confidence scoring
+INSIGHTS_MIN_STD_CONFIDENCE=0.15
+# Enable confidence level calculations
+INSIGHTS_CONFIDENCE_LEVELS_ENABLED=1
+
+# --- G17.1-B: Insight Reliability Filter ---
+# Only show insights for reliable segments (stability = strong/medium)
+INSIGHTS_REQUIRE_RELIABLE_SEGMENT=1
+# Use generic fallback cards when segment is unreliable
+INSIGHTS_FALLBACK_TO_GENERIC=1
+
+# --- G17.1-C: Funding Insight Stability ---
+# Only show funding insights for stable segments
+FUNDING_REQUIRE_STABLE_SEGMENT=1
+# Show confidence indicator badges in HTML output
+FUNDING_SHOW_CONFIDENCE_INDICATOR=1

--- a/routes/feedback_dashboard.py
+++ b/routes/feedback_dashboard.py
@@ -537,3 +537,117 @@ async def get_action_items(
     except Exception as e:
         log.error(f"Failed to get action items: {e}")
         raise HTTPException(status_code=500, detail=f"Analysis failed: {str(e)}")
+
+
+# =============================================================================
+# G17.1-D: SEGMENT STABILITY & INSIGHTS RELIABILITY ENDPOINTS
+# =============================================================================
+
+class SegmentStabilityItemResponse(BaseModel):
+    """Single segment stability item."""
+    segment_key: SegmentKeyResponse
+    segment_label: str
+    sample_size: int
+    stability: str  # strong, medium, weak
+    outliers_trimmed: bool
+    std_score_overall: float
+    max_influence_weight: float
+    is_reliable: bool
+    funding_confidence: str
+
+
+class SegmentStabilityResponse(BaseModel):
+    """Segment stability report response."""
+    total_segments: int
+    strong_segments: int
+    medium_segments: int
+    weak_segments: int
+    segments: List[SegmentStabilityItemResponse]
+
+
+class InsightsReliabilityResponse(BaseModel):
+    """Insights reliability metrics response."""
+    total_segments: int
+    reliable_segments: int
+    weak_segments: int
+    reliability_score: float
+    coverage_by_stability: Dict[str, int]
+    avg_sample_size: float
+    segments_with_outliers: int
+
+
+@router.get(
+    "/segment-stability",
+    response_model=SegmentStabilityResponse,
+    summary="Get segment stability report",
+    description="Returns stability analysis for all segments (G17.1-D).",
+)
+async def get_segment_stability() -> SegmentStabilityResponse:
+    """Get segment stability report."""
+    try:
+        from services.feedback_analyzer import get_segment_stability_report
+
+        stability_report = get_segment_stability_report()
+
+        # Count by stability level
+        strong_count = sum(1 for s in stability_report if s["stability"] == "strong")
+        medium_count = sum(1 for s in stability_report if s["stability"] == "medium")
+        weak_count = sum(1 for s in stability_report if s["stability"] == "weak")
+
+        return SegmentStabilityResponse(
+            total_segments=len(stability_report),
+            strong_segments=strong_count,
+            medium_segments=medium_count,
+            weak_segments=weak_count,
+            segments=[
+                SegmentStabilityItemResponse(
+                    segment_key=SegmentKeyResponse(
+                        size_label=s["segment_key"][0],
+                        branch_group=s["segment_key"][1],
+                        ai_act_risk=s["segment_key"][2],
+                        funding_scope=s["segment_key"][3],
+                    ),
+                    segment_label=s["segment_label"],
+                    sample_size=s["sample_size"],
+                    stability=s["stability"],
+                    outliers_trimmed=s["outliers_trimmed"],
+                    std_score_overall=s["std_score_overall"],
+                    max_influence_weight=s["max_influence_weight"],
+                    is_reliable=s["is_reliable"],
+                    funding_confidence=s["funding_confidence"],
+                )
+                for s in stability_report
+            ],
+        )
+
+    except Exception as e:
+        log.error(f"Failed to get segment stability: {e}")
+        raise HTTPException(status_code=500, detail=f"Analysis failed: {str(e)}")
+
+
+@router.get(
+    "/insights-reliability",
+    response_model=InsightsReliabilityResponse,
+    summary="Get insights reliability metrics",
+    description="Returns overall reliability metrics for insights engine (G17.1-D).",
+)
+async def get_insights_reliability() -> InsightsReliabilityResponse:
+    """Get insights reliability metrics."""
+    try:
+        from services.feedback_analyzer import get_insights_reliability_metrics
+
+        metrics = get_insights_reliability_metrics()
+
+        return InsightsReliabilityResponse(
+            total_segments=metrics["total_segments"],
+            reliable_segments=metrics["reliable_segments"],
+            weak_segments=metrics["weak_segments"],
+            reliability_score=metrics["reliability_score"],
+            coverage_by_stability=metrics["coverage_by_stability"],
+            avg_sample_size=metrics["avg_sample_size"],
+            segments_with_outliers=metrics["segments_with_outliers"],
+        )
+
+    except Exception as e:
+        log.error(f"Failed to get insights reliability: {e}")
+        raise HTTPException(status_code=500, detail=f"Analysis failed: {str(e)}")

--- a/services/feedback_analyzer.py
+++ b/services/feedback_analyzer.py
@@ -1064,8 +1064,8 @@ def _calculate_std(values: List[float]) -> float:
     if len(values) < 2:
         return 0.0
     mean = sum(values) / len(values)
-    variance = sum((x - mean) ** 2 for x in values) / (len(values) - 1)
-    return variance ** 0.5
+    variance: float = sum((x - mean) ** 2 for x in values) / (len(values) - 1)
+    return float(variance ** 0.5)
 
 
 def _winsorize_values(values: List[float], std_threshold: float = 2.5) -> Tuple[List[float], bool]:
@@ -1224,9 +1224,9 @@ def get_segment_stability_report() -> List[Dict[str, Any]]:
         })
 
     # Sort by stability (weak first, then by sample size)
-    stability_order = {"weak": 0, "medium": 1, "strong": 2}
+    stability_order: Dict[str, int] = {"weak": 0, "medium": 1, "strong": 2}
     stability_report.sort(
-        key=lambda x: (stability_order.get(x["stability"], 0), -x["sample_size"])
+        key=lambda x: (stability_order.get(str(x["stability"]), 0), -int(x["sample_size"]))
     )
 
     return stability_report

--- a/services/feedback_analyzer.py
+++ b/services/feedback_analyzer.py
@@ -536,6 +536,12 @@ def run_full_analysis(
 INSIGHTS_MIN_REPORTS_PER_SEGMENT = int(os.environ.get("INSIGHTS_MIN_REPORTS_PER_SEGMENT", "10"))
 INSIGHTS_REFRESH_INTERVAL_MIN = int(os.environ.get("INSIGHTS_REFRESH_INTERVAL_MIN", "30"))
 
+# G17.1-A: Calibration Configuration
+INSIGHTS_SEGMENT_OUTLIER_STD = float(os.environ.get("INSIGHTS_SEGMENT_OUTLIER_STD", "2.5"))
+INSIGHTS_SEGMENT_SAMPLE_WARNING = int(os.environ.get("INSIGHTS_SEGMENT_SAMPLE_WARNING", "5"))
+INSIGHTS_MIN_STD_CONFIDENCE = float(os.environ.get("INSIGHTS_MIN_STD_CONFIDENCE", "0.15"))
+INSIGHTS_CONFIDENCE_LEVELS_ENABLED = os.environ.get("INSIGHTS_CONFIDENCE_LEVELS_ENABLED", "1") == "1"
+
 # Segment snapshot cache
 _segment_snapshot: Optional[Dict[str, "SegmentStats"]] = None
 _segment_snapshot_timestamp: Optional[datetime] = None
@@ -597,6 +603,14 @@ class SegmentStats:
     funding_success_rate: float = 0.0
     top_funding_programs: List[Tuple[str, int]] = field(default_factory=list)
 
+    # G17.1-A: Stability & Calibration fields
+    segment_stability: str = "strong"  # strong, medium, weak
+    sample_size: int = 0
+    outliers_trimmed: bool = False
+    std_score_overall: float = 0.0  # Standard deviation for confidence
+    std_roi: float = 0.0
+    max_influence_weight: float = 0.0  # Highest single report influence (0-1)
+
     def to_dict(self) -> Dict[str, Any]:
         """Convert to dictionary."""
         return {
@@ -621,6 +635,12 @@ class SegmentStats:
             "top_warning_types": self.top_warning_types[:5],
             "funding_success_rate": round(self.funding_success_rate, 2),
             "top_funding_programs": self.top_funding_programs[:5],
+            # G17.1-A: Stability fields
+            "segment_stability": self.segment_stability,
+            "sample_size": self.sample_size,
+            "outliers_trimmed": self.outliers_trimmed,
+            "std_score_overall": round(self.std_score_overall, 2),
+            "max_influence_weight": round(self.max_influence_weight, 3),
         }
 
 
@@ -753,8 +773,11 @@ def build_segments_snapshot(days: int = 90, force: bool = False) -> Dict[str, Se
     for key, data in segments.items():
         report_count = len(data["reports"])
 
-        # Skip segments with too few reports
-        if report_count < INSIGHTS_MIN_REPORTS_PER_SEGMENT:
+        # G17.1-A: Apply calibration (winsorizing, stability)
+        calibrated = _calibrate_segment_data(data, report_count)
+
+        # Skip segments with too few reports (but still allow weak segments for tracking)
+        if report_count < INSIGHTS_SEGMENT_SAMPLE_WARNING:
             continue
 
         stats = SegmentStats(
@@ -764,8 +787,8 @@ def build_segments_snapshot(days: int = 90, force: bool = False) -> Dict[str, Se
             avg_score_security=_safe_avg(data["scores_sec"]),
             avg_score_value=_safe_avg(data["scores_val"]),
             avg_score_enablement=_safe_avg(data["scores_ena"]),
-            avg_score_overall=_safe_avg(data["scores_overall"]),
-            avg_roi_percent=_safe_avg(data["roi_values"]),
+            avg_score_overall=_safe_avg(calibrated["scores_overall"]),  # Use calibrated
+            avg_roi_percent=_safe_avg(calibrated["roi_values"]),  # Use calibrated
             avg_payback_months=_safe_avg(data["payback_values"]),
             avg_warnings=_safe_avg(data["warnings_count"]),
             avg_fallback_rate=_safe_avg(data["fallback_rates"]),
@@ -782,6 +805,13 @@ def build_segments_snapshot(days: int = 90, force: bool = False) -> Dict[str, Se
                 key=lambda x: x[1],
                 reverse=True,
             )[:5],
+            # G17.1-A: Stability fields
+            segment_stability=calibrated["segment_stability"],
+            sample_size=calibrated["sample_size"],
+            outliers_trimmed=calibrated["outliers_trimmed"],
+            std_score_overall=calibrated["std_score_overall"],
+            std_roi=calibrated["std_roi"],
+            max_influence_weight=calibrated["max_influence_weight"],
         )
 
         # Use string key for caching
@@ -802,6 +832,54 @@ def _safe_avg(values: List[float]) -> float:
     if not values:
         return 0.0
     return sum(values) / len(values)
+
+
+def _calibrate_segment_data(data: Dict[str, Any], report_count: int) -> Dict[str, Any]:
+    """
+    Apply G17.1-A calibration to segment data.
+
+    Args:
+        data: Raw segment aggregation data
+        report_count: Number of reports
+
+    Returns:
+        Calibrated data with stability metrics
+    """
+    # Apply winsorizing to score and ROI lists
+    scores_overall = data.get("scores_overall", [])
+    roi_values = data.get("roi_values", [])
+
+    scores_winsorized, scores_trimmed = _winsorize_values(
+        scores_overall, INSIGHTS_SEGMENT_OUTLIER_STD
+    )
+    roi_winsorized, roi_trimmed = _winsorize_values(
+        roi_values, INSIGHTS_SEGMENT_OUTLIER_STD
+    )
+
+    # Calculate standard deviations
+    std_score = _calculate_std(scores_winsorized)
+    std_roi = _calculate_std(roi_winsorized)
+
+    # Calculate max influence weight
+    max_influence = 1.0 / report_count if report_count > 0 else 1.0
+
+    # Determine stability
+    stability = _determine_segment_stability(
+        sample_size=report_count,
+        std_overall=std_score,
+        max_influence=max_influence,
+    )
+
+    return {
+        "scores_overall": scores_winsorized,
+        "roi_values": roi_winsorized,
+        "outliers_trimmed": scores_trimmed or roi_trimmed,
+        "std_score_overall": std_score,
+        "std_roi": std_roi,
+        "max_influence_weight": max_influence,
+        "segment_stability": stability,
+        "sample_size": report_count,
+    }
 
 
 def get_segment_for_report(
@@ -975,4 +1053,271 @@ def get_top_segments(limit: int = 5) -> List[Dict[str, Any]]:
     )[:limit]
 
     return [seg.to_dict() for seg in sorted_segments]
+
+
+# =============================================================================
+# G17.1-A: SEGMENT CALIBRATION & STABILITY
+# =============================================================================
+
+def _calculate_std(values: List[float]) -> float:
+    """Calculate standard deviation safely."""
+    if len(values) < 2:
+        return 0.0
+    mean = sum(values) / len(values)
+    variance = sum((x - mean) ** 2 for x in values) / (len(values) - 1)
+    return variance ** 0.5
+
+
+def _winsorize_values(values: List[float], std_threshold: float = 2.5) -> Tuple[List[float], bool]:
+    """
+    Apply winsorizing to dampen outliers beyond std_threshold standard deviations.
+
+    Args:
+        values: List of values to winsorize
+        std_threshold: Number of SDs beyond which to clip
+
+    Returns:
+        Tuple of (winsorized values, whether any outliers were trimmed)
+    """
+    if len(values) < 3:
+        return values, False
+
+    mean = sum(values) / len(values)
+    std = _calculate_std(values)
+
+    if std == 0:
+        return values, False
+
+    lower_bound = mean - (std_threshold * std)
+    upper_bound = mean + (std_threshold * std)
+
+    winsorized = []
+    outliers_found = False
+
+    for v in values:
+        if v < lower_bound:
+            winsorized.append(lower_bound)
+            outliers_found = True
+        elif v > upper_bound:
+            winsorized.append(upper_bound)
+            outliers_found = True
+        else:
+            winsorized.append(v)
+
+    return winsorized, outliers_found
+
+
+def _determine_segment_stability(
+    sample_size: int,
+    std_overall: float,
+    max_influence: float,
+) -> str:
+    """
+    Determine segment stability level.
+
+    Args:
+        sample_size: Number of reports in segment
+        std_overall: Standard deviation of overall scores
+        max_influence: Maximum influence weight of single report
+
+    Returns:
+        Stability level: "strong", "medium", or "weak"
+    """
+    # Weak if sample too small
+    if sample_size < INSIGHTS_SEGMENT_SAMPLE_WARNING:
+        return "weak"
+
+    # Weak if below minimum threshold
+    if sample_size < INSIGHTS_MIN_REPORTS_PER_SEGMENT:
+        return "weak"
+
+    # Weak if single report has too much influence (>50%)
+    if max_influence > 0.5:
+        return "weak"
+
+    # Medium if std is high relative to confidence threshold
+    if std_overall > INSIGHTS_MIN_STD_CONFIDENCE * 100:  # Scale for 0-100 scores
+        return "medium"
+
+    # Medium if sample is borderline
+    if sample_size < INSIGHTS_MIN_REPORTS_PER_SEGMENT * 1.5:
+        return "medium"
+
+    return "strong"
+
+
+def calibrate_segment_minimums(
+    segment_data: Dict[str, Any],
+    report_count: int,
+) -> Dict[str, Any]:
+    """
+    Calibrate segment data by applying outlier trimming and stability assessment.
+
+    Args:
+        segment_data: Raw segment aggregation data
+        report_count: Number of reports in segment
+
+    Returns:
+        Calibrated data with stability metrics
+    """
+    calibrated = dict(segment_data)
+
+    # Apply winsorizing to score lists
+    scores_overall = segment_data.get("scores_overall", [])
+    roi_values = segment_data.get("roi_values", [])
+
+    scores_winsorized, scores_trimmed = _winsorize_values(
+        scores_overall, INSIGHTS_SEGMENT_OUTLIER_STD
+    )
+    roi_winsorized, roi_trimmed = _winsorize_values(
+        roi_values, INSIGHTS_SEGMENT_OUTLIER_STD
+    )
+
+    calibrated["scores_overall"] = scores_winsorized
+    calibrated["roi_values"] = roi_winsorized
+    calibrated["outliers_trimmed"] = scores_trimmed or roi_trimmed
+
+    # Calculate standard deviations
+    calibrated["std_score_overall"] = _calculate_std(scores_winsorized)
+    calibrated["std_roi"] = _calculate_std(roi_winsorized)
+
+    # Calculate max influence weight
+    if report_count > 0:
+        calibrated["max_influence_weight"] = 1.0 / report_count
+    else:
+        calibrated["max_influence_weight"] = 1.0
+
+    # Determine stability
+    calibrated["segment_stability"] = _determine_segment_stability(
+        sample_size=report_count,
+        std_overall=calibrated["std_score_overall"],
+        max_influence=calibrated["max_influence_weight"],
+    )
+
+    calibrated["sample_size"] = report_count
+
+    return calibrated
+
+
+def get_segment_stability_report() -> List[Dict[str, Any]]:
+    """
+    Get stability report for all segments.
+
+    Returns:
+        List of segment stability information
+    """
+    snapshot = build_segments_snapshot()
+
+    stability_report = []
+
+    for key_str, stats in snapshot.items():
+        stability_report.append({
+            "segment_key": stats.segment_key,
+            "segment_label": _format_segment_label(stats.segment_key),
+            "sample_size": stats.sample_size,
+            "stability": stats.segment_stability,
+            "outliers_trimmed": stats.outliers_trimmed,
+            "std_score_overall": stats.std_score_overall,
+            "max_influence_weight": stats.max_influence_weight,
+            "is_reliable": stats.segment_stability in ("strong", "medium"),
+            "funding_confidence": _calculate_funding_confidence(stats),
+        })
+
+    # Sort by stability (weak first, then by sample size)
+    stability_order = {"weak": 0, "medium": 1, "strong": 2}
+    stability_report.sort(
+        key=lambda x: (stability_order.get(x["stability"], 0), -x["sample_size"])
+    )
+
+    return stability_report
+
+
+def _calculate_funding_confidence(stats: SegmentStats) -> str:
+    """Calculate funding confidence level for a segment."""
+    if not stats.top_funding_programs:
+        return "none"
+
+    # Get highest program count
+    max_count = max(count for _, count in stats.top_funding_programs) if stats.top_funding_programs else 0
+
+    if max_count < 3:
+        return "low"
+    elif max_count < 7:
+        return "medium"
+    else:
+        return "high"
+
+
+def is_segment_reliable(segment: Optional[SegmentStats]) -> bool:
+    """
+    Check if a segment is reliable enough for insights.
+
+    Args:
+        segment: Segment stats object
+
+    Returns:
+        True if segment is reliable for generating insights
+    """
+    if segment is None:
+        return False
+
+    # Must have minimum sample size
+    if segment.sample_size < INSIGHTS_MIN_REPORTS_PER_SEGMENT:
+        return False
+
+    # Must not be weak stability
+    if segment.segment_stability == "weak":
+        return False
+
+    # Single report shouldn't have >50% influence
+    if segment.max_influence_weight > 0.5:
+        return False
+
+    return True
+
+
+def get_insights_reliability_metrics() -> Dict[str, Any]:
+    """
+    Get overall insights reliability metrics.
+
+    Returns:
+        Dictionary with reliability metrics
+    """
+    snapshot = build_segments_snapshot()
+
+    if not snapshot:
+        return {
+            "total_segments": 0,
+            "reliable_segments": 0,
+            "weak_segments": 0,
+            "reliability_score": 0.0,
+            "coverage_by_stability": {"strong": 0, "medium": 0, "weak": 0},
+            "avg_sample_size": 0.0,
+            "segments_with_outliers": 0,
+        }
+
+    stability_counts = {"strong": 0, "medium": 0, "weak": 0}
+    total_sample = 0
+    outlier_count = 0
+
+    for stats in snapshot.values():
+        stability_counts[stats.segment_stability] = (
+            stability_counts.get(stats.segment_stability, 0) + 1
+        )
+        total_sample += stats.sample_size
+        if stats.outliers_trimmed:
+            outlier_count += 1
+
+    total_segments = len(snapshot)
+    reliable = stability_counts["strong"] + stability_counts["medium"]
+
+    return {
+        "total_segments": total_segments,
+        "reliable_segments": reliable,
+        "weak_segments": stability_counts["weak"],
+        "reliability_score": round(reliable / total_segments * 100, 1) if total_segments > 0 else 0.0,
+        "coverage_by_stability": stability_counts,
+        "avg_sample_size": round(total_sample / total_segments, 1) if total_segments > 0 else 0.0,
+        "segments_with_outliers": outlier_count,
+    }
 

--- a/services/feedback_analyzer.py
+++ b/services/feedback_analyzer.py
@@ -281,7 +281,7 @@ def _extract_leaked_term(message: str) -> Optional[str]:
     if match:
         return match.group(1).lower()
 
-    return None
+    return None  # type: ignore[unreachable]  # mypy false positive: re.search can return None
 
 
 def identify_research_degradation(
@@ -1226,7 +1226,10 @@ def get_segment_stability_report() -> List[Dict[str, Any]]:
     # Sort by stability (weak first, then by sample size)
     stability_order: Dict[str, int] = {"weak": 0, "medium": 1, "strong": 2}
     stability_report.sort(
-        key=lambda x: (stability_order.get(str(x["stability"]), 0), -int(x["sample_size"]))
+        key=lambda x: (
+            stability_order.get(str(x["stability"]), 0),
+            -int(str(x["sample_size"]))
+        )
     )
 
     return stability_report

--- a/services/feedback_analyzer.py
+++ b/services/feedback_analyzer.py
@@ -281,7 +281,7 @@ def _extract_leaked_term(message: str) -> Optional[str]:
     if match:
         return match.group(1).lower()
 
-    return None  # type: ignore[unreachable]  # mypy false positive: re.search can return None
+    return None
 
 
 def identify_research_degradation(

--- a/services/funding_recommender.py
+++ b/services/funding_recommender.py
@@ -545,6 +545,10 @@ def get_recommendations_for_report(
 FUNDING_INSIGHTS_ENABLED = os.getenv("FUNDING_INSIGHTS_ENABLED", "1").lower() in ("1", "true", "yes")
 FUNDING_MIN_CASES_PER_PROGRAM = int(os.getenv("FUNDING_MIN_CASES_PER_PROGRAM", "5"))
 
+# G17.1-C: Funding Insight Stability Configuration
+FUNDING_REQUIRE_STABLE_SEGMENT = os.getenv("FUNDING_REQUIRE_STABLE_SEGMENT", "1") == "1"
+FUNDING_SHOW_CONFIDENCE_INDICATOR = os.getenv("FUNDING_SHOW_CONFIDENCE_INDICATOR", "1") == "1"
+
 
 @dataclass
 class FundingInsight:
@@ -556,6 +560,8 @@ class FundingInsight:
     avg_relevance_score: float
     insight_text: str
     severity: str = "info"  # info, highlight, opportunity
+    # G17.1-C: Confidence level
+    confidence_level: str = "medium"  # high, medium, low
 
 
 def enrich_funding_recommendations_with_feedback(
@@ -584,7 +590,7 @@ def enrich_funding_recommendations_with_feedback(
     if not FUNDING_INSIGHTS_ENABLED:
         return {"html": "", "insights": []}
 
-    from services.feedback_analyzer import get_segment_for_report, SegmentStats
+    from services.feedback_analyzer import get_segment_for_report, is_segment_reliable, SegmentStats
 
     segment = get_segment_for_report(report_sections, profile)
 
@@ -593,6 +599,23 @@ def enrich_funding_recommendations_with_feedback(
             "html": "",
             "insights": [],
             "message": "Nicht genügend Segmentdaten für Funding-Insights",
+            "is_reliable": False,
+            "segment_stability": "unknown",
+        }
+
+    # G17.1-C: Check segment reliability
+    segment_is_reliable = is_segment_reliable(segment)
+    segment_stability = getattr(segment, "segment_stability", "unknown")
+
+    # If reliability filter is enabled and segment is unreliable
+    if FUNDING_REQUIRE_STABLE_SEGMENT and not segment_is_reliable:
+        log.info(f"Segment unstable (stability={segment_stability}) for funding insights")
+        return {
+            "html": "",
+            "insights": [],
+            "message": "Segment-Daten noch nicht stabil genug für Funding-Insights",
+            "is_reliable": False,
+            "segment_stability": segment_stability,
         }
 
     insights = _build_funding_insights(segment, recommendations, lang)
@@ -602,6 +625,8 @@ def enrich_funding_recommendations_with_feedback(
             "html": "",
             "insights": [],
             "message": "Keine Funding-Insights für dieses Segment verfügbar",
+            "is_reliable": segment_is_reliable,
+            "segment_stability": segment_stability,
         }
 
     html = _generate_funding_insights_html(insights, segment, lang)
@@ -616,9 +641,12 @@ def enrich_funding_recommendations_with_feedback(
                 "similar_profiles_count": i.similar_profiles_count,
                 "insight_text": i.insight_text,
                 "severity": i.severity,
+                "confidence_level": i.confidence_level,
             }
             for i in insights
         ],
+        "is_reliable": segment_is_reliable,
+        "segment_stability": segment_stability,
     }
 
 
@@ -637,6 +665,9 @@ def _build_funding_insights(
     if not top_programs or report_count < FUNDING_MIN_CASES_PER_PROGRAM:
         return insights
 
+    # G17.1-C: Get segment stability for confidence calculation
+    segment_stability = getattr(segment, "segment_stability", "medium")
+
     for program_id, count in top_programs[:3]:
         if count < FUNDING_MIN_CASES_PER_PROGRAM:
             continue
@@ -650,6 +681,13 @@ def _build_funding_insights(
             severity = "opportunity"
         else:
             severity = "info"
+
+        # G17.1-C: Calculate confidence level based on sample size and stability
+        confidence_level = _calculate_insight_confidence(
+            program_count=count,
+            total_count=report_count,
+            segment_stability=segment_stability,
+        )
 
         # Find program name from recommendations or database
         program_name = _get_program_name(program_id)
@@ -674,9 +712,47 @@ def _build_funding_insights(
             avg_relevance_score=0.0,  # Would need more data
             insight_text=insight_text,
             severity=severity,
+            confidence_level=confidence_level,
         ))
 
     return insights
+
+
+def _calculate_insight_confidence(
+    program_count: int,
+    total_count: int,
+    segment_stability: str,
+) -> str:
+    """
+    Calculate confidence level for a funding insight.
+
+    G17.1-C: Based on sample size, segment stability, and program frequency.
+
+    Args:
+        program_count: Number of reports with this program
+        total_count: Total reports in segment
+        segment_stability: Segment stability level
+
+    Returns:
+        Confidence level: "high", "medium", or "low"
+    """
+    # Base confidence from segment stability
+    if segment_stability == "weak":
+        return "low"
+
+    # High confidence requires: strong stability + sufficient sample
+    if segment_stability == "strong" and program_count >= 10 and total_count >= 20:
+        return "high"
+
+    # Medium stability with good sample
+    if program_count >= 7 and total_count >= 15:
+        return "high" if segment_stability == "strong" else "medium"
+
+    # Minimum viable sample
+    if program_count >= FUNDING_MIN_CASES_PER_PROGRAM:
+        return "medium" if segment_stability in ("strong", "medium") else "low"
+
+    return "low"
 
 
 def _get_program_name(program_id: str) -> str:
@@ -699,19 +775,34 @@ def _generate_funding_insights_html(
     if not insights:
         return ""
 
+    # G17.1-C: Get segment stability for header indicator
+    segment_stability = getattr(segment, "segment_stability", "medium")
+
     if lang == "de":
         title = "Real-World Funding-Insights"
         subtitle = f"Basierend auf {segment.report_count} vergleichbaren Unternehmen"
         disclaimer = "Diese Insights basieren auf aggregierten, anonymisierten Daten."
+        confidence_labels = {"high": "Hohe Konfidenz", "medium": "Mittlere Konfidenz", "low": "Begrenzte Datenbasis"}
     else:
         title = "Real-World Funding Insights"
         subtitle = f"Based on {segment.report_count} similar companies"
         disclaimer = "These insights are based on aggregated, anonymized data."
+        confidence_labels = {"high": "High confidence", "medium": "Medium confidence", "low": "Limited data"}
+
+    # G17.1-C: Add stability indicator to header if enabled
+    stability_badge = ""
+    if FUNDING_SHOW_CONFIDENCE_INDICATOR and segment_stability != "strong":
+        badge_colors = {"medium": "#ffc107", "weak": "#dc3545"}
+        badge_color = badge_colors.get(segment_stability, "#6c757d")
+        stability_text = "Eingeschränkt" if lang == "de" else "Limited"
+        if segment_stability == "medium":
+            stability_text = "Beta" if lang == "de" else "Beta"
+        stability_badge = f'<span style="font-size:9px;padding:2px 6px;background:{badge_color};color:#fff;border-radius:4px;margin-left:8px;">{stability_text}</span>'
 
     html = f"""
     <div class="funding-insights" style="margin-top:16px;padding:16px;background:#f8f9fa;border-radius:8px;border:1px solid #dee2e6;">
         <h4 style="margin:0 0 8px 0;font-size:14px;color:#495057;display:flex;align-items:center;gap:8px;">
-            <span>📊</span> {title}
+            <span>📊</span> {title}{stability_badge}
         </h4>
         <p style="margin:0 0 12px 0;font-size:11px;color:#6c757d;">{subtitle}</p>
         <div style="display:flex;flex-direction:column;gap:8px;">
@@ -732,10 +823,19 @@ def _generate_funding_insights_html(
             border_color = "#6c757d"
             icon = "ℹ️"
 
+        # G17.1-C: Add confidence badge if enabled
+        confidence_badge = ""
+        if FUNDING_SHOW_CONFIDENCE_INDICATOR:
+            conf_level = insight.confidence_level
+            conf_colors = {"high": "#28a745", "medium": "#ffc107", "low": "#6c757d"}
+            conf_color = conf_colors.get(conf_level, "#6c757d")
+            conf_text = confidence_labels.get(conf_level, conf_level)
+            confidence_badge = f'<span style="font-size:9px;padding:1px 4px;background:{conf_color};color:#fff;border-radius:3px;margin-left:6px;">{conf_text}</span>'
+
         html += f"""
             <div style="background:{bg_color};padding:10px;border-radius:4px;border-left:3px solid {border_color};">
                 <div style="font-size:12px;color:#212529;">
-                    {icon} <strong>{insight.program_name}</strong>
+                    {icon} <strong>{insight.program_name}</strong>{confidence_badge}
                 </div>
                 <p style="margin:4px 0 0 0;font-size:11px;color:#495057;">
                     {insight.insight_text}

--- a/services/insights_engine.py
+++ b/services/insights_engine.py
@@ -24,6 +24,10 @@ log = logging.getLogger(__name__)
 INSIGHTS_ENGINE_ENABLED = os.environ.get("INSIGHTS_ENGINE_ENABLED", "1") == "1"
 INSIGHTS_TOP_CARDS_PER_REPORT = int(os.environ.get("INSIGHTS_TOP_CARDS_PER_REPORT", "5"))
 
+# G17.1-B: Reliability Filter Configuration
+INSIGHTS_REQUIRE_RELIABLE_SEGMENT = os.environ.get("INSIGHTS_REQUIRE_RELIABLE_SEGMENT", "1") == "1"
+INSIGHTS_FALLBACK_TO_GENERIC = os.environ.get("INSIGHTS_FALLBACK_TO_GENERIC", "1") == "1"
+
 
 # =============================================================================
 # DATA STRUCTURES
@@ -56,6 +60,11 @@ class InsightResult:
     cards_html: str = ""
     segment_label: str = ""
     has_sufficient_data: bool = False
+    # G17.1-B: Reliability metadata
+    is_reliable: bool = False
+    is_generic_fallback: bool = False
+    segment_stability: str = "unknown"  # strong, medium, weak, unknown
+    reliability_note: str = ""
 
     def to_dict(self) -> Dict[str, Any]:
         """Convert to dictionary."""
@@ -65,6 +74,11 @@ class InsightResult:
             "cards_html": self.cards_html,
             "segment_label": self.segment_label,
             "has_sufficient_data": self.has_sufficient_data,
+            # G17.1-B fields
+            "is_reliable": self.is_reliable,
+            "is_generic_fallback": self.is_generic_fallback,
+            "segment_stability": self.segment_stability,
+            "reliability_note": self.reliability_note,
         }
 
 
@@ -93,6 +107,7 @@ def build_report_insights(
     from services.feedback_analyzer import (
         get_segment_for_report,
         get_segment_comparison,
+        is_segment_reliable,
         SegmentStats,
     )
 
@@ -105,9 +120,33 @@ def build_report_insights(
         return InsightResult(
             summary_html="<p>Für Ihr Segment liegen noch nicht genügend Vergleichsdaten vor.</p>",
             has_sufficient_data=False,
+            segment_stability="unknown",
         )
 
-    # Build cards
+    # G17.1-B: Check segment reliability
+    segment_is_reliable = is_segment_reliable(segment_stats)
+    segment_stability = getattr(segment_stats, "segment_stability", "unknown")
+
+    # If reliability filter is enabled and segment is unreliable, use fallback
+    if INSIGHTS_REQUIRE_RELIABLE_SEGMENT and not segment_is_reliable:
+        log.info(f"Segment unstable (stability={segment_stability}), using fallback cards")
+
+        if INSIGHTS_FALLBACK_TO_GENERIC:
+            # Build generic fallback cards based on size/branch
+            return _build_generic_fallback_insights(
+                report_sections, profile, segment_stats, segment_stability
+            )
+        else:
+            # Return empty result with reliability note
+            return InsightResult(
+                summary_html="<p>Die Datenbasis für Ihr Segment ist noch nicht ausreichend für detaillierte Insights.</p>",
+                has_sufficient_data=False,
+                is_reliable=False,
+                segment_stability=segment_stability,
+                reliability_note="Segment hat zu wenige Datenpunkte oder zu hohe Varianz",
+            )
+
+    # Build cards (reliable segment path)
     cards: List[InsightCard] = []
 
     # 1. Position card
@@ -143,17 +182,246 @@ def build_report_insights(
     summary_html = _build_summary_html(cards, segment_label)
     cards_html = _build_cards_html(cards)
 
+    # G17.1-B: Add reliability indicator for medium stability
+    reliability_note = ""
+    if segment_stability == "medium":
+        reliability_note = "Segment-Daten basieren auf begrenzter Stichprobe"
+        # Add subtle note to summary
+        summary_html = _add_reliability_note_to_summary(summary_html, segment_stability)
+
     result = InsightResult(
         cards=cards,
         summary_html=summary_html,
         cards_html=cards_html,
         segment_label=segment_label,
         has_sufficient_data=True,
+        is_reliable=segment_is_reliable,
+        is_generic_fallback=False,
+        segment_stability=segment_stability,
+        reliability_note=reliability_note,
     )
 
-    log.info(f"Generated {len(cards)} insight cards for segment: {segment_label}")
+    log.info(f"Generated {len(cards)} insight cards for segment: {segment_label} (stability={segment_stability})")
 
     return result
+
+
+def _build_generic_fallback_insights(
+    report_sections: Dict[str, Any],
+    profile: Optional[Dict[str, Any]],
+    segment_stats: Any,
+    segment_stability: str,
+) -> InsightResult:
+    """
+    Build generic fallback insight cards when segment is unreliable.
+
+    G17.1-B: Provides general insights based on size + branch without
+    relying on potentially skewed segment statistics.
+
+    Args:
+        report_sections: Report sections dictionary
+        profile: Profile data
+        segment_stats: Segment stats (may be unreliable)
+        segment_stability: Current stability level
+
+    Returns:
+        InsightResult with generic cards
+    """
+    cards: List[InsightCard] = []
+
+    # Extract size and branch for generic insights
+    size_label = "solo"
+    branch = "other"
+
+    if profile:
+        size_label = profile.get("size_label", "solo")
+        branch = profile.get("branch", "") or "other"
+
+    # 1. General size-based insight card
+    size_card = _build_generic_size_card(size_label)
+    if size_card:
+        cards.append(size_card)
+
+    # 2. General maturity insight (if we can determine from report)
+    maturity_card = _build_generic_maturity_card(report_sections)
+    if maturity_card:
+        cards.append(maturity_card)
+
+    # 3. General AI readiness tip
+    ai_readiness_card = _build_generic_ai_readiness_card(report_sections, size_label)
+    if ai_readiness_card:
+        cards.append(ai_readiness_card)
+
+    # Sort and limit
+    cards.sort(key=lambda c: c.priority)
+    cards = cards[:INSIGHTS_TOP_CARDS_PER_REPORT]
+
+    # Build HTML outputs
+    segment_label = f"{_size_label_de(size_label)} · Allgemein"
+    summary_html = _build_generic_summary_html(cards, segment_label)
+    cards_html = _build_cards_html(cards)
+
+    return InsightResult(
+        cards=cards,
+        summary_html=summary_html,
+        cards_html=cards_html,
+        segment_label=segment_label,
+        has_sufficient_data=True,
+        is_reliable=False,
+        is_generic_fallback=True,
+        segment_stability=segment_stability,
+        reliability_note="Allgemeine Insights - spezifische Segment-Daten noch nicht ausreichend",
+    )
+
+
+def _build_generic_size_card(size_label: str) -> Optional[InsightCard]:
+    """Build generic insight card based on company size."""
+    size_insights = {
+        "solo": {
+            "title": "Typische Herausforderungen für Solo-Unternehmer",
+            "body": """<p>📊 Als Solo-Unternehmer stehen Sie vor einzigartigen Herausforderungen bei der KI-Einführung:</p>
+            <ul style="margin:8px 0;padding-left:20px;">
+                <li>Begrenzte Zeit für Experimentieren mit neuen Tools</li>
+                <li>Fokus auf schnelle ROI-Realisierung</li>
+                <li>Niedrigschwellige, sofort einsetzbare Lösungen bevorzugt</li>
+            </ul>
+            <p class="insight-detail">Empfehlung: Starten Sie mit einem fokussierten Use Case.</p>""",
+        },
+        "team": {
+            "title": "KI-Potenzial für kleine Teams",
+            "body": """<p>📊 Kleine Teams (2-10 Personen) profitieren besonders von:</p>
+            <ul style="margin:8px 0;padding-left:20px;">
+                <li>Automatisierung wiederkehrender Aufgaben</li>
+                <li>Kollaborativen KI-Tools für Wissensaustausch</li>
+                <li>Skalierbare Lösungen, die mit dem Team wachsen</li>
+            </ul>
+            <p class="insight-detail">Empfehlung: Definieren Sie gemeinsame KI-Richtlinien.</p>""",
+        },
+        "kmu": {
+            "title": "KI-Strategie für KMU",
+            "body": """<p>📊 Als KMU haben Sie die Ressourcen für strategische KI-Implementierung:</p>
+            <ul style="margin:8px 0;padding-left:20px;">
+                <li>Abteilungsübergreifende KI-Governance erforderlich</li>
+                <li>Integration mit bestehenden Systemen priorisieren</li>
+                <li>Mitarbeiter-Enablement als Erfolgsfaktor</li>
+            </ul>
+            <p class="insight-detail">Empfehlung: Etablieren Sie ein KI-Kompetenzzentrum.</p>""",
+        },
+    }
+
+    insight = size_insights.get(size_label, size_insights["team"])
+
+    return InsightCard(
+        title=insight["title"],
+        severity="info",
+        body_html=insight["body"],
+        category="general",
+        priority=1,
+    )
+
+
+def _build_generic_maturity_card(report_sections: Dict[str, Any]) -> Optional[InsightCard]:
+    """Build generic maturity insight card."""
+    overall_score = 0.0
+    try:
+        overall_score = float(report_sections.get("REIFEGRAD_GESAMT", 0))
+    except (ValueError, TypeError):
+        return None
+
+    if overall_score <= 0:
+        return None
+
+    if overall_score >= 70:
+        title = "Fortgeschrittene KI-Reife"
+        body = """<p>✅ Ihr Gesamt-Score deutet auf eine <strong>fortgeschrittene KI-Reife</strong> hin.</p>
+        <p class="insight-detail">Fokussieren Sie sich auf Optimierung und Skalierung bestehender KI-Initiativen.</p>"""
+        severity = "highlight"
+    elif overall_score >= 50:
+        title = "Solide KI-Grundlage"
+        body = """<p>📊 Sie haben eine <strong>solide Grundlage</strong> für KI-Initiativen geschaffen.</p>
+        <p class="insight-detail">Nächste Schritte: Vertiefen Sie Governance und erweitern Sie Use Cases systematisch.</p>"""
+        severity = "info"
+    else:
+        title = "KI-Einstiegsphase"
+        body = """<p>📈 Sie befinden sich in der <strong>Einstiegsphase</strong> Ihrer KI-Journey.</p>
+        <p class="insight-detail">Empfehlung: Beginnen Sie mit Quick Wins und bauen Sie schrittweise Kompetenz auf.</p>"""
+        severity = "opportunity"
+
+    return InsightCard(
+        title=title,
+        severity=severity,
+        body_html=body,
+        category="maturity",
+        priority=2,
+    )
+
+
+def _build_generic_ai_readiness_card(
+    report_sections: Dict[str, Any],
+    size_label: str,
+) -> Optional[InsightCard]:
+    """Build generic AI readiness tip card."""
+    # Check governance score if available
+    gov_score = 0.0
+    try:
+        gov_score = float(report_sections.get("REIFEGRAD_GOVERNANCE", 0))
+    except (ValueError, TypeError):
+        pass
+
+    if gov_score > 0 and gov_score < 50:
+        return InsightCard(
+            title="Governance als Schlüssel zum KI-Erfolg",
+            severity="opportunity",
+            body_html="""<p>🔐 <strong>KI-Governance</strong> ist ein häufiger Engpass bei der KI-Einführung.</p>
+            <p class="insight-detail">Definieren Sie klare Richtlinien für Datenschutz, Qualitätssicherung
+            und Verantwortlichkeiten, bevor Sie skalieren.</p>""",
+            category="governance",
+            priority=3,
+        )
+
+    return InsightCard(
+        title="Kontinuierliches Lernen",
+        severity="info",
+        body_html="""<p>📚 <strong>KI-Kompetenz</strong> entwickelt sich kontinuierlich weiter.</p>
+        <p class="insight-detail">Planen Sie regelmäßige Reviews Ihrer KI-Strategie ein,
+        um mit den technologischen Entwicklungen Schritt zu halten.</p>""",
+        category="general",
+        priority=4,
+    )
+
+
+def _size_label_de(size_label: str) -> str:
+    """Get German label for size."""
+    labels = {
+        "solo": "Solo-Unternehmer",
+        "team": "Kleines Team",
+        "kmu": "KMU",
+    }
+    return labels.get(size_label, size_label)
+
+
+def _build_generic_summary_html(cards: List[InsightCard], segment_label: str) -> str:
+    """Build summary HTML for generic fallback cards."""
+    if not cards:
+        return "<p>Allgemeine Empfehlungen für Ihre KI-Strategie.</p>"
+
+    return f"""<p>Basierend auf Ihrem Profil (<strong>{segment_label}</strong>) haben wir
+    {len(cards)} allgemeine Empfehlungen für Ihre KI-Strategie zusammengestellt.</p>
+    <p class="insight-note" style="font-size:11px;color:#6c757d;margin-top:8px;">
+    <em>Hinweis: Für detailliertere, segmentspezifische Insights werden mehr Vergleichsdaten benötigt.</em>
+    </p>"""
+
+
+def _add_reliability_note_to_summary(summary_html: str, stability: str) -> str:
+    """Add subtle reliability note to summary HTML for medium stability segments."""
+    if stability != "medium":
+        return summary_html
+
+    note = """<p class="reliability-note" style="font-size:10px;color:#6c757d;margin-top:8px;font-style:italic;">
+    * Basierend auf einer begrenzten Stichprobe. Werte können bei mehr Daten präziser werden.
+    </p>"""
+
+    return summary_html + note
 
 
 def _build_position_card(

--- a/tests/test_g17_1_segment_calibration.py
+++ b/tests/test_g17_1_segment_calibration.py
@@ -1,0 +1,661 @@
+# -*- coding: utf-8 -*-
+"""
+Sprint G17.1 Tests: Segment Calibration & Insight Reliability
+
+Tests for:
+- G17.1-A: Segment coverage calibration (outlier detection, winsorizing)
+- G17.1-B: Insight reliability filter
+- G17.1-C: Funding insight stability
+- G17.1-D: Dashboard endpoints
+- G17.1-E: Integration tests
+
+Version: 1.0.0
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Dict, List
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# =============================================================================
+# TEST G17.1-A: SEGMENT CALIBRATION
+# =============================================================================
+
+class TestG17_1A_SegmentCalibration:
+    """Tests for segment calibration functions."""
+
+    def setup_method(self) -> None:
+        """Clear feedback store before each test."""
+        from services.feedback_loop import clear_feedback_store
+        clear_feedback_store()
+        from services import feedback_analyzer
+        feedback_analyzer._segment_snapshot = None
+        feedback_analyzer._segment_snapshot_timestamp = None
+
+    def test_calculate_std_empty(self) -> None:
+        """Standard deviation of empty list should be 0."""
+        from services.feedback_analyzer import _calculate_std
+
+        assert _calculate_std([]) == 0.0
+        assert _calculate_std([50.0]) == 0.0  # Single value
+
+    def test_calculate_std_values(self) -> None:
+        """Standard deviation should be calculated correctly."""
+        from services.feedback_analyzer import _calculate_std
+
+        # Known values: [2, 4, 4, 4, 5, 5, 7, 9] has std ~= 2.138
+        values = [2.0, 4.0, 4.0, 4.0, 5.0, 5.0, 7.0, 9.0]
+        std = _calculate_std(values)
+        assert 2.0 < std < 2.3  # Approximately 2.138
+
+    def test_winsorize_values_no_outliers(self) -> None:
+        """Values within threshold should not be modified."""
+        from services.feedback_analyzer import _winsorize_values
+
+        values = [50.0, 55.0, 60.0, 65.0, 70.0]
+        winsorized, trimmed = _winsorize_values(values, std_threshold=2.5)
+
+        assert winsorized == values
+        assert trimmed is False
+
+    def test_winsorize_values_with_outliers(self) -> None:
+        """Outliers beyond threshold should be clipped."""
+        from services.feedback_analyzer import _winsorize_values
+
+        # Create data with very extreme outlier using a lower threshold
+        # Mean ~50, std ~1.5, so 1.5 std threshold would flag 53+
+        values = [50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 50.0, 100.0]  # 100 is extreme
+        winsorized, trimmed = _winsorize_values(values, std_threshold=1.5)  # Lower threshold
+
+        assert trimmed is True
+        assert winsorized[-1] < 100.0  # Outlier was clipped
+        assert len(winsorized) == len(values)
+
+    def test_winsorize_values_small_list(self) -> None:
+        """Small lists should not be modified."""
+        from services.feedback_analyzer import _winsorize_values
+
+        values = [50.0, 60.0]  # Too small for winsorizing
+        winsorized, trimmed = _winsorize_values(values, std_threshold=2.5)
+
+        assert winsorized == values
+        assert trimmed is False
+
+    def test_determine_segment_stability_weak(self) -> None:
+        """Segments with small sample size should be weak."""
+        from services.feedback_analyzer import _determine_segment_stability
+
+        stability = _determine_segment_stability(
+            sample_size=3,  # Below threshold
+            std_overall=5.0,
+            max_influence=0.33,
+        )
+        assert stability == "weak"
+
+    def test_determine_segment_stability_strong(self) -> None:
+        """Segments with good sample and low variance should be strong."""
+        from services.feedback_analyzer import _determine_segment_stability
+
+        stability = _determine_segment_stability(
+            sample_size=25,  # Good sample
+            std_overall=8.0,  # Low variance
+            max_influence=0.04,  # Low influence
+        )
+        assert stability == "strong"
+
+    def test_determine_segment_stability_medium(self) -> None:
+        """Borderline segments should be medium."""
+        from services.feedback_analyzer import _determine_segment_stability
+
+        stability = _determine_segment_stability(
+            sample_size=12,  # Just above minimum
+            std_overall=20.0,  # Higher variance
+            max_influence=0.08,
+        )
+        # Could be medium due to sample size or std
+        assert stability in ("medium", "strong")
+
+    def test_determine_segment_stability_high_influence(self) -> None:
+        """High single-report influence should result in weak."""
+        from services.feedback_analyzer import _determine_segment_stability
+
+        stability = _determine_segment_stability(
+            sample_size=2,  # Results in 50% influence
+            std_overall=5.0,
+            max_influence=0.5,
+        )
+        assert stability == "weak"
+
+    def test_calibrate_segment_data(self) -> None:
+        """Calibration should add stability metadata."""
+        from services.feedback_analyzer import _calibrate_segment_data
+
+        data = {
+            "scores_overall": [50.0, 60.0, 55.0, 58.0, 52.0, 100.0],  # 100 is outlier
+            "roi_values": [120.0, 130.0, 125.0, 128.0, 122.0],
+        }
+
+        calibrated = _calibrate_segment_data(data, report_count=6)
+
+        assert "segment_stability" in calibrated
+        assert "std_score_overall" in calibrated
+        assert "max_influence_weight" in calibrated
+        assert "outliers_trimmed" in calibrated
+        assert calibrated["sample_size"] == 6
+
+    def test_segment_stats_to_dict_includes_stability(self) -> None:
+        """SegmentStats.to_dict should include stability fields."""
+        from services.feedback_analyzer import SegmentStats
+
+        stats = SegmentStats(
+            segment_key=("solo", "consulting", "minimal", "DE"),
+            report_count=20,
+            segment_stability="strong",
+            sample_size=20,
+            outliers_trimmed=False,
+            std_score_overall=8.5,
+            max_influence_weight=0.05,
+        )
+
+        result = stats.to_dict()
+
+        assert result["segment_stability"] == "strong"
+        assert result["sample_size"] == 20
+        assert result["outliers_trimmed"] is False
+        assert result["std_score_overall"] == 8.5
+
+
+# =============================================================================
+# TEST G17.1-B: INSIGHT RELIABILITY FILTER
+# =============================================================================
+
+class TestG17_1B_InsightReliabilityFilter:
+    """Tests for insight reliability filter."""
+
+    def setup_method(self) -> None:
+        """Clear stores before each test."""
+        from services.feedback_loop import clear_feedback_store
+        clear_feedback_store()
+        from services import feedback_analyzer
+        feedback_analyzer._segment_snapshot = None
+        feedback_analyzer._segment_snapshot_timestamp = None
+
+    def test_insight_result_includes_reliability_fields(self) -> None:
+        """InsightResult should include reliability metadata."""
+        from services.insights_engine import InsightResult
+
+        result = InsightResult(
+            cards=[],
+            summary_html="<p>Test</p>",
+            has_sufficient_data=True,
+            is_reliable=True,
+            is_generic_fallback=False,
+            segment_stability="strong",
+            reliability_note="",
+        )
+
+        result_dict = result.to_dict()
+
+        assert "is_reliable" in result_dict
+        assert "is_generic_fallback" in result_dict
+        assert "segment_stability" in result_dict
+        assert result_dict["is_reliable"] is True
+
+    def test_build_report_insights_no_segment(self) -> None:
+        """Should return insufficient data when no segment found."""
+        from services.insights_engine import build_report_insights
+
+        result = build_report_insights({})
+
+        assert result.has_sufficient_data is False
+        assert result.segment_stability == "unknown"
+
+    @patch("services.feedback_analyzer.get_segment_for_report")
+    @patch("services.feedback_analyzer.get_segment_comparison")
+    @patch("services.feedback_analyzer.is_segment_reliable")
+    def test_build_report_insights_reliable_segment(
+        self,
+        mock_is_reliable: MagicMock,
+        mock_comparison: MagicMock,
+        mock_segment: MagicMock,
+    ) -> None:
+        """Reliable segment should generate specific insights."""
+        # Setup mocks with all required attributes
+        mock_segment.return_value = MagicMock(
+            segment_stability="strong",
+            avg_score_governance=70.0,
+            avg_score_security=65.0,
+            avg_score_value=60.0,
+            avg_score_enablement=55.0,
+            avg_score_overall=62.5,
+            avg_roi_percent=0.0,
+            avg_payback_months=0.0,
+            top_warning_types=[],
+        )
+        mock_comparison.return_value = {
+            "segment_found": True,
+            "segment_label": "Solo · Consulting",
+            "position": "durchschnitt",
+            "position_text": "im Durchschnitt",
+            "current_score": 65.0,
+            "segment_avg_score": 62.5,
+            "report_count": 25,
+        }
+        mock_is_reliable.return_value = True
+
+        from services.insights_engine import build_report_insights
+
+        result = build_report_insights(
+            {"REIFEGRAD_GESAMT": 65},
+            {"size_label": "solo"}
+        )
+
+        assert result.is_reliable is True
+        assert result.is_generic_fallback is False
+        assert result.segment_stability == "strong"
+
+    @patch("services.feedback_analyzer.get_segment_for_report")
+    @patch("services.feedback_analyzer.get_segment_comparison")
+    @patch("services.feedback_analyzer.is_segment_reliable")
+    def test_build_report_insights_unreliable_fallback(
+        self,
+        mock_is_reliable: MagicMock,
+        mock_comparison: MagicMock,
+        mock_segment: MagicMock,
+    ) -> None:
+        """Unreliable segment should use generic fallback."""
+        # Setup mocks
+        mock_segment.return_value = MagicMock(
+            segment_stability="weak",
+        )
+        mock_comparison.return_value = {
+            "segment_found": True,
+            "segment_label": "Solo · Other",
+        }
+        mock_is_reliable.return_value = False
+
+        from services.insights_engine import build_report_insights
+
+        result = build_report_insights(
+            {"REIFEGRAD_GESAMT": 65},
+            {"size_label": "solo"}
+        )
+
+        assert result.is_generic_fallback is True
+        assert result.is_reliable is False
+
+    def test_generic_fallback_cards_exist(self) -> None:
+        """Generic fallback should generate cards."""
+        from services.insights_engine import _build_generic_fallback_insights
+
+        mock_segment = MagicMock(segment_stability="weak")
+
+        result = _build_generic_fallback_insights(
+            report_sections={"REIFEGRAD_GESAMT": 55},
+            profile={"size_label": "team"},
+            segment_stats=mock_segment,
+            segment_stability="weak",
+        )
+
+        assert len(result.cards) > 0
+        assert result.is_generic_fallback is True
+
+    def test_generic_size_card_solo(self) -> None:
+        """Generic size card for solo should exist."""
+        from services.insights_engine import _build_generic_size_card
+
+        card = _build_generic_size_card("solo")
+
+        assert card is not None
+        assert "Solo" in card.title or "Solo" in card.body_html
+
+    def test_generic_size_card_team(self) -> None:
+        """Generic size card for team should exist."""
+        from services.insights_engine import _build_generic_size_card
+
+        card = _build_generic_size_card("team")
+
+        assert card is not None
+        assert "Team" in card.title or "Team" in card.body_html
+
+    def test_generic_maturity_card_high(self) -> None:
+        """High maturity should get highlight card."""
+        from services.insights_engine import _build_generic_maturity_card
+
+        card = _build_generic_maturity_card({"REIFEGRAD_GESAMT": 75})
+
+        assert card is not None
+        assert card.severity == "highlight"
+
+    def test_generic_maturity_card_low(self) -> None:
+        """Low maturity should get opportunity card."""
+        from services.insights_engine import _build_generic_maturity_card
+
+        card = _build_generic_maturity_card({"REIFEGRAD_GESAMT": 35})
+
+        assert card is not None
+        assert card.severity == "opportunity"
+
+
+# =============================================================================
+# TEST G17.1-C: FUNDING INSIGHT STABILITY
+# =============================================================================
+
+class TestG17_1C_FundingInsightStability:
+    """Tests for funding insight stability."""
+
+    def setup_method(self) -> None:
+        """Clear stores before each test."""
+        from services.feedback_loop import clear_feedback_store
+        clear_feedback_store()
+        from services import feedback_analyzer
+        feedback_analyzer._segment_snapshot = None
+        feedback_analyzer._segment_snapshot_timestamp = None
+
+    def test_funding_insight_has_confidence_level(self) -> None:
+        """FundingInsight should have confidence_level field."""
+        from services.funding_recommender import FundingInsight
+
+        insight = FundingInsight(
+            program_id="test",
+            program_name="Test Program",
+            success_rate=0.3,
+            similar_profiles_count=20,
+            avg_relevance_score=0.7,
+            insight_text="Test insight",
+            severity="info",
+            confidence_level="high",
+        )
+
+        assert insight.confidence_level == "high"
+
+    def test_calculate_insight_confidence_weak_segment(self) -> None:
+        """Weak segment should result in low confidence."""
+        from services.funding_recommender import _calculate_insight_confidence
+
+        confidence = _calculate_insight_confidence(
+            program_count=10,
+            total_count=20,
+            segment_stability="weak",
+        )
+
+        assert confidence == "low"
+
+    def test_calculate_insight_confidence_strong_high_sample(self) -> None:
+        """Strong segment with high sample should be high confidence."""
+        from services.funding_recommender import _calculate_insight_confidence
+
+        confidence = _calculate_insight_confidence(
+            program_count=15,
+            total_count=30,
+            segment_stability="strong",
+        )
+
+        assert confidence == "high"
+
+    def test_calculate_insight_confidence_medium_sample(self) -> None:
+        """Medium stability with moderate sample should be medium confidence."""
+        from services.funding_recommender import _calculate_insight_confidence
+
+        confidence = _calculate_insight_confidence(
+            program_count=6,
+            total_count=12,
+            segment_stability="medium",
+        )
+
+        assert confidence == "medium"
+
+    @patch("services.feedback_analyzer.get_segment_for_report")
+    @patch("services.feedback_analyzer.is_segment_reliable")
+    def test_enrich_funding_unreliable_segment(
+        self,
+        mock_is_reliable: MagicMock,
+        mock_segment: MagicMock,
+    ) -> None:
+        """Unreliable segment should return empty insights."""
+        mock_segment.return_value = MagicMock(
+            segment_stability="weak",
+        )
+        mock_is_reliable.return_value = False
+
+        from services.funding_recommender import enrich_funding_recommendations_with_feedback
+
+        result = enrich_funding_recommendations_with_feedback({})
+
+        assert result["insights"] == []
+        assert result["is_reliable"] is False
+
+    @patch("services.feedback_analyzer.get_segment_for_report")
+    @patch("services.feedback_analyzer.is_segment_reliable")
+    def test_enrich_funding_reliable_segment(
+        self,
+        mock_is_reliable: MagicMock,
+        mock_segment: MagicMock,
+    ) -> None:
+        """Reliable segment should return insights with confidence."""
+        mock_segment.return_value = MagicMock(
+            segment_stability="strong",
+            report_count=25,
+            top_funding_programs=[("go_digital", 10), ("digital_jetzt", 8)],
+        )
+        mock_is_reliable.return_value = True
+
+        from services.funding_recommender import enrich_funding_recommendations_with_feedback
+
+        result = enrich_funding_recommendations_with_feedback({})
+
+        assert result["is_reliable"] is True
+        assert result["segment_stability"] == "strong"
+        if result["insights"]:
+            assert "confidence_level" in result["insights"][0]
+
+
+# =============================================================================
+# TEST G17.1-D: DASHBOARD ENDPOINTS
+# =============================================================================
+
+# Check if fastapi is available
+try:
+    from fastapi import APIRouter
+    FASTAPI_AVAILABLE = True
+except ImportError:
+    FASTAPI_AVAILABLE = False
+
+
+@pytest.mark.skipif(not FASTAPI_AVAILABLE, reason="fastapi not installed")
+class TestG17_1D_DashboardEndpoints:
+    """Tests for dashboard endpoints."""
+
+    def setup_method(self) -> None:
+        """Clear stores before each test."""
+        from services.feedback_loop import clear_feedback_store
+        clear_feedback_store()
+        from services import feedback_analyzer
+        feedback_analyzer._segment_snapshot = None
+        feedback_analyzer._segment_snapshot_timestamp = None
+
+    def test_segment_stability_endpoint_exists(self) -> None:
+        """Segment stability endpoint should be defined."""
+        from routes.feedback_dashboard import router
+
+        routes = [r.path for r in router.routes]
+        assert any(r.endswith("/segment-stability") for r in routes)
+
+    def test_insights_reliability_endpoint_exists(self) -> None:
+        """Insights reliability endpoint should be defined."""
+        from routes.feedback_dashboard import router
+
+        routes = [r.path for r in router.routes]
+        assert any(r.endswith("/insights-reliability") for r in routes)
+
+    def test_get_segment_stability_report_function(self) -> None:
+        """get_segment_stability_report should return list."""
+        from services.feedback_analyzer import get_segment_stability_report
+
+        result = get_segment_stability_report()
+        assert isinstance(result, list)
+
+    def test_get_insights_reliability_metrics_function(self) -> None:
+        """get_insights_reliability_metrics should return dict."""
+        from services.feedback_analyzer import get_insights_reliability_metrics
+
+        result = get_insights_reliability_metrics()
+
+        assert isinstance(result, dict)
+        assert "total_segments" in result
+        assert "reliable_segments" in result
+        assert "reliability_score" in result
+
+
+# =============================================================================
+# TEST G17.1-E: END-TO-END INTEGRATION
+# =============================================================================
+
+class TestG17_1E_Integration:
+    """End-to-end integration tests."""
+
+    def setup_method(self) -> None:
+        """Clear stores before each test."""
+        from services.feedback_loop import clear_feedback_store
+        clear_feedback_store()
+        from services import feedback_analyzer
+        feedback_analyzer._segment_snapshot = None
+        feedback_analyzer._segment_snapshot_timestamp = None
+
+    def _populate_test_data(self, count: int = 20) -> None:
+        """Populate with test feedback data."""
+        from services.feedback_loop import capture_realworld_feedback
+
+        for i in range(count):
+            capture_realworld_feedback(
+                report_id=10000 + i,
+                warnings=[{"message": f"warning {i}", "section": "test"}],
+                ai_act_risk_level="minimal",
+                fallback_rate=0.1 * (i % 3),
+                funding_source="DE",
+                size_label="solo" if i % 2 == 0 else "team",
+            )
+
+    def test_full_calibration_flow(self) -> None:
+        """Test complete flow: feedback -> calibration -> insights."""
+        from services.feedback_loop import get_recent_feedback
+        from services.feedback_analyzer import (
+            build_segments_snapshot,
+            get_segment_stability_report,
+            is_segment_reliable,
+        )
+
+        # 1. Capture feedback
+        self._populate_test_data(20)
+
+        entries = get_recent_feedback(days=7)
+        assert len(entries) == 20
+
+        # 2. Build calibrated segments
+        snapshot = build_segments_snapshot(days=90, force=True)
+        assert isinstance(snapshot, dict)
+
+        # 3. Get stability report
+        stability_report = get_segment_stability_report()
+        assert isinstance(stability_report, list)
+
+        # 4. Each segment should have stability info
+        for seg in stability_report:
+            assert "stability" in seg
+            assert seg["stability"] in ("strong", "medium", "weak")
+            assert "is_reliable" in seg
+
+    def test_insights_with_calibration(self) -> None:
+        """Test insights generation respects calibration."""
+        from services.insights_engine import build_report_insights
+
+        self._populate_test_data(20)
+
+        sections = {"REIFEGRAD_GESAMT": 65}
+        profile = {"size_label": "solo", "ai_act_override_risk_level": "minimal"}
+
+        result = build_report_insights(sections, profile)
+
+        # Should have stability info
+        assert result.segment_stability in ("strong", "medium", "weak", "unknown")
+        # Should indicate reliability
+        assert isinstance(result.is_reliable, bool)
+        assert isinstance(result.is_generic_fallback, bool)
+
+    def test_funding_insights_with_calibration(self) -> None:
+        """Test funding insights respect calibration."""
+        from services.funding_recommender import enrich_funding_recommendations_with_feedback
+
+        self._populate_test_data(20)
+
+        sections = {"REIFEGRAD_GESAMT": 65}
+        profile = {"size_label": "solo", "funding_source": "DE"}
+
+        result = enrich_funding_recommendations_with_feedback(sections, profile)
+
+        # Should have reliability info
+        assert "is_reliable" in result
+        assert "segment_stability" in result
+
+    def test_no_pii_in_calibration_outputs(self) -> None:
+        """Calibration outputs should not contain PII."""
+        import re
+        from services.feedback_analyzer import get_segment_stability_report
+        from services.insights_engine import build_report_insights
+
+        self._populate_test_data(20)
+
+        # Check stability report
+        stability_report = get_segment_stability_report()
+        stability_str = str(stability_report)
+
+        # Check for PII patterns
+        email_pattern = r"[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+"
+        assert not re.search(email_pattern, stability_str)
+
+        # Check insights
+        result = build_report_insights(
+            {"REIFEGRAD_GESAMT": 65},
+            {"size_label": "solo"}
+        )
+
+        all_html = result.summary_html + result.cards_html
+        assert not re.search(email_pattern, all_html)
+
+
+# =============================================================================
+# TEST CONFIGURATION VARIABLES
+# =============================================================================
+
+class TestG17_1_Configuration:
+    """Tests for configuration variables."""
+
+    def test_calibration_config_exists(self) -> None:
+        """Calibration config variables should exist."""
+        from services import feedback_analyzer
+
+        assert hasattr(feedback_analyzer, "INSIGHTS_SEGMENT_OUTLIER_STD")
+        assert hasattr(feedback_analyzer, "INSIGHTS_SEGMENT_SAMPLE_WARNING")
+        assert hasattr(feedback_analyzer, "INSIGHTS_MIN_STD_CONFIDENCE")
+        assert hasattr(feedback_analyzer, "INSIGHTS_CONFIDENCE_LEVELS_ENABLED")
+
+    def test_reliability_filter_config_exists(self) -> None:
+        """Reliability filter config variables should exist."""
+        from services import insights_engine
+
+        assert hasattr(insights_engine, "INSIGHTS_REQUIRE_RELIABLE_SEGMENT")
+        assert hasattr(insights_engine, "INSIGHTS_FALLBACK_TO_GENERIC")
+
+    def test_funding_stability_config_exists(self) -> None:
+        """Funding stability config variables should exist."""
+        from services import funding_recommender
+
+        assert hasattr(funding_recommender, "FUNDING_REQUIRE_STABLE_SEGMENT")
+        assert hasattr(funding_recommender, "FUNDING_SHOW_CONFIDENCE_INDICATOR")
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
Sprint G17.1 - Segment Calibration & Insight Reliability Mini-Sprint

G17.1-A: Segment Coverage Calibration (feedback_analyzer.py)
- Add outlier detection using winsorizing (>2.5 SD threshold)
- Calculate segment stability (strong/medium/weak)
- Track std deviation and max influence weight per segment
- Extend SegmentStats with calibration metadata

G17.1-B: Insight Reliability Filter (insights_engine.py)
- Check segment reliability before generating detailed insights
- Add generic fallback cards for unreliable segments
- Include reliability metadata in InsightResult
- Add subtle reliability notes for medium stability

G17.1-C: Funding Insight Stability (funding_recommender.py)
- Add confidence_level field to FundingInsight
- Check segment stability before generating funding insights
- Display confidence badges in HTML output

G17.1-D: Dashboard Endpoints (feedback_dashboard.py)
- GET /api/dashboard/feedback/segment-stability
- GET /api/dashboard/feedback/insights-reliability

G17.1-E: Test Suite
- tests/test_g17_1_segment_calibration.py with 37 tests