### PR TITLE
feat(G23): add KPI Visualisation Layer

### DIFF
--- a/gpt_analyze.py
+++ b/gpt_analyze.py
@@ -4772,7 +4772,31 @@ def analyze_briefing(db: Session, briefing_id: int, run_id: str) -> tuple[int, s
 
     sections["CHANGELOG_SHORT"] = os.getenv("CHANGELOG_SHORT", "—")
     sections["AUDITOR_INITIALS"] = os.getenv("AUDITOR_INITIALS", "KSJ")
-    sections.setdefault("KPI_HTML","")
+
+    # G23: KPI Visualisation Layer
+    try:
+        from utils.kpi_visuals import generate_kpi_visuals
+        kpi_data = {
+            "roi": answers.get("ROI_12M") or sections.get("ROI_12M") or 0,
+            "payback_months": answers.get("PAYBACK_MONTHS") or sections.get("PAYBACK_MONTHS") or 0,
+            "time_savings_eur": answers.get("EINSPARUNG_MONAT_EUR") or sections.get("EINSPARUNG_MONAT_EUR") or 0,
+        }
+        # Add industry benchmark if available from branch profile
+        if answers.get("branch_avg_roi"):
+            kpi_data["industry_roi"] = answers.get("branch_avg_roi")
+        kpi_visuals = generate_kpi_visuals(kpi_data, lang=sections.get("LANG", "de"))
+        sections["KPI_VISUALS_HTML"] = kpi_visuals.get("html", "")
+        sections["KPI_HTML"] = kpi_visuals.get("bar_html", "")
+        log.debug("[%s] 📊 G23 KPI visuals generated", run_id)
+    except ImportError:
+        log.debug("[%s] G23 kpi_visuals not available - skipping", run_id)
+        sections.setdefault("KPI_HTML", "")
+        sections.setdefault("KPI_VISUALS_HTML", "")
+    except Exception as exc:
+        log.warning("[%s] ⚠️ G23 KPI visuals generation failed: %s", run_id, exc)
+        sections.setdefault("KPI_HTML", "")
+        sections.setdefault("KPI_VISUALS_HTML", "")
+
     sections.setdefault("FEEDBACK_BOX_HTML","Feedback willkommen – was war hilfreich, was fehlt?")
     sections.setdefault("DATA_COVERAGE_HTML","")
     sections.setdefault("FREITEXT_SNIPPETS_HTML","")

--- a/templates/pdf_template.html
+++ b/templates/pdf_template.html
@@ -1282,6 +1282,42 @@
             line-height: 1.3;
         }
 
+        /* G23: KPI Visuals CSS */
+        .kpi-visuals {
+            margin: 16pt 0;
+            break-inside: avoid;
+        }
+        .kpi-bars {
+            display: flex;
+            flex-direction: column;
+            gap: 10pt;
+        }
+        .kpi-bar {
+            display: block;
+            max-width: 100%;
+        }
+        .kpi-sparkline-container {
+            margin-top: 12pt;
+            padding: 10pt;
+            background: var(--color-bg-surface);
+            border-radius: var(--radius-card);
+        }
+        .kpi-benchmark-container {
+            margin-top: 12pt;
+            padding: 10pt;
+            background: var(--color-bg-surface);
+            border-radius: var(--radius-card);
+        }
+        @media print {
+            .kpi-visuals {
+                break-inside: avoid;
+                page-break-inside: avoid;
+            }
+            .kpi-bar, .kpi-sparkline, .kpi-benchmark {
+                max-width: 100%;
+            }
+        }
+
         /* Step Cards (for Starter Kit) */
         .step-cards {
             display: grid;
@@ -1665,6 +1701,12 @@
                                     Diese Kennzahlen sind Näherungen und dienen als Orientierung. In den Branchen-Kapiteln finden Sie eine
                                     detaillierte Einordnung im Kontext Ihrer Branche und Unternehmensgröße.
                                 </p>
+                                <!-- G23: KPI Visuals -->
+                                {% if KPI_VISUALS_HTML %}
+                                <div class="kpi-visuals">
+                                    {{ KPI_VISUALS_HTML|safe }}
+                                </div>
+                                {% endif %}
                             </div>
                             <div class="exec-summary card card-muted">
                                 <h3 class="exec-title">Ihr KI-Profil in einem Satz</h3>

--- a/templates/pdf_template_en.html
+++ b/templates/pdf_template_en.html
@@ -755,6 +755,43 @@
             color: var(--color-text-muted);
             margin-top: var(--space-xs);
         }
+
+        /* G23: KPI Visuals CSS */
+        .kpi-visuals {
+            margin: 16pt 0;
+            break-inside: avoid;
+        }
+        .kpi-bars {
+            display: flex;
+            flex-direction: column;
+            gap: 10pt;
+        }
+        .kpi-bar {
+            display: block;
+            max-width: 100%;
+        }
+        .kpi-sparkline-container {
+            margin-top: 12pt;
+            padding: 10pt;
+            background: var(--color-bg-surface);
+            border-radius: var(--radius-card);
+        }
+        .kpi-benchmark-container {
+            margin-top: 12pt;
+            padding: 10pt;
+            background: var(--color-bg-surface);
+            border-radius: var(--radius-card);
+        }
+        @media print {
+            .kpi-visuals {
+                break-inside: avoid;
+                page-break-inside: avoid;
+            }
+            .kpi-bar, .kpi-sparkline, .kpi-benchmark {
+                max-width: 100%;
+            }
+        }
+
         /* ================================================
            TABLES (PLATIN++ V5.2 Light Mode)
            ================================================ */
