### PR TITLE
feat(G27): add Executive Snapshot One-Pager for PDF page 2

### DIFF
--- a/prompts/de/exec_snapshot.md
+++ b/prompts/de/exec_snapshot.md
@@ -1,0 +1,78 @@
+# Executive Snapshot – One-Pager (Seite 2)
+
+Du generierst einen kompakten Executive Snapshot für C-Level, Investoren und Pitches.
+Der Snapshot fasst die wichtigsten Erkenntnisse des PLATIN++ Reports zusammen.
+
+## Kontext
+
+**Unternehmen:** {{COMPANY_NAME}}
+**Branche:** {{BRANCH_LABEL}}
+**Größe:** {{SIZE_LABEL}}
+**Reifegrad:** {{MATURITY_LEVEL}}
+
+## 8 Pflichtbausteine
+
+### Block 1: KPI Visuals
+- ROI 12 Monate: {{ROI_12M}}%
+- Payback-Zeitraum: {{PAYBACK_MONTHS}} Monate
+- Zeitersparnis: {{EINSPARUNG_STUNDEN_MONAT}} Std/Monat
+- Geldersparnis: {{EINSPARUNG_MONAT_EUR}} €/Monat
+
+### Block 2: Top 3 Tools
+Aus Tools Engine 4.0 (G25):
+- Name, Kategorie
+- Cost-Level Badge (1-5)
+- Complexity Badge (1-5)
+- EU-Hosting Badge (falls zutreffend)
+
+### Block 3: Top 3 Förderprogramme
+Aus Funding Matrix (G26):
+- Programmname
+- Jahr (2025/2026/2027)
+- Ebene (EU/Bund/Land)
+- Förderquote
+- Match-Score
+- ⚡ Flag bei zeitkritischen Programmen (2025)
+- 🔮 Flag bei provisorischen Programmen (2027)
+
+### Block 4: Branche + Risiko-Badge
+- Branchenkürzel
+- AI Act Risiko-Level
+- DSGVO-Relevanz (falls zutreffend)
+
+### Block 5: 3 Quick Wins
+Konkrete, sofort umsetzbare Maßnahmen:
+- Aus Tools Engine 4.0
+- Aus Funding Engine 2.0
+- Aus KPI-Potenzial
+
+### Block 6: 3 Hauptrisiken
+- Aus Branch Risks (G24)
+- Aus Tool Compliance Score
+- Aus AI Act Level
+
+### Block 7: Mini 3-Schritt Roadmap
+1. **Setup** – KI-Tools einrichten
+2. **Workflow** – Prozesse automatisieren
+3. **Optimierung** – Skalieren & ROI maximieren
+
+### Block 8: Förder-Timeline 2025–2027
+Visuelle Darstellung:
+- Deadlines
+- Öffnungsfenster
+- Strategiepotenziale
+
+## Output-Anforderungen
+
+- Extrem kompakt
+- Visuell stark
+- Keine Widersprüche zu anderen Sections
+- Board-Deck Qualität
+- Keine Füllwörter
+
+## Verbotene Phrasen
+
+- "Wir empfehlen..."
+- "Es ist wichtig zu beachten..."
+- "Zusammenfassend lässt sich sagen..."
+- Generische Floskeln

--- a/prompts/en/exec_snapshot.md
+++ b/prompts/en/exec_snapshot.md
@@ -1,0 +1,78 @@
+# Executive Snapshot – One-Pager (Page 2)
+
+You generate a compact Executive Snapshot for C-Level executives, investors, and pitches.
+The snapshot summarizes the key findings of the PLATIN++ Report.
+
+## Context
+
+**Company:** {{COMPANY_NAME}}
+**Industry:** {{BRANCH_LABEL}}
+**Size:** {{SIZE_LABEL}}
+**Maturity Level:** {{MATURITY_LEVEL}}
+
+## 8 Required Building Blocks
+
+### Block 1: KPI Visuals
+- ROI 12 Months: {{ROI_12M}}%
+- Payback Period: {{PAYBACK_MONTHS}} months
+- Time Savings: {{EINSPARUNG_STUNDEN_MONAT}} hrs/month
+- Cost Savings: {{EINSPARUNG_MONAT_EUR}} €/month
+
+### Block 2: Top 3 Tools
+From Tools Engine 4.0 (G25):
+- Name, Category
+- Cost-Level Badge (1-5)
+- Complexity Badge (1-5)
+- EU-Hosting Badge (if applicable)
+
+### Block 3: Top 3 Funding Programmes
+From Funding Matrix (G26):
+- Programme name
+- Year (2025/2026/2027)
+- Level (EU/Federal/State)
+- Funding rate
+- Match score
+- ⚡ Flag for time-critical programmes (2025)
+- 🔮 Flag for provisional programmes (2027)
+
+### Block 4: Industry + Risk Badge
+- Industry short label
+- AI Act Risk Level
+- GDPR relevance (if applicable)
+
+### Block 5: 3 Quick Wins
+Concrete, immediately actionable measures:
+- From Tools Engine 4.0
+- From Funding Engine 2.0
+- From KPI potential
+
+### Block 6: 3 Key Risks
+- From Branch Risks (G24)
+- From Tool Compliance Score
+- From AI Act Level
+
+### Block 7: Mini 3-Step Roadmap
+1. **Setup** – Configure AI tools
+2. **Workflow** – Automate processes
+3. **Optimization** – Scale & maximize ROI
+
+### Block 8: Funding Timeline 2025–2027
+Visual representation:
+- Deadlines
+- Opening windows
+- Strategic opportunities
+
+## Output Requirements
+
+- Extremely compact
+- Visually strong
+- No contradictions with other sections
+- Board-deck quality
+- No filler words
+
+## Forbidden Phrases
+
+- "We recommend..."
+- "It is important to note..."
+- "In summary, it can be said..."
+- Generic phrases

--- a/services/consistency_engine.py
+++ b/services/consistency_engine.py
@@ -447,6 +447,7 @@ class ConsistencyEngine:
         self._check_risk_level_consistency()
         self._check_roadmap_alignment()
         self._check_narrative_coherence()
+        self._check_exec_snapshot_consistency()  # G27
 
         # Calculate domain scores
         self._calculate_domain_scores()
@@ -1122,12 +1123,137 @@ class ConsistencyEngine:
                 ))
 
     # -------------------------------------------------------------------------
+    # DOMAIN 7: Executive Snapshot Consistency (G27)
+    # -------------------------------------------------------------------------
+
+    def _check_exec_snapshot_consistency(self) -> None:
+        """G27: Check Executive Snapshot consistency with other sections."""
+        snapshot_html = self.sections.get("EXEC_SNAPSHOT_HTML", "")
+
+        if not snapshot_html:
+            log.debug("[G27] Exec Snapshot consistency: Skipping (no snapshot)")
+            return
+
+        self.report.checked_rules += 5
+
+        # Rule SNAPSHOT_001: KPIs must match Business Case
+        bc_html = self.sections.get("BUSINESS_CASE_HTML", "")
+        if bc_html and snapshot_html:
+            # Extract ROI from both
+            import re
+            snapshot_roi_match = re.search(r'(\d+(?:[.,]\d+)?)\s*%', snapshot_html)
+            bc_roi_match = re.search(r'ROI[:\s]*(\d+(?:[.,]\d+)?)\s*%', bc_html, re.IGNORECASE)
+
+            if snapshot_roi_match and bc_roi_match:
+                snapshot_roi = float(snapshot_roi_match.group(1).replace(",", "."))
+                bc_roi = float(bc_roi_match.group(1).replace(",", "."))
+
+                if abs(snapshot_roi - bc_roi) > 20:  # More than 20% deviation
+                    self.report.add_issue(ConsistencyIssue(
+                        rule_id="SNAPSHOT_001",
+                        severity="ERROR",
+                        domain="snapshot",
+                        source_section="exec_snapshot",
+                        target_section="business_case",
+                        message="Snapshot ROI weicht stark vom Business Case ab",
+                        expected=f"ROI ~{bc_roi:.0f}% (wie Business Case)",
+                        actual=f"Snapshot zeigt {snapshot_roi:.0f}%",
+                        suggestion="Synchronisiere KPI-Werte zwischen Snapshot und Business Case",
+                    ))
+
+        # Rule SNAPSHOT_002: Tools must match Tools Engine 4.0
+        ki_stack_html = self.sections.get("KI_STACK_SUMMARY_HTML", "")
+        if ki_stack_html and snapshot_html:
+            ki_stack_tools = _extract_tool_names(ki_stack_html)
+            snapshot_tools = _extract_tool_names(snapshot_html)
+
+            if ki_stack_tools and snapshot_tools:
+                # Check if snapshot tools are subset of ki_stack tools
+                mismatched = [t for t in snapshot_tools
+                              if not any(t.lower() in kt.lower() or kt.lower() in t.lower()
+                                        for kt in ki_stack_tools)]
+
+                if len(mismatched) > len(snapshot_tools) * 0.5:
+                    self.report.add_issue(ConsistencyIssue(
+                        rule_id="SNAPSHOT_002",
+                        severity="WARNING",
+                        domain="snapshot",
+                        source_section="exec_snapshot",
+                        target_section="ki_stack_summary",
+                        message="Snapshot Tools stimmen nicht mit KI-Stack überein",
+                        expected="Tools aus KI-Stack Summary",
+                        actual=f"Abweichende Tools: {', '.join(mismatched[:2])}",
+                        suggestion="Verwende Tools aus Tools Engine 4.0",
+                    ))
+
+        # Rule SNAPSHOT_003: Funding must match Funding Engine 2.0
+        funding_html = self.sections.get("FUNDING_MATRIX_2025_HTML", "") or self.sections.get("FOERDERPOTENZIAL_HTML", "")
+        if funding_html and snapshot_html:
+            funding_progs = _extract_funding_programs(funding_html)
+            snapshot_progs = _extract_funding_programs(snapshot_html)
+
+            if snapshot_progs and funding_progs:
+                mismatched = [p for p in snapshot_progs
+                              if not any(p.lower() in fp.lower() or fp.lower() in p.lower()
+                                        for fp in funding_progs)]
+
+                if mismatched:
+                    self.report.add_issue(ConsistencyIssue(
+                        rule_id="SNAPSHOT_003",
+                        severity="WARNING",
+                        domain="snapshot",
+                        source_section="exec_snapshot",
+                        target_section="funding_matrix",
+                        message="Snapshot Förderprogramme stimmen nicht mit Matrix überein",
+                        expected="Programme aus Funding Engine 2.0",
+                        actual=f"Unbekannte Programme: {', '.join(mismatched[:2])}",
+                        suggestion="Verwende Programme aus Funding Matrix",
+                    ))
+
+        # Rule SNAPSHOT_004: Quick Wins must not contain unsuitable tools
+        size = self.briefing.get("unternehmensgroesse", "").lower()
+        if "solo" in size and snapshot_html:
+            enterprise_indicators = ["enterprise", "team-plan", "business-plan", "konzern"]
+            snapshot_lower = snapshot_html.lower()
+
+            has_enterprise = any(ind in snapshot_lower for ind in enterprise_indicators)
+            if has_enterprise:
+                self.report.add_issue(ConsistencyIssue(
+                    rule_id="SNAPSHOT_004",
+                    severity="WARNING",
+                    domain="snapshot",
+                    source_section="exec_snapshot",
+                    target_section="briefing",
+                    message="Snapshot enthält Enterprise-Tools für Solo-Unternehmer",
+                    expected="Solo-geeignete Quick Wins",
+                    actual="Enterprise-Tools in Snapshot gefunden",
+                    suggestion="Wähle Solo-freundliche Alternativen",
+                ))
+
+        # Rule SNAPSHOT_005: Risk level must be consistent
+        ai_act_risk = self.sections.get("AI_ACT_RISK_LEVEL", "").lower()
+        snapshot_lower = snapshot_html.lower()
+
+        if ai_act_risk == "high-risk" and "minimal" in snapshot_lower and "risk" in snapshot_lower:
+            self.report.add_issue(ConsistencyIssue(
+                rule_id="SNAPSHOT_005",
+                severity="ERROR",
+                domain="snapshot",
+                source_section="exec_snapshot",
+                target_section="ai_act",
+                message="Snapshot zeigt 'minimal risk' obwohl AI Act High-Risk klassifiziert",
+                expected="Konsistente Risiko-Darstellung",
+                actual="Widersprüchliche Risiko-Level",
+                suggestion="Synchronisiere Risiko-Level mit AI Act Analyse",
+            ))
+
+    # -------------------------------------------------------------------------
     # SCORING
     # -------------------------------------------------------------------------
 
     def _calculate_domain_scores(self) -> None:
         """Calculate scores per domain."""
