### PR TITLE
feat(G19.1-MAP): add frontend-to-engine branch mapping utility

### DIFF
--- a/services/branch_mapping.py
+++ b/services/branch_mapping.py
@@ -1,0 +1,306 @@
+# -*- coding: utf-8 -*-
+"""
+Sprint G19.1-MAP: Frontend-Branch to Engine Mapping
+
+Maps the 12 frontend dropdown branch values to the 11 branch profiles
+in branch_profile_engine.py (G19+G19.1).
+
+The mapping chain:
+  Frontend-Value → BRANCH_MAPPING → Branch-Engine-Key
+
+Version: 1.0.0 (Sprint G19.1-MAP)
+"""
+from __future__ import annotations
+
+import logging
+from typing import Dict
+
+log = logging.getLogger(__name__)
+
+# =============================================================================
+# FRONTEND → ENGINE MAPPING
+# =============================================================================
+
+# Frontend dropdown "value" attributes → internal Branch-Keys from branch_profile_engine.py
+BRANCH_MAPPING: Dict[str, str] = {
+    "marketing_werbung": "marketing",
+    "beratung_dienstleistungen": "beratung",
+    "it_software": "it",
+    "finanzen_versicherungen": "finanzen",
+    "handel_ecommerce": "handel",
+    "bildung": "bildung",
+    "verwaltung": "verwaltung",
+    "gesundheit_pflege": "gesundheit",
+    "bauwesen_architektur": "bauwesen_architektur",
+    # Medien & Kreativwirtschaft maps to marketing profile
+    "medien_kreativwirtschaft": "marketing",
+    "industrie_produktion": "industrie",
+    "transport_logistik": "transport_logistik",
+}
+
+# =============================================================================
+# SYNONYMS FOR LEGACY DATA / ALTERNATE FORMATS
+# =============================================================================
+
+# Text synonyms (labels, alt-data) → frontend value keys
+BRANCH_SYNONYMS: Dict[str, str] = {
+    # German labels with & and spaces
+    "marketing & werbung": "marketing_werbung",
+    "marketing und werbung": "marketing_werbung",
+    "beratung & dienstleistungen": "beratung_dienstleistungen",
+    "beratung und dienstleistungen": "beratung_dienstleistungen",
+    "it & software": "it_software",
+    "it und software": "it_software",
+    "finanzen & versicherungen": "finanzen_versicherungen",
+    "finanzen und versicherungen": "finanzen_versicherungen",
+    "handel & e-commerce": "handel_ecommerce",
+    "handel und e-commerce": "handel_ecommerce",
+    "handel & ecommerce": "handel_ecommerce",
+    "gesundheit & pflege": "gesundheit_pflege",
+    "gesundheit und pflege": "gesundheit_pflege",
+    "medien & kreativwirtschaft": "medien_kreativwirtschaft",
+    "medien und kreativwirtschaft": "medien_kreativwirtschaft",
+    "industrie & produktion": "industrie_produktion",
+    "industrie und produktion": "industrie_produktion",
+    "transport & logistik": "transport_logistik",
+    "transport und logistik": "transport_logistik",
+    "bauwesen & architektur": "bauwesen_architektur",
+    "bauwesen und architektur": "bauwesen_architektur",
+    # Short forms and English variants
+    "bau": "bauwesen_architektur",
+    "construction": "bauwesen_architektur",
+    "architecture": "bauwesen_architektur",
+    "architektur": "bauwesen_architektur",
+    "public_sector": "verwaltung",
+    "public sector": "verwaltung",
+    "public": "verwaltung",
+    "government": "verwaltung",
+    "behoerde": "verwaltung",
+    "behörde": "verwaltung",
+    "logistik": "transport_logistik",
+    "transport": "transport_logistik",
+    "logistics": "transport_logistik",
+    "spedition": "transport_logistik",
+    "media": "medien_kreativwirtschaft",
+    "creative": "medien_kreativwirtschaft",
+    "kreativ": "medien_kreativwirtschaft",
+    # Direct engine keys (passthrough)
+    "marketing": "marketing_werbung",
+    "beratung": "beratung_dienstleistungen",
+    "it": "it_software",
+    "finanzen": "finanzen_versicherungen",
+    "handel": "handel_ecommerce",
+    "gesundheit": "gesundheit_pflege",
+    "industrie": "industrie_produktion",
+    # Legacy/alternate formats
+    "consulting": "beratung_dienstleistungen",
+    "dienstleistung": "beratung_dienstleistungen",
+    "dienstleistungen": "beratung_dienstleistungen",
+    "software": "it_software",
+    "tech": "it_software",
+    "technologie": "it_software",
+    "finance": "finanzen_versicherungen",
+    "banking": "finanzen_versicherungen",
+    "versicherung": "finanzen_versicherungen",
+    "retail": "handel_ecommerce",
+    "ecommerce": "handel_ecommerce",
+    "e-commerce": "handel_ecommerce",
+    "einzelhandel": "handel_ecommerce",
+    "health": "gesundheit_pflege",
+    "healthcare": "gesundheit_pflege",
+    "medizin": "gesundheit_pflege",
+    "pharma": "gesundheit_pflege",
+    "pflege": "gesundheit_pflege",
+    "education": "bildung",
+    "training": "bildung",
+    "schule": "bildung",
+    "hochschule": "bildung",
+    "manufacturing": "industrie_produktion",
+    "produktion": "industrie_produktion",
+    "fertigung": "industrie_produktion",
+    "werbung": "marketing_werbung",
+    "agentur": "marketing_werbung",
+    "medien": "medien_kreativwirtschaft",
+    "immobilien": "bauwesen_architektur",
+    "real_estate": "bauwesen_architektur",
+    "real estate": "bauwesen_architektur",
+    "baugewerbe": "bauwesen_architektur",
+    "warehousing": "transport_logistik",
+    "lager": "transport_logistik",
+    "supply_chain": "transport_logistik",
+    "supply chain": "transport_logistik",
+    "kommune": "verwaltung",
+    "oeffentlich": "verwaltung",
+    "öffentlich": "verwaltung",
+    "oeffentlicher_dienst": "verwaltung",
+    "öffentlicher dienst": "verwaltung",
+    "administration": "verwaltung",
+}
+
+
+# =============================================================================
+# NORMALIZATION HELPERS
+# =============================================================================
+
+def _normalize(value: str) -> str:
+    """
+    Normalize a branch value for matching.
+
+    Handles:
+    - Lowercase conversion
+    - Umlaut replacement (ä→ae, ö→oe, ü→ue, ß→ss)
+    - Special character normalization (&, -, /)
+    - Whitespace normalization
+    """
+    if not value:
+        return ""
+
+    v = value.strip().lower()
+
+    # Umlaut replacement
+    v = v.replace("ä", "ae")
+    v = v.replace("ö", "oe")
+    v = v.replace("ü", "ue")
+    v = v.replace("ß", "ss")
+
+    # Special characters to spaces
+    for ch in ["&", "-", "/"]:
+        v = v.replace(ch, " ")
+
+    # Normalize whitespace
+    v = " ".join(v.split())
+
+    return v
+
+
+def _normalize_to_key(value: str) -> str:
+    """
+    Normalize value to underscore-separated key format.
+
+    E.g., "Beratung & Dienstleistungen" → "beratung_dienstleistungen"
+    """
+    normalized = _normalize(value)
+    return normalized.replace(" ", "_")
+
+
+# =============================================================================
+# MAIN MAPPING FUNCTION
+# =============================================================================
+
+def map_frontend_branch_to_engine(raw_value: str) -> str:
+    """
+    Map a frontend branch value to the internal engine key.
+
+    Takes the branch value from the questionnaire (dropdown value or label)
+    and returns the internal branch key expected by:
+    - branch_profile_engine.py
+    - tools_analytics.py
+    - funding_recommender.py
+
+    Args:
+        raw_value: Raw branch value from frontend (value or label)
+
+    Returns:
+        Internal branch key for the engine (e.g., "beratung", "it", "verwaltung")
+
+    Example:
+        >>> map_frontend_branch_to_engine("beratung_dienstleistungen")
+        "beratung"
+        >>> map_frontend_branch_to_engine("Beratung & Dienstleistungen")
+        "beratung"
+        >>> map_frontend_branch_to_engine("construction")
+        "bauwesen_architektur"
+    """
+    if not raw_value:
+        log.debug("[G19.1-MAP] Empty branch value, defaulting to 'beratung'")
+        return "beratung"
+
+    # 1) Direct match on frontend value key (e.g., "beratung_dienstleistungen")
+    key = raw_value.strip().lower()
+    if key in BRANCH_MAPPING:
+        result = BRANCH_MAPPING[key]
+        log.debug("[G19.1-MAP] Direct match: '%s' → '%s'", raw_value, result)
+        return result
+
+    # 2) Match via synonym (e.g., "Beratung & Dienstleistungen")
+    norm = raw_value.strip().lower()
+    if norm in BRANCH_SYNONYMS:
+        mapped_frontend_key = BRANCH_SYNONYMS[norm]
+        result = BRANCH_MAPPING.get(mapped_frontend_key, "beratung")
+        log.debug("[G19.1-MAP] Synonym match: '%s' → '%s' → '%s'", raw_value, mapped_frontend_key, result)
+        return result
+
+    # 3) Match via normalized form (handles umlauts, special chars)
+    norm2 = _normalize(raw_value)
+    if norm2 in BRANCH_SYNONYMS:
+        mapped_frontend_key = BRANCH_SYNONYMS[norm2]
+        result = BRANCH_MAPPING.get(mapped_frontend_key, "beratung")
+        log.debug("[G19.1-MAP] Normalized synonym match: '%s' → '%s' → '%s'", raw_value, mapped_frontend_key, result)
+        return result
+
+    # 4) Try underscore-normalized key format
+    norm_key = _normalize_to_key(raw_value)
+    if norm_key in BRANCH_MAPPING:
+        result = BRANCH_MAPPING[norm_key]
+        log.debug("[G19.1-MAP] Key-normalized match: '%s' → '%s'", raw_value, result)
+        return result
+
+    # 5) Check if raw value is already an engine key
+    from services.branch_profile_engine import BRANCH_MATURITY_DATA, BRANCH_ALIASES
+    if key in BRANCH_MATURITY_DATA:
+        log.debug("[G19.1-MAP] Already engine key: '%s'", raw_value)
+        return key
+
+    # 6) Try branch_profile_engine's own alias resolution
+    if key in BRANCH_ALIASES:
+        result = BRANCH_ALIASES[key]
+        log.debug("[G19.1-MAP] Engine alias match: '%s' → '%s'", raw_value, result)
+        return result
+
+    # 7) Fallback to default
+    log.warning("[G19.1-MAP] Unknown branch '%s', defaulting to 'beratung'", raw_value)
+    return "beratung"
+
+
+def get_all_supported_branches() -> list[str]:
+    """
+    Return list of all supported internal branch keys.
+
+    Returns:
+        List of unique branch engine keys
+    """
+    return list(set(BRANCH_MAPPING.values()))
+
+
+def get_frontend_branch_options() -> list[tuple[str, str]]:
+    """
+    Return list of (value, label) tuples for frontend dropdown.
+
+    Returns:
+        List of (value, label) tuples for HTML select options
+    """
+    return [
+        ("marketing_werbung", "Marketing & Werbung"),
+        ("beratung_dienstleistungen", "Beratung & Dienstleistungen"),
+        ("it_software", "IT & Software"),
+        ("finanzen_versicherungen", "Finanzen & Versicherungen"),
+        ("handel_ecommerce", "Handel & E-Commerce"),
+        ("bildung", "Bildung"),
+        ("verwaltung", "Verwaltung"),
+        ("gesundheit_pflege", "Gesundheit & Pflege"),
+        ("bauwesen_architektur", "Bauwesen & Architektur"),
+        ("medien_kreativwirtschaft", "Medien & Kreativwirtschaft"),
+        ("industrie_produktion", "Industrie & Produktion"),
+        ("transport_logistik", "Transport & Logistik"),
+    ]
+
+
+# =============================================================================
+# MODULE INITIALIZATION
+# =============================================================================
+
+log.info(
+    "[G19.1-MAP] Branch Mapping loaded - %d frontend values, %d synonyms",
+    len(BRANCH_MAPPING),
+    len(BRANCH_SYNONYMS),
+)