@@ -1629,6 +1666,12 @@
                                     </div>
                                 </div>
                             </div>
+                            <!-- G23: KPI Visuals -->
+                            {% if KPI_VISUALS_HTML %}
+                            <div class="kpi-visuals">
+                                {{ KPI_VISUALS_HTML|safe }}
+                            </div>
+                            {% endif %}
                         </div>
                         <div class="exec-summary">
                             <div class="exec-highlight">

--- a/tests/test_g23_kpi_visuals.py
+++ b/tests/test_g23_kpi_visuals.py
@@ -1,0 +1,543 @@
+# -*- coding: utf-8 -*-
+"""
+Sprint G23: KPI Visualisation Layer Tests
+
+Tests for the SVG-based KPI visualization generators.
+"""
+import os
+import sys
+
+try:
+    import pytest
+except ImportError:
+    pytest = None
+
+# Ensure project root in path
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from utils.kpi_visuals import (
+    generate_kpi_visuals,
+    generate_kpi_bar,
+    generate_sparkline,
+    generate_benchmark_bar,
+    get_kpi_visuals_css,
+    ENABLE_KPI_VISUALS,
+    COLOR_PRIMARY,
+    COLOR_SUCCESS,
+    COLOR_WARNING,
+)
+
+
+# =============================================================================
+# generate_kpi_bar Tests
+# =============================================================================
+
+class TestGenerateKpiBar:
+    """Tests for the generate_kpi_bar function."""
+
+    def test_basic_bar_generation(self):
+        """Test that a basic KPI bar is generated."""
+        result = generate_kpi_bar(
+            value=100,
+            max_value=200,
+            label="Test KPI",
+            kpi_type="default"
+        )
+        assert "<svg" in result
+        assert "</svg>" in result
+        assert "Test KPI" in result
+
+    def test_roi_bar_format(self):
+        """Test ROI bar displays percentage format."""
+        result = generate_kpi_bar(
+            value=150,
+            max_value=200,
+            label="ROI",
+            kpi_type="roi"
+        )
+        assert "150%" in result
+        assert COLOR_PRIMARY in result
+
+    def test_payback_bar_format_de(self):
+        """Test payback bar displays German format."""
+        result = generate_kpi_bar(
+            value=6.5,
+            max_value=24,
+            label="Payback",
+            kpi_type="payback",
+            lang="de"
+        )
+        assert "6.5 Mon." in result
+        assert COLOR_WARNING in result
+
+    def test_payback_bar_format_en(self):
+        """Test payback bar displays English format."""
+        result = generate_kpi_bar(
+            value=6.5,
+            max_value=24,
+            label="Payback",
+            kpi_type="payback",
+            lang="en"
+        )
+        assert "6.5 mo." in result
+
+    def test_savings_bar_format_de(self):
+        """Test savings bar displays German format."""
+        result = generate_kpi_bar(
+            value=40,
+            max_value=160,
+            label="Savings",
+            kpi_type="savings",
+            lang="de"
+        )
+        assert "40 h/Mon." in result
+        assert COLOR_SUCCESS in result
+
+    def test_savings_bar_format_en(self):
+        """Test savings bar displays English format."""
+        result = generate_kpi_bar(
+            value=40,
+            max_value=160,
+            label="Savings",
+            kpi_type="savings",
+            lang="en"
+        )
+        assert "40 h/mo." in result
+
+    def test_bar_dimensions(self):
+        """Test custom bar dimensions are applied."""
+        result = generate_kpi_bar(
+            value=100,
+            max_value=200,
+            label="Test",
+            width=300,
+            height=50
+        )
+        assert 'width="300"' in result
+        assert 'height="50"' in result
+
+    def test_zero_max_value_handled(self):
+        """Test that zero max_value doesn't cause division error."""
+        result = generate_kpi_bar(
+            value=100,
+            max_value=0,
+            label="Test"
+        )
+        assert "<svg" in result
+        # Fill width should be 0
+
+    def test_value_exceeding_max(self):
+        """Test that values exceeding max are capped at 100%."""
+        result = generate_kpi_bar(
+            value=300,
+            max_value=200,
+            label="Test"
+        )
+        assert "<svg" in result
+        # Should contain bar element
+
+    def test_svg_is_pdf_safe(self):
+        """Test that SVG doesn't contain PDF-unsafe elements."""
+        result = generate_kpi_bar(
+            value=100,
+            max_value=200,
+            label="Test"
+        )
+        # PDF unsafe elements should NOT be present
+        assert "filter=" not in result
+        assert "mask=" not in result
+        assert "gradient" not in result.lower()
+        assert "transform=" not in result
+        assert "animate" not in result.lower()
+
+
+# =============================================================================
+# generate_sparkline Tests
+# =============================================================================
+
+class TestGenerateSparkline:
+    """Tests for the generate_sparkline function."""
+
+    def test_basic_sparkline_generation(self):
+        """Test that a basic sparkline is generated."""
+        values = [10, 20, 30, 40, 50, 60, 70, 80, 90, 100, 110, 120]
+        result = generate_sparkline(values=values)
+        assert "<svg" in result
+        assert "</svg>" in result
+        assert "polyline" in result
+
+    def test_empty_values_returns_empty(self):
+        """Test that empty values returns empty string."""
+        result = generate_sparkline(values=[])
+        assert result == ""
+
+    def test_single_value_returns_empty(self):
+        """Test that single value returns empty string."""
+        result = generate_sparkline(values=[100])
+        assert result == ""
+
+    def test_values_padded_to_12(self):
+        """Test that values are padded to 12 points."""
+        values = [10, 20, 30]
+        result = generate_sparkline(values=values)
+        assert "<svg" in result
+        # Should have polyline with 12 points
+
+    def test_values_trimmed_to_12(self):
+        """Test that values are trimmed to 12 points."""
+        values = list(range(20))
+        result = generate_sparkline(values=values)
+        assert "<svg" in result
+
+    def test_endpoints_shown(self):
+        """Test that endpoints are shown when requested."""
+        values = list(range(12))
+        result = generate_sparkline(values=values, show_endpoints=True)
+        assert "circle" in result
+
+    def test_endpoints_hidden(self):
+        """Test that endpoints are hidden when requested."""
+        values = list(range(12))
+        result = generate_sparkline(values=values, show_endpoints=False)
+        assert "circle" not in result
+
+    def test_label_shown(self):
+        """Test that label is displayed."""
+        values = list(range(12))
+        result = generate_sparkline(values=values, label="Test Label")
+        assert "Test Label" in result
+
+    def test_custom_color(self):
+        """Test that custom color is applied."""
+        values = list(range(12))
+        result = generate_sparkline(values=values, color="#ff0000")
+        assert "#ff0000" in result
+
+    def test_sparkline_is_pdf_safe(self):
+        """Test that sparkline doesn't contain PDF-unsafe elements."""
+        values = list(range(12))
+        result = generate_sparkline(values=values)
+        # PDF unsafe elements should NOT be present
+        assert "filter=" not in result
+        assert "mask=" not in result
+        assert "gradient" not in result.lower()
+        assert "animate" not in result.lower()
+
+
+# =============================================================================
+# generate_benchmark_bar Tests
+# =============================================================================
+
+class TestGenerateBenchmarkBar:
+    """Tests for the generate_benchmark_bar function."""
+
+    def test_basic_benchmark_generation(self):
+        """Test that a basic benchmark bar is generated."""
+        result = generate_benchmark_bar(
+            your_value=75,
+            industry_value=60,
+            max_value=100,
+            label="Test Benchmark"
+        )
+        assert "<svg" in result
+        assert "</svg>" in result
+        assert "Test Benchmark" in result
+
+    def test_german_labels(self):
+        """Test German labels."""
+        result = generate_benchmark_bar(
+            your_value=75,
+            industry_value=60,
+            max_value=100,
+            label="ROI",
+            lang="de"
+        )
+        assert "Sie" in result
+        assert "Branche" in result
+
+    def test_english_labels(self):
+        """Test English labels."""
+        result = generate_benchmark_bar(
+            your_value=75,
+            industry_value=60,
+            max_value=100,
+            label="ROI",
+            lang="en"
+        )
+        assert "You" in result
+        assert "Industry" in result
+
+    def test_values_displayed(self):
+        """Test that values are displayed."""
+        result = generate_benchmark_bar(
+            your_value=75,
+            industry_value=60,
+            max_value=100,
+            label="Test"
+        )
+        assert "75%" in result
+        assert "60%" in result
+
+    def test_zero_max_value_handled(self):
+        """Test that zero max_value is handled."""
+        result = generate_benchmark_bar(
+            your_value=75,
+            industry_value=60,
+            max_value=0,
+            label="Test"
+        )
+        assert "<svg" in result
+
+    def test_benchmark_is_pdf_safe(self):
+        """Test that benchmark bar doesn't contain PDF-unsafe elements."""
+        result = generate_benchmark_bar(
+            your_value=75,
+            industry_value=60,
+            max_value=100,
+            label="Test"
+        )
+        assert "filter=" not in result
+        assert "mask=" not in result
+        assert "gradient" not in result.lower()
+
+
+# =============================================================================
+# generate_kpi_visuals Tests (Main Function)
+# =============================================================================
+
+class TestGenerateKpiVisuals:
+    """Tests for the main generate_kpi_visuals function."""
+
+    def test_basic_generation(self):
+        """Test basic KPI visuals generation."""
+        kpi_data = {
+            "roi": 150,
+            "payback_months": 6,
+            "time_savings_hours": 40
+        }
+        result = generate_kpi_visuals(kpi_data)
+        assert "html" in result
+        assert "bar_html" in result
+
+    def test_empty_kpi_data(self):
+        """Test with empty KPI data."""
+        result = generate_kpi_visuals({})
+        # Should return empty strings when no values
+        assert result.get("html") == ""
+
+    def test_roi_bar_generated(self):
+        """Test that ROI bar is generated when ROI provided."""
+        kpi_data = {"roi": 150}
+        result = generate_kpi_visuals(kpi_data)
+        assert result["bar_html"] != ""
+
+    def test_payback_bar_generated(self):
+        """Test that payback bar is generated when payback provided."""
+        kpi_data = {"payback_months": 6}
+        result = generate_kpi_visuals(kpi_data)
+        assert result["bar_html"] != ""
+
+    def test_time_savings_bar_generated(self):
+        """Test that time savings bar is generated."""
+        kpi_data = {"time_savings_hours": 40}
+        result = generate_kpi_visuals(kpi_data)
+        assert result["bar_html"] != ""
+
+    def test_time_savings_from_eur(self):
+        """Test that time savings can be derived from EUR."""
+        kpi_data = {"time_savings_eur": 6000}  # 6000 EUR / 60 = 100 hours
+        result = generate_kpi_visuals(kpi_data)
+        assert result["bar_html"] != ""
+
+    def test_alternative_key_names(self):
+        """Test that alternative key names work."""
+        kpi_data = {
+            "ROI_12M": 150,
+            "PAYBACK_MONTHS": 6,
+            "EINSPARUNG_STUNDEN": 40
+        }
+        result = generate_kpi_visuals(kpi_data)
+        assert result["bar_html"] != ""
+
+    def test_sparkline_with_monthly_values(self):
+        """Test sparkline generation with monthly values."""
+        kpi_data = {
+            "roi": 150,
+            "monthly_values": list(range(12))
+        }
+        result = generate_kpi_visuals(kpi_data, include_sparkline=True)
+        assert result["sparkline_html"] != ""
+
+    def test_sparkline_synthetic_from_roi(self):
+        """Test synthetic sparkline generated from ROI."""
+        kpi_data = {"roi": 150}
+        result = generate_kpi_visuals(kpi_data, include_sparkline=True)
+        # Should generate synthetic trend based on ROI
+        assert result["sparkline_html"] != ""
+
+    def test_sparkline_disabled(self):
+        """Test that sparkline can be disabled."""
+        kpi_data = {"roi": 150, "monthly_values": list(range(12))}
+        result = generate_kpi_visuals(kpi_data, include_sparkline=False)
+        assert result["sparkline_html"] == ""
+
+    def test_benchmark_with_industry_data(self):
+        """Test benchmark bar with industry data."""
+        kpi_data = {
+            "roi": 150,
+            "industry_roi": 100
+        }
+        result = generate_kpi_visuals(kpi_data, include_benchmark=True)
+        assert result["benchmark_html"] != ""
+
+    def test_benchmark_disabled(self):
+        """Test that benchmark can be disabled."""
+        kpi_data = {"roi": 150, "industry_roi": 100}
+        result = generate_kpi_visuals(kpi_data, include_benchmark=False)
+        assert result["benchmark_html"] == ""
+
+    def test_german_language(self):
+        """Test German language labels."""
+        kpi_data = {"roi": 150, "payback_months": 6}
+        result = generate_kpi_visuals(kpi_data, lang="de")
+        assert "ROI (12 Monate)" in result["bar_html"]
+        assert "Amortisation" in result["bar_html"]
+
+    def test_english_language(self):
+        """Test English language labels."""
+        kpi_data = {"roi": 150, "payback_months": 6}
+        result = generate_kpi_visuals(kpi_data, lang="en")
+        assert "ROI (12 months)" in result["bar_html"]
+        assert "Payback Period" in result["bar_html"]
+
+    def test_combined_html_includes_all(self):
+        """Test that combined HTML includes all components."""
+        kpi_data = {
+            "roi": 150,
+            "payback_months": 6,
+            "time_savings_hours": 40,
+            "monthly_values": list(range(12)),
+            "industry_roi": 100
+        }
+        result = generate_kpi_visuals(kpi_data)
+        html = result["html"]
+        assert "kpi-visuals" in html
+        assert "kpi-bars" in html
+
+    def test_result_dict_structure(self):
+        """Test that result has correct structure."""
+        result = generate_kpi_visuals({"roi": 150})
+        assert "bar_html" in result
+        assert "sparkline_html" in result
+        assert "benchmark_html" in result
+        assert "html" in result
+
+
+# =============================================================================
+# CSS Utility Tests
+# =============================================================================
+
+class TestGetKpiVisualsCss:
+    """Tests for the get_kpi_visuals_css function."""
+
+    def test_css_returned(self):
+        """Test that CSS is returned."""
+        css = get_kpi_visuals_css()
+        assert ".kpi-visuals" in css
+
+    def test_css_contains_required_classes(self):
+        """Test that CSS contains required classes."""
+        css = get_kpi_visuals_css()
+        assert ".kpi-bars" in css
+        assert ".kpi-bar" in css
+        assert ".kpi-sparkline-container" in css
+        assert ".kpi-benchmark-container" in css
+
+    def test_css_contains_print_styles(self):
+        """Test that CSS contains print styles."""
+        css = get_kpi_visuals_css()
+        assert "@media print" in css
+        assert "break-inside: avoid" in css
+
+
+# =============================================================================
+# Environment Variable Tests
+# =============================================================================
+
+class TestEnvConfiguration:
+    """Tests for environment configuration."""
+
+    def test_enable_flag_default(self):
+        """Test that ENABLE_KPI_VISUALS defaults to True."""
+        # Default should be enabled
+        assert ENABLE_KPI_VISUALS is True or os.getenv("ENABLE_KPI_VISUALS") == "0"
+
+
+# =============================================================================
+# Integration Tests
+# =============================================================================
+
+class TestIntegration:
+    """Integration tests for KPI visuals."""
+
+    def test_full_workflow(self):
+        """Test complete workflow of generating KPI visuals."""
+        # Simulate data from gpt_analyze.py
+        kpi_data = {
+            "roi": 145.5,
+            "payback_months": 8.2,
+            "time_savings_hours": 32,
+            "monthly_values": [5, 12, 18, 25, 35, 48, 62, 78, 95, 110, 125, 145],
+            "industry_roi": 85
+        }
+
+        result = generate_kpi_visuals(kpi_data, lang="de")
+
+        # Verify all outputs are present
+        assert result["bar_html"] != ""
+        assert result["sparkline_html"] != ""
+        assert result["benchmark_html"] != ""
+        assert result["html"] != ""
+
+        # Verify HTML structure
+        html = result["html"]
+        assert "kpi-visuals" in html
+        assert "<svg" in html
+
+    def test_minimal_data_workflow(self):
+        """Test workflow with minimal data."""
+        kpi_data = {"roi": 100}
+        result = generate_kpi_visuals(kpi_data, lang="en")
+
+        # Should still generate valid output
+        assert result["bar_html"] != ""
+        assert result["html"] != ""
+
+
+if __name__ == "__main__":
+    if pytest:
+        pytest.main([__file__, "-v"])
+    else:
+        print("pytest not installed, running basic tests...")
+        # Run basic sanity checks
+        print("\nTesting generate_kpi_bar...")
+        bar = generate_kpi_bar(100, 200, "Test", "roi")
+        assert "<svg" in bar and "</svg>" in bar
+        print("  OK: Basic bar generation")
+
+        print("\nTesting generate_sparkline...")
+        sparkline = generate_sparkline(list(range(12)))
+        assert "<svg" in sparkline and "polyline" in sparkline
+        print("  OK: Sparkline generation")
+
+        print("\nTesting generate_benchmark_bar...")
+        benchmark = generate_benchmark_bar(75, 60, 100, "Test")
+        assert "<svg" in benchmark
+        print("  OK: Benchmark bar generation")
+
+        print("\nTesting generate_kpi_visuals...")
+        result = generate_kpi_visuals({"roi": 150, "payback_months": 6})
+        assert result["bar_html"] != "" and result["html"] != ""
+        print("  OK: Main function")
+
+        print("\nAll basic tests passed!")