-        domains = ["tools", "funding", "kpi", "risk", "roadmap", "narrative"]
+        domains = ["tools", "funding", "kpi", "risk", "roadmap", "narrative", "snapshot"]
 
         for domain in domains:
             domain_issues = [i for i in self.report.issues if i.domain == domain]

--- a/services/exec_snapshot.py
+++ b/services/exec_snapshot.py
@@ -1,0 +1,734 @@
+# -*- coding: utf-8 -*-
+"""
+Sprint G27: Executive Snapshot One-Pager (PDF Page 2)
+
+Generates a compact, visually strong executive summary combining:
+- KPI Visuals (G23)
+- Tools Engine 4.0 (G25)
+- Funding Matrix (G26)
+- Branch Risk + Industry Badge (G20/G24)
+- Deep Dive Insights (G24)
+- Starter Kit (G20)
+- Risk Indicators (G22)
+
+Output: EXEC_SNAPSHOT_HTML for PDF page 2.
+
+Version: 1.0.0 (Sprint G27)
+"""
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+log = logging.getLogger(__name__)
+
+__all__ = [
+    "generate_exec_snapshot",
+    "ExecSnapshotData",
+    "inject_exec_snapshot_into_sections",
+    "EXEC_SNAPSHOT_ENABLED",
+]
+
+# =============================================================================
+# CONFIGURATION
+# =============================================================================
+
+EXEC_SNAPSHOT_ENABLED = os.getenv("EXEC_SNAPSHOT_ENABLED", "1").lower() in ("1", "true", "yes")
+
+
+# =============================================================================
+# DATA STRUCTURES
+# =============================================================================
+
+@dataclass
+class KPIData:
+    """KPI data for snapshot."""
+    roi_12m: float = 0.0
+    payback_months: float = 0.0
+    time_savings_hours: float = 0.0
+    time_savings_eur: float = 0.0
+    industry_benchmark_roi: float = 120.0
+
+
+@dataclass
+class ToolCard:
+    """Tool card for snapshot."""
+    name: str
+    category: str
+    cost_level: int = 3
+    complexity_level: int = 3
+    compliance_score: int = 2
+    vendor_risk: int = 2
+    eu_hosting: Optional[bool] = None
+
+
+@dataclass
+class FundingCard:
+    """Funding card for snapshot."""
+    name: str
+    year: int
+    level: str  # eu, federal, state
+    funding_rate: str
+    match_score: float
+    is_time_critical: bool = False
+    is_provisional: bool = False
+
+
+@dataclass
+class ExecSnapshotData:
+    """Complete data for executive snapshot."""
+    # Block 1: KPIs
+    kpis: KPIData = field(default_factory=KPIData)
+
+    # Block 2: Top 3 Tools
+    tools: List[ToolCard] = field(default_factory=list)
+
+    # Block 3: Top 3 Funding
+    funding: List[FundingCard] = field(default_factory=list)
+
+    # Block 4: Branch + Risk
+    branch_label: str = ""
+    branch_short: str = ""
+    ai_act_risk: str = "minimal"
+    dsgvo_relevant: bool = False
+
+    # Block 5: Quick Wins
+    quick_wins: List[str] = field(default_factory=list)
+
+    # Block 6: Key Risks
+    key_risks: List[str] = field(default_factory=list)
+
+    # Block 7: Mini Roadmap
+    roadmap_steps: List[Dict[str, str]] = field(default_factory=list)
+
+    # Block 8: Timeline data
+    funding_timeline: List[Dict[str, Any]] = field(default_factory=list)
+
+
+# =============================================================================
+# DATA EXTRACTION
+# =============================================================================
+
+def _extract_kpi_data(sections: Dict[str, Any], briefing: Dict[str, Any]) -> KPIData:
+    """Extract KPI data from sections and briefing."""
+    return KPIData(
+        roi_12m=float(sections.get("ROI_12M", 0) or briefing.get("ROI_12M", 0) or 0),
+        payback_months=float(sections.get("PAYBACK_MONTHS", 0) or briefing.get("PAYBACK_MONTHS", 0) or 0),
+        time_savings_hours=float(sections.get("EINSPARUNG_STUNDEN_MONAT", 0) or briefing.get("einsparung_stunden_monat", 0) or 0),
+        time_savings_eur=float(sections.get("EINSPARUNG_MONAT_EUR", 0) or briefing.get("einsparung_monat_eur", 0) or 0),
+        industry_benchmark_roi=float(sections.get("INDUSTRY_BENCHMARK_ROI", 120) or 120),
+    )
+
+
+def _extract_tools(sections: Dict[str, Any], limit: int = 3) -> List[ToolCard]:
+    """Extract top tools from sections."""
+    tools: List[ToolCard] = []
+
+    # Try to get tools from various sources
+    tools_data = sections.get("TOOLS_V4_DATA", [])
+    if isinstance(tools_data, list):
+        for tool in tools_data[:limit]:
+            if isinstance(tool, dict):
+                tools.append(ToolCard(
+                    name=tool.get("name", ""),
+                    category=tool.get("category", ""),
+                    cost_level=int(tool.get("cost_level", 3)),
+                    complexity_level=int(tool.get("complexity_level", 3)),
+                    compliance_score=int(tool.get("compliance_score", 2)),
+                    vendor_risk=int(tool.get("vendor_risk", 2)),
+                    eu_hosting=tool.get("eu_hosting"),
+                ))
+
+    # Fallback: Extract from HTML if no structured data
+    if not tools:
+        tools_html = sections.get("KI_STACK_SUMMARY_HTML", "")
+        # Simple extraction - in production this would be more sophisticated
+        import re
+        tool_names = re.findall(r'<strong[^>]*>([A-Za-z0-9\s\-\.]+(?:AI|GPT)?)</strong>', tools_html)
+        for name in tool_names[:limit]:
+            if len(name) > 2 and len(name) < 40:
+                tools.append(ToolCard(name=name.strip(), category="KI-Tool"))
+
+    return tools
+
+
+def _extract_funding(sections: Dict[str, Any], limit: int = 3) -> List[FundingCard]:
+    """Extract top funding programmes from sections."""
+    funding: List[FundingCard] = []
+
+    # Try to get from FUNDING_V2_DATA
+    funding_data = sections.get("FUNDING_V2_DATA", [])
+    if isinstance(funding_data, list):
+        for prog in funding_data[:limit]:
+            if isinstance(prog, dict):
+                year = int(prog.get("year", 2025))
+                funding.append(FundingCard(
+                    name=prog.get("name", ""),
+                    year=year,
+                    level=prog.get("level", "federal"),
+                    funding_rate=prog.get("funding_rate", ""),
+                    match_score=float(prog.get("match_score", 0)),
+                    is_time_critical=(year == 2025),
+                    is_provisional=(year == 2027),
+                ))
+
+    return funding
+
+
+def _extract_quick_wins(sections: Dict[str, Any], briefing: Dict[str, Any]) -> List[str]:
+    """Extract quick wins from sections."""
+    wins: List[str] = []
+
+    # From structured data
+    qw_data = sections.get("QUICK_WINS_DATA", [])
+    if isinstance(qw_data, list):
+        for win in qw_data[:3]:
+            if isinstance(win, str):
+                wins.append(win)
+            elif isinstance(win, dict):
+                wins.append(win.get("title", "") or win.get("text", ""))
+
+    # Fallback defaults based on context
+    if not wins:
+        branch = briefing.get("branche", "").lower()
+        if "beratung" in branch:
+            wins = [
+                "ChatGPT für Recherche & Texterstellung einsetzen",
+                "Automatische Terminplanung mit KI-Assistent",
+                "Dokumentenanalyse mit PDF-KI beschleunigen",
+            ]
+        elif "it" in branch or "software" in branch:
+            wins = [
+                "GitHub Copilot für Code-Beschleunigung",
+                "KI-gestützte Code-Reviews automatisieren",
+                "Testgenerierung mit KI-Tools",
+            ]
+        else:
+            wins = [
+                "KI-Assistenten für Routineaufgaben nutzen",
+                "Automatisierung von Dokumentenprozessen",
+                "Datenanalyse mit KI-Tools beschleunigen",
+            ]
+
+    return wins[:3]
+
+
+def _extract_key_risks(sections: Dict[str, Any], briefing: Dict[str, Any]) -> List[str]:
+    """Extract key risks from sections."""
+    risks: List[str] = []
+
+    # From structured data
+    risk_data = sections.get("KEY_RISKS_DATA", [])
+    if isinstance(risk_data, list):
+        for risk in risk_data[:3]:
+            if isinstance(risk, str):
+                risks.append(risk)
+            elif isinstance(risk, dict):
+                risks.append(risk.get("title", "") or risk.get("text", ""))
+
+    # From branch risks
+    branch_risks = sections.get("BRANCH_RISKS", [])
+    if not risks and isinstance(branch_risks, list):
+        risks = [r.get("title", r) if isinstance(r, dict) else str(r) for r in branch_risks[:3]]
+
+    # Fallback defaults
+    if not risks:
+        ai_act_risk = sections.get("AI_ACT_RISK_LEVEL", "minimal").lower()
+        if ai_act_risk == "high-risk":
+            risks = [
+                "AI Act High-Risk Klassifikation erfordert Compliance",
+                "Dokumentationspflichten für KI-Systeme",
+                "Vendor Lock-in bei Enterprise-Tools",
+            ]
+        else:
+            risks = [
+                "Datenschutz bei Cloud-KI-Diensten beachten",
+                "Mitarbeiter-Akzeptanz sicherstellen",
+                "Abhängigkeit von externen KI-Anbietern",
+            ]
+
+    return risks[:3]
+
+
+def _extract_roadmap_steps(sections: Dict[str, Any]) -> List[Dict[str, str]]:
+    """Extract mini roadmap steps."""
+    steps_raw = sections.get("ROADMAP_STEPS", [])
+
+    if not steps_raw:
+        # Default 3-step roadmap
+        steps: List[Dict[str, str]] = [
+            {"phase": "1", "title": "Setup", "description": "KI-Tools einrichten & Team schulen"},
+            {"phase": "2", "title": "Workflow", "description": "Erste Prozesse automatisieren"},
+            {"phase": "3", "title": "Optimierung", "description": "Skalieren & ROI maximieren"},
+        ]
+    else:
+        steps = list(steps_raw)
+
+    return steps[:3]
+
+
+def _extract_funding_timeline(sections: Dict[str, Any]) -> List[Dict[str, Any]]:
+    """Extract funding timeline data."""
+    timeline = []
+
+    funding_data = sections.get("FUNDING_V2_DATA", [])
+    if isinstance(funding_data, list):
+        for year in [2025, 2026, 2027]:
+            year_progs = [p for p in funding_data if isinstance(p, dict) and p.get("year") == year]
+            timeline.append({
+                "year": year,
+                "count": len(year_progs),
+                "programmes": [p.get("name", "") for p in year_progs[:2]],
+            })
+
+    if not timeline:
+        timeline = [
+            {"year": 2025, "count": 5, "programmes": ["go-digital", "Digital Jetzt"]},
+            {"year": 2026, "count": 3, "programmes": ["AI Made in Germany"]},
+            {"year": 2027, "count": 2, "programmes": ["Horizon Europe AI"]},
+        ]
+
+    return timeline
+
+
+# =============================================================================
+# HTML GENERATION - BLOCK 1: KPI VISUALS
+# =============================================================================
+
+def _generate_kpi_block(kpis: KPIData, lang: str = "de") -> str:
+    """Generate KPI visual block."""
+    labels = {
+        "de": {"roi": "ROI 12M", "payback": "Payback", "savings": "Ersparnis/Mt", "benchmark": "Sie vs. Branche"},
+        "en": {"roi": "ROI 12M", "payback": "Payback", "savings": "Savings/Mo", "benchmark": "You vs. Industry"},
+    }
+    l = labels.get(lang, labels["de"])
+
+    # Calculate bar widths
+    roi_pct = min(100, (kpis.roi_12m / 300) * 100) if kpis.roi_12m > 0 else 0
+    payback_pct = min(100, ((24 - kpis.payback_months) / 24) * 100) if kpis.payback_months > 0 else 0
+    savings_pct = min(100, (kpis.time_savings_eur / 5000) * 100) if kpis.time_savings_eur > 0 else 0
+    benchmark_you = min(100, (kpis.roi_12m / 200) * 100) if kpis.roi_12m > 0 else 0
+    benchmark_ind = min(100, (kpis.industry_benchmark_roi / 200) * 100)
+
+    return f'''
+    <div class="snapshot-block kpi-block">
+        <h4 class="snapshot-block-title">📊 KPIs</h4>
+        <div class="kpi-mini-bars">
+            <div class="kpi-mini-row">
+                <span class="kpi-label">{l["roi"]}</span>
+                <div class="kpi-bar-track">
+                    <div class="kpi-bar-fill kpi-roi" style="width: {roi_pct:.0f}%;"></div>
+                </div>
+                <span class="kpi-value">{kpis.roi_12m:.0f}%</span>
+            </div>
+            <div class="kpi-mini-row">
+                <span class="kpi-label">{l["payback"]}</span>
+                <div class="kpi-bar-track">
+                    <div class="kpi-bar-fill kpi-payback" style="width: {payback_pct:.0f}%;"></div>
+                </div>
+                <span class="kpi-value">{kpis.payback_months:.0f} Mt</span>
+            </div>
+            <div class="kpi-mini-row">
+                <span class="kpi-label">{l["savings"]}</span>
+                <div class="kpi-bar-track">
+                    <div class="kpi-bar-fill kpi-savings" style="width: {savings_pct:.0f}%;"></div>
+                </div>
+                <span class="kpi-value">{kpis.time_savings_eur:,.0f} €</span>
+            </div>
+        </div>
+        <div class="kpi-benchmark">
+            <span class="benchmark-label">{l["benchmark"]}</span>
+            <div class="benchmark-bars">
+                <div class="benchmark-bar you" style="width: {benchmark_you:.0f}%;"></div>
+                <div class="benchmark-bar industry" style="width: {benchmark_ind:.0f}%;"></div>
+            </div>
+        </div>
+    </div>
+    '''
+
+
+# =============================================================================
+# HTML GENERATION - BLOCK 2: TOOL CARDS
+# =============================================================================
+
+def _generate_tools_block(tools: List[ToolCard], lang: str = "de") -> str:
+    """Generate tool cards block."""
+    title = "🛠️ Top Tools" if lang == "de" else "🛠️ Top Tools"
+
+    if not tools:
+        return f'''
+        <div class="snapshot-block tools-block">
+            <h4 class="snapshot-block-title">{title}</h4>
+            <p class="muted small">Keine Tools ausgewählt</p>
+        </div>
+        '''
+
+    cards_html = ""
+    for tool in tools[:3]:
+        # Cost badge
+        cost_labels = ["", "€", "€€", "€€€", "€€€€", "€€€€€"]
+        cost_badge = cost_labels[min(tool.cost_level, 5)]
+
+        # Complexity badge
+        complexity_icons = ["", "●", "●●", "●●●", "●●●●", "●●●●●"]
+        complexity_badge = complexity_icons[min(tool.complexity_level, 5)]
+
+        # EU badge
+        eu_badge = '<span class="badge eu-badge">🇪🇺</span>' if tool.eu_hosting else ""
+
+        cards_html += f'''
+            <div class="tool-mini-card">
+                <div class="tool-name">{tool.name}</div>
+                <div class="tool-badges">
+                    <span class="badge cost-level-{tool.cost_level}">{cost_badge}</span>
+                    <span class="badge complexity-{tool.complexity_level}" title="Komplexität">{complexity_badge}</span>
+                    {eu_badge}
+                </div>
+            </div>
+        '''
+
+    return f'''
+    <div class="snapshot-block tools-block">
+        <h4 class="snapshot-block-title">{title}</h4>
+        <div class="tool-mini-cards">
+            {cards_html}
+        </div>
+    </div>
+    '''
+
+
+# =============================================================================
+# HTML GENERATION - BLOCK 3: FUNDING SNAPSHOT
+# =============================================================================
+
+def _generate_funding_block(funding: List[FundingCard], lang: str = "de") -> str:
+    """Generate funding snapshot block."""
+    title = "💰 Förderung" if lang == "de" else "💰 Funding"
+
+    if not funding:
+        return f'''
+        <div class="snapshot-block funding-block">
+            <h4 class="snapshot-block-title">{title}</h4>
+            <p class="muted small">Keine passenden Programme</p>
+        </div>
+        '''
+
+    cards_html = ""
+    for prog in funding[:3]:
+        # Year badge color
+        year_class = f"year-{prog.year}"
+
+        # Level label
+        level_labels = {"eu": "EU", "federal": "Bund", "state": "Land", "regional": "Regional"}
+        level_label = level_labels.get(prog.level, prog.level)
+
+        # Flags
+        flags = ""
+        if prog.is_time_critical:
+            flags += '<span class="flag time-critical">⚡</span>'
+        if prog.is_provisional:
+            flags += '<span class="flag provisional">🔮</span>'
+
+        match_pct = int(prog.match_score * 100)
+
+        cards_html += f'''
+            <div class="funding-mini-card">
+                <div class="funding-header">
+                    <span class="funding-name">{prog.name}</span>
+                    {flags}
+                </div>
+                <div class="funding-details">
+                    <span class="badge {year_class}">{prog.year}</span>
+                    <span class="badge level-{prog.level}">{level_label}</span>
+                    <span class="funding-rate">{prog.funding_rate}</span>
+                    <span class="match-score">{match_pct}%</span>
+                </div>
+            </div>
+        '''
+
+    return f'''
+    <div class="snapshot-block funding-block">
+        <h4 class="snapshot-block-title">{title}</h4>
+        <div class="funding-mini-cards">
+            {cards_html}
+        </div>
+    </div>
+    '''
+
+
+# =============================================================================
+# HTML GENERATION - BLOCK 4: BRANCH + RISK BADGE
+# =============================================================================
+
+def _generate_branch_block(data: ExecSnapshotData, lang: str = "de") -> str:
+    """Generate branch and risk badge block."""
+    title = "🏢 Profil" if lang == "de" else "🏢 Profile"
+
+    # AI Act risk color
+    risk_colors = {
+        "minimal": "risk-low",
+        "limited": "risk-medium",
+        "high-risk": "risk-high",
+        "unacceptable": "risk-critical",
+    }
+    risk_class = risk_colors.get(data.ai_act_risk.lower(), "risk-low")
+    risk_label = data.ai_act_risk.replace("-", " ").title()
+
+    dsgvo_badge = '<span class="badge dsgvo-badge">DSGVO</span>' if data.dsgvo_relevant else ""
+
+    return f'''
+    <div class="snapshot-block branch-block">
+        <h4 class="snapshot-block-title">{title}</h4>
+        <div class="branch-badges">
+            <span class="badge branch-badge">{data.branch_short or data.branch_label or "Unternehmen"}</span>
+            <span class="badge {risk_class}">AI Act: {risk_label}</span>
+            {dsgvo_badge}
+        </div>
+    </div>
+    '''
+
+
+# =============================================================================
+# HTML GENERATION - BLOCK 5: QUICK WINS
+# =============================================================================
+
+def _generate_quickwins_block(wins: List[str], lang: str = "de") -> str:
+    """Generate quick wins block."""
+    title = "✅ Quick Wins" if lang == "de" else "✅ Quick Wins"
+
+    items_html = ""
+    for i, win in enumerate(wins[:3], 1):
+        items_html += f'<li class="quickwin-item"><span class="qw-num">{i}</span> {win}</li>'
+
+    return f'''
+    <div class="snapshot-block quickwins-block">
+        <h4 class="snapshot-block-title">{title}</h4>
+        <ol class="quickwins-list">
+            {items_html}
+        </ol>
+    </div>
+    '''
+
+
+# =============================================================================
+# HTML GENERATION - BLOCK 6: KEY RISKS
+# =============================================================================
+
+def _generate_risks_block(risks: List[str], lang: str = "de") -> str:
+    """Generate key risks block."""
+    title = "⚠️ Risiken" if lang == "de" else "⚠️ Risks"
+
+    items_html = ""
+    for risk in risks[:3]:
+        items_html += f'<li class="risk-item">⚡ {risk}</li>'
+
+    return f'''
+    <div class="snapshot-block risks-block">
+        <h4 class="snapshot-block-title">{title}</h4>
+        <ul class="risks-list">
+            {items_html}
+        </ul>
+    </div>
+    '''
+
+
+# =============================================================================
+# HTML GENERATION - BLOCK 7: MINI ROADMAP
+# =============================================================================
+
+def _generate_roadmap_block(steps: List[Dict[str, str]], lang: str = "de") -> str:
+    """Generate mini 3-step roadmap block."""
+    title = "🗺️ Roadmap" if lang == "de" else "🗺️ Roadmap"
+
+    steps_html = ""
+    for step in steps[:3]:
+        phase = step.get("phase", "")
+        step_title = step.get("title", "")
+        desc = step.get("description", "")
+        steps_html += f'''
+            <div class="roadmap-step">
+                <div class="step-number">{phase}</div>
+                <div class="step-content">
+                    <div class="step-title">{step_title}</div>
+                    <div class="step-desc">{desc}</div>
+                </div>
+            </div>
+        '''
+
+    return f'''
+    <div class="snapshot-block roadmap-block">
+        <h4 class="snapshot-block-title">{title}</h4>
+        <div class="roadmap-steps">
+            {steps_html}
+        </div>
+    </div>
+    '''
+
+
+# =============================================================================
+# HTML GENERATION - BLOCK 8: FUNDING TIMELINE
+# =============================================================================
+
+def _generate_timeline_block(timeline: List[Dict[str, Any]], lang: str = "de") -> str:
+    """Generate funding timeline SVG block."""
+    title = "📅 Förder-Timeline" if lang == "de" else "📅 Funding Timeline"
+
+    # Generate simple timeline bars
+    years_html = ""
+    for item in timeline[:3]:
+        year = item.get("year", 2025)
+        count = item.get("count", 0)
+        progs = item.get("programmes", [])
+
+        year_colors = {2025: "#3b82f6", 2026: "#8b5cf6", 2027: "#ec4899"}
+        color = year_colors.get(year, "#6b7280")
+        bar_width = min(100, count * 20)
+
+        prog_text = ", ".join(progs[:2]) if progs else ""
+
+        years_html += f'''
+            <div class="timeline-year">
+                <span class="timeline-label">{year}</span>
+                <div class="timeline-bar-track">
+                    <div class="timeline-bar" style="width: {bar_width}%; background: {color};"></div>
+                </div>
+                <span class="timeline-count">{count}</span>
+            </div>
+        '''
+
+    return f'''
+    <div class="snapshot-block timeline-block">
+        <h4 class="snapshot-block-title">{title}</h4>
+        <div class="timeline-container">
+            {years_html}
+        </div>
+    </div>
+    '''
+
+
+# =============================================================================
+# MAIN GENERATION FUNCTION
+# =============================================================================
+
+def generate_exec_snapshot(
+    sections: Dict[str, Any],
+    briefing: Dict[str, Any],
+    lang: str = "de",
+) -> str:
+    """
+    Generate complete Executive Snapshot HTML.
+
+    Args:
+        sections: Report sections dictionary
+        briefing: Briefing/answers dictionary
+        lang: Language code ("de" or "en")
+
+    Returns:
+        HTML string for EXEC_SNAPSHOT_HTML
+    """
+    if not EXEC_SNAPSHOT_ENABLED:
+        return ""
+
+    log.info("[G27] Generating Executive Snapshot...")
+
+    # Extract all data
+    data = ExecSnapshotData(
+        kpis=_extract_kpi_data(sections, briefing),
+        tools=_extract_tools(sections),
+        funding=_extract_funding(sections),
+        branch_label=str(briefing.get("branche", "") or sections.get("BRANCH_LABEL", "")),
+        branch_short=str(sections.get("BRANCH_SHORT_LABEL", "") or briefing.get("branche", "")[:15]),
+        ai_act_risk=str(sections.get("AI_ACT_RISK_LEVEL", "minimal")),
+        dsgvo_relevant=bool(sections.get("DSGVO_RELEVANT", False)),
+        quick_wins=_extract_quick_wins(sections, briefing),
+        key_risks=_extract_key_risks(sections, briefing),
+        roadmap_steps=_extract_roadmap_steps(sections),
+        funding_timeline=_extract_funding_timeline(sections),
+    )
+
+    # Generate all 8 blocks
+    kpi_html = _generate_kpi_block(data.kpis, lang)
+    tools_html = _generate_tools_block(data.tools, lang)
+    funding_html = _generate_funding_block(data.funding, lang)
+    branch_html = _generate_branch_block(data, lang)
+    quickwins_html = _generate_quickwins_block(data.quick_wins, lang)
+    risks_html = _generate_risks_block(data.key_risks, lang)
+    roadmap_html = _generate_roadmap_block(data.roadmap_steps, lang)
+    timeline_html = _generate_timeline_block(data.funding_timeline, lang)
+
+    # Compose full snapshot
+    title = "Executive Snapshot" if lang == "en" else "Executive Snapshot"
+
+    html = f'''
+    <div class="exec-snapshot-container">
+        <div class="exec-snapshot-header">
+            <h2 class="exec-snapshot-title">📋 {title}</h2>
+            <span class="exec-snapshot-badge">G27</span>
+        </div>
+
+        <div class="exec-snapshot-grid">
+            <!-- Row 1: KPIs + Tools + Branch -->
+            <div class="snapshot-row row-1">
+                {kpi_html}
+                {tools_html}
+                {branch_html}
+            </div>
+
+            <!-- Row 2: Funding + Quick Wins + Risks -->
+            <div class="snapshot-row row-2">
+                {funding_html}
+                {quickwins_html}
+                {risks_html}
+            </div>
+
+            <!-- Row 3: Roadmap + Timeline -->
+            <div class="snapshot-row row-3">
+                {roadmap_html}
+                {timeline_html}
+            </div>
+        </div>
+    </div>
+    '''
+
+    log.info("[G27] Executive Snapshot generated successfully")
+    return html
+
+
+def inject_exec_snapshot_into_sections(
+    sections: Dict[str, Any],
+    briefing: Dict[str, Any],
+    lang: str = "de",
+) -> Dict[str, Any]:
+    """
+    Inject Executive Snapshot into report sections.
+
+    Args:
+        sections: Report sections dictionary
+        briefing: Briefing dictionary
+        lang: Language code
+
+    Returns:
+        Updated sections with EXEC_SNAPSHOT_HTML
+    """
+    if not EXEC_SNAPSHOT_ENABLED:
+        sections["EXEC_SNAPSHOT_HTML"] = ""
+        return sections
+
+    try:
+        html = generate_exec_snapshot(sections, briefing, lang)
+        sections["EXEC_SNAPSHOT_HTML"] = html
+        log.info("✅ [G27] Injected Executive Snapshot into report")
+    except Exception as e:
+        log.error("[G27] Failed to generate Executive Snapshot: %s", e)
+        sections["EXEC_SNAPSHOT_HTML"] = ""
+
+    return sections
+
+
+# =============================================================================
+# MODULE INITIALIZATION
+# =============================================================================
+
+log.info("[G27] Executive Snapshot module loaded (enabled=%s)", EXEC_SNAPSHOT_ENABLED)