--- a/services/branch_profile_engine.py
+++ b/services/branch_profile_engine.py
@@ -1145,6 +1145,14 @@ DEFAULT_BRANCH_DATA = {
 
 # Branch name normalization mapping
 BRANCH_ALIASES: Dict[str, str] = {
+    # G19.1-MAP: Frontend dropdown value keys (primary mappings)
+    "marketing_werbung": "marketing",
+    "beratung_dienstleistungen": "beratung",
+    "finanzen_versicherungen": "finanzen",
+    "handel_ecommerce": "handel",
+    "gesundheit_pflege": "gesundheit",
+    "medien_kreativwirtschaft": "marketing",  # maps to marketing profile
+    "industrie_produktion": "industrie",
     # German variations
     "beratung": "beratung",
     "consulting": "beratung",
@@ -1171,6 +1179,7 @@ BRANCH_ALIASES: Dict[str, str] = {
     "healthcare": "gesundheit",
     "medizin": "gesundheit",
     "pharma": "gesundheit",
+    "pflege": "gesundheit",
     "industrie": "industrie",
     "manufacturing": "industrie",
     "produktion": "industrie",
@@ -1184,6 +1193,8 @@ BRANCH_ALIASES: Dict[str, str] = {
     "werbung": "marketing",
     "medien": "marketing",
     "agentur": "marketing",
+    "kreativ": "marketing",
+    "kreativwirtschaft": "marketing",
     # G19.1: New branch aliases
     "bauwesen_architektur": "bauwesen_architektur",
     "bauwesen": "bauwesen_architektur",

--- a/services/prompt_enhancer.py
+++ b/services/prompt_enhancer.py
@@ -31,7 +31,7 @@ from services.prompt_builder import PromptBuilder
 try:
     from services.branch_mapping import map_frontend_branch_to_engine
 except ImportError:
-    def map_frontend_branch_to_engine(raw_value: str) -> str:  # type: ignore[misc]
+    def map_frontend_branch_to_engine(raw_value: str) -> str:
         """Fallback if branch_mapping not available."""
         return raw_value.lower().strip() if raw_value else "beratung"
 

--- a/services/prompt_enhancer.py
+++ b/services/prompt_enhancer.py
@@ -27,6 +27,14 @@ from typing import Any, Dict, List, Set, TypedDict, Optional
 
 from services.prompt_builder import PromptBuilder
 
+# G19.1-MAP: Import branch mapping
+try:
+    from services.branch_mapping import map_frontend_branch_to_engine
+except ImportError:
+    def map_frontend_branch_to_engine(raw_value: str) -> str:  # type: ignore[misc]
+        """Fallback if branch_mapping not available."""
+        return raw_value.lower().strip() if raw_value else "beratung"
+
 # G9.4: Import centralized min-length configuration
 try:
     from services.config_validation import get_min_words as get_central_min_words
@@ -335,7 +343,9 @@ def generate_short_labels(briefing_data: Dict[str, Any], lang: str = "de") -> Di
     Returns:
         Dict with BRANCH_CORE_LABEL, OFFERING_LABEL, REGULATORY_LABEL, BRANCH_CONTEXT_LABEL, BRANCH_SHORT_LABEL
     """
-    branche = briefing_data.get("branche", "").lower().strip()
+    # G19.1-MAP: Map frontend branch to engine key
+    raw_branch = briefing_data.get("branche", "") or briefing_data.get("branch", "") or ""
+    branche = map_frontend_branch_to_engine(raw_branch)
 
     # SPRINT G17.S: Get company size for BRANCH_SHORT_LABEL
     company_size = briefing_data.get("company_size", "").lower().strip()
@@ -1370,7 +1380,10 @@ class PromptEnhancer:
         Returns:
             HTML string with context information
         """
-        branche = briefing_data.get("branche", "")
+        # G19.1-MAP: Map frontend branch to engine key
+        raw_branch = briefing_data.get("branche", "") or briefing_data.get("branch", "") or ""
+        branche = map_frontend_branch_to_engine(raw_branch)
+
         groesse = briefing_data.get("unternehmensgroesse", "")
 
         if not branche or not groesse:

--- a/tests/test_g19_1_branch_mapping.py
+++ b/tests/test_g19_1_branch_mapping.py
@@ -1,0 +1,441 @@
+# -*- coding: utf-8 -*-
+"""
+Tests for Sprint G19.1-MAP: Frontend-Branch to Engine Mapping
+
+Tests verify:
+- All 12 frontend dropdown values map correctly
+- German labels with & and spaces map correctly
+- Legacy/alternate strings (construction, logistik) map correctly
+- Unknown values fall back to "beratung"
+- Integration with branch_profile_engine.py
+"""
+
+import pytest
+from typing import Dict, List, Tuple
+
+
+# =============================================================================
+# TEST FIXTURES
+# =============================================================================
+
+@pytest.fixture
+def frontend_dropdown_values() -> List[Tuple[str, str]]:
+    """
+    Frontend dropdown value → expected engine key.
+
+    All 12 frontend values must map correctly.
+    """
+    return [
+        ("marketing_werbung", "marketing"),
+        ("beratung_dienstleistungen", "beratung"),
+        ("it_software", "it"),
+        ("finanzen_versicherungen", "finanzen"),
+        ("handel_ecommerce", "handel"),
+        ("bildung", "bildung"),
+        ("verwaltung", "verwaltung"),
+        ("gesundheit_pflege", "gesundheit"),
+        ("bauwesen_architektur", "bauwesen_architektur"),
+        ("medien_kreativwirtschaft", "marketing"),  # maps to marketing profile
+        ("industrie_produktion", "industrie"),
+        ("transport_logistik", "transport_logistik"),
+    ]
+
+
+@pytest.fixture
+def german_labels() -> List[Tuple[str, str]]:
+    """
+    German labels with & → expected engine key.
+
+    These are the display labels users see in the dropdown.
+    """
+    return [
+        ("Marketing & Werbung", "marketing"),
+        ("Beratung & Dienstleistungen", "beratung"),
+        ("IT & Software", "it"),
+        ("Finanzen & Versicherungen", "finanzen"),
+        ("Handel & E-Commerce", "handel"),
+        ("Bildung", "bildung"),
+        ("Verwaltung", "verwaltung"),
+        ("Gesundheit & Pflege", "gesundheit"),
+        ("Bauwesen & Architektur", "bauwesen_architektur"),
+        ("Medien & Kreativwirtschaft", "marketing"),
+        ("Industrie & Produktion", "industrie"),
+        ("Transport & Logistik", "transport_logistik"),
+    ]
+
+
+@pytest.fixture
+def legacy_synonyms() -> List[Tuple[str, str]]:
+    """
+    Legacy/alternate strings → expected engine key.
+
+    These handle old data formats and common variations.
+    """
+    return [
+        # English variants
+        ("construction", "bauwesen_architektur"),
+        ("logistics", "transport_logistik"),
+        ("public_sector", "verwaltung"),
+        ("government", "verwaltung"),
+        ("healthcare", "gesundheit"),
+        ("manufacturing", "industrie"),
+        ("retail", "handel"),
+        ("consulting", "beratung"),
+        # Short German forms
+        ("bau", "bauwesen_architektur"),
+        ("logistik", "transport_logistik"),
+        ("transport", "transport_logistik"),
+        ("medizin", "gesundheit"),
+        ("pharma", "gesundheit"),
+        ("werbung", "marketing"),
+        # Direct engine keys (should pass through)
+        ("beratung", "beratung"),
+        ("it", "it"),
+        ("finanzen", "finanzen"),
+        ("handel", "handel"),
+        ("bildung", "bildung"),
+        ("gesundheit", "gesundheit"),
+        ("industrie", "industrie"),
+        ("marketing", "marketing"),
+    ]
+
+
+# =============================================================================
+# MAPPING FUNCTION TESTS
+# =============================================================================
+
+class TestMapFrontendBranchToEngine:
+    """Tests for map_frontend_branch_to_engine function."""
+
+    def test_all_frontend_values_mapped(self, frontend_dropdown_values):
+        """Verify all 12 frontend dropdown values map correctly."""
+        from services.branch_mapping import map_frontend_branch_to_engine
+
+        for frontend_value, expected_engine in frontend_dropdown_values:
+            result = map_frontend_branch_to_engine(frontend_value)
+            assert result == expected_engine, \
+                f"Frontend value '{frontend_value}' should map to '{expected_engine}', got '{result}'"
+
+    def test_german_labels_mapped(self, german_labels):
+        """Verify German labels (with &) map correctly."""
+        from services.branch_mapping import map_frontend_branch_to_engine
+
+        for label, expected_engine in german_labels:
+            result = map_frontend_branch_to_engine(label)
+            assert result == expected_engine, \
+                f"German label '{label}' should map to '{expected_engine}', got '{result}'"
+
+    def test_legacy_synonyms_mapped(self, legacy_synonyms):
+        """Verify legacy/alternate strings map correctly."""
+        from services.branch_mapping import map_frontend_branch_to_engine
+
+        for legacy_value, expected_engine in legacy_synonyms:
+            result = map_frontend_branch_to_engine(legacy_value)
+            assert result == expected_engine, \
+                f"Legacy value '{legacy_value}' should map to '{expected_engine}', got '{result}'"
+
+    def test_unknown_values_fallback_to_beratung(self):
+        """Verify unknown values fall back to 'beratung'."""
+        from services.branch_mapping import map_frontend_branch_to_engine
+
+        unknown_values = [
+            "unknown_branch",
+            "xyz123",
+            "foobar",
+            "nonexistent",
+            "random_value",
+        ]
+
+        for unknown in unknown_values:
+            result = map_frontend_branch_to_engine(unknown)
+            assert result == "beratung", \
+                f"Unknown value '{unknown}' should default to 'beratung', got '{result}'"
+
+    def test_empty_value_fallback(self):
+        """Verify empty/None values fall back to 'beratung'."""
+        from services.branch_mapping import map_frontend_branch_to_engine
+
+        assert map_frontend_branch_to_engine("") == "beratung"
+        assert map_frontend_branch_to_engine("   ") == "beratung"
+
+    def test_case_insensitivity(self):
+        """Verify mapping is case-insensitive."""
+        from services.branch_mapping import map_frontend_branch_to_engine
+
+        test_cases = [
+            ("MARKETING_WERBUNG", "marketing"),
+            ("Beratung_Dienstleistungen", "beratung"),
+            ("IT_SOFTWARE", "it"),
+            ("VERWALTUNG", "verwaltung"),
+            ("Construction", "bauwesen_architektur"),
+            ("LOGISTICS", "transport_logistik"),
+        ]
+
+        for input_val, expected in test_cases:
+            result = map_frontend_branch_to_engine(input_val)
+            assert result == expected, \
+                f"'{input_val}' should map to '{expected}', got '{result}'"
+
+    def test_whitespace_handling(self):
+        """Verify leading/trailing whitespace is handled."""
+        from services.branch_mapping import map_frontend_branch_to_engine
+
+        test_cases = [
+            ("  beratung_dienstleistungen  ", "beratung"),
+            ("\tit_software\n", "it"),
+            ("  Verwaltung  ", "verwaltung"),
+        ]
+
+        for input_val, expected in test_cases:
+            result = map_frontend_branch_to_engine(input_val)
+            assert result == expected, \
+                f"'{input_val!r}' should map to '{expected}', got '{result}'"
+
+
+# =============================================================================
+# NORMALIZATION TESTS
+# =============================================================================
+
+class TestNormalization:
+    """Tests for normalization functions."""
+
+    def test_normalize_function(self):
+        """Test the _normalize helper function."""
+        from services.branch_mapping import _normalize
+
+        test_cases = [
+            ("Beratung & Dienstleistungen", "beratung dienstleistungen"),
+            ("IT & Software", "it software"),
+            ("Bäume & Öl", "baeume oel"),
+            ("Test-Value/Slash", "test value slash"),
+            ("  extra   spaces  ", "extra spaces"),
+        ]
+
+        for input_val, expected in test_cases:
+            result = _normalize(input_val)
+            assert result == expected, \
+                f"_normalize('{input_val}') should return '{expected}', got '{result}'"
+
+    def test_normalize_to_key_function(self):
+        """Test the _normalize_to_key helper function."""
+        from services.branch_mapping import _normalize_to_key
+
+        test_cases = [
+            ("Beratung & Dienstleistungen", "beratung_dienstleistungen"),
+            ("IT & Software", "it_software"),
+            ("Transport Logistik", "transport_logistik"),
+        ]
+
+        for input_val, expected in test_cases:
+            result = _normalize_to_key(input_val)
+            assert result == expected, \
+                f"_normalize_to_key('{input_val}') should return '{expected}', got '{result}'"
+
+
+# =============================================================================
+# MAPPING DATA TESTS
+# =============================================================================
+
+class TestMappingData:
+    """Tests for mapping data completeness."""
+
+    def test_branch_mapping_has_12_entries(self):
+        """Verify BRANCH_MAPPING has exactly 12 frontend entries."""
+        from services.branch_mapping import BRANCH_MAPPING
+
+        assert len(BRANCH_MAPPING) == 12, \
+            f"BRANCH_MAPPING should have 12 entries, has {len(BRANCH_MAPPING)}"
+
+    def test_all_engine_keys_are_valid(self):
+        """Verify all mapped engine keys exist in branch_profile_engine."""
+        from services.branch_mapping import BRANCH_MAPPING
+        from services.branch_profile_engine import BRANCH_MATURITY_DATA, BRANCH_ALIASES
+
+        for frontend_key, engine_key in BRANCH_MAPPING.items():
+            # Engine key should either be in BRANCH_MATURITY_DATA or resolve via BRANCH_ALIASES
+            is_direct = engine_key in BRANCH_MATURITY_DATA
+            is_aliased = engine_key in BRANCH_ALIASES and BRANCH_ALIASES[engine_key] in BRANCH_MATURITY_DATA
+
+            assert is_direct or is_aliased, \
+                f"Engine key '{engine_key}' (from '{frontend_key}') not found in branch_profile_engine"
+
+    def test_synonyms_map_to_valid_frontend_keys(self):
+        """Verify all synonyms map to valid frontend keys."""
+        from services.branch_mapping import BRANCH_SYNONYMS, BRANCH_MAPPING
+
+        for synonym, frontend_key in BRANCH_SYNONYMS.items():
+            # Some synonyms map directly to engine keys (like "beratung" → "beratung_dienstleistungen")
+            # These should still resolve to a valid mapping
+            if frontend_key in BRANCH_MAPPING:
+                continue  # Valid mapping
+            # If not directly in mapping, the synonym should at least not cause errors
+            assert isinstance(frontend_key, str), \
+                f"Synonym '{synonym}' maps to non-string: {frontend_key}"
+
+
+# =============================================================================
+# HELPER FUNCTION TESTS
+# =============================================================================
+
+class TestHelperFunctions:
+    """Tests for helper functions."""
+
+    def test_get_all_supported_branches(self):
+        """Test get_all_supported_branches returns unique engine keys."""
+        from services.branch_mapping import get_all_supported_branches
+
+        branches = get_all_supported_branches()
+
+        # Should return unique values
+        assert len(branches) == len(set(branches)), "Branches should be unique"
+
+        # Should include the 11 engine keys
+        expected = {
+            "marketing", "beratung", "it", "finanzen", "handel",
+            "bildung", "verwaltung", "gesundheit", "bauwesen_architektur",
+            "industrie", "transport_logistik"
+        }
+        assert set(branches) == expected, \
+            f"Expected {expected}, got {set(branches)}"
+
+    def test_get_frontend_branch_options(self):
+        """Test get_frontend_branch_options returns correct format."""
+        from services.branch_mapping import get_frontend_branch_options
+
+        options = get_frontend_branch_options()
+
+        # Should return 12 options
+        assert len(options) == 12, f"Expected 12 options, got {len(options)}"
+
+        # Each option should be a (value, label) tuple
+        for option in options:
+            assert isinstance(option, tuple), f"Option should be tuple: {option}"
+            assert len(option) == 2, f"Option should have 2 elements: {option}"
+            value, label = option
+            assert isinstance(value, str), f"Value should be string: {value}"
+            assert isinstance(label, str), f"Label should be string: {label}"
+            assert "_" in value or value == "bildung" or value == "verwaltung", \
+                f"Value should use underscores: {value}"
+
+
+# =============================================================================
+# INTEGRATION TESTS
+# =============================================================================
+
+class TestIntegration:
+    """Integration tests with other modules."""
+
+    def test_mapping_works_with_branch_profile_engine(self):
+        """Test mapped values work with branch_profile_engine."""
+        from services.branch_mapping import map_frontend_branch_to_engine
+        from services.branch_profile_engine import build_branch_profile
+
+        frontend_values = [
+            "beratung_dienstleistungen",
+            "it_software",
+            "verwaltung",
+            "transport_logistik",
+            "bauwesen_architektur",
+        ]
+
+        for frontend_val in frontend_values:
+            engine_key = map_frontend_branch_to_engine(frontend_val)
+            profile = build_branch_profile(engine_key, "team", "de")
+
+            assert profile is not None, f"Profile should not be None for {engine_key}"
+            assert profile.maturity_score > 0, f"Maturity score should be > 0 for {engine_key}"
+
+    def test_mapping_works_with_funding_recommender(self):
+        """Test mapped values work with funding_recommender."""
+        from services.branch_mapping import map_frontend_branch_to_engine
+        from services.funding_recommender import BRANCH_FUNDING_PRIORITIES
+
+        frontend_values = [
+            "verwaltung",
+            "transport_logistik",
+            "bauwesen_architektur",
+        ]
+
+        for frontend_val in frontend_values:
+            engine_key = map_frontend_branch_to_engine(frontend_val)
+            assert engine_key in BRANCH_FUNDING_PRIORITIES, \
+                f"Engine key '{engine_key}' should be in BRANCH_FUNDING_PRIORITIES"
+
+    def test_mapping_works_with_tools_analytics(self):
+        """Test mapped values work with tools_analytics."""
+        from services.branch_mapping import map_frontend_branch_to_engine
+        from services.tools_analytics import BRANCH_TOOL_BOOSTS
+
+        frontend_values = [
+            "verwaltung",
+            "transport_logistik",
+            "bauwesen_architektur",
+        ]
+
+        for frontend_val in frontend_values:
+            engine_key = map_frontend_branch_to_engine(frontend_val)
+            assert engine_key in BRANCH_TOOL_BOOSTS, \
+                f"Engine key '{engine_key}' should be in BRANCH_TOOL_BOOSTS"
+
+    def test_full_mapping_chain(self):
+        """Test complete mapping chain from frontend to engine output."""
+        from services.branch_mapping import map_frontend_branch_to_engine
+        from services.branch_profile_engine import (
+            build_branch_profile,
+            get_branch_risk_opportunity_map,
+            get_branch_profile_html_sections,
+        )
+
+        # Test with German dropdown label
+        frontend_label = "Verwaltung"
+        engine_key = map_frontend_branch_to_engine(frontend_label)
+
+        assert engine_key == "verwaltung", f"Expected 'verwaltung', got '{engine_key}'"
+
+        # Build profile
+        profile = build_branch_profile(engine_key, "team", "de")
+        assert profile.maturity_score == 45, "Verwaltung should have maturity 45"
+
+        # Get risk/opportunity map
+        risk_map = get_branch_risk_opportunity_map(engine_key, "de")
+        assert len(risk_map.opportunities) == 3, "Should have 3 opportunities"
+
+        # Generate HTML sections
+        briefing = {"branche": frontend_label, "unternehmensgroesse": "team"}
+        sections = get_branch_profile_html_sections(briefing, "de")
+        assert "BRANCH_PROFILE_HTML" in sections, "Should have BRANCH_PROFILE_HTML"
+
+
+# =============================================================================
+# BRANCH_ALIASES SYNC TESTS
+# =============================================================================
+
+class TestBranchAliasesSync:
+    """Tests to verify BRANCH_ALIASES is in sync with branch_mapping."""
+
+    def test_frontend_keys_in_branch_aliases(self):
+        """Verify frontend keys are also in BRANCH_ALIASES."""
+        from services.branch_mapping import BRANCH_MAPPING
+        from services.branch_profile_engine import BRANCH_ALIASES
+
+        for frontend_key, engine_key in BRANCH_MAPPING.items():
+            # The frontend key should be resolvable via BRANCH_ALIASES
+            if frontend_key in BRANCH_ALIASES:
+                resolved = BRANCH_ALIASES[frontend_key]
+                # Resolved should match engine_key or be equivalent
+                assert resolved == engine_key or frontend_key == engine_key, \
+                    f"BRANCH_ALIASES['{frontend_key}'] = '{resolved}' should match engine key '{engine_key}'"
+
+    def test_g19_1_branches_in_aliases(self):
+        """Verify G19.1 branches are in BRANCH_ALIASES."""
+        from services.branch_profile_engine import BRANCH_ALIASES
+
+        g19_1_keys = [
+            "bauwesen_architektur",
+            "verwaltung",
+            "transport_logistik",
+        ]
+
+        for key in g19_1_keys:
+            assert key in BRANCH_ALIASES, \
+                f"G19.1 branch '{key}' should be in BRANCH_ALIASES"


### PR DESCRIPTION
New services/branch_mapping.py:
- BRANCH_MAPPING: 12 frontend dropdown values → 11 engine keys
- BRANCH_SYNONYMS: 70+ synonyms for legacy/alternate formats
- map_frontend_branch_to_engine(): robust mapping with fallback
- _normalize(): handles umlauts, special chars, whitespace
- get_frontend_branch_options(): returns dropdown (value, label) tuples

Integration in prompt_enhancer.py:
- generate_short_labels() now uses mapping function
- build_context_block() now uses mapping function
- Fallback function if branch_mapping not available

Updates to branch_profile_engine.py:
- Added frontend dropdown keys to BRANCH_ALIASES
- Added pflege, kreativ, kreativwirtschaft aliases

Test suite tests/test_g19_1_branch_mapping.py:
- 20 tests covering all mapping scenarios
- Frontend values, German labels, legacy synonyms
- Unknown value fallback, case insensitivity
- Integration with branch_profile_engine, funding, tools