### PR TITLE
feat(G32): add Recommendations Engine with prioritized action recomme…

### DIFF
--- a/gpt_analyze.py
+++ b/gpt_analyze.py
@@ -5124,6 +5124,50 @@ def analyze_briefing(db: Session, briefing_id: int, run_id: str) -> tuple[int, s
         log.warning("[%s] ⚠️ G30 Business Case Engine 2.0 failed: %s", run_id, e)
         sections.setdefault("BUSINESS_CASE_ENGINE_HTML", "")
 
+    # =========================================================================
+    # SPRINT G32: Recommendations Engine – Meta-Empfehlungsschicht
+    # =========================================================================
+    try:
+        from services.recommendations_engine import (
+            generate_recommendations_report,
+            recommendations_report_to_html,
+        )
+
+        # Build context summaries from previous engines
+        tools_summary = sections.get("KI_STACK_SUMMARY_HTML", "")[:2000] if sections.get("KI_STACK_SUMMARY_HTML") else ""
+        funding_summary = sections.get("FUNDING_MATRIX_2025_HTML", "")[:2000] if sections.get("FUNDING_MATRIX_2025_HTML") else ""
+        risk_summary = sections.get("RISK_ENGINE_HTML", "")[:2000] if sections.get("RISK_ENGINE_HTML") else ""
+        strategy_summary = sections.get("STRATEGY_PLAN_HTML", "")[:2000] if sections.get("STRATEGY_PLAN_HTML") else ""
+        bc_summary = sections.get("BUSINESS_CASE_ENGINE_HTML", "")[:2000] if sections.get("BUSINESS_CASE_ENGINE_HTML") else ""
+
+        reco_report = generate_recommendations_report(
+            context=None,
+            tools_summary=tools_summary,
+            funding_summary=funding_summary,
+            risk_summary=risk_summary,
+            strategy_summary=strategy_summary,
+            business_case_summary=bc_summary,
+            briefing=answers,
+            llm_response=None,  # Will use extraction-based generation
+        )
+
+        sections["RECOMMENDATIONS_ENGINE_HTML"] = recommendations_report_to_html(reco_report, lang=report_lang)
+        sections["_reco_report"] = reco_report  # Store for consistency checks
+
+        # Extract key values for template usage
+        sections["RECO_COUNT"] = len(reco_report.recommendations)
+        sections["RECO_TOP_3_IDS"] = reco_report.top_3_ids
+        sections["RECO_SUMMARY"] = reco_report.summary
+
+        log.info("[%s] ✅ G32 Recommendations Engine generated: %d recommendations, top_3=%s",
+                 run_id, len(reco_report.recommendations), reco_report.top_3_ids[:3])
+    except ImportError:
+        log.debug("[%s] G32 recommendations_engine not available", run_id)
+        sections.setdefault("RECOMMENDATIONS_ENGINE_HTML", "")
+    except Exception as e:
+        log.warning("[%s] ⚠️ G32 Recommendations Engine failed: %s", run_id, e)
+        sections.setdefault("RECOMMENDATIONS_ENGINE_HTML", "")
+
     log.info("[%s] 🎨 Rendering final HTML...", run_id)
     # --- Sanitize dynamic sections to prevent HTML leaks (z. B. eingebettetes <html> im Pilot-Plan) ---
     try:

--- a/gpt_analyze.py
+++ b/gpt_analyze.py
@@ -5133,20 +5133,14 @@ def analyze_briefing(db: Session, briefing_id: int, run_id: str) -> tuple[int, s
             recommendations_report_to_html,
         )
 
-        # Build context summaries from previous engines
-        tools_summary = sections.get("KI_STACK_SUMMARY_HTML", "")[:2000] if sections.get("KI_STACK_SUMMARY_HTML") else ""
-        funding_summary = sections.get("FUNDING_MATRIX_2025_HTML", "")[:2000] if sections.get("FUNDING_MATRIX_2025_HTML") else ""
-        risk_summary = sections.get("RISK_ENGINE_HTML", "")[:2000] if sections.get("RISK_ENGINE_HTML") else ""
-        strategy_summary = sections.get("STRATEGY_PLAN_HTML", "")[:2000] if sections.get("STRATEGY_PLAN_HTML") else ""
-        bc_summary = sections.get("BUSINESS_CASE_ENGINE_HTML", "")[:2000] if sections.get("BUSINESS_CASE_ENGINE_HTML") else ""
-
         reco_report = generate_recommendations_report(
             context=None,
-            tools_summary=tools_summary,
-            funding_summary=funding_summary,
-            risk_summary=risk_summary,
-            strategy_summary=strategy_summary,
-            business_case_summary=bc_summary,
+            sections=sections,
+            tools_data=sections.get("_tools_data"),
+            funding_data=sections.get("_funding_data"),
+            risk_report=sections.get("_risk_report"),
+            strategy_plan=sections.get("_strategy_plan"),
+            business_case=sections.get("_bc_report"),
             briefing=answers,
             llm_response=None,  # Will use extraction-based generation
         )

--- a/prompts/de/recommendations_engine.md
+++ b/prompts/de/recommendations_engine.md
@@ -1,0 +1,318 @@
+# Recommendations Engine – Meta-Empfehlungsschicht (G32)
+
+Du generierst priorisierte Handlungsempfehlungen basierend auf allen vorherigen Analysen.
+Diese Empfehlungen sind konkret, umsetzbar und auf das Unternehmen zugeschnitten.
+
+## Kontext
+
+**Unternehmen:** {{COMPANY_NAME}}
+**Branche:** {{BRANCH_LABEL}} ({{BRANCH_SHORT_LABEL}})
+**Größe:** {{SIZE_LABEL}}
+**Reifegrad:** {{MATURITY_LEVEL}}
+**Region:** {{BUNDESLAND}}
+
+### Vorhandene Engine-Ergebnisse
+
+**Tools Engine 4.0 (G25):**
+{{TOOLS_SUMMARY}}
+
+**Funding Engine v2 (G26):**
+{{FUNDING_SUMMARY}}
+
+**Risk Engine 2.0 (G29):**
+{{RISK_SUMMARY}}
+
+**Strategy Engine (G28):**
+{{STRATEGY_SUMMARY}}
+
+**Business Case Engine 2.0 (G30):**
+{{BUSINESS_CASE_SUMMARY}}
+
+**KPI-Baseline:**
+- ROI: {{ROI_12M}}%
+- Payback: {{PAYBACK_MONTHS}} Monate
+- Zeitersparnis: {{EINSPARUNG_STUNDEN_MONAT}} Std/Monat
+
+## Anforderungen
+
+Generiere 5-10 konkrete Handlungsempfehlungen basierend auf allen Eingabedaten.
+Markiere genau 3 davon als Top-Prioritäten.
+
+Berücksichtige dabei die Unternehmensgröße ({{SIZE_LABEL}}):
+
+- **Solo/Freelancer**:
+  - Max. 5 Empfehlungen, davon max. 2 mit Impact=high
+  - Weniger parallele Initiativen (max. 2)
+  - Fokus auf schnell umsetzbare Maßnahmen
+  - Geringere Investment-Anforderungen
+
+- **Team (2-10 MA)**:
+  - 5-8 Empfehlungen, moderate Mischung
+  - Bis zu 3 parallele Initiativen
+  - Balance zwischen Quick Wins und strategischen Maßnahmen
+
+- **KMU (>10 MA)**:
+  - 8-10 Empfehlungen erlaubt
+  - Mehrere parallele Initiativen möglich (bis zu 5)
+  - Strukturierte Maßnahmenpakete
+  - Höhere Investitionen möglich
+
+Branchenspezifik beachten:
+- Empfehlungen müssen zur Branche {{BRANCH_SHORT_LABEL}} passen
+- Regulierte Branchen: Compliance-Empfehlungen priorisieren
+- Tech-Branchen: Schnellere Tool-Adoption empfehlen
+
+## Output-Format
+
+Du MUSST exakt dieses JSON-Schema ausgeben – keine weiteren Texte, nur JSON:
+
+```json
+{
+  "summary": "Zusammenfassung der Empfehlungen in 2-3 Sätzen.",
+  "top_3_ids": ["rec1", "rec2", "rec3"],
+  "recommendations": [
+    {
+      "id": "rec1",
+      "title": "Empfehlungstitel",
+      "description": "Konkrete Beschreibung der Maßnahme",
+      "reason": "Begründung, warum diese Empfehlung wichtig ist",
+      "impact_level": "high",
+      "urgency_level": "medium",
+      "risk_relation": "reduces_risk",
+      "required_investment": 5000.0,
+      "related_tools": ["Tool A", "Tool B"],
+      "related_funding": ["Förderprogramm X"],
+      "related_risks": ["Identifiziertes Risiko Y"],
+      "timeline_phase": "phase_1"
+    }
+  ]
+}
+```
+
+## Feldspezifikationen
+
+### summary
+2-3 Sätze Zusammenfassung:
+- Anzahl der Empfehlungen
+- Schwerpunkte (Tools, Risiken, Funding)
+- Erwarteter Gesamteffekt
+
+### top_3_ids
+Genau 3 IDs der wichtigsten Empfehlungen.
+Auswahl basierend auf:
+- Impact × Urgency Score
+- Strategische Bedeutung
+- Schnelle Umsetzbarkeit
+
+### recommendations (5-10 Einträge)
+
+**id**: Eindeutige ID (z.B. "rec1", "rec_tool_1", "rec_risk_1")
+
+**title**: Kurzer, aktionsorientierter Titel (max. 60 Zeichen)
+- Beginnt mit Verb (Implementieren, Starten, Beantragen, etc.)
+- Konkret, nicht generisch
+
+**description**: Detaillierte Beschreibung (2-3 Sätze)
+- Was genau tun?
+- Wie umsetzen?
+- Erwartetes Ergebnis
+
+**reason**: Begründung (1-2 Sätze)
+- Warum ist diese Maßnahme wichtig?
+- Bezug zu Analyse-Ergebnissen
+
+**impact_level**: "low" | "medium" | "high"
+- `high`: Signifikanter Einfluss auf ROI, Effizienz oder Risiko
+- `medium`: Moderater positiver Effekt
+- `low`: Kleine Verbesserung, aber sinnvoll
+
+**urgency_level**: "low" | "medium" | "high"
+- `high`: Sofort starten (Phase 1)
+- `medium`: Innerhalb von 3 Monaten
+- `low`: Kann später erfolgen (Phase 2-3)
+
+**risk_relation**: "reduces_risk" | "requires_mitigation" | "neutral"
+- `reduces_risk`: Empfehlung adressiert identifiziertes Risiko
+- `requires_mitigation`: Empfehlung führt neue Risiken ein
+- `neutral`: Kein direkter Risiko-Bezug
+
+**required_investment**: Optional, Float in EUR
+- Geschätzte Kosten für die Umsetzung
+- null wenn nicht kalkulierbar
+
+**related_tools**: Liste von Tool-Namen aus Tools Engine
+- Nur Tools verwenden, die in Tools Engine empfohlen wurden
+- Max. 3 Tools pro Empfehlung
+
+**related_funding**: Liste von Förderprogrammen aus Funding Engine
+- Nur Programme verwenden, die in Funding Engine identifiziert wurden
+- Relevanz für die Empfehlung muss gegeben sein
+
+**related_risks**: Liste von Risiko-Titeln aus Risk Engine
+- Bei risk_relation="reduces_risk": Mindestens 1 Risiko angeben
+- Risiken müssen im Risk Report existieren
+
+**timeline_phase**: "phase_1" | "phase_2" | "phase_3"
+- Muss mit Strategy Engine Phasen konsistent sein
+- `phase_1`: Quick Wins, sofortige Maßnahmen (Monat 1-3)
+- `phase_2`: Konsolidierung, Aufbau (Monat 4-6)
+- `phase_3`: Skalierung, Optimierung (Monat 7-12)
+
+## Validierungsregeln
+
+### Konsistenz mit anderen Engines
+
+1. **Tools-Konsistenz (RECO_001)**
+   - related_tools nur aus Tools Engine verwenden
+   - Fit-Score für Unternehmensgröße muss >= 0.3 sein
+   - Keine Tools mit sehr hohem vendor_risk ohne Mitigation
+
+2. **Risk-Konsistenz (RECO_002)**
+   - Bei risk_relation="reduces_risk" muss related_risks mindestens ein
+     tatsächlich hohes/kritisches Risiko aus Risk Report enthalten
+
+3. **Funding-Konsistenz (RECO_003)**
+   - related_funding nur aus Funding Engine verwenden
+   - Programme müssen zur Unternehmensgröße und Branche passen
+
+4. **Strategy-Konsistenz (RECO_004)**
+   - timeline_phase muss mit Strategy Plan konsistent sein
+   - Keine Phase_1-Empfehlung für Phase_3-Maßnahmen
+
+5. **Size-Konsistenz (RECO_005)**
+   - Anzahl und Komplexität passend zur Unternehmensgröße
+   - Solo: max. 5 Empfehlungen, max. 2 high impact
+   - Team: max. 8 Empfehlungen
+   - KMU: max. 10 Empfehlungen
+
+### Qualitätskriterien
+
+- Keine generischen Empfehlungen ("KI einführen")
+- Jede Empfehlung muss konkret und messbar sein
+- Keine Dopplungen in den Empfehlungen
+- top_3_ids muss Teilmenge der recommendation IDs sein
+
+## Verbotene Phrasen
+
+- "Es empfiehlt sich..."
+- "Grundsätzlich sollte..."
+- "Im Allgemeinen..."
+- "Erwägen Sie..."
+- Generische Floskeln ohne konkrete Handlung
+
+## Beispiel-Output (KMU Produktion)
+
+```json
+{
+  "summary": "Für Ihr mittelständisches Produktionsunternehmen wurden 7 priorisierte Handlungsempfehlungen identifiziert. Der Fokus liegt auf Tool-Implementierung, Risiko-Mitigation und Förder-Nutzung mit einer Gesamtinvestition von ca. 25.000€.",
+  "top_3_ids": ["rec1", "rec2", "rec4"],
+  "recommendations": [
+    {
+      "id": "rec1",
+      "title": "ChatGPT Enterprise für Prozessdokumentation implementieren",
+      "description": "Starten Sie mit ChatGPT Enterprise für die automatisierte Erstellung von Produktionsdokumentationen. Beginnen Sie mit 3 Pilotprozessen im Qualitätsmanagement.",
+      "reason": "Höchster Fit-Score (0.9) für KMU, schnellster ROI und direkte Zeitersparnis in der Dokumentation.",
+      "impact_level": "high",
+      "urgency_level": "high",
+      "risk_relation": "neutral",
+      "required_investment": 8000.0,
+      "related_tools": ["ChatGPT Enterprise"],
+      "related_funding": ["Digital Jetzt"],
+      "related_risks": [],
+      "timeline_phase": "phase_1"
+    },
+    {
+      "id": "rec2",
+      "title": "Förderantrag Digital Jetzt bis Q1 einreichen",
+      "description": "Bereiten Sie den Förderantrag für 'Digital Jetzt' vor. Fördersumme bis zu 50% der Investitionskosten möglich.",
+      "reason": "Auslaufendes Programm mit hoher Passung zu Ihrer Branche und Größe.",
+      "impact_level": "high",
+      "urgency_level": "high",
+      "risk_relation": "neutral",
+      "required_investment": 500.0,
+      "related_tools": ["ChatGPT Enterprise", "Microsoft Copilot"],
+      "related_funding": ["Digital Jetzt"],
+      "related_risks": [],
+      "timeline_phase": "phase_1"
+    },
+    {
+      "id": "rec3",
+      "title": "AI Act Dokumentation aufbauen",
+      "description": "Etablieren Sie ein Dokumentationssystem für AI Act Compliance. Beginnen Sie mit Risikoklassifizierung der geplanten KI-Anwendungen.",
+      "reason": "High-Risk Klassifizierung erfordert strukturierte Dokumentation vor Produktivbetrieb.",
+      "impact_level": "medium",
+      "urgency_level": "medium",
+      "risk_relation": "reduces_risk",
+      "required_investment": 2000.0,
+      "related_tools": [],
+      "related_funding": [],
+      "related_risks": ["AI Act Compliance", "Dokumentationspflicht"],
+      "timeline_phase": "phase_1"
+    },
+    {
+      "id": "rec4",
+      "title": "DSGVO-konforme Datenverarbeitung sicherstellen",
+      "description": "Führen Sie eine Datenschutz-Folgenabschätzung (DSFA) durch und implementieren Sie technische Schutzmaßnahmen.",
+      "reason": "Hohes DSGVO-Risiko aufgrund von Mitarbeiterdaten-Verarbeitung identifiziert.",
+      "impact_level": "high",
+      "urgency_level": "medium",
+      "risk_relation": "reduces_risk",
+      "required_investment": 3000.0,
+      "related_tools": [],
+      "related_funding": [],
+      "related_risks": ["Datenschutz (DSGVO)", "Profiling-Risiko"],
+      "timeline_phase": "phase_1"
+    },
+    {
+      "id": "rec5",
+      "title": "KI-Champion im Team benennen",
+      "description": "Identifizieren Sie einen KI-Champion, der die Adoption vorantreibt und als Ansprechpartner fungiert.",
+      "reason": "Change Management ist kritisch für erfolgreiche KI-Einführung in mittelständischen Unternehmen.",
+      "impact_level": "medium",
+      "urgency_level": "medium",
+      "risk_relation": "reduces_risk",
+      "required_investment": null,
+      "related_tools": [],
+      "related_funding": [],
+      "related_risks": ["Mitarbeiterakzeptanz"],
+      "timeline_phase": "phase_2"
+    },
+    {
+      "id": "rec6",
+      "title": "KPI-Dashboard für ROI-Tracking einrichten",
+      "description": "Implementieren Sie ein Dashboard zur Überwachung der KI-KPIs (Zeitersparnis, Qualität, ROI).",
+      "reason": "Transparentes Tracking ermöglicht Optimierung und Nachweis des Business Case.",
+      "impact_level": "medium",
+      "urgency_level": "low",
+      "risk_relation": "neutral",
+      "required_investment": 1500.0,
+      "related_tools": ["Microsoft Copilot"],
+      "related_funding": [],
+      "related_risks": [],
+      "timeline_phase": "phase_2"
+    },
+    {
+      "id": "rec7",
+      "title": "KI-Stack auf weitere Abteilungen skalieren",
+      "description": "Nach erfolgreicher Pilotphase: Rollout der KI-Tools auf Einkauf und Vertrieb planen.",
+      "reason": "Skalierung maximiert den ROI der getätigten Investitionen.",
+      "impact_level": "high",
+      "urgency_level": "low",
+      "risk_relation": "requires_mitigation",
+      "required_investment": 10000.0,
+      "related_tools": ["ChatGPT Enterprise", "Microsoft Copilot"],
+      "related_funding": ["Digital Jetzt"],
+      "related_risks": [],
+      "timeline_phase": "phase_3"
+    }
+  ]
+}
+```
+
+## Wichtig
+
+- Nur JSON ausgeben, keine Erklärungen oder Markdown
+- Genau 3 IDs in top_3_ids
+- 5-10 Empfehlungen, passend zur Unternehmensgröße
+- Alle Verknüpfungen müssen auf tatsächlich existierende Elemente verweisen
+- Konkret, messbar, umsetzbar – keine generischen Ratschläge

--- a/prompts/en/recommendations_engine.md
+++ b/prompts/en/recommendations_engine.md
@@ -1,0 +1,318 @@
+# Recommendations Engine – Meta-Recommendation Layer (G32)
+
+You generate prioritized action recommendations based on all previous analyses.
+These recommendations are concrete, actionable, and tailored to the company.
+
+## Context
+
+**Company:** {{COMPANY_NAME}}
+**Industry:** {{BRANCH_LABEL}} ({{BRANCH_SHORT_LABEL}})
+**Size:** {{SIZE_LABEL}}
+**Maturity:** {{MATURITY_LEVEL}}
+**Region:** {{BUNDESLAND}}
+
+### Available Engine Results
+
+**Tools Engine 4.0 (G25):**
+{{TOOLS_SUMMARY}}
+
+**Funding Engine v2 (G26):**
+{{FUNDING_SUMMARY}}
+
+**Risk Engine 2.0 (G29):**
+{{RISK_SUMMARY}}
+
+**Strategy Engine (G28):**
+{{STRATEGY_SUMMARY}}
+
+**Business Case Engine 2.0 (G30):**
+{{BUSINESS_CASE_SUMMARY}}
+
+**KPI Baseline:**
+- ROI: {{ROI_12M}}%
+- Payback: {{PAYBACK_MONTHS}} months
+- Time Savings: {{EINSPARUNG_STUNDEN_MONAT}} hrs/month
+
+## Requirements
+
+Generate 5-10 concrete action recommendations based on all input data.
+Mark exactly 3 of them as top priorities.
+
+Consider the company size ({{SIZE_LABEL}}):
+
+- **Solo/Freelancer**:
+  - Max. 5 recommendations, max. 2 with Impact=high
+  - Fewer parallel initiatives (max. 2)
+  - Focus on quickly implementable measures
+  - Lower investment requirements
+
+- **Team (2-10 employees)**:
+  - 5-8 recommendations, moderate mix
+  - Up to 3 parallel initiatives
+  - Balance between quick wins and strategic measures
+
+- **SME (>10 employees)**:
+  - 8-10 recommendations allowed
+  - Multiple parallel initiatives possible (up to 5)
+  - Structured action packages
+  - Higher investments possible
+
+Consider industry specifics:
+- Recommendations must fit industry {{BRANCH_SHORT_LABEL}}
+- Regulated industries: Prioritize compliance recommendations
+- Tech industries: Recommend faster tool adoption
+
+## Output Format
+
+You MUST output exactly this JSON schema – no additional text, only JSON:
+
+```json
+{
+  "summary": "Summary of recommendations in 2-3 sentences.",
+  "top_3_ids": ["rec1", "rec2", "rec3"],
+  "recommendations": [
+    {
+      "id": "rec1",
+      "title": "Recommendation title",
+      "description": "Concrete description of the measure",
+      "reason": "Rationale why this recommendation is important",
+      "impact_level": "high",
+      "urgency_level": "medium",
+      "risk_relation": "reduces_risk",
+      "required_investment": 5000.0,
+      "related_tools": ["Tool A", "Tool B"],
+      "related_funding": ["Funding Programme X"],
+      "related_risks": ["Identified Risk Y"],
+      "timeline_phase": "phase_1"
+    }
+  ]
+}
+```
+
+## Field Specifications
+
+### summary
+2-3 sentences summary:
+- Number of recommendations
+- Focus areas (tools, risks, funding)
+- Expected overall effect
+
+### top_3_ids
+Exactly 3 IDs of the most important recommendations.
+Selection based on:
+- Impact × Urgency Score
+- Strategic importance
+- Quick implementability
+
+### recommendations (5-10 entries)
+
+**id**: Unique ID (e.g., "rec1", "rec_tool_1", "rec_risk_1")
+
+**title**: Short, action-oriented title (max. 60 characters)
+- Starts with verb (Implement, Start, Apply, etc.)
+- Concrete, not generic
+
+**description**: Detailed description (2-3 sentences)
+- What exactly to do?
+- How to implement?
+- Expected outcome
+
+**reason**: Rationale (1-2 sentences)
+- Why is this measure important?
+- Reference to analysis results
+
+**impact_level**: "low" | "medium" | "high"
+- `high`: Significant impact on ROI, efficiency, or risk
+- `medium`: Moderate positive effect
+- `low`: Small improvement, but worthwhile
+
+**urgency_level**: "low" | "medium" | "high"
+- `high`: Start immediately (Phase 1)
+- `medium`: Within 3 months
+- `low`: Can be done later (Phase 2-3)
+
+**risk_relation**: "reduces_risk" | "requires_mitigation" | "neutral"
+- `reduces_risk`: Recommendation addresses identified risk
+- `requires_mitigation`: Recommendation introduces new risks
+- `neutral`: No direct risk relation
+
+**required_investment**: Optional, Float in EUR
+- Estimated cost for implementation
+- null if not calculable
+
+**related_tools**: List of tool names from Tools Engine
+- Only use tools recommended by Tools Engine
+- Max. 3 tools per recommendation
+
+**related_funding**: List of funding programmes from Funding Engine
+- Only use programmes identified by Funding Engine
+- Relevance to the recommendation must be given
+
+**related_risks**: List of risk titles from Risk Engine
+- For risk_relation="reduces_risk": At least 1 risk required
+- Risks must exist in Risk Report
+
+**timeline_phase**: "phase_1" | "phase_2" | "phase_3"
+- Must be consistent with Strategy Engine phases
+- `phase_1`: Quick wins, immediate measures (Month 1-3)
+- `phase_2`: Consolidation, building (Month 4-6)
+- `phase_3`: Scaling, optimization (Month 7-12)
+
+## Validation Rules
+
+### Consistency with Other Engines
+
+1. **Tools Consistency (RECO_001)**
+   - related_tools only from Tools Engine
+   - Fit score for company size must be >= 0.3
+   - No tools with very high vendor_risk without mitigation
+
+2. **Risk Consistency (RECO_002)**
+   - For risk_relation="reduces_risk", related_risks must contain at least one
+     actually high/critical risk from Risk Report
+
+3. **Funding Consistency (RECO_003)**
+   - related_funding only from Funding Engine
+   - Programmes must match company size and industry
+
+4. **Strategy Consistency (RECO_004)**
+   - timeline_phase must be consistent with Strategy Plan
+   - No Phase_1 recommendation for Phase_3 measures
+
+5. **Size Consistency (RECO_005)**
+   - Count and complexity matching company size
+   - Solo: max. 5 recommendations, max. 2 high impact
+   - Team: max. 8 recommendations
+   - SME: max. 10 recommendations
+
+### Quality Criteria
+
+- No generic recommendations ("Introduce AI")
+- Every recommendation must be concrete and measurable
+- No duplicates in recommendations
+- top_3_ids must be subset of recommendation IDs
+
+## Prohibited Phrases
+
+- "It is recommended..."
+- "Generally speaking..."
+- "In general..."
+- "Consider..."
+- Generic phrases without concrete action
+
+## Example Output (SME Manufacturing)
+
+```json
+{
+  "summary": "For your mid-sized manufacturing company, 7 prioritized action recommendations have been identified. Focus areas are tool implementation, risk mitigation, and funding utilization with a total investment of approx. EUR 25,000.",
+  "top_3_ids": ["rec1", "rec2", "rec4"],
+  "recommendations": [
+    {
+      "id": "rec1",
+      "title": "Implement ChatGPT Enterprise for process documentation",
+      "description": "Start with ChatGPT Enterprise for automated creation of production documentation. Begin with 3 pilot processes in quality management.",
+      "reason": "Highest fit score (0.9) for SME, fastest ROI and direct time savings in documentation.",
+      "impact_level": "high",
+      "urgency_level": "high",
+      "risk_relation": "neutral",
+      "required_investment": 8000.0,
+      "related_tools": ["ChatGPT Enterprise"],
+      "related_funding": ["Digital Jetzt"],
+      "related_risks": [],
+      "timeline_phase": "phase_1"
+    },
+    {
+      "id": "rec2",
+      "title": "Submit Digital Jetzt funding application by Q1",
+      "description": "Prepare the funding application for 'Digital Jetzt'. Funding up to 50% of investment costs possible.",
+      "reason": "Expiring programme with high match to your industry and size.",
+      "impact_level": "high",
+      "urgency_level": "high",
+      "risk_relation": "neutral",
+      "required_investment": 500.0,
+      "related_tools": ["ChatGPT Enterprise", "Microsoft Copilot"],
+      "related_funding": ["Digital Jetzt"],
+      "related_risks": [],
+      "timeline_phase": "phase_1"
+    },
+    {
+      "id": "rec3",
+      "title": "Build AI Act documentation system",
+      "description": "Establish a documentation system for AI Act compliance. Start with risk classification of planned AI applications.",
+      "reason": "High-risk classification requires structured documentation before production deployment.",
+      "impact_level": "medium",
+      "urgency_level": "medium",
+      "risk_relation": "reduces_risk",
+      "required_investment": 2000.0,
+      "related_tools": [],
+      "related_funding": [],
+      "related_risks": ["AI Act Compliance", "Documentation Requirements"],
+      "timeline_phase": "phase_1"
+    },
+    {
+      "id": "rec4",
+      "title": "Ensure GDPR-compliant data processing",
+      "description": "Conduct a Data Protection Impact Assessment (DPIA) and implement technical safeguards.",
+      "reason": "High GDPR risk identified due to employee data processing.",
+      "impact_level": "high",
+      "urgency_level": "medium",
+      "risk_relation": "reduces_risk",
+      "required_investment": 3000.0,
+      "related_tools": [],
+      "related_funding": [],
+      "related_risks": ["Data Protection (GDPR)", "Profiling Risk"],
+      "timeline_phase": "phase_1"
+    },
+    {
+      "id": "rec5",
+      "title": "Appoint AI champion in the team",
+      "description": "Identify an AI champion who drives adoption and serves as point of contact.",
+      "reason": "Change management is critical for successful AI adoption in mid-sized companies.",
+      "impact_level": "medium",
+      "urgency_level": "medium",
+      "risk_relation": "reduces_risk",
+      "required_investment": null,
+      "related_tools": [],
+      "related_funding": [],
+      "related_risks": ["Employee Acceptance"],
+      "timeline_phase": "phase_2"
+    },
+    {
+      "id": "rec6",
+      "title": "Set up KPI dashboard for ROI tracking",
+      "description": "Implement a dashboard to monitor AI KPIs (time savings, quality, ROI).",
+      "reason": "Transparent tracking enables optimization and proof of business case.",
+      "impact_level": "medium",
+      "urgency_level": "low",
+      "risk_relation": "neutral",
+      "required_investment": 1500.0,
+      "related_tools": ["Microsoft Copilot"],
+      "related_funding": [],
+      "related_risks": [],
+      "timeline_phase": "phase_2"
+    },
+    {
+      "id": "rec7",
+      "title": "Scale AI stack to additional departments",
+      "description": "After successful pilot phase: Plan rollout of AI tools to procurement and sales.",
+      "reason": "Scaling maximizes ROI of investments made.",
+      "impact_level": "high",
+      "urgency_level": "low",
+      "risk_relation": "requires_mitigation",
+      "required_investment": 10000.0,
+      "related_tools": ["ChatGPT Enterprise", "Microsoft Copilot"],
+      "related_funding": ["Digital Jetzt"],
+      "related_risks": [],
+      "timeline_phase": "phase_3"
+    }
+  ]
+}
+```
+
+## Important
+
+- Output only JSON, no explanations or markdown
+- Exactly 3 IDs in top_3_ids
+- 5-10 recommendations, matching company size
+- All references must point to actually existing elements
+- Concrete, measurable, actionable – no generic advice

--- a/services/consistency_engine.py
+++ b/services/consistency_engine.py
@@ -450,6 +450,7 @@ class ConsistencyEngine:
         self._check_exec_snapshot_consistency()  # G27
         self._check_risk_engine_consistency()  # G29
         self._check_business_case_consistency()  # G30
+        self._check_recommendations_consistency()  # G32
 
         # Calculate domain scores
         self._calculate_domain_scores()
@@ -1909,12 +1910,397 @@ class ConsistencyEngine:
         return cost_sum if found_costs else None
 
     # -------------------------------------------------------------------------
+    # DOMAIN 10: Recommendations Engine Consistency (G32)
+    # -------------------------------------------------------------------------
+
+    def _check_recommendations_consistency(self) -> None:
+        """
+        G32: Check Recommendations Engine consistency with other engines.
+
+        Rules:
+        - RECO_001: Tools fit validation (fit >= 0.3 for size, no high vendor_risk)
+        - RECO_002: Risk relation validation (reduces_risk must reference high/critical risks)
+        - RECO_003: Funding consistency (programmes must exist in Funding Engine)
+        - RECO_004: Strategy phase consistency (timeline_phase matches Strategy Plan)
+        - RECO_005: Size-appropriate count (Solo: max 5, Team: max 8, KMU: max 10)
+        """
+        reco_html = self.sections.get("RECOMMENDATIONS_ENGINE_HTML", "")
+
+        if not reco_html:
+            log.debug("[G32] Recommendations consistency: Skipping (no recommendations section)")
+            return
+
+        self.report.checked_rules += 5
+
+        reco_html_lower = reco_html.lower()
+
+        # Get company size
+        size = self.briefing.get("unternehmensgroesse", "").lower()
+        size_label = "solo" if "solo" in size or "freiberuf" in size else (
+            "team" if "team" in size or "klein" in size else "kmu"
+        )
+
+        # Rule RECO_001: Tools fit validation
+        # related_tools must have fit >= 0.3 for company size, no high vendor_risk
+        tools_html = self.sections.get("KI_STACK_SUMMARY_HTML", "") or self.sections.get("TOOLS_HTML", "")
+
+        if tools_html and reco_html:
+            # Extract tool names from recommendations
+            reco_tools = self._extract_related_tools_from_reco(reco_html)
+            tools_engine_tools = _extract_tool_names(tools_html)
+
+            # Check if recommended tools are from Tools Engine
+            invalid_tools = []
+            for tool in reco_tools:
+                if not any(tool.lower() in t.lower() or t.lower() in tool.lower()
+                          for t in tools_engine_tools):
+                    invalid_tools.append(tool)
+
+            if invalid_tools:
+                self.report.add_issue(ConsistencyIssue(
+                    rule_id="RECO_001",
+                    severity="ERROR",
+                    domain="recommendations",
+                    source_section="recommendations_engine",
+                    target_section="tools_engine",
+                    message="Empfehlungen referenzieren Tools nicht aus Tools Engine",
+                    expected="Nur Tools aus Tools Engine 4.0 verwenden",
+                    actual=f"Unbekannte Tools: {', '.join(invalid_tools[:3])}",
+                    suggestion="Verwende nur Tools, die von Tools Engine empfohlen wurden",
+                ))
+
+            # Check for tools with high vendor risk (vendor-risk >= 4)
+            high_vendor_tools = self._extract_high_vendor_risk_tools(tools_html)
+            risky_reco_tools = [t for t in reco_tools
+                               if any(t.lower() in hvt.lower() or hvt.lower() in t.lower()
+                                     for hvt in high_vendor_tools)]
+
+            if risky_reco_tools:
+                # Check if mitigation is mentioned
+                has_mitigation = any(term in reco_html_lower for term in [
+                    "mitigation", "risiko", "risk", "alternativ", "vorsicht"
+                ])
+
+                if not has_mitigation:
+                    self.report.add_issue(ConsistencyIssue(
+                        rule_id="RECO_001",
+                        severity="WARNING",
+                        domain="recommendations",
+                        source_section="recommendations_engine",
+                        target_section="tools_engine",
+                        message="Empfehlungen enthalten Tools mit hohem Vendor-Risiko ohne Mitigation",
+                        expected="Mitigation-Hinweis für riskante Tools",
+                        actual=f"Tools mit hohem Vendor-Risk: {', '.join(risky_reco_tools[:2])}",
+                        suggestion="Füge Risiko-Hinweise für Tools mit vendor_risk >= 4 hinzu",
+                    ))
+
+        # Rule RECO_002: Risk relation validation
+        # If risk_relation="reduces_risk", related_risks must contain high/critical risks
+        risk_html = self.sections.get("RISK_ENGINE_HTML", "") or self.sections.get("RISKS_HTML", "")
+
+        if risk_html and reco_html:
+            # Check for "reduces_risk" markers in recommendations
+            has_reduces_risk = "reduces_risk" in reco_html_lower or "reduziert risiko" in reco_html_lower
+
+            if has_reduces_risk:
+                # Check if related risks reference actual high/critical risks from Risk Engine
+                high_risks = self._extract_high_risks_from_engine(risk_html)
+                related_risks = self._extract_related_risks_from_reco(reco_html)
+
+                if related_risks:
+                    # Check if any related risk matches a high risk
+                    matching_risks = [r for r in related_risks
+                                     if any(r.lower() in hr.lower() or hr.lower() in r.lower()
+                                           for hr in high_risks)]
+
+                    if not matching_risks and high_risks:
+                        self.report.add_issue(ConsistencyIssue(
+                            rule_id="RECO_002",
+                            severity="WARNING",
+                            domain="recommendations",
+                            source_section="recommendations_engine",
+                            target_section="risk_engine",
+                            message="reduces_risk Empfehlungen referenzieren keine kritischen Risiken",
+                            expected="Referenz auf high/critical Risiken aus Risk Engine",
+                            actual=f"Referenzierte Risiken nicht in High-Risk Liste gefunden",
+                            suggestion="Verknüpfe reduces_risk Empfehlungen mit tatsächlich kritischen Risiken",
+                        ))
+                elif has_reduces_risk:
+                    self.report.add_issue(ConsistencyIssue(
+                        rule_id="RECO_002",
+                        severity="ERROR",
+                        domain="recommendations",
+                        source_section="recommendations_engine",
+                        target_section="risk_engine",
+                        message="reduces_risk Empfehlung ohne related_risks",
+                        expected="Bei risk_relation='reduces_risk' mindestens 1 related_risk",
+                        actual="Keine related_risks angegeben",
+                        suggestion="Füge related_risks für reduces_risk Empfehlungen hinzu",
+                    ))
+
+        # Rule RECO_003: Funding consistency
+        # related_funding must exist in Funding Engine
+        funding_html = self.sections.get("FUNDING_MATRIX_2025_HTML", "") or self.sections.get("FOERDERPOTENZIAL_HTML", "")
+
+        if funding_html and reco_html:
+            reco_funding = self._extract_related_funding_from_reco(reco_html)
+            funding_engine_programs = _extract_funding_programs(funding_html)
+
+            if reco_funding:
+                invalid_funding = []
+                for prog in reco_funding:
+                    if not any(prog.lower() in fp.lower() or fp.lower() in prog.lower()
+                              for fp in funding_engine_programs):
+                        invalid_funding.append(prog)
+
+                if invalid_funding:
+                    self.report.add_issue(ConsistencyIssue(
+                        rule_id="RECO_003",
+                        severity="ERROR",
+                        domain="recommendations",
+                        source_section="recommendations_engine",
+                        target_section="funding_engine",
+                        message="Empfehlungen referenzieren unbekannte Förderprogramme",
+                        expected="Nur Programme aus Funding Engine V2 verwenden",
+                        actual=f"Unbekannte Programme: {', '.join(invalid_funding[:2])}",
+                        suggestion="Verwende nur Programme, die in Funding Engine identifiziert wurden",
+                    ))
+
+        # Rule RECO_004: Strategy phase consistency
+        # timeline_phase must align with Strategy Plan
+        strategy_html = self.sections.get("STRATEGY_PLAN_HTML", "") or self.sections.get("ROADMAP_12M_HTML", "")
+
+        if strategy_html and reco_html:
+            # Check for phase misalignment
+            # Phase 1 recommendations should not reference Phase 3 measures
+            phase_1_recos = "phase_1" in reco_html_lower or "phase 1" in reco_html_lower
+            phase_3_strategy = "phase_3" in strategy_html.lower() or "phase 3" in strategy_html.lower()
+
+            # Look for urgent measures in phase_3
+            urgent_in_phase_3 = False
+            if "urgency_level.*high" in reco_html_lower or "urgency.*hoch" in reco_html_lower:
+                # Check if urgent items are in phase_3
+                import re
+                urgent_phase_3 = re.search(r'urgency[^}]*high[^}]*phase_3', reco_html_lower, re.DOTALL)
+                if urgent_phase_3:
+                    urgent_in_phase_3 = True
+
+            if urgent_in_phase_3:
+                self.report.add_issue(ConsistencyIssue(
+                    rule_id="RECO_004",
+                    severity="WARNING",
+                    domain="recommendations",
+                    source_section="recommendations_engine",
+                    target_section="strategy_plan",
+                    message="Dringende Empfehlung (urgency=high) in Phase 3",
+                    expected="urgency=high sollte in Phase 1 sein",
+                    actual="High-Urgency Empfehlung für Phase 3 gefunden",
+                    suggestion="Verschiebe dringende Empfehlungen in frühere Phasen",
+                ))
+
+        # Rule RECO_005: Size-appropriate count
+        # Solo: max 5, Team: max 8, KMU: max 10
+        reco_count = self._count_recommendations(reco_html)
+        high_impact_count = self._count_high_impact_recommendations(reco_html)
+
+        size_limits = {
+            "solo": (5, 2),   # max 5 total, max 2 high impact
+            "team": (8, 4),   # max 8 total, max 4 high impact
+            "kmu": (10, 6),   # max 10 total, max 6 high impact
+        }
+
+        max_total, max_high = size_limits.get(size_label, (10, 6))
+
+        if reco_count > max_total:
+            self.report.add_issue(ConsistencyIssue(
+                rule_id="RECO_005",
+                severity="ERROR",
+                domain="recommendations",
+                source_section="recommendations_engine",
+                target_section="briefing",
+                message=f"Zu viele Empfehlungen für Unternehmensgröße '{size_label}'",
+                expected=f"Max. {max_total} Empfehlungen für {size_label}",
+                actual=f"{reco_count} Empfehlungen gefunden",
+                suggestion=f"Reduziere auf max. {max_total} Empfehlungen",
+            ))
+
+        if high_impact_count > max_high:
+            self.report.add_issue(ConsistencyIssue(
+                rule_id="RECO_005",
+                severity="WARNING",
+                domain="recommendations",
+                source_section="recommendations_engine",
+                target_section="briefing",
+                message=f"Zu viele High-Impact Empfehlungen für '{size_label}'",
+                expected=f"Max. {max_high} High-Impact Empfehlungen für {size_label}",
+                actual=f"{high_impact_count} High-Impact Empfehlungen",
+                suggestion=f"Reduziere High-Impact Empfehlungen auf max. {max_high}",
+            ))
+
+    def _extract_related_tools_from_reco(self, html: str) -> List[str]:
+        """Extract related tools from Recommendations Engine HTML."""
+        if not html:
+            return []
+
+        tools: List[str] = []
+
+        import re
+
+        # Pattern: related_tools: ["Tool A", "Tool B"]
+        tools_pattern = r'related_tools["\s:]*\[(.*?)\]'
+        matches = re.findall(tools_pattern, html, re.IGNORECASE | re.DOTALL)
+
+        for match in matches:
+            # Extract tool names from the list
+            tool_names = re.findall(r'"([^"]+)"', match)
+            tools.extend(tool_names)
+
+        # Also extract from HTML list items
+        li_pattern = r'<li[^>]*>([A-Za-z0-9\s\-\.]+(?:AI|GPT|Bot|Tool|Cloud|Pro|Plus)?)</li>'
+        for match in re.finditer(li_pattern, html, re.IGNORECASE):
+            name = match.group(1).strip()
+            if len(name) > 2 and len(name) < 50:
+                tools.append(name)
+
+        return list(set(tools))
+
+    def _extract_high_vendor_risk_tools(self, html: str) -> List[str]:
+        """Extract tools with high vendor risk (>=4) from Tools Engine HTML."""
+        if not html:
+            return []
+
+        tools: List[str] = []
+
+        import re
+
+        # Look for vendor-risk-4 or vendor-risk-5 badges
+        pattern = r'vendor[\-_]risk[\-_]?[45]'
+
+        if re.search(pattern, html.lower()):
+            # Extract tool names near these badges
+            tool_names = _extract_tool_names(html)
+            # For simplicity, return all tools from section with high vendor risk indicators
+            tools = tool_names[:5]
+
+        return tools
+
+    def _extract_high_risks_from_engine(self, html: str) -> List[str]:
+        """Extract high/critical risk titles from Risk Engine HTML."""
+        if not html:
+            return []
+
+        risks: List[str] = []
+
+        import re
+
+        # Look for high/critical risk indicators
+        high_patterns = [
+            r'(kritisch|critical|hoch|high)[\s\-]?risk[:\s]*([^<]+)',
+            r'risk[:\s]*([^<]+?)[\s]*(?:kritisch|critical|hoch|high)',
+            r'<strong>([^<]+)</strong>\s*(?:kritisch|critical|hoch|high)',
+        ]
+
+        for pattern in high_patterns:
+            matches = re.findall(pattern, html.lower())
+            for match in matches:
+                if isinstance(match, tuple):
+                    risk_name = match[-1].strip()
+                else:
+                    risk_name = match.strip()
+                if len(risk_name) > 3 and len(risk_name) < 100:
+                    risks.append(risk_name)
+
+        return list(set(risks))
+
+    def _extract_related_risks_from_reco(self, html: str) -> List[str]:
+        """Extract related risks from Recommendations Engine HTML."""
+        if not html:
+            return []
+
+        risks: List[str] = []
+
+        import re
+
+        # Pattern: related_risks: ["Risk A", "Risk B"]
+        risks_pattern = r'related_risks["\s:]*\[(.*?)\]'
+        matches = re.findall(risks_pattern, html, re.IGNORECASE | re.DOTALL)
+
+        for match in matches:
+            risk_names = re.findall(r'"([^"]+)"', match)
+            risks.extend(risk_names)
+
+        return list(set(risks))
+
+    def _extract_related_funding_from_reco(self, html: str) -> List[str]:
+        """Extract related funding programmes from Recommendations Engine HTML."""
+        if not html:
+            return []
+
+        funding: List[str] = []
+
+        import re
+
+        # Pattern: related_funding: ["Programme A", "Programme B"]
+        funding_pattern = r'related_funding["\s:]*\[(.*?)\]'
+        matches = re.findall(funding_pattern, html, re.IGNORECASE | re.DOTALL)
+
+        for match in matches:
+            prog_names = re.findall(r'"([^"]+)"', match)
+            funding.extend(prog_names)
+
+        return list(set(funding))
+
+    def _count_recommendations(self, html: str) -> int:
+        """Count total recommendations in HTML."""
+        if not html:
+            return 0
+
+        import re
+
+        # Count recommendation cards or IDs
+        patterns = [
+            r'"id":\s*"rec\d+"',  # JSON ID pattern
+            r'class="[^"]*recommendation-card[^"]*"',  # CSS class pattern
+            r'class="[^"]*reco-card[^"]*"',  # Alternative CSS class
+            r'<div[^>]*recommendation[^>]*>',  # Generic div pattern
+        ]
+
+        max_count = 0
+        for pattern in patterns:
+            count = len(re.findall(pattern, html, re.IGNORECASE))
+            if count > max_count:
+                max_count = count
+
+        return max_count
+
+    def _count_high_impact_recommendations(self, html: str) -> int:
+        """Count high-impact recommendations in HTML."""
+        if not html:
+            return 0
+
+        import re
+
+        # Count impact_level: "high" patterns
+        patterns = [
+            r'"impact_level":\s*"high"',
+            r'impact[\-_]?level[:\s]*high',
+            r'class="[^"]*impact-high[^"]*"',
+        ]
+
+        total_count = 0
+        for pattern in patterns:
+            count = len(re.findall(pattern, html, re.IGNORECASE))
+            total_count += count
+
+        return total_count
+
+    # -------------------------------------------------------------------------
     # SCORING
     # -------------------------------------------------------------------------
 
     def _calculate_domain_scores(self) -> None:
         """Calculate scores per domain."""
-        domains = ["tools", "funding", "kpi", "risk", "roadmap", "narrative", "snapshot", "risk_engine", "business_case"]
+        domains = ["tools", "funding", "kpi", "risk", "roadmap", "narrative", "snapshot", "risk_engine", "business_case", "recommendations"]
 
         for domain in domains:
             domain_issues = [i for i in self.report.issues if i.domain == domain]

--- a/services/recommendations_engine.py
+++ b/services/recommendations_engine.py
@@ -1,0 +1,978 @@
+# -*- coding: utf-8 -*-
+"""
+Sprint G32: Recommendations Engine – Meta-Empfehlungsschicht
+============================================================
+
+Eine Meta-Engine, die:
+- 5-10 konkrete Handlungsempfehlungen erzeugt
+- 3 davon als Top-Prioritäten markiert
+- Impact, Dringlichkeit, Risiko-Bezug und Phase (1-3) je Empfehlung ausweist
+- Tools/Funding/Risiken/Strategie/Business Case verknüpft
+- Size-aware (Solo/Team/KMU) und branch-aware ist
+
+Version: 1.0.0 (Sprint G32)
+Author: Claude + Wolf
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Literal, Tuple
+
+log = logging.getLogger(__name__)
+
+__all__ = [
+    "Recommendation",
+    "RecommendationsReport",
+    "generate_recommendations_report",
+    "recommendations_report_to_html",
+    "RECOMMENDATIONS_ENGINE_ENABLED",
+]
+
+
+# =============================================================================
+# CONFIGURATION
+# =============================================================================
+
+RECOMMENDATIONS_ENGINE_ENABLED = True
+
+# Valid values
+IMPACT_LEVELS = ["low", "medium", "high"]
+URGENCY_LEVELS = ["low", "medium", "high"]
+RISK_RELATIONS = ["reduces_risk", "requires_mitigation", "neutral"]
+TIMELINE_PHASES = ["phase_1", "phase_2", "phase_3"]
+
+# Constraints by size
+SIZE_CONSTRAINTS = {
+    "solo": {
+        "max_recommendations": 5,
+        "max_high_impact": 2,
+        "max_parallel_initiatives": 2,
+    },
+    "team": {
+        "max_recommendations": 8,
+        "max_high_impact": 4,
+        "max_parallel_initiatives": 3,
+    },
+    "kmu": {
+        "max_recommendations": 10,
+        "max_high_impact": 6,
+        "max_parallel_initiatives": 5,
+    },
+}
+
+
+# =============================================================================
+# DATA STRUCTURES
+# =============================================================================
+
+@dataclass
+class Recommendation:
+    """
+    Einzelne Handlungsempfehlung mit allen Metadaten.
+    """
+    id: str
+    title: str
+    description: str
+    reason: str
+    impact_level: str  # "low" | "medium" | "high"
+    urgency_level: str  # "low" | "medium" | "high"
+    risk_relation: str  # "reduces_risk" | "requires_mitigation" | "neutral"
+    required_investment: Optional[float] = None
+    related_tools: List[str] = field(default_factory=list)
+    related_funding: List[str] = field(default_factory=list)
+    related_risks: List[str] = field(default_factory=list)
+    timeline_phase: str = "phase_1"  # "phase_1" | "phase_2" | "phase_3"
+
+    def __post_init__(self) -> None:
+        """Validate and normalize values."""
+        # Validate impact level
+        if self.impact_level not in IMPACT_LEVELS:
+            log.warning("[G32] Invalid impact_level: %s, defaulting to 'medium'", self.impact_level)
+            self.impact_level = "medium"
+
+        # Validate urgency level
+        if self.urgency_level not in URGENCY_LEVELS:
+            log.warning("[G32] Invalid urgency_level: %s, defaulting to 'medium'", self.urgency_level)
+            self.urgency_level = "medium"
+
+        # Validate risk relation
+        if self.risk_relation not in RISK_RELATIONS:
+            log.warning("[G32] Invalid risk_relation: %s, defaulting to 'neutral'", self.risk_relation)
+            self.risk_relation = "neutral"
+
+        # Validate timeline phase
+        if self.timeline_phase not in TIMELINE_PHASES:
+            log.warning("[G32] Invalid timeline_phase: %s, defaulting to 'phase_1'", self.timeline_phase)
+            self.timeline_phase = "phase_1"
+
+        # Ensure lists
+        if not isinstance(self.related_tools, list):
+            self.related_tools = []
+        if not isinstance(self.related_funding, list):
+            self.related_funding = []
+        if not isinstance(self.related_risks, list):
+            self.related_risks = []
+
+        # Normalize investment
+        if self.required_investment is not None:
+            self.required_investment = max(0.0, float(self.required_investment))
+
+    @property
+    def priority_score(self) -> int:
+        """Calculate priority score based on impact and urgency."""
+        impact_scores = {"high": 3, "medium": 2, "low": 1}
+        urgency_scores = {"high": 3, "medium": 2, "low": 1}
+
+        return impact_scores.get(self.impact_level, 2) * urgency_scores.get(self.urgency_level, 2)
+
+    @property
+    def phase_number(self) -> int:
+        """Get phase as number (1, 2, or 3)."""
+        phase_map = {"phase_1": 1, "phase_2": 2, "phase_3": 3}
+        return phase_map.get(self.timeline_phase, 1)
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert to dictionary for JSON serialization."""
+        return {
+            "id": self.id,
+            "title": self.title,
+            "description": self.description,
+            "reason": self.reason,
+            "impact_level": self.impact_level,
+            "urgency_level": self.urgency_level,
+            "risk_relation": self.risk_relation,
+            "required_investment": self.required_investment,
+            "related_tools": self.related_tools,
+            "related_funding": self.related_funding,
+            "related_risks": self.related_risks,
+            "timeline_phase": self.timeline_phase,
+            "priority_score": self.priority_score,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "Recommendation":
+        """Create from dictionary."""
+        return cls(
+            id=data.get("id", "rec_unknown"),
+            title=data.get("title", ""),
+            description=data.get("description", ""),
+            reason=data.get("reason", ""),
+            impact_level=data.get("impact_level", "medium"),
+            urgency_level=data.get("urgency_level", "medium"),
+            risk_relation=data.get("risk_relation", "neutral"),
+            required_investment=data.get("required_investment"),
+            related_tools=data.get("related_tools", []),
+            related_funding=data.get("related_funding", []),
+            related_risks=data.get("related_risks", []),
+            timeline_phase=data.get("timeline_phase", "phase_1"),
+        )
+
+
+@dataclass
+class RecommendationsReport:
+    """
+    Vollständiger Empfehlungs-Report mit Top-3 Priorisierung.
+    """
+    recommendations: List[Recommendation] = field(default_factory=list)
+    summary: str = ""
+    top_3_ids: List[str] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        """Validate and normalize values."""
+        if not isinstance(self.recommendations, list):
+            self.recommendations = []
+        if not isinstance(self.top_3_ids, list):
+            self.top_3_ids = []
+
+        # Ensure top_3_ids is subset of recommendation IDs
+        rec_ids = {r.id for r in self.recommendations}
+        self.top_3_ids = [tid for tid in self.top_3_ids if tid in rec_ids][:3]
+
+    @property
+    def top_3_recommendations(self) -> List[Recommendation]:
+        """Get the top 3 priority recommendations."""
+        return [r for r in self.recommendations if r.id in self.top_3_ids]
+
+    @property
+    def other_recommendations(self) -> List[Recommendation]:
+        """Get recommendations not in top 3."""
+        return [r for r in self.recommendations if r.id not in self.top_3_ids]
+
+    @property
+    def phase_1_recommendations(self) -> List[Recommendation]:
+        """Get recommendations for phase 1."""
+        return [r for r in self.recommendations if r.timeline_phase == "phase_1"]
+
+    @property
+    def phase_2_recommendations(self) -> List[Recommendation]:
+        """Get recommendations for phase 2."""
+        return [r for r in self.recommendations if r.timeline_phase == "phase_2"]
+
+    @property
+    def phase_3_recommendations(self) -> List[Recommendation]:
+        """Get recommendations for phase 3."""
+        return [r for r in self.recommendations if r.timeline_phase == "phase_3"]
+
+    @property
+    def total_investment(self) -> float:
+        """Calculate total required investment."""
+        return sum(
+            r.required_investment or 0
+            for r in self.recommendations
+        )
+
+    @property
+    def high_impact_count(self) -> int:
+        """Count recommendations with high impact."""
+        return sum(1 for r in self.recommendations if r.impact_level == "high")
+
+    def get_recommendation(self, rec_id: str) -> Optional[Recommendation]:
+        """Get recommendation by ID."""
+        for r in self.recommendations:
+            if r.id == rec_id:
+                return r
+        return None
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert to dictionary for JSON serialization."""
+        return {
+            "recommendations": [r.to_dict() for r in self.recommendations],
+            "summary": self.summary,
+            "top_3_ids": self.top_3_ids,
+            "total_investment": self.total_investment,
+            "high_impact_count": self.high_impact_count,
+            "count": len(self.recommendations),
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "RecommendationsReport":
+        """Create from dictionary."""
+        recommendations_data = data.get("recommendations", [])
+        recommendations = [
+            Recommendation.from_dict(r) if isinstance(r, dict) else r
+            for r in recommendations_data
+        ]
+
+        return cls(
+            recommendations=recommendations,
+            summary=data.get("summary", ""),
+            top_3_ids=data.get("top_3_ids", []),
+        )
+
+
+# =============================================================================
+# EXTRACTION FUNCTIONS
+# =============================================================================
+
+def _extract_tools_summary(tools_data: Optional[Any]) -> List[Dict[str, Any]]:
+    """Extract tool names and fit scores from Tools Engine data."""
+    if not tools_data:
+        return []
+
+    tools_list = tools_data if isinstance(tools_data, list) else []
+    result = []
+
+    for tool in tools_list:
+        if isinstance(tool, dict):
+            result.append({
+                "name": tool.get("name", ""),
+                "fit_solo": tool.get("fit_solo", 0.5),
+                "fit_team": tool.get("fit_team", 0.5),
+                "fit_kmu": tool.get("fit_kmu", 0.5),
+                "vendor_risk": tool.get("vendor_risk", 3),
+                "cost_level": tool.get("cost_level", 3),
+            })
+        else:
+            result.append({
+                "name": getattr(tool, "name", ""),
+                "fit_solo": getattr(tool, "fit_solo", 0.5),
+                "fit_team": getattr(tool, "fit_team", 0.5),
+                "fit_kmu": getattr(tool, "fit_kmu", 0.5),
+                "vendor_risk": getattr(tool, "vendor_risk", 3),
+                "cost_level": getattr(tool, "cost_level", 3),
+            })
+
+    return result
+
+
+def _extract_funding_summary(funding_data: Optional[Any]) -> List[str]:
+    """Extract funding program names from Funding Engine data."""
+    if not funding_data:
+        return []
+
+    programmes: List[Any] = []
+    if hasattr(funding_data, "programmes"):
+        programmes = funding_data.programmes
+    elif isinstance(funding_data, dict):
+        programmes = funding_data.get("programmes", [])
+    elif isinstance(funding_data, list):
+        programmes = funding_data
+
+    return [
+        p.get("name", "") if isinstance(p, dict) else getattr(p, "name", "")
+        for p in programmes[:5]
+    ]
+
+
+def _extract_risk_summary(risk_report: Optional[Any]) -> List[Dict[str, Any]]:
+    """Extract risk items from Risk Engine report."""
+    if not risk_report:
+        return []
+
+    risk_matrix = []
+    if hasattr(risk_report, "risk_matrix"):
+        risk_matrix = risk_report.risk_matrix
+    elif isinstance(risk_report, dict):
+        risk_matrix = risk_report.get("risk_matrix", [])
+
+    result = []
+    for risk in risk_matrix:
+        if isinstance(risk, dict):
+            result.append({
+                "id": risk.get("id", ""),
+                "title": risk.get("title", ""),
+                "color": risk.get("color", "medium"),
+                "likelihood": risk.get("likelihood", 3),
+                "impact": risk.get("impact", 3),
+            })
+        else:
+            result.append({
+                "id": getattr(risk, "id", ""),
+                "title": getattr(risk, "title", ""),
+                "color": getattr(risk, "color", "medium"),
+                "likelihood": getattr(risk, "likelihood", 3),
+                "impact": getattr(risk, "impact", 3),
+            })
+
+    return result
+
+
+def _extract_strategy_phases(strategy_plan: Optional[Any]) -> List[Dict[str, Any]]:
+    """Extract strategy phases from Strategy Engine plan."""
+    if not strategy_plan:
+        return []
+
+    phases = []
+    if hasattr(strategy_plan, "phases"):
+        phases = strategy_plan.phases
+    elif isinstance(strategy_plan, dict):
+        phases = strategy_plan.get("phases", [])
+
+    result = []
+    for i, phase in enumerate(phases[:3], 1):
+        if isinstance(phase, dict):
+            result.append({
+                "number": i,
+                "title": phase.get("title", f"Phase {i}"),
+                "focus": phase.get("focus", ""),
+            })
+        else:
+            result.append({
+                "number": i,
+                "title": getattr(phase, "title", f"Phase {i}"),
+                "focus": getattr(phase, "focus", ""),
+            })
+
+    return result
+
+
+def _extract_business_case_summary(business_case: Optional[Any]) -> Dict[str, Any]:
+    """Extract business case KPIs from Business Case Engine."""
+    if not business_case:
+        return {}
+
+    result = {}
+
+    if hasattr(business_case, "realistic_scenario"):
+        realistic = business_case.realistic_scenario
+        if realistic:
+            result["roi_12m"] = getattr(realistic, "roi_12m", 0)
+            result["payback_months"] = getattr(realistic, "payback_months", 0)
+            result["monthly_savings"] = getattr(realistic, "monthly_savings", 0)
+    elif isinstance(business_case, dict):
+        scenarios = business_case.get("scenarios", [])
+        realistic = next(
+            (s for s in scenarios if s.get("name") == "realistic"),
+            scenarios[0] if scenarios else {}
+        )
+        result["roi_12m"] = realistic.get("roi_12m", 0)
+        result["payback_months"] = realistic.get("payback_months", 0)
+        result["monthly_savings"] = realistic.get("monthly_savings", 0)
+
+    if hasattr(business_case, "investment_total"):
+        result["investment_total"] = business_case.investment_total
+    elif isinstance(business_case, dict):
+        result["investment_total"] = business_case.get("investment_total", 0)
+
+    return result
+
+
+def _determine_size_label(briefing: Optional[Dict[str, Any]]) -> str:
+    """Determine company size label from briefing."""
+    if not briefing:
+        return "team"
+
+    size = str(briefing.get("unternehmensgroesse", "")).lower()
+
+    if "solo" in size or "freiberuf" in size or "einzelunternehm" in size:
+        return "solo"
+    elif "kmu" in size or "mittel" in size or ">10" in size:
+        return "kmu"
+    else:
+        return "team"
+
+
+# =============================================================================
+# RECOMMENDATION GENERATION
+# =============================================================================
+
+def _generate_default_recommendations(
+    tools_summary: List[Dict[str, Any]],
+    funding_summary: List[str],
+    risk_summary: List[Dict[str, Any]],
+    strategy_phases: List[Dict[str, Any]],
+    bc_summary: Dict[str, Any],
+    size_label: str,
+    branch: str,
+) -> List[Recommendation]:
+    """
+    Generate default recommendations based on extracted data.
+    Used when LLM response is not available.
+    """
+    recommendations: List[Recommendation] = []
+
+    constraints = SIZE_CONSTRAINTS.get(size_label, SIZE_CONSTRAINTS["team"])
+    max_recs = constraints["max_recommendations"]
+
+    # Recommendation 1: Tool Implementation (always relevant)
+    if tools_summary:
+        top_tool = tools_summary[0]
+        recommendations.append(Recommendation(
+            id="rec_tool_1",
+            title=f"{top_tool['name']} implementieren",
+            description=f"Starten Sie mit der Implementierung von {top_tool['name']} als erstes KI-Tool.",
+            reason="Höchster Fit-Score für Ihre Unternehmensgröße und Branche.",
+            impact_level="high",
+            urgency_level="high",
+            risk_relation="neutral",
+            required_investment=1000.0 if size_label == "solo" else 5000.0,
+            related_tools=[top_tool["name"]],
+            related_funding=funding_summary[:1] if funding_summary else [],
+            related_risks=[],
+            timeline_phase="phase_1",
+        ))
+
+    # Recommendation 2: Risk Mitigation (if high risks exist)
+    high_risks = [r for r in risk_summary if r.get("color") in ["high", "critical"]]
+    if high_risks:
+        top_risk = high_risks[0]
+        recommendations.append(Recommendation(
+            id="rec_risk_1",
+            title=f"Risiko '{top_risk['title']}' adressieren",
+            description=f"Entwickeln Sie einen Maßnahmenplan zur Reduzierung des Risikos '{top_risk['title']}'.",
+            reason="Dieses Risiko wurde als hoch/kritisch eingestuft und erfordert sofortige Aufmerksamkeit.",
+            impact_level="high",
+            urgency_level="high",
+            risk_relation="reduces_risk",
+            required_investment=None,
+            related_tools=[],
+            related_funding=[],
+            related_risks=[top_risk["title"]],
+            timeline_phase="phase_1",
+        ))
+
+    # Recommendation 3: Funding Application
+    if funding_summary:
+        recommendations.append(Recommendation(
+            id="rec_funding_1",
+            title=f"Förderantrag für '{funding_summary[0]}' stellen",
+            description=f"Bereiten Sie einen Förderantrag für das Programm '{funding_summary[0]}' vor.",
+            reason="Passende Fördermöglichkeit zur Reduzierung der Investitionskosten.",
+            impact_level="medium",
+            urgency_level="medium",
+            risk_relation="neutral",
+            required_investment=500.0,
+            related_tools=tools_summary[0]["name"] if tools_summary else [],
+            related_funding=[funding_summary[0]],
+            related_risks=[],
+            timeline_phase="phase_1",
+        ))
+
+    # Recommendation 4: Training & Adoption
+    recommendations.append(Recommendation(
+        id="rec_training_1",
+        title="Team-Training und Change Management",
+        description="Planen Sie Schulungen und Change-Management-Maßnahmen für die KI-Einführung.",
+        reason="Erfolgreiche KI-Adoption erfordert geschulte Mitarbeiter und Akzeptanz.",
+        impact_level="medium",
+        urgency_level="medium",
+        risk_relation="reduces_risk",
+        required_investment=2000.0 if size_label == "kmu" else 500.0,
+        related_tools=[],
+        related_funding=[],
+        related_risks=["Mitarbeiterakzeptanz"],
+        timeline_phase="phase_2",
+    ))
+
+    # Recommendation 5: Process Documentation
+    recommendations.append(Recommendation(
+        id="rec_process_1",
+        title="KI-Prozesse dokumentieren",
+        description="Dokumentieren Sie alle KI-gestützten Prozesse für Compliance und Wissenstransfer.",
+        reason="Dokumentation ist für AI Act Compliance und Qualitätssicherung erforderlich.",
+        impact_level="medium",
+        urgency_level="low",
+        risk_relation="reduces_risk",
+        required_investment=None,
+        related_tools=[],
+        related_funding=[],
+        related_risks=["AI Act Compliance"],
+        timeline_phase="phase_2",
+    ))
+
+    # Recommendation 6: ROI Tracking (if business case exists)
+    if bc_summary.get("roi_12m"):
+        recommendations.append(Recommendation(
+            id="rec_kpi_1",
+            title="KPI-Tracking implementieren",
+            description=f"Richten Sie ein Dashboard zur Überwachung der KI-KPIs ein (Ziel: {bc_summary['roi_12m']:.0f}% ROI).",
+            reason="Kontinuierliches Tracking ermöglicht Optimierung und Nachweis des Business Case.",
+            impact_level="medium",
+            urgency_level="medium",
+            risk_relation="neutral",
+            required_investment=1000.0,
+            related_tools=[],
+            related_funding=[],
+            related_risks=[],
+            timeline_phase="phase_2",
+        ))
+
+    # Recommendation 7: Scale & Optimize (Phase 3)
+    if len(tools_summary) > 1:
+        recommendations.append(Recommendation(
+            id="rec_scale_1",
+            title="KI-Stack erweitern",
+            description=f"Evaluieren Sie die Integration weiterer Tools wie {tools_summary[1]['name'] if len(tools_summary) > 1 else 'zusätzliche KI-Tools'}.",
+            reason="Nach erfolgreicher Pilotphase kann der KI-Stack systematisch erweitert werden.",
+            impact_level="high",
+            urgency_level="low",
+            risk_relation="requires_mitigation",
+            required_investment=3000.0 if size_label == "solo" else 10000.0,
+            related_tools=[t["name"] for t in tools_summary[1:3]],
+            related_funding=funding_summary[:2] if funding_summary else [],
+            related_risks=[],
+            timeline_phase="phase_3",
+        ))
+
+    # Recommendation 8: Vendor Review (if vendor risks exist)
+    vendor_risks = [t for t in tools_summary if t.get("vendor_risk", 3) >= 4]
+    if vendor_risks:
+        recommendations.append(Recommendation(
+            id="rec_vendor_1",
+            title="Vendor-Risiken evaluieren",
+            description="Führen Sie eine detaillierte Vendor-Prüfung für Tools mit hohem Vendor-Risiko durch.",
+            reason="Tools mit hohem Vendor-Risiko erfordern zusätzliche Due Diligence.",
+            impact_level="medium",
+            urgency_level="medium",
+            risk_relation="reduces_risk",
+            required_investment=None,
+            related_tools=[t["name"] for t in vendor_risks[:2]],
+            related_funding=[],
+            related_risks=["Vendor & Hosting"],
+            timeline_phase="phase_1",
+        ))
+
+    # Limit based on size
+    return recommendations[:max_recs]
+
+
+def _select_top_3(recommendations: List[Recommendation]) -> List[str]:
+    """Select top 3 recommendations by priority score."""
+    sorted_recs = sorted(
+        recommendations,
+        key=lambda r: (r.priority_score, r.phase_number == 1),
+        reverse=True
+    )
+    return [r.id for r in sorted_recs[:3]]
+
+
+def _generate_summary(
+    recommendations: List[Recommendation],
+    size_label: str,
+    branch: str,
+) -> str:
+    """Generate narrative summary for recommendations."""
+    count = len(recommendations)
+    high_impact = sum(1 for r in recommendations if r.impact_level == "high")
+    phase_1 = sum(1 for r in recommendations if r.timeline_phase == "phase_1")
+
+    size_names = {"solo": "Einzelunternehmer", "team": "Teams", "kmu": "KMU"}
+    size_name = size_names.get(size_label, "Unternehmen")
+
+    parts = []
+
+    parts.append(f"Für Ihr {size_name} in der Branche {branch} wurden {count} konkrete Handlungsempfehlungen identifiziert.")
+
+    if high_impact > 0:
+        parts.append(f"Davon haben {high_impact} eine hohe Auswirkung auf Ihren KI-Erfolg.")
+
+    if phase_1 > 0:
+        parts.append(f"Starten Sie mit den {phase_1} Empfehlungen für Phase 1, um schnelle Ergebnisse zu erzielen.")
+
+    total_invest = sum(r.required_investment or 0 for r in recommendations)
+    if total_invest > 0:
+        parts.append(f"Die geschätzte Gesamtinvestition beträgt ca. {total_invest:,.0f} €.")
+
+    return " ".join(parts)
+
+
+# =============================================================================
+# MAIN GENERATION FUNCTION
+# =============================================================================
+
+def generate_recommendations_report(
+    context: Optional[Any] = None,
+    sections: Optional[Dict[str, str]] = None,
+    tools_data: Optional[Any] = None,
+    funding_data: Optional[Any] = None,
+    risk_report: Optional[Any] = None,
+    strategy_plan: Optional[Any] = None,
+    business_case: Optional[Any] = None,
+    briefing: Optional[Dict[str, Any]] = None,
+    llm_response: Optional[Dict[str, Any]] = None,
+) -> RecommendationsReport:
+    """
+    Generate comprehensive recommendations report.
+
+    Aggregates data from all engines (G20-G30) and creates prioritized
+    actionable recommendations.
+
+    Args:
+        context: ReportContext object (optional)
+        sections: Dict of section_key -> HTML content
+        tools_data: Tools Engine 4.0 output
+        funding_data: Funding Engine v2 output
+        risk_report: Risk Engine 2.0 output
+        strategy_plan: Strategy Engine output
+        business_case: Business Case Engine 2.0 output
+        briefing: Original briefing/answers dict
+        llm_response: Parsed JSON from LLM (if available)
+
+    Returns:
+        RecommendationsReport with prioritized recommendations
+    """
+    log.info("[G32] Generating Recommendations Report...")
+
+    sections = sections or {}
+    briefing = briefing or {}
+
+    # Determine size and branch
+    size_label = _determine_size_label(briefing)
+    branch = briefing.get("branche", "Allgemein")
+
+    # Extract summaries from all engines
+    tools_summary = _extract_tools_summary(tools_data)
+    funding_summary = _extract_funding_summary(funding_data)
+    risk_summary = _extract_risk_summary(risk_report)
+    strategy_phases = _extract_strategy_phases(strategy_plan)
+    bc_summary = _extract_business_case_summary(business_case)
+
+    # If LLM response provided, use it
+    if llm_response:
+        recommendations_data = llm_response.get("recommendations", [])
+        recommendations = [
+            Recommendation.from_dict(r) if isinstance(r, dict) else r
+            for r in recommendations_data
+        ]
+
+        top_3_ids = llm_response.get("top_3_ids", [])
+        summary = llm_response.get("summary", "")
+
+        # Validate top_3_ids
+        rec_ids = {r.id for r in recommendations}
+        top_3_ids = [tid for tid in top_3_ids if tid in rec_ids][:3]
+
+        if not top_3_ids and recommendations:
+            top_3_ids = _select_top_3(recommendations)
+
+        if not summary:
+            summary = _generate_summary(recommendations, size_label, branch)
+
+    else:
+        # Generate default recommendations
+        recommendations = _generate_default_recommendations(
+            tools_summary=tools_summary,
+            funding_summary=funding_summary,
+            risk_summary=risk_summary,
+            strategy_phases=strategy_phases,
+            bc_summary=bc_summary,
+            size_label=size_label,
+            branch=branch,
+        )
+
+        top_3_ids = _select_top_3(recommendations)
+        summary = _generate_summary(recommendations, size_label, branch)
+
+    report = RecommendationsReport(
+        recommendations=recommendations,
+        summary=summary,
+        top_3_ids=top_3_ids,
+    )
+
+    log.info(
+        "[G32] Recommendations Report generated: %d recommendations, top_3=%s",
+        len(recommendations), top_3_ids
+    )
+
+    return report
+
+
+# =============================================================================
+# HTML RENDERING
+# =============================================================================
+
+def recommendations_report_to_html(
+    report: RecommendationsReport,
+    lang: str = "de",
+) -> str:
+    """
+    Generate HTML section for the Recommendations Report.
+
+    Uses Platin++ CSS classes for styling.
+
+    Args:
+        report: RecommendationsReport object
+        lang: Language code ("de" or "en")
+
+    Returns:
+        HTML string for PDF template
+    """
+    # Labels
+    if lang == "en":
+        labels = {
+            "title": "Action Recommendations",
+            "top_priorities": "Top Priorities",
+            "further_recommendations": "Further Recommendations",
+            "impact": "Impact",
+            "urgency": "Urgency",
+            "phase": "Phase",
+            "investment": "Investment",
+            "related_tools": "Related Tools",
+            "related_funding": "Funding",
+            "related_risks": "Risk Relation",
+            "reason": "Rationale",
+            "reduces_risk": "Reduces Risk",
+            "requires_mitigation": "Requires Mitigation",
+            "neutral": "Neutral",
+            "high": "High",
+            "medium": "Medium",
+            "low": "Low",
+            "summary": "Summary",
+        }
+    else:
+        labels = {
+            "title": "Handlungsempfehlungen",
+            "top_priorities": "Top-Prioritäten",
+            "further_recommendations": "Weitere Empfehlungen",
+            "impact": "Auswirkung",
+            "urgency": "Dringlichkeit",
+            "phase": "Phase",
+            "investment": "Investition",
+            "related_tools": "Verknüpfte Tools",
+            "related_funding": "Förderung",
+            "related_risks": "Risiko-Bezug",
+            "reason": "Begründung",
+            "reduces_risk": "Reduziert Risiko",
+            "requires_mitigation": "Erfordert Mitigation",
+            "neutral": "Neutral",
+            "high": "Hoch",
+            "medium": "Mittel",
+            "low": "Niedrig",
+            "summary": "Zusammenfassung",
+        }
+
+    # Color maps
+    impact_colors = {"high": "#dc2626", "medium": "#f59e0b", "low": "#22c55e"}
+    urgency_colors = {"high": "#dc2626", "medium": "#f59e0b", "low": "#22c55e"}
+    phase_colors = {"phase_1": "#3b82f6", "phase_2": "#8b5cf6", "phase_3": "#06b6d4"}
+    risk_colors = {"reduces_risk": "#22c55e", "requires_mitigation": "#f59e0b", "neutral": "#6b7280"}
+
+    html_parts = [f'''
+    <div class="recommendations-engine" style="font-size:11pt;">
+        <div style="display:flex;align-items:center;gap:10px;margin-bottom:16px;">
+            <span style="font-size:20px;">🎯</span>
+            <span style="font-size:11px;padding:2px 8px;background:#8b5cf6;color:#fff;border-radius:4px;font-weight:600;">G32</span>
+        </div>
+    ''']
+
+    # Summary
+    if report.summary:
+        html_parts.append(f'''
+        <div class="summary-section" style="padding:16px;background:#f8fafc;border-radius:8px;margin-bottom:24px;border-left:4px solid #8b5cf6;">
+            <p style="margin:0;color:#475569;line-height:1.6;">{report.summary}</p>
+        </div>
+        ''')
+
+    # Top 3 Priorities
+    top_3 = report.top_3_recommendations
+    if top_3:
+        html_parts.append(f'''
+        <div class="top-priorities-section" style="margin-bottom:32px;">
+            <p style="margin:0 0 16px 0;font-weight:600;font-size:14pt;color:#1e293b;">⭐ {labels["top_priorities"]}</p>
+            <div style="display:flex;flex-direction:column;gap:16px;">
+        ''')
+
+        for rec in top_3:
+            impact_color = impact_colors.get(rec.impact_level, "#6b7280")
+            urgency_color = urgency_colors.get(rec.urgency_level, "#6b7280")
+            phase_color = phase_colors.get(rec.timeline_phase, "#3b82f6")
+            risk_color = risk_colors.get(rec.risk_relation, "#6b7280")
+
+            risk_label = labels.get(rec.risk_relation, rec.risk_relation)
+            impact_label = labels.get(rec.impact_level, rec.impact_level)
+            urgency_label = labels.get(rec.urgency_level, rec.urgency_level)
+
+            html_parts.append(f'''
+            <div class="report-card-highlight" style="padding:20px;background:linear-gradient(135deg,#fff 0%,#f0f9ff 100%);border-radius:12px;border:2px solid #8b5cf6;box-shadow:0 4px 12px rgba(139,92,246,0.15);">
+                <div style="display:flex;justify-content:space-between;align-items:flex-start;margin-bottom:12px;">
+                    <h3 style="margin:0;font-size:13pt;color:#1e293b;font-weight:600;">{rec.title}</h3>
+                    <span style="font-size:10px;padding:2px 8px;background:{phase_color};color:#fff;border-radius:4px;">Phase {rec.phase_number}</span>
+                </div>
+
+                <p style="margin:0 0 12px 0;color:#475569;line-height:1.5;">{rec.description}</p>
+
+                <div style="display:flex;flex-wrap:wrap;gap:8px;margin-bottom:12px;">
+                    <span style="font-size:9px;padding:2px 6px;background:{impact_color};color:#fff;border-radius:3px;">{labels["impact"]}: {impact_label}</span>
+                    <span style="font-size:9px;padding:2px 6px;background:{urgency_color};color:#fff;border-radius:3px;">{labels["urgency"]}: {urgency_label}</span>
+                    <span style="font-size:9px;padding:2px 6px;background:{risk_color};color:#fff;border-radius:3px;">{risk_label}</span>
+                    {f'<span style="font-size:9px;padding:2px 6px;background:#1e293b;color:#fff;border-radius:3px;">{rec.required_investment:,.0f} €</span>' if rec.required_investment else ''}
+                </div>
+
+                <p style="margin:0;font-size:10pt;color:#64748b;font-style:italic;">💡 {rec.reason}</p>
+
+                {f'<div style="margin-top:8px;font-size:9pt;color:#64748b;">{labels["related_tools"]}: {", ".join(rec.related_tools[:3])}</div>' if rec.related_tools else ''}
+            </div>
+            ''')
+
+        html_parts.append('</div></div>')
+
+    # Other Recommendations
+    others = report.other_recommendations
+    if others:
+        html_parts.append(f'''
+        <div class="other-recommendations-section">
+            <p style="margin:0 0 16px 0;font-weight:600;font-size:12pt;color:#1e293b;">{labels["further_recommendations"]}</p>
+            <div style="display:flex;flex-direction:column;gap:12px;">
+        ''')
+
+        for rec in others:
+            impact_color = impact_colors.get(rec.impact_level, "#6b7280")
+            urgency_color = urgency_colors.get(rec.urgency_level, "#6b7280")
+            phase_color = phase_colors.get(rec.timeline_phase, "#3b82f6")
+
+            impact_label = labels.get(rec.impact_level, rec.impact_level)
+            urgency_label = labels.get(rec.urgency_level, rec.urgency_level)
+
+            html_parts.append(f'''
+            <div class="report-card-muted" style="padding:16px;background:#fff;border-radius:8px;border:1px solid #e2e8f0;">
+                <div style="display:flex;justify-content:space-between;align-items:flex-start;margin-bottom:8px;">
+                    <h4 style="margin:0;font-size:11pt;color:#1e293b;font-weight:600;">{rec.title}</h4>
+                    <span style="font-size:9px;padding:2px 6px;background:{phase_color};color:#fff;border-radius:3px;">Phase {rec.phase_number}</span>
+                </div>
+
+                <p style="margin:0 0 8px 0;color:#64748b;font-size:10pt;line-height:1.4;">{rec.description}</p>
+
+                <div style="display:flex;flex-wrap:wrap;gap:6px;">
+                    <span style="font-size:8px;padding:2px 5px;background:{impact_color}22;color:{impact_color};border-radius:3px;border:1px solid {impact_color}44;">{labels["impact"]}: {impact_label}</span>
+                    <span style="font-size:8px;padding:2px 5px;background:{urgency_color}22;color:{urgency_color};border-radius:3px;border:1px solid {urgency_color}44;">{labels["urgency"]}: {urgency_label}</span>
+                    {f'<span style="font-size:8px;padding:2px 5px;background:#1e293b22;color:#1e293b;border-radius:3px;">{rec.required_investment:,.0f} €</span>' if rec.required_investment else ''}
+                </div>
+            </div>
+            ''')
+
+        html_parts.append('</div></div>')
+
+    html_parts.append('</div>')
+
+    return '\n'.join(html_parts)
+
+
+# =============================================================================
+# VALIDATION HELPERS (for Consistency Engine)
+# =============================================================================
+
+def validate_recommendations_for_size(
+    report: RecommendationsReport,
+    size_label: str,
+) -> Tuple[bool, List[str]]:
+    """
+    Validate recommendations count and complexity for company size.
+
+    Returns:
+        Tuple of (is_valid, list of error messages)
+    """
+    errors: List[str] = []
+
+    constraints = SIZE_CONSTRAINTS.get(size_label, SIZE_CONSTRAINTS["team"])
+
+    # Check max recommendations
+    if len(report.recommendations) > constraints["max_recommendations"]:
+        errors.append(
+            f"Zu viele Empfehlungen für {size_label}: "
+            f"{len(report.recommendations)} > {constraints['max_recommendations']}"
+        )
+
+    # Check max high impact
+    if report.high_impact_count > constraints["max_high_impact"]:
+        errors.append(
+            f"Zu viele High-Impact Empfehlungen für {size_label}: "
+            f"{report.high_impact_count} > {constraints['max_high_impact']}"
+        )
+
+    return len(errors) == 0, errors
+
+
+def validate_tool_fit(
+    recommendations: List[Recommendation],
+    tools_data: Optional[Any],
+    size_label: str,
+) -> Tuple[bool, List[str]]:
+    """
+    Validate that recommended tools have sufficient fit for company size.
+
+    Returns:
+        Tuple of (is_valid, list of error messages)
+    """
+    errors: List[str] = []
+
+    if not tools_data:
+        return True, []
+
+    tools_summary = _extract_tools_summary(tools_data)
+    tools_by_name = {t["name"].lower(): t for t in tools_summary}
+
+    fit_key = f"fit_{size_label}"
+
+    for rec in recommendations:
+        for tool_name in rec.related_tools:
+            tool = tools_by_name.get(tool_name.lower())
+            if tool:
+                fit_score = tool.get(fit_key, 0.5)
+                if fit_score < 0.3:
+                    errors.append(
+                        f"Empfehlung '{rec.id}' referenziert Tool '{tool_name}' "
+                        f"mit niedrigem Fit-Score ({fit_score:.1f}) für {size_label}"
+                    )
+
+    return len(errors) == 0, errors
+
+
+# =============================================================================
+# MODULE INITIALIZATION
+# =============================================================================
+
+log.info("[G32] Recommendations Engine loaded")

--- a/templates/pdf_template.html
+++ b/templates/pdf_template.html
@@ -2557,6 +2557,24 @@
                     </div>
                 </section>
                 {% endif %}
+                <!-- G32: Recommendations Engine – Priorisierte Handlungsempfehlungen -->
+                {% if RECOMMENDATIONS_ENGINE_HTML %}
+                <section class="section chapter" id="recommendations-engine">
+                    <div class="section-header">
+                        <div class="section-title">
+                            <span class="section-kicker">Handlungsempfehlungen</span>
+                            <h2>Priorisierte Maßnahmen</h2>
+                        </div>
+                        <span class="section-pill">
+                            <span class="pill-dot"></span>
+                            Top 3 • Impact • Timeline
+                        </span>
+                    </div>
+                    <div class="section-body">
+                        {{ RECOMMENDATIONS_ENGINE_HTML|safe }}
+                    </div>
+                </section>
+                {% endif %}
                 <!-- ROADMAP -->
                 <section class="section chapter">
                     <div class="section-header">

--- a/templates/pdf_template_en.html
+++ b/templates/pdf_template_en.html
@@ -2074,6 +2074,24 @@
                     </div>
                 </section>
                 {% endif %}
+                <!-- G32: Recommendations Engine – Prioritized Action Recommendations -->
+                {% if RECOMMENDATIONS_ENGINE_HTML %}
+                <section class="section chapter" id="recommendations-engine">
+                    <div class="section-header">
+                        <div class="section-title">
+                            <span class="section-kicker">Action Recommendations</span>
+                            <h2>Prioritized Measures</h2>
+                        </div>
+                        <span class="section-pill">
+                            <span class="pill-dot"></span>
+                            Top 3 • Impact • Timeline
+                        </span>
+                    </div>
+                    <div class="section-body">
+                        {{ RECOMMENDATIONS_ENGINE_HTML|safe }}
+                    </div>
+                </section>
+                {% endif %}
 <!-- ROADMAP -->
                 <section class="section chapter">
                     <div class="section-header">

--- a/tests/test_g32_recommendations_engine.py
+++ b/tests/test_g32_recommendations_engine.py
@@ -1,0 +1,1082 @@
+# -*- coding: utf-8 -*-
+"""
+Sprint G32: Recommendations Engine Tests
+========================================
+
+Comprehensive test suite for Recommendations Engine with 40+ tests covering:
+- Data structures (Recommendation, RecommendationsReport)
+- Priority scoring and phase grouping
+- Size constraints validation
+- HTML generation
+- Consistency Engine integration (RECO_001-RECO_005)
+
+Version: 1.0.0 (Sprint G32)
+"""
+from __future__ import annotations
+
+import pytest
+from typing import Dict, Any, List, Optional
+
+
+# =============================================================================
+# TEST: Data Structures - Recommendation
+# =============================================================================
+
+class TestRecommendation:
+    """Tests for Recommendation dataclass."""
+
+    def test_basic_creation(self) -> None:
+        """Test Recommendation can be instantiated with basic values."""
+        from services.recommendations_engine import Recommendation
+
+        rec = Recommendation(
+            id="rec1",
+            title="Implement ChatGPT",
+            description="Start with ChatGPT for documentation.",
+            reason="Highest fit score for your company.",
+            impact_level="high",
+            urgency_level="high",
+            risk_relation="neutral",
+            required_investment=5000.0,
+            related_tools=["ChatGPT"],
+            related_funding=["Digital Jetzt"],
+            related_risks=[],
+            timeline_phase="phase_1",
+        )
+
+        assert rec.id == "rec1"
+        assert rec.title == "Implement ChatGPT"
+        assert rec.impact_level == "high"
+        assert rec.urgency_level == "high"
+        assert rec.risk_relation == "neutral"
+        assert rec.required_investment == 5000.0
+        assert rec.timeline_phase == "phase_1"
+
+    def test_invalid_impact_level_normalized(self) -> None:
+        """Test invalid impact_level is normalized to medium."""
+        from services.recommendations_engine import Recommendation
+
+        rec = Recommendation(
+            id="rec1",
+            title="Test",
+            description="Test",
+            reason="Test",
+            impact_level="invalid",
+            urgency_level="high",
+            risk_relation="neutral",
+        )
+
+        assert rec.impact_level == "medium"
+
+    def test_invalid_urgency_level_normalized(self) -> None:
+        """Test invalid urgency_level is normalized to medium."""
+        from services.recommendations_engine import Recommendation
+
+        rec = Recommendation(
+            id="rec1",
+            title="Test",
+            description="Test",
+            reason="Test",
+            impact_level="high",
+            urgency_level="super_urgent",
+            risk_relation="neutral",
+        )
+
+        assert rec.urgency_level == "medium"
+
+    def test_invalid_risk_relation_normalized(self) -> None:
+        """Test invalid risk_relation is normalized to neutral."""
+        from services.recommendations_engine import Recommendation
+
+        rec = Recommendation(
+            id="rec1",
+            title="Test",
+            description="Test",
+            reason="Test",
+            impact_level="high",
+            urgency_level="high",
+            risk_relation="unknown",
+        )
+
+        assert rec.risk_relation == "neutral"
+
+    def test_invalid_timeline_phase_normalized(self) -> None:
+        """Test invalid timeline_phase is normalized to phase_1."""
+        from services.recommendations_engine import Recommendation
+
+        rec = Recommendation(
+            id="rec1",
+            title="Test",
+            description="Test",
+            reason="Test",
+            impact_level="high",
+            urgency_level="high",
+            risk_relation="neutral",
+            timeline_phase="phase_99",
+        )
+
+        assert rec.timeline_phase == "phase_1"
+
+    def test_negative_investment_normalized(self) -> None:
+        """Test negative investment is normalized to zero."""
+        from services.recommendations_engine import Recommendation
+
+        rec = Recommendation(
+            id="rec1",
+            title="Test",
+            description="Test",
+            reason="Test",
+            impact_level="high",
+            urgency_level="high",
+            risk_relation="neutral",
+            required_investment=-1000.0,
+        )
+
+        assert rec.required_investment == 0.0
+
+    def test_none_investment_remains_none(self) -> None:
+        """Test None investment remains None."""
+        from services.recommendations_engine import Recommendation
+
+        rec = Recommendation(
+            id="rec1",
+            title="Test",
+            description="Test",
+            reason="Test",
+            impact_level="high",
+            urgency_level="high",
+            risk_relation="neutral",
+            required_investment=None,
+        )
+
+        assert rec.required_investment is None
+
+    def test_priority_score_high_high(self) -> None:
+        """Test priority score for high impact and high urgency."""
+        from services.recommendations_engine import Recommendation
+
+        rec = Recommendation(
+            id="rec1",
+            title="Test",
+            description="Test",
+            reason="Test",
+            impact_level="high",
+            urgency_level="high",
+            risk_relation="neutral",
+        )
+
+        assert rec.priority_score == 9  # 3 * 3
+
+    def test_priority_score_medium_medium(self) -> None:
+        """Test priority score for medium impact and medium urgency."""
+        from services.recommendations_engine import Recommendation
+
+        rec = Recommendation(
+            id="rec1",
+            title="Test",
+            description="Test",
+            reason="Test",
+            impact_level="medium",
+            urgency_level="medium",
+            risk_relation="neutral",
+        )
+
+        assert rec.priority_score == 4  # 2 * 2
+
+    def test_priority_score_low_low(self) -> None:
+        """Test priority score for low impact and low urgency."""
+        from services.recommendations_engine import Recommendation
+
+        rec = Recommendation(
+            id="rec1",
+            title="Test",
+            description="Test",
+            reason="Test",
+            impact_level="low",
+            urgency_level="low",
+            risk_relation="neutral",
+        )
+
+        assert rec.priority_score == 1  # 1 * 1
+
+    def test_priority_score_high_low(self) -> None:
+        """Test priority score for high impact and low urgency."""
+        from services.recommendations_engine import Recommendation
+
+        rec = Recommendation(
+            id="rec1",
+            title="Test",
+            description="Test",
+            reason="Test",
+            impact_level="high",
+            urgency_level="low",
+            risk_relation="neutral",
+        )
+
+        assert rec.priority_score == 3  # 3 * 1
+
+    def test_phase_number_property(self) -> None:
+        """Test phase_number property for all phases."""
+        from services.recommendations_engine import Recommendation
+
+        for phase, expected_num in [("phase_1", 1), ("phase_2", 2), ("phase_3", 3)]:
+            rec = Recommendation(
+                id="rec1",
+                title="Test",
+                description="Test",
+                reason="Test",
+                impact_level="high",
+                urgency_level="high",
+                risk_relation="neutral",
+                timeline_phase=phase,
+            )
+            assert rec.phase_number == expected_num
+
+    def test_to_dict_serialization(self) -> None:
+        """Test Recommendation serialization to dict."""
+        from services.recommendations_engine import Recommendation
+
+        rec = Recommendation(
+            id="rec1",
+            title="Test Title",
+            description="Test Description",
+            reason="Test Reason",
+            impact_level="high",
+            urgency_level="medium",
+            risk_relation="reduces_risk",
+            required_investment=5000.0,
+            related_tools=["Tool A"],
+            related_funding=["Funding A"],
+            related_risks=["Risk A"],
+            timeline_phase="phase_2",
+        )
+
+        data = rec.to_dict()
+
+        assert data["id"] == "rec1"
+        assert data["title"] == "Test Title"
+        assert data["impact_level"] == "high"
+        assert data["urgency_level"] == "medium"
+        assert data["risk_relation"] == "reduces_risk"
+        assert data["required_investment"] == 5000.0
+        assert data["related_tools"] == ["Tool A"]
+        assert data["timeline_phase"] == "phase_2"
+        assert data["priority_score"] == 6  # 3 * 2
+
+    def test_from_dict_deserialization(self) -> None:
+        """Test Recommendation creation from dict."""
+        from services.recommendations_engine import Recommendation
+
+        data = {
+            "id": "rec2",
+            "title": "Test from Dict",
+            "description": "Description",
+            "reason": "Reason",
+            "impact_level": "low",
+            "urgency_level": "high",
+            "risk_relation": "requires_mitigation",
+            "required_investment": 1000.0,
+            "related_tools": ["Tool B"],
+            "related_funding": [],
+            "related_risks": ["Risk B"],
+            "timeline_phase": "phase_3",
+        }
+
+        rec = Recommendation.from_dict(data)
+
+        assert rec.id == "rec2"
+        assert rec.title == "Test from Dict"
+        assert rec.impact_level == "low"
+        assert rec.urgency_level == "high"
+        assert rec.required_investment == 1000.0
+        assert rec.timeline_phase == "phase_3"
+
+    def test_from_dict_with_missing_fields(self) -> None:
+        """Test Recommendation creation from partial dict."""
+        from services.recommendations_engine import Recommendation
+
+        data = {
+            "id": "rec3",
+            "title": "Partial",
+        }
+
+        rec = Recommendation.from_dict(data)
+
+        assert rec.id == "rec3"
+        assert rec.impact_level == "medium"  # Default
+        assert rec.urgency_level == "medium"  # Default
+        assert rec.risk_relation == "neutral"  # Default
+        assert rec.timeline_phase == "phase_1"  # Default
+
+
+# =============================================================================
+# TEST: Data Structures - RecommendationsReport
+# =============================================================================
+
+class TestRecommendationsReport:
+    """Tests for RecommendationsReport dataclass."""
+
+    def test_basic_creation(self) -> None:
+        """Test RecommendationsReport can be instantiated."""
+        from services.recommendations_engine import Recommendation, RecommendationsReport
+
+        rec1 = Recommendation(
+            id="rec1", title="Test1", description="D1", reason="R1",
+            impact_level="high", urgency_level="high", risk_relation="neutral",
+        )
+        rec2 = Recommendation(
+            id="rec2", title="Test2", description="D2", reason="R2",
+            impact_level="medium", urgency_level="medium", risk_relation="neutral",
+        )
+
+        report = RecommendationsReport(
+            recommendations=[rec1, rec2],
+            summary="Test summary",
+            top_3_ids=["rec1"],
+        )
+
+        assert len(report.recommendations) == 2
+        assert report.summary == "Test summary"
+        assert report.top_3_ids == ["rec1"]
+
+    def test_top_3_ids_validated(self) -> None:
+        """Test top_3_ids is validated against recommendation IDs."""
+        from services.recommendations_engine import Recommendation, RecommendationsReport
+
+        rec1 = Recommendation(
+            id="rec1", title="Test1", description="D1", reason="R1",
+            impact_level="high", urgency_level="high", risk_relation="neutral",
+        )
+
+        report = RecommendationsReport(
+            recommendations=[rec1],
+            summary="Test",
+            top_3_ids=["rec1", "rec_invalid", "rec_another_invalid"],
+        )
+
+        # Only valid IDs should remain
+        assert report.top_3_ids == ["rec1"]
+
+    def test_top_3_ids_limited_to_3(self) -> None:
+        """Test top_3_ids is limited to exactly 3 entries."""
+        from services.recommendations_engine import Recommendation, RecommendationsReport
+
+        recs = [
+            Recommendation(id=f"rec{i}", title=f"Test{i}", description="D", reason="R",
+                          impact_level="high", urgency_level="high", risk_relation="neutral")
+            for i in range(5)
+        ]
+
+        report = RecommendationsReport(
+            recommendations=recs,
+            summary="Test",
+            top_3_ids=["rec0", "rec1", "rec2", "rec3", "rec4"],
+        )
+
+        assert len(report.top_3_ids) == 3
+        assert report.top_3_ids == ["rec0", "rec1", "rec2"]
+
+    def test_top_3_recommendations_property(self) -> None:
+        """Test top_3_recommendations property."""
+        from services.recommendations_engine import Recommendation, RecommendationsReport
+
+        recs = [
+            Recommendation(id=f"rec{i}", title=f"Test{i}", description="D", reason="R",
+                          impact_level="high", urgency_level="high", risk_relation="neutral")
+            for i in range(5)
+        ]
+
+        report = RecommendationsReport(
+            recommendations=recs,
+            summary="Test",
+            top_3_ids=["rec0", "rec2", "rec4"],
+        )
+
+        top_3 = report.top_3_recommendations
+        assert len(top_3) == 3
+        assert all(r.id in ["rec0", "rec2", "rec4"] for r in top_3)
+
+    def test_other_recommendations_property(self) -> None:
+        """Test other_recommendations property."""
+        from services.recommendations_engine import Recommendation, RecommendationsReport
+
+        recs = [
+            Recommendation(id=f"rec{i}", title=f"Test{i}", description="D", reason="R",
+                          impact_level="high", urgency_level="high", risk_relation="neutral")
+            for i in range(5)
+        ]
+
+        report = RecommendationsReport(
+            recommendations=recs,
+            summary="Test",
+            top_3_ids=["rec0", "rec2", "rec4"],
+        )
+
+        others = report.other_recommendations
+        assert len(others) == 2
+        assert all(r.id in ["rec1", "rec3"] for r in others)
+
+    def test_phase_recommendations_properties(self) -> None:
+        """Test phase_1/2/3_recommendations properties."""
+        from services.recommendations_engine import Recommendation, RecommendationsReport
+
+        recs = [
+            Recommendation(id="rec1", title="P1", description="D", reason="R",
+                          impact_level="high", urgency_level="high", risk_relation="neutral",
+                          timeline_phase="phase_1"),
+            Recommendation(id="rec2", title="P1b", description="D", reason="R",
+                          impact_level="high", urgency_level="medium", risk_relation="neutral",
+                          timeline_phase="phase_1"),
+            Recommendation(id="rec3", title="P2", description="D", reason="R",
+                          impact_level="medium", urgency_level="medium", risk_relation="neutral",
+                          timeline_phase="phase_2"),
+            Recommendation(id="rec4", title="P3", description="D", reason="R",
+                          impact_level="low", urgency_level="low", risk_relation="neutral",
+                          timeline_phase="phase_3"),
+        ]
+
+        report = RecommendationsReport(recommendations=recs, summary="Test", top_3_ids=["rec1"])
+
+        assert len(report.phase_1_recommendations) == 2
+        assert len(report.phase_2_recommendations) == 1
+        assert len(report.phase_3_recommendations) == 1
+
+    def test_total_investment_property(self) -> None:
+        """Test total_investment property calculation."""
+        from services.recommendations_engine import Recommendation, RecommendationsReport
+
+        recs = [
+            Recommendation(id="rec1", title="T1", description="D", reason="R",
+                          impact_level="high", urgency_level="high", risk_relation="neutral",
+                          required_investment=5000.0),
+            Recommendation(id="rec2", title="T2", description="D", reason="R",
+                          impact_level="medium", urgency_level="medium", risk_relation="neutral",
+                          required_investment=3000.0),
+            Recommendation(id="rec3", title="T3", description="D", reason="R",
+                          impact_level="low", urgency_level="low", risk_relation="neutral",
+                          required_investment=None),  # Should be treated as 0
+        ]
+
+        report = RecommendationsReport(recommendations=recs, summary="Test", top_3_ids=["rec1"])
+
+        assert report.total_investment == 8000.0
+
+    def test_high_impact_count_property(self) -> None:
+        """Test high_impact_count property."""
+        from services.recommendations_engine import Recommendation, RecommendationsReport
+
+        recs = [
+            Recommendation(id="rec1", title="T1", description="D", reason="R",
+                          impact_level="high", urgency_level="high", risk_relation="neutral"),
+            Recommendation(id="rec2", title="T2", description="D", reason="R",
+                          impact_level="high", urgency_level="medium", risk_relation="neutral"),
+            Recommendation(id="rec3", title="T3", description="D", reason="R",
+                          impact_level="medium", urgency_level="medium", risk_relation="neutral"),
+            Recommendation(id="rec4", title="T4", description="D", reason="R",
+                          impact_level="low", urgency_level="low", risk_relation="neutral"),
+        ]
+
+        report = RecommendationsReport(recommendations=recs, summary="Test", top_3_ids=["rec1"])
+
+        assert report.high_impact_count == 2
+
+    def test_get_recommendation_by_id(self) -> None:
+        """Test get_recommendation method."""
+        from services.recommendations_engine import Recommendation, RecommendationsReport
+
+        recs = [
+            Recommendation(id="rec1", title="T1", description="D", reason="R",
+                          impact_level="high", urgency_level="high", risk_relation="neutral"),
+            Recommendation(id="rec2", title="T2", description="D", reason="R",
+                          impact_level="medium", urgency_level="medium", risk_relation="neutral"),
+        ]
+
+        report = RecommendationsReport(recommendations=recs, summary="Test", top_3_ids=["rec1"])
+
+        assert report.get_recommendation("rec1").title == "T1"
+        assert report.get_recommendation("rec2").title == "T2"
+        assert report.get_recommendation("rec_invalid") is None
+
+    def test_to_dict_serialization(self) -> None:
+        """Test RecommendationsReport serialization to dict."""
+        from services.recommendations_engine import Recommendation, RecommendationsReport
+
+        recs = [
+            Recommendation(id="rec1", title="T1", description="D", reason="R",
+                          impact_level="high", urgency_level="high", risk_relation="neutral",
+                          required_investment=5000.0),
+        ]
+
+        report = RecommendationsReport(
+            recommendations=recs,
+            summary="Summary text",
+            top_3_ids=["rec1"],
+        )
+
+        data = report.to_dict()
+
+        assert data["summary"] == "Summary text"
+        assert data["top_3_ids"] == ["rec1"]
+        assert data["count"] == 1
+        assert data["total_investment"] == 5000.0
+        assert data["high_impact_count"] == 1
+        assert len(data["recommendations"]) == 1
+
+    def test_from_dict_deserialization(self) -> None:
+        """Test RecommendationsReport creation from dict."""
+        from services.recommendations_engine import RecommendationsReport
+
+        data = {
+            "recommendations": [
+                {"id": "rec1", "title": "T1", "description": "D", "reason": "R",
+                 "impact_level": "high", "urgency_level": "high", "risk_relation": "neutral"},
+            ],
+            "summary": "From dict",
+            "top_3_ids": ["rec1"],
+        }
+
+        report = RecommendationsReport.from_dict(data)
+
+        assert report.summary == "From dict"
+        assert len(report.recommendations) == 1
+        assert report.recommendations[0].id == "rec1"
+
+
+# =============================================================================
+# TEST: Size Constraints
+# =============================================================================
+
+class TestSizeConstraints:
+    """Tests for company size constraints."""
+
+    def test_size_constraints_exist(self) -> None:
+        """Test SIZE_CONSTRAINTS dict contains all sizes."""
+        from services.recommendations_engine import SIZE_CONSTRAINTS
+
+        assert "solo" in SIZE_CONSTRAINTS
+        assert "team" in SIZE_CONSTRAINTS
+        assert "kmu" in SIZE_CONSTRAINTS
+
+    def test_solo_constraints(self) -> None:
+        """Test Solo constraints are correct."""
+        from services.recommendations_engine import SIZE_CONSTRAINTS
+
+        solo = SIZE_CONSTRAINTS["solo"]
+        assert solo["max_recommendations"] == 5
+        assert solo["max_high_impact"] == 2
+        assert solo["max_parallel_initiatives"] == 2
+
+    def test_team_constraints(self) -> None:
+        """Test Team constraints are correct."""
+        from services.recommendations_engine import SIZE_CONSTRAINTS
+
+        team = SIZE_CONSTRAINTS["team"]
+        assert team["max_recommendations"] == 8
+        assert team["max_high_impact"] == 4
+        assert team["max_parallel_initiatives"] == 3
+
+    def test_kmu_constraints(self) -> None:
+        """Test KMU constraints are correct."""
+        from services.recommendations_engine import SIZE_CONSTRAINTS
+
+        kmu = SIZE_CONSTRAINTS["kmu"]
+        assert kmu["max_recommendations"] == 10
+        assert kmu["max_high_impact"] == 6
+        assert kmu["max_parallel_initiatives"] == 5
+
+
+# =============================================================================
+# TEST: Validation Functions
+# =============================================================================
+
+class TestValidationFunctions:
+    """Tests for validation helper functions."""
+
+    def test_validate_recommendations_for_size_solo_valid(self) -> None:
+        """Test validation passes for valid Solo report."""
+        from services.recommendations_engine import (
+            Recommendation, RecommendationsReport, validate_recommendations_for_size
+        )
+
+        recs = [
+            Recommendation(id=f"rec{i}", title=f"T{i}", description="D", reason="R",
+                          impact_level="medium", urgency_level="medium", risk_relation="neutral")
+            for i in range(3)
+        ]
+
+        report = RecommendationsReport(recommendations=recs, summary="Test", top_3_ids=["rec0"])
+
+        is_valid, errors = validate_recommendations_for_size(report, "solo")
+        assert is_valid is True
+        assert len(errors) == 0
+
+    def test_validate_recommendations_for_size_solo_too_many(self) -> None:
+        """Test validation fails for Solo with too many recommendations."""
+        from services.recommendations_engine import (
+            Recommendation, RecommendationsReport, validate_recommendations_for_size
+        )
+
+        recs = [
+            Recommendation(id=f"rec{i}", title=f"T{i}", description="D", reason="R",
+                          impact_level="medium", urgency_level="medium", risk_relation="neutral")
+            for i in range(7)  # More than 5
+        ]
+
+        report = RecommendationsReport(recommendations=recs, summary="Test", top_3_ids=["rec0"])
+
+        is_valid, errors = validate_recommendations_for_size(report, "solo")
+        assert is_valid is False
+        assert len(errors) >= 1
+        assert "Zu viele Empfehlungen" in errors[0]
+
+    def test_validate_recommendations_for_size_solo_too_many_high_impact(self) -> None:
+        """Test validation fails for Solo with too many high impact recommendations."""
+        from services.recommendations_engine import (
+            Recommendation, RecommendationsReport, validate_recommendations_for_size
+        )
+
+        recs = [
+            Recommendation(id=f"rec{i}", title=f"T{i}", description="D", reason="R",
+                          impact_level="high", urgency_level="medium", risk_relation="neutral")
+            for i in range(4)  # 4 high impact, max is 2 for Solo
+        ]
+
+        report = RecommendationsReport(recommendations=recs, summary="Test", top_3_ids=["rec0"])
+
+        is_valid, errors = validate_recommendations_for_size(report, "solo")
+        assert is_valid is False
+        assert any("High-Impact" in e for e in errors)
+
+    def test_validate_recommendations_for_size_kmu_valid(self) -> None:
+        """Test validation passes for valid KMU report."""
+        from services.recommendations_engine import (
+            Recommendation, RecommendationsReport, validate_recommendations_for_size
+        )
+
+        recs = [
+            Recommendation(id=f"rec{i}", title=f"T{i}", description="D", reason="R",
+                          impact_level="high", urgency_level="high", risk_relation="neutral")
+            for i in range(6)  # 6 high impact, max is 6 for KMU
+        ]
+
+        report = RecommendationsReport(recommendations=recs, summary="Test", top_3_ids=["rec0"])
+
+        is_valid, errors = validate_recommendations_for_size(report, "kmu")
+        assert is_valid is True
+
+
+# =============================================================================
+# TEST: Report Generation
+# =============================================================================
+
+class TestReportGeneration:
+    """Tests for report generation function."""
+
+    def test_generate_with_empty_input(self) -> None:
+        """Test report generation with minimal input."""
+        from services.recommendations_engine import generate_recommendations_report
+
+        report = generate_recommendations_report(
+            briefing={"unternehmensgroesse": "Team", "branche": "IT"}
+        )
+
+        assert report is not None
+        assert isinstance(report.recommendations, list)
+        assert isinstance(report.summary, str)
+
+    def test_generate_with_tools_data(self) -> None:
+        """Test report generation with tools data."""
+        from services.recommendations_engine import generate_recommendations_report
+
+        tools_data = [
+            {"name": "ChatGPT Enterprise", "fit_solo": 0.9, "fit_team": 0.8, "fit_kmu": 0.7,
+             "vendor_risk": 2, "cost_level": 3},
+            {"name": "Microsoft Copilot", "fit_solo": 0.7, "fit_team": 0.9, "fit_kmu": 0.9,
+             "vendor_risk": 2, "cost_level": 4},
+        ]
+
+        report = generate_recommendations_report(
+            tools_data=tools_data,
+            briefing={"unternehmensgroesse": "Team", "branche": "IT"}
+        )
+
+        # Should include tool-related recommendation
+        tool_recs = [r for r in report.recommendations if r.related_tools]
+        assert len(tool_recs) >= 1
+
+    def test_generate_with_funding_data(self) -> None:
+        """Test report generation with funding data."""
+        from services.recommendations_engine import generate_recommendations_report
+
+        funding_data = {"programmes": [{"name": "Digital Jetzt"}]}
+
+        report = generate_recommendations_report(
+            funding_data=funding_data,
+            briefing={"unternehmensgroesse": "KMU", "branche": "Produktion"}
+        )
+
+        # Should include funding-related recommendation
+        funding_recs = [r for r in report.recommendations if r.related_funding]
+        assert len(funding_recs) >= 1
+
+    def test_generate_respects_solo_limits(self) -> None:
+        """Test generated recommendations respect Solo size limits."""
+        from services.recommendations_engine import generate_recommendations_report
+
+        tools_data = [{"name": f"Tool{i}", "fit_solo": 0.8, "fit_team": 0.8, "fit_kmu": 0.8,
+                       "vendor_risk": 2, "cost_level": 2} for i in range(10)]
+
+        report = generate_recommendations_report(
+            tools_data=tools_data,
+            briefing={"unternehmensgroesse": "Solo/Freelancer", "branche": "IT"}
+        )
+
+        assert len(report.recommendations) <= 5
+
+    def test_generate_selects_top_3(self) -> None:
+        """Test top_3_ids is populated."""
+        from services.recommendations_engine import generate_recommendations_report
+
+        report = generate_recommendations_report(
+            briefing={"unternehmensgroesse": "Team", "branche": "IT"}
+        )
+
+        # If we have at least 3 recommendations, we should have 3 top IDs
+        if len(report.recommendations) >= 3:
+            assert len(report.top_3_ids) == 3
+
+    def test_generate_summary_not_empty(self) -> None:
+        """Test summary is generated."""
+        from services.recommendations_engine import generate_recommendations_report
+
+        report = generate_recommendations_report(
+            briefing={"unternehmensgroesse": "Team", "branche": "Beratung"}
+        )
+
+        assert len(report.summary) > 0
+
+
+# =============================================================================
+# TEST: HTML Generation
+# =============================================================================
+
+class TestHTMLGeneration:
+    """Tests for HTML rendering function."""
+
+    def test_html_contains_summary(self) -> None:
+        """Test HTML includes summary section."""
+        from services.recommendations_engine import (
+            Recommendation, RecommendationsReport, recommendations_report_to_html
+        )
+
+        rec = Recommendation(id="rec1", title="Test", description="Desc", reason="Reason",
+                            impact_level="high", urgency_level="high", risk_relation="neutral")
+        report = RecommendationsReport(
+            recommendations=[rec],
+            summary="This is the summary",
+            top_3_ids=["rec1"],
+        )
+
+        html = recommendations_report_to_html(report, lang="de")
+
+        assert "This is the summary" in html
+
+    def test_html_contains_top_priorities(self) -> None:
+        """Test HTML includes top priorities section."""
+        from services.recommendations_engine import (
+            Recommendation, RecommendationsReport, recommendations_report_to_html
+        )
+
+        rec = Recommendation(id="rec1", title="Priority One", description="Desc", reason="Reason",
+                            impact_level="high", urgency_level="high", risk_relation="neutral")
+        report = RecommendationsReport(
+            recommendations=[rec],
+            summary="Summary",
+            top_3_ids=["rec1"],
+        )
+
+        html = recommendations_report_to_html(report, lang="de")
+
+        assert "Priority One" in html
+        assert "Top-Prioritäten" in html
+
+    def test_html_german_labels(self) -> None:
+        """Test HTML uses German labels."""
+        from services.recommendations_engine import (
+            Recommendation, RecommendationsReport, recommendations_report_to_html
+        )
+
+        rec = Recommendation(id="rec1", title="Test", description="Desc", reason="Reason",
+                            impact_level="high", urgency_level="high", risk_relation="reduces_risk")
+        report = RecommendationsReport(recommendations=[rec], summary="S", top_3_ids=["rec1"])
+
+        html = recommendations_report_to_html(report, lang="de")
+
+        assert "Auswirkung" in html
+        assert "Dringlichkeit" in html
+
+    def test_html_english_labels(self) -> None:
+        """Test HTML uses English labels."""
+        from services.recommendations_engine import (
+            Recommendation, RecommendationsReport, recommendations_report_to_html
+        )
+
+        rec = Recommendation(id="rec1", title="Test", description="Desc", reason="Reason",
+                            impact_level="high", urgency_level="high", risk_relation="reduces_risk")
+        report = RecommendationsReport(recommendations=[rec], summary="S", top_3_ids=["rec1"])
+
+        html = recommendations_report_to_html(report, lang="en")
+
+        assert "Impact" in html
+        assert "Urgency" in html
+
+    def test_html_includes_investment(self) -> None:
+        """Test HTML includes investment amount when specified."""
+        from services.recommendations_engine import (
+            Recommendation, RecommendationsReport, recommendations_report_to_html
+        )
+
+        rec = Recommendation(id="rec1", title="Test", description="Desc", reason="Reason",
+                            impact_level="high", urgency_level="high", risk_relation="neutral",
+                            required_investment=5000.0)
+        report = RecommendationsReport(recommendations=[rec], summary="S", top_3_ids=["rec1"])
+
+        html = recommendations_report_to_html(report, lang="de")
+
+        assert "5,000" in html or "5.000" in html or "5000" in html
+
+    def test_html_includes_related_tools(self) -> None:
+        """Test HTML includes related tools."""
+        from services.recommendations_engine import (
+            Recommendation, RecommendationsReport, recommendations_report_to_html
+        )
+
+        rec = Recommendation(id="rec1", title="Test", description="Desc", reason="Reason",
+                            impact_level="high", urgency_level="high", risk_relation="neutral",
+                            related_tools=["ChatGPT Enterprise", "Microsoft Copilot"])
+        report = RecommendationsReport(recommendations=[rec], summary="S", top_3_ids=["rec1"])
+
+        html = recommendations_report_to_html(report, lang="de")
+
+        assert "ChatGPT Enterprise" in html
+
+    def test_html_includes_phase_badge(self) -> None:
+        """Test HTML includes phase badges."""
+        from services.recommendations_engine import (
+            Recommendation, RecommendationsReport, recommendations_report_to_html
+        )
+
+        rec = Recommendation(id="rec1", title="Test", description="Desc", reason="Reason",
+                            impact_level="high", urgency_level="high", risk_relation="neutral",
+                            timeline_phase="phase_2")
+        report = RecommendationsReport(recommendations=[rec], summary="S", top_3_ids=["rec1"])
+
+        html = recommendations_report_to_html(report, lang="de")
+
+        assert "Phase 2" in html
+
+    def test_html_g32_badge(self) -> None:
+        """Test HTML includes G32 sprint badge."""
+        from services.recommendations_engine import (
+            RecommendationsReport, recommendations_report_to_html
+        )
+
+        report = RecommendationsReport(recommendations=[], summary="Empty", top_3_ids=[])
+        html = recommendations_report_to_html(report, lang="de")
+
+        assert "G32" in html
+
+    def test_html_other_recommendations_section(self) -> None:
+        """Test HTML includes 'other recommendations' section."""
+        from services.recommendations_engine import (
+            Recommendation, RecommendationsReport, recommendations_report_to_html
+        )
+
+        recs = [
+            Recommendation(id=f"rec{i}", title=f"Rec {i}", description="D", reason="R",
+                          impact_level="medium", urgency_level="medium", risk_relation="neutral")
+            for i in range(5)
+        ]
+        report = RecommendationsReport(
+            recommendations=recs,
+            summary="S",
+            top_3_ids=["rec0", "rec1", "rec2"],
+        )
+
+        html = recommendations_report_to_html(report, lang="de")
+
+        assert "Weitere Empfehlungen" in html
+        assert "Rec 3" in html
+        assert "Rec 4" in html
+
+
+# =============================================================================
+# TEST: Consistency Engine Integration
+# =============================================================================
+
+class TestConsistencyEngineIntegration:
+    """Tests for consistency engine RECO_001-RECO_005 rules."""
+
+    def test_reco_domain_in_consistency_engine(self) -> None:
+        """Test 'recommendations' domain exists in consistency engine."""
+        from services.consistency_engine import ConsistencyEngine
+
+        sections = {"RECOMMENDATIONS_ENGINE_HTML": "<div>test</div>"}
+        briefing = {"unternehmensgroesse": "Team"}
+
+        engine = ConsistencyEngine(sections, briefing)
+        report = engine.check_all()
+
+        # Domain should be calculated
+        assert "recommendations" in report.domain_scores
+
+    def test_consistency_skips_without_reco_html(self) -> None:
+        """Test consistency check skips when no recommendations HTML."""
+        from services.consistency_engine import ConsistencyEngine
+
+        sections = {}
+        briefing = {"unternehmensgroesse": "Team"}
+
+        engine = ConsistencyEngine(sections, briefing)
+        report = engine.check_all()
+
+        # No RECO issues when section missing
+        reco_issues = [i for i in report.issues if i.rule_id.startswith("RECO_")]
+        assert len(reco_issues) == 0
+
+
+# =============================================================================
+# TEST: Edge Cases
+# =============================================================================
+
+class TestEdgeCases:
+    """Tests for edge cases and error handling."""
+
+    def test_empty_recommendations_list(self) -> None:
+        """Test report with empty recommendations list."""
+        from services.recommendations_engine import RecommendationsReport
+
+        report = RecommendationsReport(
+            recommendations=[],
+            summary="No recommendations",
+            top_3_ids=[],
+        )
+
+        assert len(report.recommendations) == 0
+        assert report.total_investment == 0.0
+        assert report.high_impact_count == 0
+
+    def test_recommendation_with_empty_lists(self) -> None:
+        """Test recommendation with empty related lists."""
+        from services.recommendations_engine import Recommendation
+
+        rec = Recommendation(
+            id="rec1",
+            title="Test",
+            description="Desc",
+            reason="Reason",
+            impact_level="high",
+            urgency_level="high",
+            risk_relation="neutral",
+            related_tools=[],
+            related_funding=[],
+            related_risks=[],
+        )
+
+        assert rec.related_tools == []
+        assert rec.related_funding == []
+        assert rec.related_risks == []
+
+    def test_recommendation_lists_normalized(self) -> None:
+        """Test non-list related fields are normalized to empty lists."""
+        from services.recommendations_engine import Recommendation
+
+        rec = Recommendation(
+            id="rec1",
+            title="Test",
+            description="Desc",
+            reason="Reason",
+            impact_level="high",
+            urgency_level="high",
+            risk_relation="neutral",
+            related_tools=None,  # type: ignore
+            related_funding=None,  # type: ignore
+            related_risks=None,  # type: ignore
+        )
+
+        assert rec.related_tools == []
+        assert rec.related_funding == []
+        assert rec.related_risks == []
+
+    def test_determine_size_label_solo(self) -> None:
+        """Test size label determination for Solo."""
+        from services.recommendations_engine import _determine_size_label
+
+        assert _determine_size_label({"unternehmensgroesse": "Solo/Freelancer"}) == "solo"
+        assert _determine_size_label({"unternehmensgroesse": "Freiberufler"}) == "solo"
+        assert _determine_size_label({"unternehmensgroesse": "Einzelunternehmen"}) == "solo"
+
+    def test_determine_size_label_kmu(self) -> None:
+        """Test size label determination for KMU."""
+        from services.recommendations_engine import _determine_size_label
+
+        assert _determine_size_label({"unternehmensgroesse": "KMU (>10 Mitarbeiter)"}) == "kmu"
+        assert _determine_size_label({"unternehmensgroesse": "Mittelstand"}) == "kmu"
+
+    def test_determine_size_label_team(self) -> None:
+        """Test size label determination for Team (default)."""
+        from services.recommendations_engine import _determine_size_label
+
+        assert _determine_size_label({"unternehmensgroesse": "Team (2-10 MA)"}) == "team"
+        assert _determine_size_label({"unternehmensgroesse": "Unknown"}) == "team"
+        assert _determine_size_label({}) == "team"
+        assert _determine_size_label(None) == "team"
+
+
+# =============================================================================
+# TEST: Module Loading
+# =============================================================================
+
+class TestModuleLoading:
+    """Tests for module loading and exports."""
+
+    def test_module_exports(self) -> None:
+        """Test all expected exports are available."""
+        from services.recommendations_engine import (
+            Recommendation,
+            RecommendationsReport,
+            generate_recommendations_report,
+            recommendations_report_to_html,
+            RECOMMENDATIONS_ENGINE_ENABLED,
+        )
+
+        assert Recommendation is not None
+        assert RecommendationsReport is not None
+        assert generate_recommendations_report is not None
+        assert recommendations_report_to_html is not None
+        assert RECOMMENDATIONS_ENGINE_ENABLED is True
+
+    def test_constants_defined(self) -> None:
+        """Test constants are properly defined."""
+        from services.recommendations_engine import (
+            IMPACT_LEVELS,
+            URGENCY_LEVELS,
+            RISK_RELATIONS,
+            TIMELINE_PHASES,
+        )
+
+        assert "low" in IMPACT_LEVELS
+        assert "medium" in IMPACT_LEVELS
+        assert "high" in IMPACT_LEVELS
+
+        assert "low" in URGENCY_LEVELS
+        assert "medium" in URGENCY_LEVELS
+        assert "high" in URGENCY_LEVELS
+
+        assert "reduces_risk" in RISK_RELATIONS
+        assert "requires_mitigation" in RISK_RELATIONS
+        assert "neutral" in RISK_RELATIONS
+
+        assert "phase_1" in TIMELINE_PHASES
+        assert "phase_2" in TIMELINE_PHASES
+        assert "phase_3" in TIMELINE_PHASES


### PR DESCRIPTION
…ndations

- Add services/recommendations_engine.py with Recommendation and RecommendationsReport dataclasses
- Generate 5-10 prioritized recommendations based on all engines (G20-G30)
- Mark top 3 priorities with impact × urgency scoring
- Size-aware constraints (Solo max 5, Team max 8, KMU max 10)
- Branch-aware recommendations with timeline phases (1-3)
- Add prompts/de/recommendations_engine.md and en versions for LLM generation
- Extend consistency_engine.py with RECO_001-RECO_005 validation rules
- Integrate into gpt_analyze.py after G30 Business Case Engine
- Update PDF templates with recommendations section
- Add comprehensive test suite with 59 tests (100% pass)