### PR TITLE
feat(b2.2-T): add B2.2 placeholders to PDF templates

### DIFF
--- a/templates/pdf_template.html
+++ b/templates/pdf_template.html
@@ -1512,6 +1512,42 @@
                 <section class="chapter">
                     {{FOERDERPOTENZIAL_HTML}}
                 </section>
+                <!-- SPRINT B2.2: Tools × Funding Alignment -->
+                {% if TOOLS_FUNDING_ALIGNMENT_HTML %}
+                <section class="section chapter" id="tools-funding-alignment">
+                    <div class="section-header">
+                        <div class="section-title">
+                            <span class="section-kicker">Premium Insights</span>
+                            <h2>Tools × Förderprogramme</h2>
+                        </div>
+                        <span class="section-pill">
+                            <span class="pill-dot"></span>
+                            Ausgewählte Tool-Empfehlungen und passende Förderprogramme im Abgleich
+                        </span>
+                    </div>
+                    <div class="section-body">
+                        {{ TOOLS_FUNDING_ALIGNMENT_HTML|safe }}
+                    </div>
+                </section>
+                {% endif %}
+                <!-- SPRINT B2.2: Starter Kit -->
+                {% if STARTER_KIT_HTML %}
+                <section class="section chapter" id="starter-kit">
+                    <div class="section-header">
+                        <div class="section-title">
+                            <span class="section-kicker">Ihr Einstieg</span>
+                            <h2>Starter-Kit: Tools & Förderpfad</h2>
+                        </div>
+                        <span class="section-pill">
+                            <span class="pill-dot"></span>
+                            Konkrete Kombination aus KI-Tools, Förderbausteinen und pragmatischem Einstiegspfad
+                        </span>
+                    </div>
+                    <div class="section-body">
+                        {{ STARTER_KIT_HTML|safe }}
+                    </div>
+                </section>
+                {% endif %}
                 <!-- NEUE SEKTIONEN: Monetarisierung, Skill-Plan, Templates -->
                 {% if MONETARISIERUNG_HTML %}
                 <section class="section chapter">

--- a/templates/pdf_template_en.html
+++ b/templates/pdf_template_en.html
@@ -1499,6 +1499,42 @@
                     </div>
                 </section>
                 {% endif %}
+                <!-- SPRINT B2.2: Tools × Funding Alignment -->
+                {% if TOOLS_FUNDING_ALIGNMENT_HTML %}
+                <section class="section chapter" id="tools-funding-alignment">
+                    <div class="section-header">
+                        <div class="section-title">
+                            <span class="section-kicker">Premium Insights</span>
+                            <h2>Tools × Funding Alignment</h2>
+                        </div>
+                        <span class="section-pill">
+                            <span class="pill-dot"></span>
+                            Recommended tools matched with relevant funding programmes
+                        </span>
+                    </div>
+                    <div class="section-body">
+                        {{ TOOLS_FUNDING_ALIGNMENT_HTML|safe }}
+                    </div>
+                </section>
+                {% endif %}
+                <!-- SPRINT B2.2: Starter Kit -->
+                {% if STARTER_KIT_HTML %}
+                <section class="section chapter" id="starter-kit">
+                    <div class="section-header">
+                        <div class="section-title">
+                            <span class="section-kicker">Your Starting Point</span>
+                            <h2>Starter Kit: Tools & Funding Path</h2>
+                        </div>
+                        <span class="section-pill">
+                            <span class="pill-dot"></span>
+                            A curated combination of tools, funding options and a pragmatic first implementation path
+                        </span>
+                    </div>
+                    <div class="section-body">
+                        {{ STARTER_KIT_HTML|safe }}
+                    </div>
+                </section>
+                {% endif %}
                 <!-- NEW SECTIONS: Monetization, Skill Plan, Templates -->
                 {% if MONETARISIERUNG_HTML %}
                 <section class="section chapter">


### PR DESCRIPTION
Template Integration for Sprint B2.2:
- DE: Added Tools × Förderprogramme section after FOERDERPOTENZIAL
- DE: Added Starter-Kit: Tools & Förderpfad section
- EN: Added Tools × Funding Alignment section after FUNDING
- EN: Added Starter Kit: Tools & Funding Path section

Both sections use conditional rendering ({% if VAR %}) and consistent styling with existing section classes.

Placeholders added:
- {{ TOOLS_FUNDING_ALIGNMENT_HTML|safe }}
- {{ STARTER_KIT_HTML|safe }}