--- a/utils/kpi_visuals.py
+++ b/utils/kpi_visuals.py
@@ -1,0 +1,480 @@
+# -*- coding: utf-8 -*-
+"""
+Sprint G23: KPI Visualisation Layer
+
+Generates SVG visualizations for KPI metrics:
+- Horizontal KPI bars (ROI, Payback, Savings)
+- 12-month sparkline (trend curve)
+- Benchmark bars (You vs Industry)
+
+All SVGs are PDF-safe:
+- No filters, masks, gradients
+- No transform, rotate, skew
+- Stroke-only or flat fills
+- No animations or foreignObjects
+
+Version: 1.0.0 (Sprint G23)
+"""
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, Dict, List, Optional, Tuple
+
+log = logging.getLogger(__name__)
+
+__all__ = [
+    "generate_kpi_visuals",
+    "generate_kpi_bar",
+    "generate_sparkline",
+    "generate_benchmark_bar",
+]
+
+# =============================================================================
+# ENV CONFIGURATION
+# =============================================================================
+
+ENABLE_KPI_VISUALS = os.getenv("ENABLE_KPI_VISUALS", "1").lower() in ("1", "true", "yes")
+
+# Color palette (PLATIN++ brand colors)
+COLOR_PRIMARY = "#007bff"      # Blue - primary/ROI
+COLOR_SUCCESS = "#28a745"      # Green - positive/savings
+COLOR_WARNING = "#ffc107"      # Yellow - payback
+COLOR_DANGER = "#dc3545"       # Red - negative values
+COLOR_SECONDARY = "#6c757d"    # Gray - industry/benchmark
+COLOR_LIGHT = "#f8f9fa"        # Light background
+COLOR_MUTED = "#dee2e6"        # Muted borders
+COLOR_TEXT = "#212529"         # Dark text
+
+
+# =============================================================================
+# KPI BAR GENERATOR
+# =============================================================================
+
+def generate_kpi_bar(
+    value: float,
+    max_value: float,
+    label: str,
+    kpi_type: str = "default",
+    width: int = 200,
+    height: int = 40,
+    lang: str = "de"
+) -> str:
+    """
+    Generate a horizontal KPI progress bar.
+
+    Args:
+        value: Current KPI value
+        max_value: Maximum value for 100% bar
+        label: KPI label text
+        kpi_type: One of "roi", "payback", "savings", "default"
+        width: SVG width in pixels
+        height: SVG height in pixels
+        lang: Language code
+
+    Returns:
+        SVG string
+    """
+    # Calculate fill percentage (capped at 100%)
+    if max_value <= 0:
+        fill_pct = 0
+    else:
+        fill_pct = min(100, (value / max_value) * 100)
+
+    # Bar dimensions
+    bar_height = 12
+    bar_y = height - bar_height - 8
+    bar_width_actual = width - 60  # Leave space for label
+
+    # Color based on KPI type
+    color_map = {
+        "roi": COLOR_PRIMARY,
+        "payback": COLOR_WARNING,
+        "savings": COLOR_SUCCESS,
+        "default": COLOR_PRIMARY,
+    }
+    fill_color = color_map.get(kpi_type, COLOR_PRIMARY)
+
+    # Fill width
+    fill_width = (fill_pct / 100) * bar_width_actual
+
+    # Format value display
+    if kpi_type == "roi":
+        value_text = f"{value:.0f}%"
+    elif kpi_type == "payback":
+        unit = "Mon." if lang == "de" else "mo."
+        value_text = f"{value:.1f} {unit}"
+    elif kpi_type == "savings":
+        unit = "h/Mon." if lang == "de" else "h/mo."
+        value_text = f"{value:.0f} {unit}"
+    else:
+        value_text = f"{value:.1f}"
+
+    svg = f"""<svg class="kpi-bar kpi-bar-{kpi_type}" width="{width}" height="{height}" viewBox="0 0 {width} {height}" xmlns="http://www.w3.org/2000/svg" style="font-family:system-ui,-apple-system,sans-serif;">
+  <!-- Label -->
+  <text x="0" y="14" font-size="11" font-weight="600" fill="{COLOR_TEXT}">{label}</text>
+  <!-- Value -->
+  <text x="{width}" y="14" text-anchor="end" font-size="11" font-weight="700" fill="{fill_color}">{value_text}</text>
+  <!-- Background bar -->
+  <rect class="kpi-bar-bg" x="0" y="{bar_y}" width="{bar_width_actual}" height="{bar_height}" fill="{COLOR_MUTED}" rx="6"/>
+  <!-- Fill bar -->
+  <rect class="kpi-bar-fill {kpi_type}" x="0" y="{bar_y}" width="{fill_width}" height="{bar_height}" fill="{fill_color}" rx="6"/>
+</svg>"""
+
+    return svg.strip()
+
+
+# =============================================================================
+# SPARKLINE GENERATOR
+# =============================================================================
+
+def generate_sparkline(
+    values: List[float],
+    width: int = 200,
+    height: int = 50,
+    color: str = COLOR_PRIMARY,
+    show_endpoints: bool = True,
+    label: str = ""
+) -> str:
+    """
+    Generate a 12-month sparkline (trend curve).
+
+    Args:
+        values: List of 12 monthly values
+        width: SVG width in pixels
+        height: SVG height in pixels
+        color: Line color
+        show_endpoints: Whether to show start/end dots
+        label: Optional label text
+
+    Returns:
+        SVG string
+    """
+    if not values or len(values) < 2:
+        return ""
+
+    # Normalize to exactly 12 points
+    if len(values) < 12:
+        # Pad with last value
+        values = values + [values[-1]] * (12 - len(values))
+    elif len(values) > 12:
+        values = values[:12]
+
+    # Calculate scaling
+    min_val = min(values)
+    max_val = max(values)
+    val_range = max_val - min_val if max_val != min_val else 1
+
+    # Padding
+    pad_x = 10
+    pad_y = 15 if label else 5
+    chart_width = width - (pad_x * 2)
+    chart_height = height - (pad_y * 2) - (10 if label else 0)
+
+    # Generate points
+    points = []
+    for i, val in enumerate(values):
+        x = pad_x + (i / (len(values) - 1)) * chart_width
+        y = pad_y + chart_height - ((val - min_val) / val_range) * chart_height
+        points.append(f"{x:.1f},{y:.1f}")
+
+    polyline_points = " ".join(points)
+
+    # First and last point coordinates for dots
+    first_x, first_y = points[0].split(",")
+    last_x, last_y = points[-1].split(",")
+
+    # Endpoint dots
+    endpoints_svg = ""
+    if show_endpoints:
+        endpoints_svg = f"""
+  <circle cx="{first_x}" cy="{first_y}" r="3" fill="{color}"/>
+  <circle cx="{last_x}" cy="{last_y}" r="3" fill="{color}"/>"""
+
+    # Label
+    label_svg = ""
+    if label:
+        label_svg = f"""
+  <text x="{width/2}" y="{height - 2}" text-anchor="middle" font-size="9" fill="{COLOR_SECONDARY}">{label}</text>"""
+
+    svg = f"""<svg class="kpi-sparkline" width="{width}" height="{height}" viewBox="0 0 {width} {height}" xmlns="http://www.w3.org/2000/svg" style="font-family:system-ui,-apple-system,sans-serif;">
+  <!-- Baseline -->
+  <line x1="{pad_x}" y1="{pad_y + chart_height}" x2="{width - pad_x}" y2="{pad_y + chart_height}" stroke="{COLOR_MUTED}" stroke-width="1"/>
+  <!-- Sparkline -->
+  <polyline points="{polyline_points}" fill="none" stroke="{color}" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" vector-effect="non-scaling-stroke"/>{endpoints_svg}{label_svg}
+</svg>"""
+
+    return svg.strip()
+
+
+# =============================================================================
+# BENCHMARK BAR GENERATOR
+# =============================================================================
+
+def generate_benchmark_bar(
+    your_value: float,
+    industry_value: float,
+    max_value: float,
+    label: str,
+    width: int = 200,
+    height: int = 60,
+    lang: str = "de"
+) -> str:
+    """
+    Generate a benchmark comparison bar (You vs Industry).
+
+    Args:
+        your_value: Your company's value
+        industry_value: Industry average value
+        max_value: Maximum value for scaling
+        label: KPI label text
+        width: SVG width in pixels
+        height: SVG height in pixels
+        lang: Language code
+
+    Returns:
+        SVG string
+    """
+    if max_value <= 0:
+        max_value = max(your_value, industry_value, 1)
+
+    # Bar dimensions
+    bar_height = 10
+    bar_width_actual = width - 20
+
+    # Calculate widths
+    your_width = min(100, (your_value / max_value) * 100) / 100 * bar_width_actual
+    industry_width = min(100, (industry_value / max_value) * 100) / 100 * bar_width_actual
+
+    # Labels
+    you_label = "Sie" if lang == "de" else "You"
+    industry_label = "Branche" if lang == "de" else "Industry"
+
+    svg = f"""<svg class="kpi-benchmark" width="{width}" height="{height}" viewBox="0 0 {width} {height}" xmlns="http://www.w3.org/2000/svg" style="font-family:system-ui,-apple-system,sans-serif;">
+  <!-- Title -->
+  <text x="0" y="12" font-size="10" font-weight="600" fill="{COLOR_TEXT}">{label}</text>
+
+  <!-- Your bar -->
+  <text x="0" y="28" font-size="9" fill="{COLOR_SECONDARY}">{you_label}</text>
+  <rect class="kpi-you" x="45" y="20" width="{bar_width_actual}" height="{bar_height}" fill="{COLOR_MUTED}" rx="5"/>
+  <rect class="kpi-you-fill" x="45" y="20" width="{your_width}" height="{bar_height}" fill="{COLOR_PRIMARY}" rx="5"/>
+  <text x="{width}" y="28" text-anchor="end" font-size="9" font-weight="600" fill="{COLOR_PRIMARY}">{your_value:.0f}%</text>
+
+  <!-- Industry bar -->
+  <text x="0" y="46" font-size="9" fill="{COLOR_SECONDARY}">{industry_label}</text>
+  <rect class="kpi-industry" x="45" y="38" width="{bar_width_actual}" height="{bar_height}" fill="{COLOR_MUTED}" rx="5"/>
+  <rect class="kpi-industry-fill" x="45" y="38" width="{industry_width}" height="{bar_height}" fill="{COLOR_SECONDARY}" rx="5"/>
+  <text x="{width}" y="46" text-anchor="end" font-size="9" fill="{COLOR_SECONDARY}">{industry_value:.0f}%</text>
+</svg>"""
+
+    return svg.strip()
+
+
+# =============================================================================
+# MAIN GENERATOR FUNCTION
+# =============================================================================
+
+def generate_kpi_visuals(
+    kpi: Dict[str, Any],
+    lang: str = "de",
+    include_sparkline: bool = True,
+    include_benchmark: bool = True,
+) -> Dict[str, str]:
+    """
+    Generate all KPI visualizations.
+
+    Args:
+        kpi: Dictionary containing KPI values:
+            - roi: ROI percentage (e.g., 150.0)
+            - payback_months: Payback period in months (e.g., 6.0)
+            - time_savings_hours: Monthly time savings in hours (e.g., 40.0)
+            - monthly_values: Optional list of 12 monthly values for sparkline
+            - industry_roi: Optional industry average ROI for benchmark
+            - industry_adoption: Optional industry AI adoption rate
+        lang: Language code ("de" or "en")
+        include_sparkline: Whether to include sparkline
+        include_benchmark: Whether to include benchmark bar
+
+    Returns:
+        Dictionary with:
+            - bar_html: HTML for KPI bars
+            - sparkline_html: HTML for sparkline (if included)
+            - benchmark_html: HTML for benchmark bar (if included)
+            - html: Combined HTML for all visuals
+    """
+    if not ENABLE_KPI_VISUALS:
+        log.debug("[G23] KPI visuals disabled via ENABLE_KPI_VISUALS env")
+        return {"bar_html": "", "sparkline_html": "", "benchmark_html": "", "html": ""}
+
+    result: Dict[str, str] = {
+        "bar_html": "",
+        "sparkline_html": "",
+        "benchmark_html": "",
+        "html": "",
+    }
+
+    # Extract values with defaults
+    roi = kpi.get("roi") or kpi.get("ROI_12M") or 0
+    payback = kpi.get("payback_months") or kpi.get("PAYBACK_MONTHS") or 0
+    time_savings = kpi.get("time_savings_hours") or kpi.get("EINSPARUNG_STUNDEN") or 0
+
+    # If time_savings is in EUR, estimate hours (assuming 60€/h)
+    if time_savings == 0:
+        savings_eur = kpi.get("time_savings_eur") or kpi.get("EINSPARUNG_MONAT_EUR") or 0
+        if savings_eur > 0:
+            time_savings = savings_eur / 60
+
+    # Labels based on language
+    if lang == "de":
+        roi_label = "ROI (12 Monate)"
+        payback_label = "Amortisation"
+        savings_label = "Zeitersparnis/Monat"
+    else:
+        roi_label = "ROI (12 months)"
+        payback_label = "Payback Period"
+        savings_label = "Time Savings/Month"
+
+    # Generate KPI bars
+    bars = []
+
+    if roi > 0:
+        bars.append(generate_kpi_bar(
+            value=roi,
+            max_value=200,  # 200% as max for ROI
+            label=roi_label,
+            kpi_type="roi",
+            lang=lang
+        ))
+
+    if payback > 0:
+        bars.append(generate_kpi_bar(
+            value=payback,
+            max_value=24,  # 24 months as max
+            label=payback_label,
+            kpi_type="payback",
+            lang=lang
+        ))
+
+    if time_savings > 0:
+        bars.append(generate_kpi_bar(
+            value=time_savings,
+            max_value=160,  # 160 hours (full-time) as max
+            label=savings_label,
+            kpi_type="savings",
+            lang=lang
+        ))
+
+    if bars:
+        result["bar_html"] = f"""<div class="kpi-bars">
+  {'  '.join(bars)}
+</div>"""
+
+    # Generate sparkline (if monthly values provided)
+    if include_sparkline:
+        monthly_values = kpi.get("monthly_values") or kpi.get("trend_values")
+        if monthly_values and len(monthly_values) >= 2:
+            trend_label = "12-Monats-Trend" if lang == "de" else "12-Month Trend"
+            result["sparkline_html"] = generate_sparkline(
+                values=monthly_values,
+                color=COLOR_SUCCESS,
+                label=trend_label
+            )
+        elif roi > 0:
+            # Generate synthetic trend based on ROI
+            # Assumes linear growth to reach ROI target
+            monthly_growth = roi / 12 if roi > 0 else 0
+            synthetic_values = [i * monthly_growth for i in range(1, 13)]
+            trend_label = "Erwarteter Verlauf" if lang == "de" else "Expected Trend"
+            result["sparkline_html"] = generate_sparkline(
+                values=synthetic_values,
+                color=COLOR_SUCCESS,
+                label=trend_label
+            )
+
+    # Generate benchmark bar (if industry values provided)
+    if include_benchmark:
+        industry_roi = kpi.get("industry_roi") or kpi.get("branch_avg_roi")
+        if industry_roi and roi > 0:
+            benchmark_label = "ROI-Vergleich" if lang == "de" else "ROI Comparison"
+            result["benchmark_html"] = generate_benchmark_bar(
+                your_value=roi,
+                industry_value=industry_roi,
+                max_value=max(roi, industry_roi, 100) * 1.2,
+                label=benchmark_label,
+                lang=lang
+            )
+
+    # Combine all visuals
+    html_parts = []
+    if result["bar_html"]:
+        html_parts.append(result["bar_html"])
+    if result["sparkline_html"]:
+        html_parts.append(f'<div class="kpi-sparkline-container">{result["sparkline_html"]}</div>')
+    if result["benchmark_html"]:
+        html_parts.append(f'<div class="kpi-benchmark-container">{result["benchmark_html"]}</div>')
+
+    if html_parts:
+        result["html"] = f"""<div class="kpi-visuals">
+  {chr(10).join(html_parts)}
+</div>"""
+
+    log.debug("[G23] Generated KPI visuals: bars=%s, sparkline=%s, benchmark=%s",
+              bool(result["bar_html"]), bool(result["sparkline_html"]), bool(result["benchmark_html"]))
+
+    return result
+
+
+# =============================================================================
+# UTILITY FUNCTIONS
+# =============================================================================
+
+def get_kpi_visuals_css() -> str:
+    """
+    Get CSS styles for KPI visuals (for inline embedding in templates).
+
+    Returns:
+        CSS string
+    """
+    return """
+/* G23: KPI Visuals CSS */
+.kpi-visuals {
+  margin: 1.5rem 0;
+  break-inside: avoid;
+}
+
+.kpi-bars {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.kpi-bar {
+  display: block;
+}
+
+.kpi-sparkline-container {
+  margin-top: 1rem;
+  padding: 0.75rem;
+  background: #f8f9fa;
+  border-radius: 8px;
+}
+
+.kpi-benchmark-container {
+  margin-top: 1rem;
+  padding: 0.75rem;
+  background: #f8f9fa;
+  border-radius: 8px;
+}
+
+/* Print/PDF optimization */
+@media print {
+  .kpi-visuals {
+    break-inside: avoid;
+    page-break-inside: avoid;
+  }
+
+  .kpi-bar, .kpi-sparkline, .kpi-benchmark {
+    max-width: 100%;
+  }
+}
+""".strip()

--- a/utils/kpi_visuals.py
+++ b/utils/kpi_visuals.py
@@ -77,9 +77,9 @@ def generate_kpi_bar(
     """
     # Calculate fill percentage (capped at 100%)
     if max_value <= 0:
-        fill_pct = 0
+        fill_pct = 0.0
     else:
-        fill_pct = min(100, (value / max_value) * 100)
+        fill_pct = min(100.0, (value / max_value) * 100)
 
     # Bar dimensions
     bar_height = 12


### PR DESCRIPTION
Add PDF-safe SVG visualizations for KPI metrics:
- Horizontal KPI bars (ROI, Payback, Savings)
- 12-month sparkline trend curves
- Benchmark comparison bars (You vs Industry)

New files:
- utils/kpi_visuals.py: SVG generators
- tests/test_g23_kpi_visuals.py: Test suite

Template updates:
- Add G23 CSS to both DE/EN templates
- Add KPI_VISUALS_HTML section placeholders