--- a/templates/pdf_template.html
+++ b/templates/pdf_template.html
@@ -1602,6 +1602,329 @@
             color: #475569;
         }
 
+        /* G27: Executive Snapshot One-Pager */
+        .exec-snapshot-container {
+            page-break-before: always;
+            padding: 16pt;
+            background: var(--color-bg-page);
+        }
+        .exec-snapshot-header {
+            display: flex;
+            align-items: center;
+            gap: 12pt;
+            margin-bottom: 16pt;
+            padding-bottom: 12pt;
+            border-bottom: 2px solid var(--color-brand-primary);
+        }
+        .exec-snapshot-title {
+            font-size: 20pt;
+            font-weight: 700;
+            color: var(--color-text-strong);
+            margin: 0;
+        }
+        .exec-snapshot-badge {
+            font-size: 9pt;
+            padding: 2pt 8pt;
+            background: var(--color-brand-primary);
+            color: #fff;
+            border-radius: 4pt;
+            font-weight: 600;
+        }
+        .exec-snapshot-grid {
+            display: flex;
+            flex-direction: column;
+            gap: 14pt;
+        }
+        .snapshot-row {
+            display: grid;
+            grid-template-columns: repeat(3, 1fr);
+            gap: 12pt;
+        }
+        .snapshot-row.row-3 {
+            grid-template-columns: 1fr 1fr;
+        }
+        .snapshot-block {
+            background: var(--color-bg-card);
+            border: 1px solid var(--color-border);
+            border-radius: 8pt;
+            padding: 12pt;
+        }
+        .snapshot-block-title {
+            font-size: 11pt;
+            font-weight: 700;
+            color: var(--color-text-strong);
+            margin: 0 0 10pt 0;
+            padding-bottom: 6pt;
+            border-bottom: 1px solid var(--color-border-subtle);
+        }
+
+        /* G27: KPI Mini Bars */
+        .kpi-mini-bars {
+            display: flex;
+            flex-direction: column;
+            gap: 8pt;
+        }
+        .kpi-mini-row {
+            display: flex;
+            align-items: center;
+            gap: 8pt;
+        }
+        .kpi-label {
+            font-size: 9pt;
+            color: var(--color-text-muted);
+            width: 70pt;
+            flex-shrink: 0;
+        }
+        .kpi-bar-track {
+            flex: 1;
+            height: 8pt;
+            background: var(--color-bg-surface);
+            border-radius: 4pt;
+            overflow: hidden;
+        }
+        .kpi-bar-fill {
+            height: 100%;
+            border-radius: 4pt;
+        }
+        .kpi-bar-fill.kpi-roi { background: #3b82f6; }
+        .kpi-bar-fill.kpi-payback { background: #f59e0b; }
+        .kpi-bar-fill.kpi-savings { background: #22c55e; }
+        .kpi-value {
+            font-size: 10pt;
+            font-weight: 600;
+            color: var(--color-text-strong);
+            width: 50pt;
+            text-align: right;
+        }
+        .kpi-benchmark {
+            margin-top: 8pt;
+            padding-top: 8pt;
+            border-top: 1px dashed var(--color-border);
+        }
+        .benchmark-label {
+            font-size: 8pt;
+            color: var(--color-text-muted);
+        }
+        .benchmark-bars {
+            display: flex;
+            gap: 4pt;
+            margin-top: 4pt;
+        }
+        .benchmark-bar {
+            height: 6pt;
+            border-radius: 3pt;
+        }
+        .benchmark-bar.you { background: #3b82f6; }
+        .benchmark-bar.industry { background: #94a3b8; }
+
+        /* G27: Tool Mini Cards */
+        .tool-mini-cards {
+            display: flex;
+            flex-direction: column;
+            gap: 6pt;
+        }
+        .tool-mini-card {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            padding: 6pt 8pt;
+            background: var(--color-bg-surface);
+            border-radius: 4pt;
+        }
+        .tool-name {
+            font-size: 10pt;
+            font-weight: 600;
+            color: var(--color-text-strong);
+        }
+        .tool-badges {
+            display: flex;
+            gap: 4pt;
+        }
+        .tool-badges .badge {
+            font-size: 8pt;
+            padding: 1pt 4pt;
+        }
+
+        /* G27: Funding Mini Cards */
+        .funding-mini-cards {
+            display: flex;
+            flex-direction: column;
+            gap: 6pt;
+        }
+        .funding-mini-card {
+            padding: 6pt 8pt;
+            background: var(--color-bg-surface);
+            border-radius: 4pt;
+        }
+        .funding-header {
+            display: flex;
+            align-items: center;
+            gap: 6pt;
+        }
+        .funding-name {
+            font-size: 10pt;
+            font-weight: 600;
+            color: var(--color-text-strong);
+        }
+        .funding-details {
+            display: flex;
+            align-items: center;
+            gap: 6pt;
+            margin-top: 4pt;
+        }
+        .funding-rate {
+            font-size: 9pt;
+            color: var(--color-text-muted);
+        }
+        .match-score {
+            font-size: 9pt;
+            font-weight: 600;
+            color: #22c55e;
+        }
+        .flag {
+            font-size: 10pt;
+        }
+        .flag.time-critical { color: #f59e0b; }
+        .flag.provisional { color: #8b5cf6; }
+
+        /* G27: Branch Block */
+        .branch-badges {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 6pt;
+        }
+        .branch-badge {
+            background: #dbeafe;
+            color: #1e40af;
+            font-size: 10pt;
+            padding: 4pt 8pt;
+            border-radius: 4pt;
+            font-weight: 600;
+        }
+        .risk-low { background: #dcfce7; color: #166534; }
+        .risk-medium { background: #fef3c7; color: #92400e; }
+        .risk-high { background: #fee2e2; color: #991b1b; }
+        .risk-critical { background: #7f1d1d; color: #fff; }
+        .dsgvo-badge { background: #f3e8ff; color: #6b21a8; }
+
+        /* G27: Quick Wins */
+        .quickwins-list {
+            list-style: none;
+            margin: 0;
+            padding: 0;
+        }
+        .quickwin-item {
+            display: flex;
+            align-items: flex-start;
+            gap: 8pt;
+            font-size: 10pt;
+            color: var(--color-text-normal);
+            padding: 4pt 0;
+        }
+        .qw-num {
+            width: 18pt;
+            height: 18pt;
+            background: #22c55e;
+            color: #fff;
+            border-radius: 50%;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            font-size: 9pt;
+            font-weight: 700;
+            flex-shrink: 0;
+        }
+
+        /* G27: Risks */
+        .risks-list {
+            list-style: none;
+            margin: 0;
+            padding: 0;
+        }
+        .risk-item {
+            font-size: 10pt;
+            color: var(--color-text-normal);
+            padding: 4pt 0;
+            border-bottom: 1px solid var(--color-border-subtle);
+        }
+        .risk-item:last-child { border-bottom: none; }
+
+        /* G27: Mini Roadmap */
+        .roadmap-steps {
+            display: flex;
+            gap: 8pt;
+        }
+        .roadmap-step {
+            flex: 1;
+            display: flex;
+            gap: 8pt;
+            padding: 8pt;
+            background: var(--color-bg-surface);
+            border-radius: 6pt;
+        }
+        .step-number {
+            width: 22pt;
+            height: 22pt;
+            background: var(--color-brand-primary);
+            color: #fff;
+            border-radius: 50%;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            font-size: 11pt;
+            font-weight: 700;
+            flex-shrink: 0;
+        }
+        .step-content {
+            flex: 1;
+        }
+        .step-title {
+            font-size: 10pt;
+            font-weight: 700;
+            color: var(--color-text-strong);
+        }
+        .step-desc {
+            font-size: 9pt;
+            color: var(--color-text-muted);
+            margin-top: 2pt;
+        }
+
+        /* G27: Timeline */
+        .timeline-container {
+            display: flex;
+            flex-direction: column;
+            gap: 8pt;
+        }
+        .timeline-year {
+            display: flex;
+            align-items: center;
+            gap: 8pt;
+        }
+        .timeline-label {
+            font-size: 11pt;
+            font-weight: 700;
+            color: var(--color-text-strong);
+            width: 40pt;
+        }
+        .timeline-bar-track {
+            flex: 1;
+            height: 12pt;
+            background: var(--color-bg-surface);
+            border-radius: 6pt;
+            overflow: hidden;
+        }
+        .timeline-bar {
+            height: 100%;
+            border-radius: 6pt;
+        }
+        .timeline-count {
+            font-size: 10pt;
+            font-weight: 600;
+            color: var(--color-text-muted);
+            width: 20pt;
+            text-align: right;
+        }
+
         /* Step Cards (for Starter Kit) */
         .step-cards {
             display: grid;

--- a/templates/pdf_template_en.html
+++ b/templates/pdf_template_en.html
@@ -879,6 +879,85 @@
         .funding-timeline { margin-top: 16pt; padding: 14pt; background: #f8fafc; border-radius: 8pt; }
         .funding-timeline h4 { margin: 0 0 12pt 0; font-size: 12pt; color: #475569; }
 
+        /* G27: Executive Snapshot One-Pager */
+        .exec-snapshot-container { page-break-before: always; padding: 16pt; background: var(--color-bg-page); }
+        .exec-snapshot-header { display: flex; align-items: center; gap: 12pt; margin-bottom: 16pt; padding-bottom: 12pt; border-bottom: 2px solid var(--color-brand-primary); }
+        .exec-snapshot-title { font-size: 20pt; font-weight: 700; color: var(--color-text-strong); margin: 0; }
+        .exec-snapshot-badge { font-size: 9pt; padding: 2pt 8pt; background: var(--color-brand-primary); color: #fff; border-radius: 4pt; font-weight: 600; }
+        .exec-snapshot-grid { display: flex; flex-direction: column; gap: 14pt; }
+        .snapshot-row { display: grid; grid-template-columns: repeat(3, 1fr); gap: 12pt; }
+        .snapshot-row.row-3 { grid-template-columns: 1fr 1fr; }
+        .snapshot-block { background: var(--color-bg-card); border: 1px solid var(--color-border); border-radius: 8pt; padding: 12pt; }
+        .snapshot-block-title { font-size: 11pt; font-weight: 700; color: var(--color-text-strong); margin: 0 0 10pt 0; padding-bottom: 6pt; border-bottom: 1px solid var(--color-border-subtle); }
+
+        /* G27: KPI Mini Bars */
+        .kpi-mini-bars { display: flex; flex-direction: column; gap: 8pt; }
+        .kpi-mini-row { display: flex; align-items: center; gap: 8pt; }
+        .kpi-label { font-size: 9pt; color: var(--color-text-muted); width: 70pt; flex-shrink: 0; }
+        .kpi-bar-track { flex: 1; height: 8pt; background: var(--color-bg-surface); border-radius: 4pt; overflow: hidden; }
+        .kpi-bar-fill { height: 100%; border-radius: 4pt; }
+        .kpi-bar-fill.kpi-roi { background: #3b82f6; }
+        .kpi-bar-fill.kpi-payback { background: #f59e0b; }
+        .kpi-bar-fill.kpi-savings { background: #22c55e; }
+        .kpi-value { font-size: 10pt; font-weight: 600; color: var(--color-text-strong); width: 50pt; text-align: right; }
+        .kpi-benchmark { margin-top: 8pt; padding-top: 8pt; border-top: 1px dashed var(--color-border); }
+        .benchmark-label { font-size: 8pt; color: var(--color-text-muted); }
+        .benchmark-bars { display: flex; gap: 4pt; margin-top: 4pt; }
+        .benchmark-bar { height: 6pt; border-radius: 3pt; }
+        .benchmark-bar.you { background: #3b82f6; }
+        .benchmark-bar.industry { background: #94a3b8; }
+
+        /* G27: Tool Mini Cards */
+        .tool-mini-cards { display: flex; flex-direction: column; gap: 6pt; }
+        .tool-mini-card { display: flex; justify-content: space-between; align-items: center; padding: 6pt 8pt; background: var(--color-bg-surface); border-radius: 4pt; }
+        .tool-name { font-size: 10pt; font-weight: 600; color: var(--color-text-strong); }
+        .tool-badges { display: flex; gap: 4pt; }
+        .tool-badges .badge { font-size: 8pt; padding: 1pt 4pt; }
+
+        /* G27: Funding Mini Cards */
+        .funding-mini-cards { display: flex; flex-direction: column; gap: 6pt; }
+        .funding-mini-card { padding: 6pt 8pt; background: var(--color-bg-surface); border-radius: 4pt; }
+        .funding-header { display: flex; align-items: center; gap: 6pt; }
+        .funding-name { font-size: 10pt; font-weight: 600; color: var(--color-text-strong); }
+        .funding-details { display: flex; align-items: center; gap: 6pt; margin-top: 4pt; }
+        .funding-rate { font-size: 9pt; color: var(--color-text-muted); }
+        .match-score { font-size: 9pt; font-weight: 600; color: #22c55e; }
+        .flag { font-size: 10pt; }
+        .flag.time-critical { color: #f59e0b; }
+        .flag.provisional { color: #8b5cf6; }
+
+        /* G27: Branch Block */
+        .branch-badges { display: flex; flex-wrap: wrap; gap: 6pt; }
+        .branch-badge { background: #dbeafe; color: #1e40af; font-size: 10pt; padding: 4pt 8pt; border-radius: 4pt; font-weight: 600; }
+        .risk-low { background: #dcfce7; color: #166534; }
+        .risk-medium { background: #fef3c7; color: #92400e; }
+        .risk-high { background: #fee2e2; color: #991b1b; }
+        .risk-critical { background: #7f1d1d; color: #fff; }
+        .dsgvo-badge { background: #f3e8ff; color: #6b21a8; }
+
+        /* G27: Quick Wins & Risks */
+        .quickwins-list, .risks-list { list-style: none; margin: 0; padding: 0; }
+        .quickwin-item { display: flex; align-items: flex-start; gap: 8pt; font-size: 10pt; color: var(--color-text-normal); padding: 4pt 0; }
+        .qw-num { width: 18pt; height: 18pt; background: #22c55e; color: #fff; border-radius: 50%; display: flex; align-items: center; justify-content: center; font-size: 9pt; font-weight: 700; flex-shrink: 0; }
+        .risk-item { font-size: 10pt; color: var(--color-text-normal); padding: 4pt 0; border-bottom: 1px solid var(--color-border-subtle); }
+        .risk-item:last-child { border-bottom: none; }
+
+        /* G27: Mini Roadmap */
+        .roadmap-steps { display: flex; gap: 8pt; }
+        .roadmap-step { flex: 1; display: flex; gap: 8pt; padding: 8pt; background: var(--color-bg-surface); border-radius: 6pt; }
+        .step-number { width: 22pt; height: 22pt; background: var(--color-brand-primary); color: #fff; border-radius: 50%; display: flex; align-items: center; justify-content: center; font-size: 11pt; font-weight: 700; flex-shrink: 0; }
+        .step-content { flex: 1; }
+        .step-title { font-size: 10pt; font-weight: 700; color: var(--color-text-strong); }
+        .step-desc { font-size: 9pt; color: var(--color-text-muted); margin-top: 2pt; }
+
+        /* G27: Timeline */
+        .timeline-container { display: flex; flex-direction: column; gap: 8pt; }
+        .timeline-year { display: flex; align-items: center; gap: 8pt; }
+        .timeline-label { font-size: 11pt; font-weight: 700; color: var(--color-text-strong); width: 40pt; }
+        .timeline-bar-track { flex: 1; height: 12pt; background: var(--color-bg-surface); border-radius: 6pt; overflow: hidden; }
+        .timeline-bar { height: 100%; border-radius: 6pt; }
+        .timeline-count { font-size: 10pt; font-weight: 600; color: var(--color-text-muted); width: 20pt; text-align: right; }
+
         /* ================================================
            TABLES (PLATIN++ V5.2 Light Mode)
            ================================================ */

--- a/tests/test_g27_exec_snapshot.py
+++ b/tests/test_g27_exec_snapshot.py
@@ -1,0 +1,507 @@
+# -*- coding: utf-8 -*-
+"""
+Tests for Sprint G27: Executive Snapshot One-Pager
+
+Tests cover:
+- ExecSnapshotData dataclass
+- generate_exec_snapshot() function
+- All 8 building blocks
+- HTML structure validation
+- Consistency with G22 rules
+- Language support (DE/EN)
+
+Target: 30+ tests
+"""
+
+import pytest
+from typing import Dict, Any
+
+from services.exec_snapshot import (
+    generate_exec_snapshot,
+    inject_exec_snapshot_into_sections,
+    ExecSnapshotData,
+    KPIData,
+    ToolCard,
+    FundingCard,
+    _extract_kpi_data,
+    _extract_tools,
+    _extract_funding,
+    _extract_quick_wins,
+    _extract_key_risks,
+    _extract_roadmap_steps,
+    _extract_funding_timeline,
+    _generate_kpi_block,
+    _generate_tools_block,
+    _generate_funding_block,
+    _generate_branch_block,
+    _generate_quickwins_block,
+    _generate_risks_block,
+    _generate_roadmap_block,
+    _generate_timeline_block,
+    EXEC_SNAPSHOT_ENABLED,
+)
+
+
+# =============================================================================
+# FIXTURES
+# =============================================================================
+
+@pytest.fixture
+def sample_briefing() -> Dict[str, Any]:
+    """Create a sample briefing for testing."""
+    return {
+        "branche": "IT-Beratung",
+        "unternehmensgroesse": "team",
+        "bundesland": "BY",
+        "ROI_12M": 150,
+        "PAYBACK_MONTHS": 6,
+        "einsparung_stunden_monat": 40,
+        "einsparung_monat_eur": 2400,
+    }
+
+
+@pytest.fixture
+def sample_sections() -> Dict[str, Any]:
+    """Create sample report sections for testing."""
+    return {
+        "ROI_12M": 150,
+        "PAYBACK_MONTHS": 6,
+        "EINSPARUNG_STUNDEN_MONAT": 40,
+        "EINSPARUNG_MONAT_EUR": 2400,
+        "MATURITY_LEVEL": 3,
+        "AI_ACT_RISK_LEVEL": "minimal",
+        "BRANCH_LABEL": "IT-Beratung",
+        "BRANCH_SHORT_LABEL": "IT",
+        "SIZE_LABEL": "Team (2-10)",
+        "DSGVO_RELEVANT": False,
+        "TOOLS_V4_DATA": [
+            {"name": "ChatGPT", "category": "LLM", "cost_level": 2, "complexity_level": 1, "eu_hosting": False},
+            {"name": "GitHub Copilot", "category": "Code", "cost_level": 3, "complexity_level": 2, "eu_hosting": False},
+            {"name": "Notion AI", "category": "Docs", "cost_level": 2, "complexity_level": 1, "eu_hosting": True},
+        ],
+        "FUNDING_V2_DATA": [
+            {"name": "go-digital", "year": 2025, "level": "federal", "funding_rate": "50%", "match_score": 0.85},
+            {"name": "Digital Jetzt", "year": 2025, "level": "federal", "funding_rate": "40%", "match_score": 0.75},
+        ],
+        "QUICK_WINS_DATA": [
+            "ChatGPT für Recherche einsetzen",
+            "Code-Reviews mit Copilot",
+            "Dokumente mit Notion AI",
+        ],
+        "KEY_RISKS_DATA": [
+            "Datenschutz bei Cloud-KI",
+            "Abhängigkeit von US-Anbietern",
+        ],
+        "ROADMAP_STEPS": [
+            {"phase": "1", "title": "Setup", "description": "Tools einrichten"},
+            {"phase": "2", "title": "Workflow", "description": "Prozesse anpassen"},
+            {"phase": "3", "title": "Scale", "description": "Rollout"},
+        ],
+    }
+
+
+@pytest.fixture
+def sample_kpi_data() -> KPIData:
+    """Create sample KPI data."""
+    return KPIData(
+        roi_12m=150.0,
+        payback_months=6.0,
+        time_savings_hours=40.0,
+        time_savings_eur=2400.0,
+        industry_benchmark_roi=120.0,
+    )
+
+
+@pytest.fixture
+def sample_tool_cards() -> list:
+    """Create sample tool cards."""
+    return [
+        ToolCard(name="ChatGPT", category="LLM", cost_level=2, complexity_level=1),
+        ToolCard(name="GitHub Copilot", category="Code", cost_level=3, complexity_level=2),
+    ]
+
+
+@pytest.fixture
+def sample_funding_cards() -> list:
+    """Create sample funding cards."""
+    return [
+        FundingCard(name="go-digital", year=2025, level="federal", funding_rate="50%", match_score=0.85, is_time_critical=True),
+        FundingCard(name="Horizon Europe", year=2026, level="eu", funding_rate="70%", match_score=0.7),
+    ]
+
+
+# =============================================================================
+# DATACLASS TESTS
+# =============================================================================
+
+class TestDataclasses:
+    """Tests for dataclasses."""
+
+    def test_kpi_data_creation(self) -> None:
+        """Test KPIData creation."""
+        kpi = KPIData(roi_12m=150.0, payback_months=6.0)
+        assert kpi.roi_12m == 150.0
+        assert kpi.payback_months == 6.0
+
+    def test_tool_card_creation(self) -> None:
+        """Test ToolCard creation."""
+        tool = ToolCard(name="ChatGPT", category="LLM")
+        assert tool.name == "ChatGPT"
+        assert tool.category == "LLM"
+        assert tool.cost_level == 3  # default
+
+    def test_funding_card_creation(self) -> None:
+        """Test FundingCard creation."""
+        funding = FundingCard(name="go-digital", year=2025, level="federal", funding_rate="50%", match_score=0.85)
+        assert funding.name == "go-digital"
+        assert funding.year == 2025
+        assert funding.is_time_critical is False  # default
+
+    def test_exec_snapshot_data_creation(self) -> None:
+        """Test ExecSnapshotData creation."""
+        data = ExecSnapshotData(
+            branch_label="IT-Beratung",
+            ai_act_risk="minimal",
+        )
+        assert data.branch_label == "IT-Beratung"
+        assert data.ai_act_risk == "minimal"
+        assert len(data.tools) == 0
+        assert len(data.quick_wins) == 0
+
+
+# =============================================================================
+# EXTRACTION TESTS
+# =============================================================================
+
+class TestExtraction:
+    """Tests for data extraction functions."""
+
+    def test_extract_kpi_data(self, sample_sections: Dict, sample_briefing: Dict) -> None:
+        """Test KPI data extraction."""
+        kpis = _extract_kpi_data(sample_sections, sample_briefing)
+        assert kpis.roi_12m == 150.0
+        assert kpis.payback_months == 6.0
+        assert kpis.time_savings_hours == 40.0
+
+    def test_extract_kpi_data_fallback(self) -> None:
+        """Test KPI data extraction with fallback."""
+        kpis = _extract_kpi_data({}, {"ROI_12M": 100})
+        assert kpis.roi_12m == 100.0
+
+    def test_extract_tools(self, sample_sections: Dict) -> None:
+        """Test tool extraction."""
+        tools = _extract_tools(sample_sections)
+        assert len(tools) == 3
+        assert tools[0].name == "ChatGPT"
+
+    def test_extract_tools_empty(self) -> None:
+        """Test tool extraction with no data."""
+        tools = _extract_tools({})
+        assert len(tools) == 0
+
+    def test_extract_funding(self, sample_sections: Dict) -> None:
+        """Test funding extraction."""
+        funding = _extract_funding(sample_sections)
+        assert len(funding) == 2
+        assert funding[0].name == "go-digital"
+
+    def test_extract_funding_time_critical(self, sample_sections: Dict) -> None:
+        """Test funding extraction with time-critical flag."""
+        funding = _extract_funding(sample_sections)
+        assert funding[0].is_time_critical is True  # 2025 is time-critical
+
+    def test_extract_quick_wins(self, sample_sections: Dict, sample_briefing: Dict) -> None:
+        """Test quick wins extraction."""
+        wins = _extract_quick_wins(sample_sections, sample_briefing)
+        assert len(wins) == 3
+        assert "ChatGPT" in wins[0]
+
+    def test_extract_quick_wins_fallback(self) -> None:
+        """Test quick wins fallback defaults."""
+        wins = _extract_quick_wins({}, {"branche": "beratung"})
+        assert len(wins) == 3
+
+    def test_extract_key_risks(self, sample_sections: Dict, sample_briefing: Dict) -> None:
+        """Test key risks extraction."""
+        risks = _extract_key_risks(sample_sections, sample_briefing)
+        assert len(risks) >= 2
+
+    def test_extract_roadmap_steps(self, sample_sections: Dict) -> None:
+        """Test roadmap steps extraction."""
+        steps = _extract_roadmap_steps(sample_sections)
+        assert len(steps) == 3
+        assert steps[0]["title"] == "Setup"
+
+    def test_extract_roadmap_steps_default(self) -> None:
+        """Test roadmap steps default."""
+        steps = _extract_roadmap_steps({})
+        assert len(steps) == 3
+
+    def test_extract_funding_timeline(self, sample_sections: Dict) -> None:
+        """Test funding timeline extraction."""
+        timeline = _extract_funding_timeline(sample_sections)
+        assert len(timeline) == 3  # 2025, 2026, 2027
+
+
+# =============================================================================
+# BLOCK GENERATION TESTS
+# =============================================================================
+
+class TestBlockGeneration:
+    """Tests for HTML block generation."""
+
+    def test_generate_kpi_block_de(self, sample_kpi_data: KPIData) -> None:
+        """Test German KPI block generation."""
+        html = _generate_kpi_block(sample_kpi_data, lang="de")
+        assert "KPIs" in html
+        assert "ROI 12M" in html
+        assert "150%" in html
+        assert "kpi-bar-fill" in html
+
+    def test_generate_kpi_block_en(self, sample_kpi_data: KPIData) -> None:
+        """Test English KPI block generation."""
+        html = _generate_kpi_block(sample_kpi_data, lang="en")
+        assert "KPIs" in html
+        assert "ROI 12M" in html
+
+    def test_generate_tools_block(self, sample_tool_cards: list) -> None:
+        """Test tools block generation."""
+        html = _generate_tools_block(sample_tool_cards, lang="de")
+        assert "Top Tools" in html
+        assert "ChatGPT" in html
+        assert "tool-mini-card" in html
+
+    def test_generate_tools_block_empty(self) -> None:
+        """Test tools block with no tools."""
+        html = _generate_tools_block([], lang="de")
+        assert "Keine Tools" in html
+
+    def test_generate_funding_block(self, sample_funding_cards: list) -> None:
+        """Test funding block generation."""
+        html = _generate_funding_block(sample_funding_cards, lang="de")
+        assert "Förderung" in html
+        assert "go-digital" in html
+        assert "funding-mini-card" in html
+
+    def test_generate_funding_block_flags(self, sample_funding_cards: list) -> None:
+        """Test funding block with time-critical flag."""
+        html = _generate_funding_block(sample_funding_cards, lang="de")
+        assert "time-critical" in html  # 2025 programme
+
+    def test_generate_branch_block(self) -> None:
+        """Test branch block generation."""
+        data = ExecSnapshotData(
+            branch_label="IT-Beratung",
+            branch_short="IT",
+            ai_act_risk="minimal",
+        )
+        html = _generate_branch_block(data, lang="de")
+        assert "Profil" in html
+        assert "IT" in html
+        assert "AI Act" in html
+
+    def test_generate_quickwins_block(self) -> None:
+        """Test quick wins block generation."""
+        wins = ["Win 1", "Win 2", "Win 3"]
+        html = _generate_quickwins_block(wins, lang="de")
+        assert "Quick Wins" in html
+        assert "Win 1" in html
+        assert "qw-num" in html
+
+    def test_generate_risks_block(self) -> None:
+        """Test risks block generation."""
+        risks = ["Risk 1", "Risk 2"]
+        html = _generate_risks_block(risks, lang="de")
+        assert "Risiken" in html
+        assert "Risk 1" in html
+        assert "risk-item" in html
+
+    def test_generate_roadmap_block(self) -> None:
+        """Test roadmap block generation."""
+        steps = [
+            {"phase": "1", "title": "Setup", "description": "Start"},
+            {"phase": "2", "title": "Workflow", "description": "Process"},
+            {"phase": "3", "title": "Scale", "description": "Grow"},
+        ]
+        html = _generate_roadmap_block(steps, lang="de")
+        assert "Roadmap" in html
+        assert "Setup" in html
+        assert "step-number" in html
+
+    def test_generate_timeline_block(self) -> None:
+        """Test timeline block generation."""
+        timeline = [
+            {"year": 2025, "count": 5, "programmes": ["prog1"]},
+            {"year": 2026, "count": 3, "programmes": ["prog2"]},
+        ]
+        html = _generate_timeline_block(timeline, lang="de")
+        assert "Timeline" in html
+        assert "2025" in html
+        assert "timeline-bar" in html
+
+
+# =============================================================================
+# MAIN FUNCTION TESTS
+# =============================================================================
+
+class TestGenerateExecSnapshot:
+    """Tests for main generate_exec_snapshot function."""
+
+    def test_generate_returns_html(self, sample_sections: Dict, sample_briefing: Dict) -> None:
+        """Test that function returns HTML string."""
+        html = generate_exec_snapshot(sample_sections, sample_briefing)
+        assert isinstance(html, str)
+        assert len(html) > 0
+
+    def test_generate_contains_all_blocks(self, sample_sections: Dict, sample_briefing: Dict) -> None:
+        """Test that HTML contains all 8 blocks."""
+        html = generate_exec_snapshot(sample_sections, sample_briefing, lang="de")
+        assert "kpi-block" in html
+        assert "tools-block" in html
+        assert "funding-block" in html
+        assert "branch-block" in html
+        assert "quickwins-block" in html
+        assert "risks-block" in html
+        assert "roadmap-block" in html
+        assert "timeline-block" in html
+
+    def test_generate_contains_header(self, sample_sections: Dict, sample_briefing: Dict) -> None:
+        """Test that HTML contains header."""
+        html = generate_exec_snapshot(sample_sections, sample_briefing)
+        assert "exec-snapshot-header" in html
+        assert "Executive Snapshot" in html
+        assert "G27" in html
+
+    def test_generate_contains_grid(self, sample_sections: Dict, sample_briefing: Dict) -> None:
+        """Test that HTML contains grid structure."""
+        html = generate_exec_snapshot(sample_sections, sample_briefing)
+        assert "exec-snapshot-grid" in html
+        assert "snapshot-row" in html
+
+    def test_generate_de_language(self, sample_sections: Dict, sample_briefing: Dict) -> None:
+        """Test German language output."""
+        html = generate_exec_snapshot(sample_sections, sample_briefing, lang="de")
+        assert "Förderung" in html or "funding" in html.lower()
+
+    def test_generate_en_language(self, sample_sections: Dict, sample_briefing: Dict) -> None:
+        """Test English language output."""
+        html = generate_exec_snapshot(sample_sections, sample_briefing, lang="en")
+        assert "Funding" in html or "funding" in html.lower()
+
+
+# =============================================================================
+# INJECTION TESTS
+# =============================================================================
+
+class TestInjection:
+    """Tests for inject_exec_snapshot_into_sections function."""
+
+    def test_inject_adds_exec_snapshot_html(self, sample_sections: Dict, sample_briefing: Dict) -> None:
+        """Test that injection adds EXEC_SNAPSHOT_HTML."""
+        result = inject_exec_snapshot_into_sections(sample_sections, sample_briefing)
+        assert "EXEC_SNAPSHOT_HTML" in result
+
+    def test_inject_preserves_existing(self, sample_sections: Dict, sample_briefing: Dict) -> None:
+        """Test that injection preserves existing sections."""
+        sample_sections["EXISTING_KEY"] = "existing_value"
+        result = inject_exec_snapshot_into_sections(sample_sections, sample_briefing)
+        assert result["EXISTING_KEY"] == "existing_value"
+
+    def test_inject_html_not_empty(self, sample_sections: Dict, sample_briefing: Dict) -> None:
+        """Test that injected HTML is not empty."""
+        result = inject_exec_snapshot_into_sections(sample_sections, sample_briefing)
+        assert len(result["EXEC_SNAPSHOT_HTML"]) > 100
+
+
+# =============================================================================
+# HTML STRUCTURE TESTS
+# =============================================================================
+
+class TestHTMLStructure:
+    """Tests for HTML structure validation."""
+
+    def test_html_has_valid_structure(self, sample_sections: Dict, sample_briefing: Dict) -> None:
+        """Test that HTML has valid structure."""
+        html = generate_exec_snapshot(sample_sections, sample_briefing)
+        assert html.count("<div") == html.count("</div") or html.count("<div") == html.count("</div>")
+
+    def test_html_no_forbidden_phrases(self, sample_sections: Dict, sample_briefing: Dict) -> None:
+        """Test that HTML contains no forbidden phrases."""
+        html = generate_exec_snapshot(sample_sections, sample_briefing)
+        forbidden = [
+            "Wir empfehlen",
+            "Es ist wichtig zu beachten",
+            "Zusammenfassend lässt sich sagen",
+        ]
+        for phrase in forbidden:
+            assert phrase not in html
+
+    def test_html_contains_proper_badges(self, sample_sections: Dict, sample_briefing: Dict) -> None:
+        """Test that HTML contains proper badge classes."""
+        html = generate_exec_snapshot(sample_sections, sample_briefing)
+        assert "badge" in html
+
+
+# =============================================================================
+# EDGE CASE TESTS
+# =============================================================================
+
+class TestEdgeCases:
+    """Tests for edge cases."""
+
+    def test_empty_sections(self) -> None:
+        """Test with empty sections."""
+        html = generate_exec_snapshot({}, {})
+        assert isinstance(html, str)
+
+    def test_empty_briefing(self, sample_sections: Dict) -> None:
+        """Test with empty briefing."""
+        html = generate_exec_snapshot(sample_sections, {})
+        assert isinstance(html, str)
+
+    def test_none_values(self) -> None:
+        """Test with None values in sections."""
+        sections = {
+            "ROI_12M": None,
+            "PAYBACK_MONTHS": None,
+        }
+        html = generate_exec_snapshot(sections, {})
+        assert isinstance(html, str)
+
+    def test_zero_kpi_values(self) -> None:
+        """Test with zero KPI values."""
+        sections = {
+            "ROI_12M": 0,
+            "PAYBACK_MONTHS": 0,
+            "EINSPARUNG_MONAT_EUR": 0,
+        }
+        html = generate_exec_snapshot(sections, {})
+        assert isinstance(html, str)
+        assert "0%" in html or "0 Mt" in html
+
+
+# =============================================================================
+# INTEGRATION TESTS
+# =============================================================================
+
+class TestIntegration:
+    """Integration tests."""
+
+    def test_full_workflow_de(self, sample_sections: Dict, sample_briefing: Dict) -> None:
+        """Test full workflow in German."""
+        result = inject_exec_snapshot_into_sections(sample_sections, sample_briefing, lang="de")
+        html = result["EXEC_SNAPSHOT_HTML"]
+
+        # Check all major elements
+        assert "exec-snapshot-container" in html
+        assert "Executive Snapshot" in html
+        assert len(html) > 500
+
+    def test_full_workflow_en(self, sample_sections: Dict, sample_briefing: Dict) -> None:
+        """Test full workflow in English."""
+        result = inject_exec_snapshot_into_sections(sample_sections, sample_briefing, lang="en")
+        html = result["EXEC_SNAPSHOT_HTML"]
+
+        # Check all major elements
+        assert "exec-snapshot-container" in html
+        assert len(html) > 500


### PR DESCRIPTION
Add compact, visually strong executive summary combining data from multiple engines (G23 KPIs, G25 Tools, G26 Funding, G20/G24 Branch).

New features - 8 Building Blocks:
1. KPI Visual Section (ROI, Payback, Savings bars + Benchmark)
2. Top 3 Tool Cards with G25 badges (Cost, Complexity, EU)
3. Funding Snapshot with year/level badges (2025-2027)
4. Branch Badge + AI Act Risk Indicator
5. 3 Quick Wins (actionable recommendations)
6. 3 Key Risks (branch/compliance/vendor risks)
7. Mini 3-Step Roadmap (Setup, Workflow, Optimization)
8. Funding Timeline visualization (2025-2027)

G22 Integration:
- SNAPSHOT_001: KPI consistency with Business Case
- SNAPSHOT_002: Tools consistency with Tools Engine 4.0
- SNAPSHOT_003: Funding consistency with Funding Engine 2.0
- SNAPSHOT_004: Quick Wins suitability for company size
- SNAPSHOT_005: Risk level consistency with AI Act

Files added:
- services/exec_snapshot.py (~500 lines)
- prompts/de/exec_snapshot.md
- prompts/en/exec_snapshot.md
- tests/test_g27_exec_snapshot.py (45 tests)

Files modified:
- services/consistency_engine.py (G27 SNAPSHOT rules)
- templates/pdf_template.html (G27 CSS)
- templates/pdf_template_en.html (G27 CSS)