### PR TITLE
feat(G33): add Risk Engine 3.0 with DPIA automation and AI Act Confor…

### DIFF
--- a/gpt_analyze.py
+++ b/gpt_analyze.py
@@ -5084,6 +5084,47 @@ def analyze_briefing(db: Session, briefing_id: int, run_id: str) -> tuple[int, s
         sections.setdefault("RISK_ENGINE_HTML", "")
 
     # =========================================================================
+    # SPRINT G33: Risk Engine 3.0 – DPIA & AI Act Conformity Mapping
+    # =========================================================================
+    try:
+        from services.risk_engine_v3 import generate_risk_report_v3, risk_report_v3_to_html
+
+        risk_report_v3 = generate_risk_report_v3(
+            context=None,
+            sections=sections,
+            tools_data=sections.get("_tools_data"),
+            funding_data=sections.get("_funding_data"),
+            strategy_data=sections.get("_strategy_plan"),
+            base_risk_report=sections.get("_risk_report"),
+            briefing=answers,
+            llm_response=None,
+        )
+
+        sections["RISK_ENGINE_V3_HTML"] = risk_report_v3_to_html(risk_report_v3, lang=report_lang)
+        sections["_risk_report_v3"] = risk_report_v3
+
+        # Extract key values for template usage
+        sections["DPIA_REQUIRED"] = risk_report_v3.dpia_required
+        sections["DPIA_REASON"] = risk_report_v3.dpia_reason
+        sections["AI_ACT_CONFORMITY_SCORE"] = risk_report_v3.ai_act_conformity.conformity_score
+        sections["RESIDUAL_RISK_SCORE"] = risk_report_v3.residual_risk_score
+        sections["RESIDUAL_RISK_GRADE"] = risk_report_v3.residual_risk_grade
+        sections["COMPLIANCE_STATUS"] = risk_report_v3.compliance_status
+
+        log.info("[%s] ✅ G33 Risk Engine V3 generated: DPIA=%s, Conformity=%.0f%%, Residual=%s (%s)",
+                 run_id,
+                 "Required" if risk_report_v3.dpia_required else "Not Required",
+                 risk_report_v3.ai_act_conformity.conformity_score * 100,
+                 risk_report_v3.residual_risk_grade,
+                 risk_report_v3.compliance_status)
+    except ImportError:
+        log.debug("[%s] G33 risk_engine_v3 not available", run_id)
+        sections.setdefault("RISK_ENGINE_V3_HTML", "")
+    except Exception as e:
+        log.warning("[%s] ⚠️ G33 Risk Engine V3 failed: %s", run_id, e)
+        sections.setdefault("RISK_ENGINE_V3_HTML", "")
+
+    # =========================================================================
     # SPRINT G30: Business Case Engine 2.0 – ROI-Simulation & Szenarien
     # =========================================================================
     try:

--- a/prompts/de/risk_engine_v3.md
+++ b/prompts/de/risk_engine_v3.md
@@ -1,0 +1,115 @@
+# Risk Engine 3.0 – DPIA & AI Act Conformity Mapping
+
+## Rolle
+Du bist ein Datenschutz- und KI-Compliance-Experte. Deine Aufgabe ist es, eine strukturierte Datenschutz-Folgenabschätzung (DPIA) nach DSGVO Art. 35 und ein AI Act Conformity Mapping nach EU AI Act Annex III durchzuführen.
+
+## Kontext
+- **Unternehmensgröße**: {{unternehmensgroesse}}
+- **Branche**: {{branche}}
+- **KI-Anwendung**: {{ki_anwendung}}
+- **Datentypen**: {{datentypen}}
+- **Automatisierte Entscheidungen**: {{automatisierte_entscheidungen}}
+- **AI Act Klassifizierung**: {{ai_act_class}}
+- **DSGVO Risikostufe**: {{dsgvo_risk_level}}
+- **Vendor Risk Score**: {{vendor_risk_score}}
+
+## Aufgabe
+Analysiere die KI-Implementierung und erstelle:
+
+1. **DPIA-Prüfung**: Ist eine DPIA nach Art. 35 DSGVO erforderlich?
+2. **DPIA-Einträge**: Falls ja, erstelle strukturierte DPIA-Einträge für jede relevante Verarbeitungstätigkeit
+3. **AI Act Conformity**: Prüfe Konformität mit AI Act Annex III Controls
+4. **Mitigation Plan**: Erstelle einen Maßnahmenplan zur Risikominimierung
+5. **Residual Risk**: Berechne das Restrisiko nach Mitigationen
+
+## AI Act Annex III Controls (für High-Risk Systeme)
+- `risk_management_system`: Risikomanagement-System (Art. 9)
+- `data_governance`: Daten und Datengovernance (Art. 10)
+- `technical_documentation`: Technische Dokumentation (Art. 11)
+- `record_keeping`: Aufzeichnungspflichten (Art. 12)
+- `transparency_provision`: Transparenz und Informationspflichten (Art. 13)
+- `human_oversight`: Menschliche Aufsicht (Art. 14)
+- `accuracy_robustness_security`: Genauigkeit, Robustheit und Cybersicherheit (Art. 15)
+
+## DSGVO Datenkategorien
+- `personal_basic`: Name, E-Mail, Adresse
+- `personal_contact`: Telefon, Social Media
+- `personal_financial`: Bankdaten, Zahlungsinformationen
+- `personal_professional`: Berufliche Daten
+- `sensitive_health`: Gesundheitsdaten (Art. 9)
+- `sensitive_biometric`: Biometrische Daten (Art. 9)
+- `sensitive_genetic`: Genetische Daten (Art. 9)
+- `sensitive_political`: Politische Meinungen (Art. 9)
+- `sensitive_religious`: Religiöse Überzeugungen (Art. 9)
+- `children_data`: Daten von Kindern (<16)
+- `automated_profiling`: Automatisiertes Profiling
+
+## Rechtsgrundlagen (DSGVO Art. 6)
+- `consent`: Einwilligung (Art. 6(1)(a))
+- `contract`: Vertragserfüllung (Art. 6(1)(b))
+- `legal_obligation`: Rechtliche Verpflichtung (Art. 6(1)(c))
+- `vital_interests`: Lebenswichtige Interessen (Art. 6(1)(d))
+- `public_task`: Öffentliche Aufgabe (Art. 6(1)(e))
+- `legitimate_interest`: Berechtigtes Interesse (Art. 6(1)(f))
+
+## Größen-Constraints
+- **Solo**: Max. 3 DPIA-Einträge, max. 4 Controls
+- **Team**: Max. 5 DPIA-Einträge, max. 6 Controls
+- **KMU**: Max. 8 DPIA-Einträge, max. 7 Controls
+
+## Output-Format (JSON)
+```json
+{
+  "dpia_required": true,
+  "dpia_reason": "Grund für DPIA-Erfordernis",
+  "dpia_entries": [
+    {
+      "id": "dpia_001",
+      "title": "DPIA: Kundenservice-Chatbot",
+      "description": "Folgenabschätzung für KI-gestützten Kundenservice",
+      "legal_basis": "legitimate_interest",
+      "data_categories": ["personal_basic", "personal_contact"],
+      "rights_risks": ["Recht auf Auskunft", "Recht auf Löschung"],
+      "mitigation_measures": ["Datenminimierung", "Pseudonymisierung"],
+      "residual_risk": "medium"
+    }
+  ],
+  "ai_act_conformity": {
+    "required_controls": ["transparency_provision", "human_oversight"],
+    "implemented_controls": ["transparency_provision"],
+    "missing_controls": ["human_oversight"],
+    "conformity_score": 0.5,
+    "risk_implications": ["Fehlende menschliche Aufsicht bei kritischen Entscheidungen"],
+    "remediation_timeline": "phase_2"
+  },
+  "mitigation_plan": [
+    "Human-in-the-Loop Prozess implementieren",
+    "Transparenzdokumentation erstellen"
+  ],
+  "mitigation_timeline": {
+    "phase_1": ["Human-in-the-Loop Prozess"],
+    "phase_2": ["Transparenzdokumentation"],
+    "phase_3": ["Audit-Framework"]
+  },
+  "residual_risk_score": 65.0,
+  "compliance_status": "partial",
+  "compliance_gaps": ["Menschliche Aufsicht fehlt"]
+}
+```
+
+## Wichtige Regeln
+1. **Keine narrativen Texte** – nur strukturiertes JSON
+2. **Größenanpassung** – Komplexität an Unternehmensgröße anpassen
+3. **Branchenspezifisch** – Gesundheit/Bildung erfordern höhere Schutzstandards
+4. **Konsistenz** – DPIA-Einträge müssen mit AI Act Controls konsistent sein
+5. **Vollständigkeit** – Alle Pflichtfelder müssen ausgefüllt sein
+6. **Realistische Scores** – residual_risk_score zwischen 20-80 für die meisten Fälle
+
+## DPIA-Erfordernis (Art. 35 DSGVO)
+DPIA ist erforderlich bei:
+- High-Risk AI Act Klassifizierung
+- Verarbeitung sensibler Daten (Art. 9 DSGVO)
+- Automatisierter Entscheidungsfindung mit rechtlicher Wirkung
+- Systematischer Überwachung
+- Verarbeitung von Kinderdaten
+- Großflächiger Datenverarbeitung

--- a/prompts/en/risk_engine_v3.md
+++ b/prompts/en/risk_engine_v3.md
@@ -1,0 +1,115 @@
+# Risk Engine 3.0 – DPIA & AI Act Conformity Mapping
+
+## Role
+You are a data protection and AI compliance expert. Your task is to perform a structured Data Protection Impact Assessment (DPIA) according to GDPR Art. 35 and an AI Act Conformity Mapping according to EU AI Act Annex III.
+
+## Context
+- **Company Size**: {{company_size}}
+- **Industry**: {{industry}}
+- **AI Application**: {{ai_application}}
+- **Data Types**: {{data_types}}
+- **Automated Decisions**: {{automated_decisions}}
+- **AI Act Classification**: {{ai_act_class}}
+- **GDPR Risk Level**: {{gdpr_risk_level}}
+- **Vendor Risk Score**: {{vendor_risk_score}}
+
+## Task
+Analyze the AI implementation and create:
+
+1. **DPIA Check**: Is a DPIA required under Art. 35 GDPR?
+2. **DPIA Entries**: If yes, create structured DPIA entries for each relevant processing activity
+3. **AI Act Conformity**: Check conformity with AI Act Annex III Controls
+4. **Mitigation Plan**: Create a risk mitigation plan
+5. **Residual Risk**: Calculate residual risk after mitigations
+
+## AI Act Annex III Controls (for High-Risk Systems)
+- `risk_management_system`: Risk Management System (Art. 9)
+- `data_governance`: Data and Data Governance (Art. 10)
+- `technical_documentation`: Technical Documentation (Art. 11)
+- `record_keeping`: Record-Keeping (Art. 12)
+- `transparency_provision`: Transparency and Provision of Information (Art. 13)
+- `human_oversight`: Human Oversight (Art. 14)
+- `accuracy_robustness_security`: Accuracy, Robustness and Cybersecurity (Art. 15)
+
+## GDPR Data Categories
+- `personal_basic`: Name, Email, Address
+- `personal_contact`: Phone, Social Media
+- `personal_financial`: Bank data, Payment information
+- `personal_professional`: Professional data
+- `sensitive_health`: Health data (Art. 9)
+- `sensitive_biometric`: Biometric data (Art. 9)
+- `sensitive_genetic`: Genetic data (Art. 9)
+- `sensitive_political`: Political opinions (Art. 9)
+- `sensitive_religious`: Religious beliefs (Art. 9)
+- `children_data`: Data of children (<16)
+- `automated_profiling`: Automated Profiling
+
+## Legal Basis (GDPR Art. 6)
+- `consent`: Consent (Art. 6(1)(a))
+- `contract`: Contract Performance (Art. 6(1)(b))
+- `legal_obligation`: Legal Obligation (Art. 6(1)(c))
+- `vital_interests`: Vital Interests (Art. 6(1)(d))
+- `public_task`: Public Task (Art. 6(1)(e))
+- `legitimate_interest`: Legitimate Interest (Art. 6(1)(f))
+
+## Size Constraints
+- **Solo**: Max. 3 DPIA entries, max. 4 controls
+- **Team**: Max. 5 DPIA entries, max. 6 controls
+- **SME**: Max. 8 DPIA entries, max. 7 controls
+
+## Output Format (JSON)
+```json
+{
+  "dpia_required": true,
+  "dpia_reason": "Reason for DPIA requirement",
+  "dpia_entries": [
+    {
+      "id": "dpia_001",
+      "title": "DPIA: Customer Service Chatbot",
+      "description": "Impact assessment for AI-powered customer service",
+      "legal_basis": "legitimate_interest",
+      "data_categories": ["personal_basic", "personal_contact"],
+      "rights_risks": ["Right to access", "Right to erasure"],
+      "mitigation_measures": ["Data minimization", "Pseudonymization"],
+      "residual_risk": "medium"
+    }
+  ],
+  "ai_act_conformity": {
+    "required_controls": ["transparency_provision", "human_oversight"],
+    "implemented_controls": ["transparency_provision"],
+    "missing_controls": ["human_oversight"],
+    "conformity_score": 0.5,
+    "risk_implications": ["Missing human oversight for critical decisions"],
+    "remediation_timeline": "phase_2"
+  },
+  "mitigation_plan": [
+    "Implement Human-in-the-Loop process",
+    "Create transparency documentation"
+  ],
+  "mitigation_timeline": {
+    "phase_1": ["Human-in-the-Loop process"],
+    "phase_2": ["Transparency documentation"],
+    "phase_3": ["Audit framework"]
+  },
+  "residual_risk_score": 65.0,
+  "compliance_status": "partial",
+  "compliance_gaps": ["Human oversight missing"]
+}
+```
+
+## Important Rules
+1. **No narrative text** – only structured JSON
+2. **Size adaptation** – adapt complexity to company size
+3. **Industry-specific** – Healthcare/Education require higher protection standards
+4. **Consistency** – DPIA entries must be consistent with AI Act Controls
+5. **Completeness** – All required fields must be filled
+6. **Realistic scores** – residual_risk_score between 20-80 for most cases
+
+## DPIA Requirement (Art. 35 GDPR)
+DPIA is required for:
+- High-Risk AI Act Classification
+- Processing of sensitive data (Art. 9 GDPR)
+- Automated decision-making with legal effects
+- Systematic monitoring
+- Processing of children's data
+- Large-scale data processing

--- a/services/consistency_engine.py
+++ b/services/consistency_engine.py
@@ -451,6 +451,7 @@ class ConsistencyEngine:
         self._check_risk_engine_consistency()  # G29
         self._check_business_case_consistency()  # G30
         self._check_recommendations_consistency()  # G32
+        self._check_risk_engine_v3_consistency()  # G33
 
         # Calculate domain scores
         self._calculate_domain_scores()
@@ -2295,12 +2296,373 @@ class ConsistencyEngine:
         return total_count
 
     # -------------------------------------------------------------------------
+    # DOMAIN 11: Risk Engine V3 Consistency (G33)
+    # -------------------------------------------------------------------------
+
+    def _check_risk_engine_v3_consistency(self) -> None:
+        """
+        G33: Check Risk Engine V3 (DPIA & AI Act Conformity) consistency.
+
+        Rules:
+        - RISK3_001: If dpia_required=True, Strategy Engine must contain measures
+        - RISK3_002: Missing AI Act Controls must be in Strategy Phase 1 or 2
+        - RISK3_003: Residual Risk Score cannot be < 20 if Vendor Risk > 4
+        - RISK3_004: DSGVO Data Category "sensitive" → Risk Level >= medium
+        - RISK3_005: If Funding Programme requires "High Compliance" → must be in DPIA
+        - RISK3_006: DPIA Entries must not contradict Controls
+        - RISK3_007: Mitigation Plan must reference Strategy Engine use-cases
+        - RISK3_008: AIActConformity.conformity_score < 0.5 → Strategy cannot claim "Low Risk"
+        """
+        risk_v3_html = self.sections.get("RISK_ENGINE_V3_HTML", "")
+
+        if not risk_v3_html:
+            log.debug("[G33] Risk Engine V3 consistency: Skipping (no risk_v3 section)")
+            return
+
+        self.report.checked_rules += 8
+
+        risk_v3_lower = risk_v3_html.lower()
+        strategy_html = self.sections.get("STRATEGY_PLAN_HTML", "") or self.sections.get("ROADMAP_12M_HTML", "")
+        strategy_lower = strategy_html.lower() if strategy_html else ""
+        funding_html = self.sections.get("FUNDING_MATRIX_2025_HTML", "") or self.sections.get("FOERDERPOTENZIAL_HTML", "")
+
+        # Get company size
+        size = self.briefing.get("unternehmensgroesse", "").lower()
+        size_label = "solo" if "solo" in size or "freiberuf" in size else (
+            "team" if "team" in size or "klein" in size else "kmu"
+        )
+
+        # Rule RISK3_001: If DPIA required, Strategy must contain measures
+        dpia_required = "dpia erforderlich" in risk_v3_lower or "dpia required" in risk_v3_lower or '"dpia_required": true' in risk_v3_lower
+        dpia_yes = "dpia_required.*ja" in risk_v3_lower or "dpia required.*yes" in risk_v3_lower
+
+        if dpia_required or dpia_yes:
+            dpia_keywords = ["dpia", "datenschutz", "privacy", "dsgvo", "gdpr", "folgenabschätzung", "impact assessment"]
+            has_dpia_in_strategy = any(kw in strategy_lower for kw in dpia_keywords)
+
+            if not has_dpia_in_strategy and strategy_html:
+                self.report.add_issue(ConsistencyIssue(
+                    rule_id="RISK3_001",
+                    severity="ERROR",
+                    domain="risk_engine_v3",
+                    source_section="risk_engine_v3",
+                    target_section="strategy_plan",
+                    message="DPIA erforderlich, aber keine DPIA-Maßnahmen im Strategy Plan",
+                    expected="Strategy Plan sollte DPIA-bezogene Maßnahmen enthalten",
+                    actual="Keine DPIA-Keywords im Strategy Plan gefunden",
+                    suggestion="Füge DPIA-Implementierung zum Strategy Plan hinzu",
+                ))
+
+        # Rule RISK3_002: Missing AI Act Controls must be in Strategy Phase 1 or 2
+        missing_controls = self._extract_missing_controls(risk_v3_html)
+        if missing_controls and strategy_html:
+            unaddressed_controls = []
+            for ctrl in missing_controls:
+                ctrl_keywords = ctrl.replace("_", " ").split()
+                if not any(kw in strategy_lower for kw in ctrl_keywords):
+                    unaddressed_controls.append(ctrl)
+
+            if unaddressed_controls:
+                self.report.add_issue(ConsistencyIssue(
+                    rule_id="RISK3_002",
+                    severity="ERROR",
+                    domain="risk_engine_v3",
+                    source_section="risk_engine_v3",
+                    target_section="strategy_plan",
+                    message="Fehlende AI Act Controls nicht im Strategy Plan adressiert",
+                    expected="Missing Controls sollten in Phase 1 oder 2 geplant sein",
+                    actual=f"Nicht adressiert: {', '.join(unaddressed_controls[:3])}",
+                    suggestion="Füge AI Act Control-Implementierung zum Strategy Plan hinzu",
+                ))
+
+        # Rule RISK3_003: Residual Risk Score >= 20 if Vendor Risk > 4
+        residual_score = self._extract_residual_risk_score(risk_v3_html)
+        vendor_risk = self._extract_vendor_risk_score(risk_v3_html)
+
+        if vendor_risk > 4 and residual_score is not None and residual_score < 20:
+            self.report.add_issue(ConsistencyIssue(
+                rule_id="RISK3_003",
+                severity="ERROR",
+                domain="risk_engine_v3",
+                source_section="risk_engine_v3",
+                target_section="risk_engine_v3",
+                message="Residual Risk Score zu niedrig bei hohem Vendor Risk",
+                expected="Residual Risk Score >= 20 wenn Vendor Risk > 4",
+                actual=f"Residual Score: {residual_score}, Vendor Risk: {vendor_risk}",
+                suggestion="Überprüfe Vendor Risk Mitigation oder passe Residual Score an",
+            ))
+
+        # Rule RISK3_004: Sensitive data category → Risk Level >= medium
+        has_sensitive_data = any(term in risk_v3_lower for term in [
+            "sensitive_health", "sensitive_biometric", "sensitive_genetic",
+            "sensitive_political", "sensitive_religious", "sensitive_ethnic",
+            "sensitive_sexual", "children_data", "gesundheit", "biometri",
+            "genetik", "politisch", "religiös", "kinder"
+        ])
+
+        if has_sensitive_data:
+            has_low_risk = "residual_risk.*low" in risk_v3_lower or '"low"' in risk_v3_lower
+            # Check if any DPIA entry with sensitive data has low residual risk
+            if has_low_risk and "sensitive" in risk_v3_lower:
+                self.report.add_issue(ConsistencyIssue(
+                    rule_id="RISK3_004",
+                    severity="WARNING",
+                    domain="risk_engine_v3",
+                    source_section="risk_engine_v3",
+                    target_section="risk_engine_v3",
+                    message="Sensible Datenkategorie mit niedrigem Restrisiko",
+                    expected="Verarbeitung sensibler Daten sollte Risk Level >= medium haben",
+                    actual="Sensible Daten gefunden, aber 'low' Risk Level",
+                    suggestion="Erhöhe das Risk Level für DPIA-Einträge mit sensiblen Daten",
+                ))
+
+        # Rule RISK3_005: High Compliance Funding → must be in DPIA
+        if funding_html:
+            high_compliance_funding = any(term in funding_html.lower() for term in [
+                "high compliance", "hohe compliance", "strenge anforderung",
+                "datenschutz-anforderung", "dsgvo-konform"
+            ])
+
+            if high_compliance_funding and dpia_required:
+                funding_in_dpia = "funding" in risk_v3_lower or "förder" in risk_v3_lower
+                if not funding_in_dpia:
+                    self.report.add_issue(ConsistencyIssue(
+                        rule_id="RISK3_005",
+                        severity="WARNING",
+                        domain="risk_engine_v3",
+                        source_section="funding_engine",
+                        target_section="risk_engine_v3",
+                        message="High Compliance Förderprogramm nicht in DPIA referenziert",
+                        expected="Förderprogramme mit hohen Compliance-Anforderungen sollten in DPIA erwähnt werden",
+                        actual="Funding mit Compliance-Anforderungen, aber keine Erwähnung in DPIA",
+                        suggestion="Ergänze Funding-Compliance-Anforderungen in DPIA-Analyse",
+                    ))
+
+        # Rule RISK3_006: DPIA Entries must not contradict Controls
+        # Check for contradictions between DPIA mitigations and missing controls
+        dpia_mitigations = self._extract_dpia_mitigations(risk_v3_html)
+        if dpia_mitigations and missing_controls:
+            # If human oversight is missing but DPIA claims Human-in-the-Loop
+            if "human_oversight" in missing_controls:
+                has_human_loop = any("human" in m.lower() for m in dpia_mitigations)
+                if has_human_loop:
+                    self.report.add_issue(ConsistencyIssue(
+                        rule_id="RISK3_006",
+                        severity="WARNING",
+                        domain="risk_engine_v3",
+                        source_section="risk_engine_v3",
+                        target_section="risk_engine_v3",
+                        message="DPIA-Mitigation widerspricht fehlendem AI Act Control",
+                        expected="DPIA-Mitigationen sollten mit implementierten Controls übereinstimmen",
+                        actual="Human-in-the-Loop in DPIA, aber human_oversight als fehlend markiert",
+                        suggestion="Korrigiere entweder DPIA-Mitigationen oder AI Act Control-Status",
+                    ))
+
+        # Rule RISK3_007: Mitigation Plan must reference Strategy Engine use-cases
+        mitigation_plan = self._extract_mitigation_plan(risk_v3_html)
+        strategy_phases = self._extract_strategy_phases(strategy_html)
+
+        if mitigation_plan and strategy_phases:
+            # Check if at least one mitigation references strategy content
+            mitigation_text = " ".join(mitigation_plan).lower()
+            strategy_text = " ".join(strategy_phases).lower()
+
+            common_terms = ["phase", "implementier", "implement", "einführ", "deploy"]
+            has_alignment = any(term in mitigation_text and term in strategy_text for term in common_terms)
+
+            if not has_alignment:
+                self.report.add_issue(ConsistencyIssue(
+                    rule_id="RISK3_007",
+                    severity="WARNING",
+                    domain="risk_engine_v3",
+                    source_section="risk_engine_v3",
+                    target_section="strategy_plan",
+                    message="Mitigation Plan ohne Bezug zum Strategy Plan",
+                    expected="Mitigation Plan sollte Strategy Engine Use-Cases referenzieren",
+                    actual="Keine Überschneidung zwischen Mitigation und Strategy gefunden",
+                    suggestion="Verknüpfe Mitigation-Maßnahmen mit Strategy-Phasen",
+                ))
+
+        # Rule RISK3_008: Conformity Score < 0.5 → Strategy cannot claim "Low Risk"
+        conformity_score = self._extract_conformity_score(risk_v3_html)
+        if conformity_score is not None and conformity_score < 0.5:
+            strategy_claims_low_risk = any(term in strategy_lower for term in [
+                "low risk", "niedriges risiko", "geringes risiko", "minimal risk"
+            ])
+
+            if strategy_claims_low_risk:
+                self.report.add_issue(ConsistencyIssue(
+                    rule_id="RISK3_008",
+                    severity="ERROR",
+                    domain="risk_engine_v3",
+                    source_section="strategy_plan",
+                    target_section="risk_engine_v3",
+                    message="Strategy behauptet 'Low Risk' trotz niedriger AI Act Conformity",
+                    expected="Bei Conformity Score < 50% sollte Strategy kein 'Low Risk' behaupten",
+                    actual=f"Conformity Score: {conformity_score*100:.0f}%, Strategy: 'Low Risk'",
+                    suggestion="Korrigiere Risikobewertung im Strategy Plan oder verbessere AI Act Conformity",
+                ))
+
+    def _extract_missing_controls(self, html: str) -> List[str]:
+        """Extract missing AI Act controls from Risk Engine V3 HTML."""
+        if not html:
+            return []
+
+        controls: List[str] = []
+
+        import re
+
+        # Pattern: missing_controls: ["control_a", "control_b"]
+        pattern = r'missing_controls["\s:]*\[(.*?)\]'
+        matches = re.findall(pattern, html, re.IGNORECASE | re.DOTALL)
+
+        for match in matches:
+            ctrl_names = re.findall(r'"([^"]+)"', match)
+            controls.extend(ctrl_names)
+
+        # Also look for "Missing" or "Fehlend" badges
+        missing_pattern = r'(?:missing|fehlend)[^<]*>([^<]+)<'
+        for match in re.finditer(missing_pattern, html, re.IGNORECASE):
+            ctrl = match.group(1).strip()
+            if len(ctrl) > 3 and "_" in ctrl.lower().replace(" ", "_"):
+                controls.append(ctrl.lower().replace(" ", "_"))
+
+        return list(set(controls))
+
+    def _extract_residual_risk_score(self, html: str) -> Optional[float]:
+        """Extract residual risk score from Risk Engine V3 HTML."""
+        if not html:
+            return None
+
+        import re
+
+        # Pattern: residual_risk_score: 65.0 or "65"
+        patterns = [
+            r'residual_risk_score["\s:]*(\d+(?:\.\d+)?)',
+            r'residual[^>]*>(\d+)</div>',
+        ]
+
+        for pattern in patterns:
+            match = re.search(pattern, html, re.IGNORECASE)
+            if match:
+                try:
+                    return float(match.group(1))
+                except ValueError:
+                    continue
+
+        return None
+
+    def _extract_vendor_risk_score(self, html: str) -> int:
+        """Extract vendor risk score from Risk Engine V3 HTML."""
+        if not html:
+            return 3
+
+        import re
+
+        patterns = [
+            r'vendor_risk_score["\s:]*(\d+)',
+            r'vendor[_\-]?risk[^>]*>(\d+)<',
+        ]
+
+        for pattern in patterns:
+            match = re.search(pattern, html, re.IGNORECASE)
+            if match:
+                try:
+                    return int(match.group(1))
+                except ValueError:
+                    continue
+
+        return 3
+
+    def _extract_dpia_mitigations(self, html: str) -> List[str]:
+        """Extract DPIA mitigation measures from HTML."""
+        if not html:
+            return []
+
+        mitigations: List[str] = []
+
+        import re
+
+        # Pattern: mitigation_measures: ["measure_a", "measure_b"]
+        pattern = r'mitigation_measures["\s:]*\[(.*?)\]'
+        matches = re.findall(pattern, html, re.IGNORECASE | re.DOTALL)
+
+        for match in matches:
+            measure_names = re.findall(r'"([^"]+)"', match)
+            mitigations.extend(measure_names)
+
+        return list(set(mitigations))
+
+    def _extract_mitigation_plan(self, html: str) -> List[str]:
+        """Extract mitigation plan items from HTML."""
+        if not html:
+            return []
+
+        items: List[str] = []
+
+        import re
+
+        # Pattern: mitigation_plan: ["item_a", "item_b"]
+        pattern = r'mitigation_plan["\s:]*\[(.*?)\]'
+        matches = re.findall(pattern, html, re.IGNORECASE | re.DOTALL)
+
+        for match in matches:
+            item_names = re.findall(r'"([^"]+)"', match)
+            items.extend(item_names)
+
+        return items
+
+    def _extract_strategy_phases(self, html: str) -> List[str]:
+        """Extract strategy phase content from HTML."""
+        if not html:
+            return []
+
+        phases: List[str] = []
+
+        import re
+
+        # Look for phase content
+        phase_pattern = r'phase[_\s]?\d[^>]*>([^<]+)<'
+        for match in re.finditer(phase_pattern, html, re.IGNORECASE):
+            content = match.group(1).strip()
+            if len(content) > 5:
+                phases.append(content)
+
+        return phases
+
+    def _extract_conformity_score(self, html: str) -> Optional[float]:
+        """Extract AI Act conformity score from HTML."""
+        if not html:
+            return None
+
+        import re
+
+        patterns = [
+            r'conformity_score["\s:]*(\d+(?:\.\d+)?)',
+            r'(\d+(?:\.\d+)?)\s*%[^<]*conformity',
+        ]
+
+        for pattern in patterns:
+            match = re.search(pattern, html, re.IGNORECASE)
+            if match:
+                try:
+                    score = float(match.group(1))
+                    # If percentage, convert to 0-1 scale
+                    if score > 1:
+                        score = score / 100
+                    return score
+                except ValueError:
+                    continue
+
+        return None
+
+    # -------------------------------------------------------------------------
     # SCORING
     # -------------------------------------------------------------------------
 
     def _calculate_domain_scores(self) -> None:
         """Calculate scores per domain."""
-        domains = ["tools", "funding", "kpi", "risk", "roadmap", "narrative", "snapshot", "risk_engine", "business_case", "recommendations"]
+        domains = ["tools", "funding", "kpi", "risk", "roadmap", "narrative", "snapshot", "risk_engine", "business_case", "recommendations", "risk_engine_v3"]
 
         for domain in domains:
             domain_issues = [i for i in self.report.issues if i.domain == domain]

--- a/services/risk_engine_v3.py
+++ b/services/risk_engine_v3.py
@@ -1,0 +1,1484 @@
+# -*- coding: utf-8 -*-
+"""
+Sprint G33: Risk Engine 3.0 – DPIA Automation & AI Act Conformity Mapping
+==========================================================================
+
+Extends Risk Engine 2.0 (G29) with:
+- Automated DPIA Analysis (Light-DPIA per GDPR Art. 35)
+- AI Act Conformity Mapping (Annex III Controls)
+- Enhanced GDPR Risk Assessment
+- Deep Vendor/Hosting Risk Analysis
+- Compliance Controls Section
+- Risk Matrix 2.0 (Likelihood × Severity × Mitigation)
+- Integration with Strategy (G28), Business Case (G30), Recommendations (G32)
+- Consistency rules for Consistency Engine (G22)
+
+Version: 3.0.0 (Sprint G33)
+Author: Claude + Wolf
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Tuple
+
+# Import base Risk Engine v2
+from services.risk_engine_v2 import (
+    RiskReport,
+    RiskMatrixEntry,
+    extract_risk_from_tools,
+    extract_risk_from_funding,
+    extract_ai_act_class_from_sections,
+    extract_dsgvo_risk_from_sections,
+    calculate_consolidated_score,
+    _calculate_risk_color,
+    _score_to_grade,
+)
+
+log = logging.getLogger(__name__)
+
+__all__ = [
+    "DPIAEntry",
+    "AIActConformity",
+    "RiskReportV3",
+    "generate_risk_report_v3",
+    "risk_report_v3_to_html",
+    "validate_dpia_required",
+    "validate_ai_act_conformity",
+    "RISK_ENGINE_V3_ENABLED",
+]
+
+
+# =============================================================================
+# CONFIGURATION
+# =============================================================================
+
+RISK_ENGINE_V3_ENABLED = True
+
+# AI Act Annex III Required Controls for High-Risk Systems
+AI_ACT_ANNEX_III_CONTROLS = [
+    "risk_management_system",       # Art. 9: Risk management system
+    "data_governance",              # Art. 10: Data and data governance
+    "technical_documentation",      # Art. 11: Technical documentation
+    "record_keeping",               # Art. 12: Record-keeping
+    "transparency_provision",       # Art. 13: Transparency and provision of information
+    "human_oversight",              # Art. 14: Human oversight
+    "accuracy_robustness_security", # Art. 15: Accuracy, robustness and cybersecurity
+]
+
+# DSGVO Data Categories
+DSGVO_DATA_CATEGORIES = [
+    "personal_basic",           # Name, E-Mail, Adresse
+    "personal_contact",         # Telefon, Social Media
+    "personal_financial",       # Bankdaten, Zahlungsinformationen
+    "personal_professional",    # Berufliche Daten, Arbeitgeber
+    "sensitive_health",         # Gesundheitsdaten
+    "sensitive_biometric",      # Biometrische Daten
+    "sensitive_genetic",        # Genetische Daten
+    "sensitive_political",      # Politische Meinungen
+    "sensitive_religious",      # Religiöse Überzeugungen
+    "sensitive_ethnic",         # Ethnische Herkunft
+    "sensitive_sexual",         # Sexuelle Orientierung
+    "children_data",            # Daten von Kindern (<16)
+    "behavioral_tracking",      # Verhaltens-Tracking
+    "automated_profiling",      # Automatisiertes Profiling
+]
+
+# Legal Basis Options (GDPR Art. 6)
+LEGAL_BASIS_OPTIONS = [
+    "consent",                  # Art. 6(1)(a) - Einwilligung
+    "contract",                 # Art. 6(1)(b) - Vertragserfüllung
+    "legal_obligation",         # Art. 6(1)(c) - Rechtliche Verpflichtung
+    "vital_interests",          # Art. 6(1)(d) - Lebenswichtige Interessen
+    "public_task",              # Art. 6(1)(e) - Öffentliche Aufgabe
+    "legitimate_interest",      # Art. 6(1)(f) - Berechtigtes Interesse
+]
+
+# Residual Risk Levels
+RESIDUAL_RISK_LEVELS = ["low", "medium", "high", "critical"]
+
+# Size Constraints for DPIA
+SIZE_DPIA_LIMITS = {
+    "solo": {"max_dpia_entries": 3, "max_controls": 4},
+    "team": {"max_dpia_entries": 5, "max_controls": 6},
+    "kmu": {"max_dpia_entries": 8, "max_controls": 7},
+}
+
+
+# =============================================================================
+# DATA STRUCTURES
+# =============================================================================
+
+@dataclass
+class DPIAEntry:
+    """
+    Data Protection Impact Assessment Entry per GDPR Art. 35.
+
+    Each entry represents a processing activity that requires DPIA analysis.
+    """
+    id: str
+    title: str
+    description: str
+    legal_basis: str  # From LEGAL_BASIS_OPTIONS
+    data_categories: List[str] = field(default_factory=list)
+    rights_risks: List[str] = field(default_factory=list)
+    mitigation_measures: List[str] = field(default_factory=list)
+    residual_risk: str = "medium"  # "low" | "medium" | "high" | "critical"
+
+    def __post_init__(self) -> None:
+        """Validate and normalize values."""
+        # Validate legal basis
+        if self.legal_basis not in LEGAL_BASIS_OPTIONS:
+            log.warning("[G33] Invalid legal_basis: %s, defaulting to 'legitimate_interest'", self.legal_basis)
+            self.legal_basis = "legitimate_interest"
+
+        # Validate residual risk
+        if self.residual_risk not in RESIDUAL_RISK_LEVELS:
+            log.warning("[G33] Invalid residual_risk: %s, defaulting to 'medium'", self.residual_risk)
+            self.residual_risk = "medium"
+
+        # Ensure lists
+        if not isinstance(self.data_categories, list):
+            self.data_categories = []
+        if not isinstance(self.rights_risks, list):
+            self.rights_risks = []
+        if not isinstance(self.mitigation_measures, list):
+            self.mitigation_measures = []
+
+    @property
+    def has_sensitive_data(self) -> bool:
+        """Check if entry involves sensitive data categories."""
+        sensitive_prefixes = ["sensitive_", "children_", "automated_profiling"]
+        return any(
+            any(cat.startswith(prefix) for prefix in sensitive_prefixes)
+            for cat in self.data_categories
+        )
+
+    @property
+    def risk_score(self) -> int:
+        """Calculate risk score based on data categories and residual risk."""
+        risk_map = {"low": 1, "medium": 2, "high": 3, "critical": 4}
+        base_score = risk_map.get(self.residual_risk, 2)
+
+        # Add points for sensitive data
+        if self.has_sensitive_data:
+            base_score += 1
+
+        # Add points for rights risks
+        base_score += len(self.rights_risks) // 2
+
+        return min(5, base_score)
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert to dictionary for JSON serialization."""
+        return {
+            "id": self.id,
+            "title": self.title,
+            "description": self.description,
+            "legal_basis": self.legal_basis,
+            "data_categories": self.data_categories,
+            "rights_risks": self.rights_risks,
+            "mitigation_measures": self.mitigation_measures,
+            "residual_risk": self.residual_risk,
+            "has_sensitive_data": self.has_sensitive_data,
+            "risk_score": self.risk_score,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "DPIAEntry":
+        """Create from dictionary."""
+        return cls(
+            id=data.get("id", "dpia_unknown"),
+            title=data.get("title", ""),
+            description=data.get("description", ""),
+            legal_basis=data.get("legal_basis", "legitimate_interest"),
+            data_categories=data.get("data_categories", []),
+            rights_risks=data.get("rights_risks", []),
+            mitigation_measures=data.get("mitigation_measures", []),
+            residual_risk=data.get("residual_risk", "medium"),
+        )
+
+
+@dataclass
+class AIActConformity:
+    """
+    AI Act Conformity Assessment for High-Risk Systems.
+
+    Maps required controls from Annex III and identifies gaps.
+    """
+    required_controls: List[str] = field(default_factory=list)
+    implemented_controls: List[str] = field(default_factory=list)
+    missing_controls: List[str] = field(default_factory=list)
+    conformity_score: float = 0.0  # 0.0 - 1.0
+    risk_implications: List[str] = field(default_factory=list)
+    remediation_timeline: str = "phase_2"  # "phase_1" | "phase_2" | "phase_3"
+
+    def __post_init__(self) -> None:
+        """Validate and normalize values."""
+        # Ensure lists
+        if not isinstance(self.required_controls, list):
+            self.required_controls = []
+        if not isinstance(self.implemented_controls, list):
+            self.implemented_controls = []
+        if not isinstance(self.missing_controls, list):
+            self.missing_controls = []
+        if not isinstance(self.risk_implications, list):
+            self.risk_implications = []
+
+        # Clamp conformity score
+        self.conformity_score = max(0.0, min(1.0, self.conformity_score))
+
+        # Validate remediation timeline
+        if self.remediation_timeline not in ["phase_1", "phase_2", "phase_3"]:
+            self.remediation_timeline = "phase_2"
+
+        # Auto-calculate missing controls if not set
+        if not self.missing_controls and self.required_controls:
+            self.missing_controls = [
+                ctrl for ctrl in self.required_controls
+                if ctrl not in self.implemented_controls
+            ]
+
+        # Auto-calculate conformity score if not set
+        if self.conformity_score == 0.0 and self.required_controls:
+            implemented_count = len(self.implemented_controls)
+            required_count = len(self.required_controls)
+            if required_count > 0:
+                self.conformity_score = implemented_count / required_count
+
+    @property
+    def is_compliant(self) -> bool:
+        """Check if system meets minimum conformity threshold (>= 0.8)."""
+        return self.conformity_score >= 0.8
+
+    @property
+    def conformity_grade(self) -> str:
+        """Get conformity grade (A-F)."""
+        if self.conformity_score >= 0.9:
+            return "A"
+        elif self.conformity_score >= 0.8:
+            return "B"
+        elif self.conformity_score >= 0.6:
+            return "C"
+        elif self.conformity_score >= 0.4:
+            return "D"
+        else:
+            return "F"
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert to dictionary for JSON serialization."""
+        return {
+            "required_controls": self.required_controls,
+            "implemented_controls": self.implemented_controls,
+            "missing_controls": self.missing_controls,
+            "conformity_score": round(self.conformity_score, 2),
+            "conformity_grade": self.conformity_grade,
+            "is_compliant": self.is_compliant,
+            "risk_implications": self.risk_implications,
+            "remediation_timeline": self.remediation_timeline,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "AIActConformity":
+        """Create from dictionary."""
+        return cls(
+            required_controls=data.get("required_controls", []),
+            implemented_controls=data.get("implemented_controls", []),
+            missing_controls=data.get("missing_controls", []),
+            conformity_score=float(data.get("conformity_score", 0.0)),
+            risk_implications=data.get("risk_implications", []),
+            remediation_timeline=data.get("remediation_timeline", "phase_2"),
+        )
+
+
+@dataclass
+class RiskReportV3:
+    """
+    Extended Risk Report with DPIA and AI Act Conformity.
+
+    Combines Risk Engine v2 base report with DPIA automation
+    and AI Act conformity mapping.
+    """
+    # Base Risk Report from G29
+    base: RiskReport = field(default_factory=lambda: RiskReport(ai_act_class="minimal"))
+
+    # DPIA Analysis
+    dpia_required: bool = False
+    dpia_reason: str = ""
+    dpia_entries: List[DPIAEntry] = field(default_factory=list)
+
+    # AI Act Conformity
+    ai_act_conformity: AIActConformity = field(default_factory=AIActConformity)
+
+    # Mitigation Plan
+    mitigation_plan: List[str] = field(default_factory=list)
+    mitigation_timeline: Dict[str, List[str]] = field(default_factory=dict)
+
+    # Residual Risk
+    residual_risk_score: float = 50.0  # 0-100 (higher = safer)
+    residual_risk_grade: str = "C"
+
+    # Compliance Summary
+    compliance_status: str = "partial"  # "compliant" | "partial" | "non_compliant"
+    compliance_gaps: List[str] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        """Validate and normalize values."""
+        # Ensure lists
+        if not isinstance(self.dpia_entries, list):
+            self.dpia_entries = []
+        if not isinstance(self.mitigation_plan, list):
+            self.mitigation_plan = []
+        if not isinstance(self.compliance_gaps, list):
+            self.compliance_gaps = []
+        if not isinstance(self.mitigation_timeline, dict):
+            self.mitigation_timeline = {}
+
+        # Clamp residual risk score
+        self.residual_risk_score = max(0.0, min(100.0, self.residual_risk_score))
+
+        # Calculate grade if not set
+        if not self.residual_risk_grade or self.residual_risk_grade not in "ABCDF":
+            self.residual_risk_grade = _score_to_grade(self.residual_risk_score)
+
+        # Validate compliance status
+        if self.compliance_status not in ["compliant", "partial", "non_compliant"]:
+            self.compliance_status = "partial"
+
+    @property
+    def total_dpia_entries(self) -> int:
+        """Count total DPIA entries."""
+        return len(self.dpia_entries)
+
+    @property
+    def high_risk_dpia_entries(self) -> List[DPIAEntry]:
+        """Get DPIA entries with high/critical residual risk."""
+        return [e for e in self.dpia_entries if e.residual_risk in ["high", "critical"]]
+
+    @property
+    def sensitive_data_entries(self) -> List[DPIAEntry]:
+        """Get DPIA entries involving sensitive data."""
+        return [e for e in self.dpia_entries if e.has_sensitive_data]
+
+    @property
+    def combined_risk_score(self) -> float:
+        """Calculate combined risk score from base and residual."""
+        base_score = self.base.consolidated_score
+        residual = self.residual_risk_score
+        conformity_factor = self.ai_act_conformity.conformity_score
+
+        # Weighted combination
+        combined = (base_score * 0.4 + residual * 0.4 + conformity_factor * 100 * 0.2)
+        return round(combined, 1)
+
+    @property
+    def combined_grade(self) -> str:
+        """Get combined risk grade."""
+        return _score_to_grade(self.combined_risk_score)
+
+    def get_dpia_entry(self, entry_id: str) -> Optional[DPIAEntry]:
+        """Get DPIA entry by ID."""
+        for entry in self.dpia_entries:
+            if entry.id == entry_id:
+                return entry
+        return None
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert to dictionary for JSON serialization."""
+        return {
+            "base": self.base.to_dict(),
+            "dpia_required": self.dpia_required,
+            "dpia_reason": self.dpia_reason,
+            "dpia_entries": [e.to_dict() for e in self.dpia_entries],
+            "ai_act_conformity": self.ai_act_conformity.to_dict(),
+            "mitigation_plan": self.mitigation_plan,
+            "mitigation_timeline": self.mitigation_timeline,
+            "residual_risk_score": round(self.residual_risk_score, 1),
+            "residual_risk_grade": self.residual_risk_grade,
+            "compliance_status": self.compliance_status,
+            "compliance_gaps": self.compliance_gaps,
+            "combined_risk_score": self.combined_risk_score,
+            "combined_grade": self.combined_grade,
+            "total_dpia_entries": self.total_dpia_entries,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "RiskReportV3":
+        """Create from dictionary."""
+        base_data = data.get("base", {})
+        base = RiskReport.from_dict(base_data) if base_data else RiskReport(ai_act_class="minimal")
+
+        dpia_entries_data = data.get("dpia_entries", [])
+        dpia_entries = [
+            DPIAEntry.from_dict(e) if isinstance(e, dict) else e
+            for e in dpia_entries_data
+        ]
+
+        conformity_data = data.get("ai_act_conformity", {})
+        conformity = AIActConformity.from_dict(conformity_data) if conformity_data else AIActConformity()
+
+        return cls(
+            base=base,
+            dpia_required=data.get("dpia_required", False),
+            dpia_reason=data.get("dpia_reason", ""),
+            dpia_entries=dpia_entries,
+            ai_act_conformity=conformity,
+            mitigation_plan=data.get("mitigation_plan", []),
+            mitigation_timeline=data.get("mitigation_timeline", {}),
+            residual_risk_score=float(data.get("residual_risk_score", 50.0)),
+            residual_risk_grade=data.get("residual_risk_grade", "C"),
+            compliance_status=data.get("compliance_status", "partial"),
+            compliance_gaps=data.get("compliance_gaps", []),
+        )
+
+
+# =============================================================================
+# DPIA DETERMINATION FUNCTIONS
+# =============================================================================
+
+def _determine_dpia_required(
+    ai_act_class: str,
+    dsgvo_risk_level: str,
+    data_categories: List[str],
+    briefing: Optional[Dict[str, Any]] = None,
+) -> Tuple[bool, str]:
+    """
+    Determine if DPIA is required based on GDPR Art. 35 criteria.
+
+    DPIA is required when processing is likely to result in high risk
+    to rights and freedoms of natural persons.
+
+    Returns:
+        Tuple of (dpia_required, reason)
+    """
+    reasons = []
+
+    # 1. High-Risk AI Act classification
+    if ai_act_class in ["high_risk", "unacceptable"]:
+        reasons.append("AI Act High-Risk Klassifizierung")
+
+    # 2. High DSGVO risk level
+    if dsgvo_risk_level == "hoch":
+        reasons.append("Hohes DSGVO-Risiko")
+
+    # 3. Sensitive data categories
+    sensitive_categories = [
+        cat for cat in data_categories
+        if cat.startswith("sensitive_") or cat == "children_data"
+    ]
+    if sensitive_categories:
+        reasons.append(f"Sensible Datenkategorien: {', '.join(sensitive_categories[:3])}")
+
+    # 4. Automated profiling
+    if "automated_profiling" in data_categories:
+        reasons.append("Automatisiertes Profiling")
+
+    # 5. Check briefing for DPIA triggers
+    if briefing:
+        # Systematic monitoring
+        if briefing.get("systematische_ueberwachung") or briefing.get("systematic_monitoring"):
+            reasons.append("Systematische Überwachung")
+
+        # Large-scale processing
+        if briefing.get("grosse_datenmenge") or briefing.get("large_scale_processing"):
+            reasons.append("Großflächige Datenverarbeitung")
+
+        # Automated decisions with legal effects
+        if briefing.get("automatisierte_entscheidungen") or briefing.get("automated_decisions"):
+            reasons.append("Automatisierte Entscheidungen mit rechtlicher Wirkung")
+
+        # Vulnerable groups
+        branch = str(briefing.get("branche", "")).lower()
+        if any(b in branch for b in ["gesundheit", "bildung", "kinder", "healthcare", "education"]):
+            reasons.append("Verarbeitung von Daten schutzbedürftiger Gruppen")
+
+    dpia_required = len(reasons) >= 1
+    reason_text = "; ".join(reasons) if reasons else "Keine DPIA-Anforderung identifiziert"
+
+    return dpia_required, reason_text
+
+
+def _determine_ai_act_controls(
+    ai_act_class: str,
+    tools_data: Optional[Any] = None,
+    strategy_data: Optional[Any] = None,
+) -> AIActConformity:
+    """
+    Determine required AI Act controls and assess conformity.
+
+    Args:
+        ai_act_class: AI Act classification
+        tools_data: Tools Engine data
+        strategy_data: Strategy Engine data
+
+    Returns:
+        AIActConformity assessment
+    """
+    # Only high-risk systems require full Annex III controls
+    if ai_act_class not in ["high_risk", "unacceptable"]:
+        # Limited risk systems only need transparency
+        return AIActConformity(
+            required_controls=["transparency_provision"],
+            implemented_controls=["transparency_provision"],
+            missing_controls=[],
+            conformity_score=1.0,
+            risk_implications=[],
+            remediation_timeline="phase_1",
+        )
+
+    # High-risk systems need all Annex III controls
+    required_controls = AI_ACT_ANNEX_III_CONTROLS.copy()
+    implemented_controls: List[str] = []
+    risk_implications: List[str] = []
+
+    # Check tools data for existing controls
+    if tools_data:
+        tools_list = tools_data if isinstance(tools_data, list) else []
+
+        for tool in tools_list:
+            if isinstance(tool, dict):
+                eu_hosting = tool.get("eu_hosting", False)
+                compliance_score = tool.get("compliance_score", 3)
+            else:
+                eu_hosting = getattr(tool, "eu_hosting", False)
+                compliance_score = getattr(tool, "compliance_score", 3)
+
+            # EU hosting implies some data governance
+            if eu_hosting:
+                if "data_governance" not in implemented_controls:
+                    implemented_controls.append("data_governance")
+
+            # Low compliance score implies security measures
+            if compliance_score <= 2:
+                if "accuracy_robustness_security" not in implemented_controls:
+                    implemented_controls.append("accuracy_robustness_security")
+
+    # Check strategy data for control implementations
+    if strategy_data:
+        phases = []
+        if hasattr(strategy_data, "phases"):
+            phases = strategy_data.phases
+        elif isinstance(strategy_data, dict):
+            phases = strategy_data.get("phases", [])
+
+        strategy_text = " ".join(
+            str(getattr(p, "focus", "") if hasattr(p, "focus") else p.get("focus", ""))
+            for p in phases
+        ).lower()
+
+        # Check for control keywords in strategy
+        control_keywords = {
+            "risk_management_system": ["risikomanagement", "risk management", "risikoanalyse"],
+            "technical_documentation": ["dokumentation", "documentation", "technische doku"],
+            "record_keeping": ["aufzeichnung", "logging", "protokoll", "record"],
+            "transparency_provision": ["transparenz", "transparency", "erklärbar"],
+            "human_oversight": ["human oversight", "menschliche kontrolle", "aufsicht"],
+        }
+
+        for control, keywords in control_keywords.items():
+            if any(kw in strategy_text for kw in keywords):
+                if control not in implemented_controls:
+                    implemented_controls.append(control)
+
+    # Calculate missing controls
+    missing_controls = [
+        ctrl for ctrl in required_controls
+        if ctrl not in implemented_controls
+    ]
+
+    # Generate risk implications for missing controls
+    control_implications = {
+        "risk_management_system": "Fehlendes Risikomanagement kann zu unerkannten Systemfehlern führen",
+        "data_governance": "Unzureichende Datengovernance gefährdet Datenqualität und -integrität",
+        "technical_documentation": "Fehlende technische Dokumentation erschwert Auditierbarkeit",
+        "record_keeping": "Ohne Aufzeichnungen keine Nachvollziehbarkeit von Entscheidungen",
+        "transparency_provision": "Mangelnde Transparenz verletzt Informationspflichten",
+        "human_oversight": "Ohne menschliche Aufsicht keine Kontrolle über kritische Entscheidungen",
+        "accuracy_robustness_security": "Unzureichende Sicherheit gefährdet System und Daten",
+    }
+
+    for ctrl in missing_controls:
+        if ctrl in control_implications:
+            risk_implications.append(control_implications[ctrl])
+
+    # Calculate conformity score
+    if required_controls:
+        conformity_score = len(implemented_controls) / len(required_controls)
+    else:
+        conformity_score = 1.0
+
+    # Determine remediation timeline based on gaps
+    if len(missing_controls) >= 4:
+        remediation_timeline = "phase_1"
+    elif len(missing_controls) >= 2:
+        remediation_timeline = "phase_2"
+    else:
+        remediation_timeline = "phase_3"
+
+    return AIActConformity(
+        required_controls=required_controls,
+        implemented_controls=implemented_controls,
+        missing_controls=missing_controls,
+        conformity_score=conformity_score,
+        risk_implications=risk_implications,
+        remediation_timeline=remediation_timeline,
+    )
+
+
+def _generate_dpia_entries(
+    ai_act_class: str,
+    dsgvo_risk_level: str,
+    data_categories: List[str],
+    use_cases: List[str],
+    briefing: Optional[Dict[str, Any]] = None,
+    size_label: str = "team",
+) -> List[DPIAEntry]:
+    """
+    Generate DPIA entries based on identified data processing activities.
+
+    Args:
+        ai_act_class: AI Act classification
+        dsgvo_risk_level: GDPR risk level
+        data_categories: Identified data categories
+        use_cases: Use cases from briefing
+        briefing: Briefing dictionary
+        size_label: Company size label
+
+    Returns:
+        List of DPIAEntry objects
+    """
+    entries: List[DPIAEntry] = []
+    constraints = SIZE_DPIA_LIMITS.get(size_label, SIZE_DPIA_LIMITS["team"])
+    max_entries = constraints["max_dpia_entries"]
+
+    # Entry 1: Primary KI Use Case
+    if use_cases:
+        primary_use_case = use_cases[0] if use_cases else "KI-Anwendung"
+        entries.append(DPIAEntry(
+            id="dpia_primary_usecase",
+            title=f"DPIA: {primary_use_case}",
+            description=f"Datenschutz-Folgenabschätzung für die primäre KI-Anwendung: {primary_use_case}",
+            legal_basis="legitimate_interest",
+            data_categories=[c for c in data_categories[:4] if c in DSGVO_DATA_CATEGORIES],
+            rights_risks=[
+                "Recht auf Auskunft (Art. 15 DSGVO)",
+                "Recht auf Berichtigung (Art. 16 DSGVO)",
+            ],
+            mitigation_measures=[
+                "Datenminimierung",
+                "Pseudonymisierung",
+                "Zugriffskontrolle",
+            ],
+            residual_risk="medium" if ai_act_class != "high_risk" else "high",
+        ))
+
+    # Entry 2: Automated Decision Making (if applicable)
+    if "automated_profiling" in data_categories or (briefing and briefing.get("automatisierte_entscheidungen")):
+        entries.append(DPIAEntry(
+            id="dpia_automated_decisions",
+            title="DPIA: Automatisierte Entscheidungen",
+            description="Folgenabschätzung für automatisierte Entscheidungsfindung mit KI-Unterstützung",
+            legal_basis="consent" if dsgvo_risk_level == "hoch" else "legitimate_interest",
+            data_categories=["automated_profiling", "personal_basic"],
+            rights_risks=[
+                "Recht auf Widerspruch gegen automatisierte Entscheidungen (Art. 22 DSGVO)",
+                "Recht auf menschliche Überprüfung",
+                "Recht auf Erklärung der Entscheidungslogik",
+            ],
+            mitigation_measures=[
+                "Human-in-the-Loop Prozess",
+                "Erklärbare KI (XAI)",
+                "Widerspruchsmöglichkeit",
+                "Regelmäßige Überprüfung",
+            ],
+            residual_risk="high",
+        ))
+
+    # Entry 3: Sensitive Data Processing (if applicable)
+    sensitive_cats = [c for c in data_categories if c.startswith("sensitive_")]
+    if sensitive_cats:
+        entries.append(DPIAEntry(
+            id="dpia_sensitive_data",
+            title="DPIA: Verarbeitung sensibler Daten",
+            description=f"Folgenabschätzung für die Verarbeitung besonderer Kategorien personenbezogener Daten: {', '.join(sensitive_cats[:3])}",
+            legal_basis="consent",
+            data_categories=sensitive_cats[:4],
+            rights_risks=[
+                "Besonderer Schutz nach Art. 9 DSGVO",
+                "Diskriminierungsrisiko",
+                "Stigmatisierungsrisiko",
+            ],
+            mitigation_measures=[
+                "Ausdrückliche Einwilligung",
+                "Verschlüsselung",
+                "Strenge Zugriffsbeschränkungen",
+                "Audit-Logging",
+            ],
+            residual_risk="high",
+        ))
+
+    # Entry 4: Vendor Data Transfer (if US vendors)
+    if briefing:
+        tools_html = str(briefing.get("_tools_html", "")).lower()
+        if "us" in tools_html or "openai" in tools_html or "microsoft" in tools_html:
+            entries.append(DPIAEntry(
+                id="dpia_vendor_transfer",
+                title="DPIA: Drittlandtransfer",
+                description="Folgenabschätzung für Datenübermittlung an US-Anbieter",
+                legal_basis="contract",
+                data_categories=["personal_basic", "personal_professional"],
+                rights_risks=[
+                    "Datentransfer in unsicheres Drittland",
+                    "Zugriff durch US-Behörden (CLOUD Act)",
+                ],
+                mitigation_measures=[
+                    "Standardvertragsklauseln (SCCs)",
+                    "Transfer Impact Assessment (TIA)",
+                    "Zusätzliche Schutzmaßnahmen",
+                    "Datenminimierung",
+                ],
+                residual_risk="medium",
+            ))
+
+    return entries[:max_entries]
+
+
+def _generate_mitigation_plan(
+    dpia_entries: List[DPIAEntry],
+    ai_act_conformity: AIActConformity,
+    strategy_data: Optional[Any] = None,
+) -> Tuple[List[str], Dict[str, List[str]]]:
+    """
+    Generate mitigation plan and timeline based on DPIA and AI Act gaps.
+
+    Returns:
+        Tuple of (mitigation_plan, mitigation_timeline)
+    """
+    plan: List[str] = []
+    timeline: Dict[str, List[str]] = {
+        "phase_1": [],
+        "phase_2": [],
+        "phase_3": [],
+    }
+
+    # Add mitigations from AI Act missing controls
+    for ctrl in ai_act_conformity.missing_controls:
+        ctrl_name = ctrl.replace("_", " ").title()
+        plan.append(f"AI Act Control implementieren: {ctrl_name}")
+
+        # Prioritize by control importance
+        if ctrl in ["human_oversight", "transparency_provision"]:
+            timeline["phase_1"].append(ctrl_name)
+        elif ctrl in ["risk_management_system", "data_governance"]:
+            timeline["phase_2"].append(ctrl_name)
+        else:
+            timeline["phase_3"].append(ctrl_name)
+
+    # Add mitigations from high-risk DPIA entries
+    for entry in dpia_entries:
+        if entry.residual_risk in ["high", "critical"]:
+            for measure in entry.mitigation_measures[:2]:
+                if measure not in plan:
+                    plan.append(f"DPIA-Maßnahme: {measure}")
+                    timeline["phase_1"].append(measure)
+
+    # Add general compliance measures
+    plan.append("Regelmäßige Compliance-Audits durchführen")
+    plan.append("Dokumentation und Nachweispflichten sicherstellen")
+
+    timeline["phase_2"].append("Compliance-Audit")
+    timeline["phase_3"].append("Dokumentationsreview")
+
+    return plan, timeline
+
+
+def _calculate_residual_risk_score(
+    base_score: float,
+    dpia_entries: List[DPIAEntry],
+    ai_act_conformity: AIActConformity,
+    mitigation_plan: List[str],
+) -> float:
+    """
+    Calculate residual risk score after mitigations.
+
+    Higher score = safer (like base consolidated score).
+
+    Returns:
+        Score from 0-100
+    """
+    # Start with base score
+    score = base_score
+
+    # Penalty for high-risk DPIA entries
+    high_risk_count = sum(1 for e in dpia_entries if e.residual_risk in ["high", "critical"])
+    score -= high_risk_count * 5
+
+    # Penalty for missing AI Act controls
+    missing_count = len(ai_act_conformity.missing_controls)
+    score -= missing_count * 3
+
+    # Bonus for mitigation plan
+    mitigation_bonus = min(15, len(mitigation_plan) * 2)
+    score += mitigation_bonus
+
+    # Bonus for conformity
+    conformity_bonus = ai_act_conformity.conformity_score * 10
+    score += conformity_bonus
+
+    return max(0.0, min(100.0, score))
+
+
+def _determine_compliance_status(
+    residual_risk_score: float,
+    ai_act_conformity: AIActConformity,
+    dpia_entries: List[DPIAEntry],
+) -> Tuple[str, List[str]]:
+    """
+    Determine overall compliance status and gaps.
+
+    Returns:
+        Tuple of (status, gaps)
+    """
+    gaps: List[str] = []
+
+    # Check AI Act conformity
+    if not ai_act_conformity.is_compliant:
+        gaps.append(f"AI Act Conformity nur {ai_act_conformity.conformity_score*100:.0f}% (min. 80% erforderlich)")
+        for ctrl in ai_act_conformity.missing_controls[:3]:
+            gaps.append(f"Fehlende Kontrolle: {ctrl.replace('_', ' ').title()}")
+
+    # Check DPIA entries for critical risks
+    critical_entries = [e for e in dpia_entries if e.residual_risk == "critical"]
+    if critical_entries:
+        gaps.append(f"{len(critical_entries)} kritische DPIA-Risiken unmitigiert")
+
+    # Check residual risk score
+    if residual_risk_score < 40:
+        gaps.append(f"Residual Risk Score zu niedrig ({residual_risk_score:.0f}/100)")
+
+    # Determine status
+    if not gaps:
+        status = "compliant"
+    elif len(gaps) <= 2 and residual_risk_score >= 50:
+        status = "partial"
+    else:
+        status = "non_compliant"
+
+    return status, gaps
+
+
+def _determine_size_label(briefing: Optional[Dict[str, Any]]) -> str:
+    """Determine company size label from briefing."""
+    if not briefing:
+        return "team"
+
+    size = str(briefing.get("unternehmensgroesse", "")).lower()
+
+    if "solo" in size or "freiberuf" in size or "einzelunternehm" in size:
+        return "solo"
+    elif "kmu" in size or "mittel" in size or ">10" in size:
+        return "kmu"
+    else:
+        return "team"
+
+
+# =============================================================================
+# MAIN GENERATION FUNCTION
+# =============================================================================
+
+def generate_risk_report_v3(
+    context: Optional[Any] = None,
+    sections: Optional[Dict[str, str]] = None,
+    tools_data: Optional[Any] = None,
+    funding_data: Optional[Any] = None,
+    strategy_data: Optional[Any] = None,
+    base_risk_report: Optional[RiskReport] = None,
+    briefing: Optional[Dict[str, Any]] = None,
+    llm_response: Optional[Dict[str, Any]] = None,
+) -> RiskReportV3:
+    """
+    Generate comprehensive Risk Report V3 with DPIA and AI Act Conformity.
+
+    Combines Risk Engine v2 base analysis with:
+    - DPIA automation (GDPR Art. 35)
+    - AI Act Annex III conformity mapping
+    - Enhanced mitigation planning
+    - Compliance status assessment
+
+    Args:
+        context: ReportContext object (optional)
+        sections: Dict of section_key -> HTML content
+        tools_data: Tools Engine 4.0 output
+        funding_data: Funding Engine v2 output
+        strategy_data: Strategy Engine output
+        base_risk_report: Existing RiskReport from G29 (optional)
+        briefing: Original briefing/answers dict
+        llm_response: Parsed JSON from LLM (if available)
+
+    Returns:
+        RiskReportV3 with complete DPIA and AI Act analysis
+    """
+    log.info("[G33] Generating Risk Report V3 with DPIA & AI Act Conformity...")
+
+    sections = sections or {}
+    briefing = briefing or {}
+
+    # Determine size
+    size_label = _determine_size_label(briefing)
+
+    # Use existing base report or create default
+    if base_risk_report:
+        base = base_risk_report
+    else:
+        # Create minimal base report
+        ai_act_class = extract_ai_act_class_from_sections(sections) or "minimal"
+        dsgvo_info = extract_dsgvo_risk_from_sections(sections, briefing)
+        vendor_info = extract_risk_from_tools(tools_data, sections)
+
+        base = RiskReport(
+            ai_act_class=ai_act_class,
+            dsgvo_risk_level=dsgvo_info.get("dsgvo_risk_level", "mittel"),
+            dsgvo_risk_factors=dsgvo_info.get("dsgvo_risk_factors", []),
+            vendor_category=vendor_info.get("vendor_category", "eu_compliant"),
+            vendor_risk_score=vendor_info.get("vendor_risk_score", 3),
+            vendor_flags=vendor_info.get("vendor_flags", []),
+            consolidated_score=50.0,
+            consolidated_grade="C",
+        )
+
+    # Extract data categories from briefing
+    data_categories: List[str] = []
+    if briefing:
+        raw_data_types = briefing.get("datentypen", [])
+        if isinstance(raw_data_types, str):
+            raw_data_types = [raw_data_types]
+
+        # Map to standard categories
+        type_mapping = {
+            "name": "personal_basic",
+            "email": "personal_basic",
+            "adresse": "personal_basic",
+            "telefon": "personal_contact",
+            "bank": "personal_financial",
+            "zahlung": "personal_financial",
+            "beruf": "personal_professional",
+            "arbeit": "personal_professional",
+            "gesundheit": "sensitive_health",
+            "medizin": "sensitive_health",
+            "biometri": "sensitive_biometric",
+            "genetik": "sensitive_genetic",
+            "politik": "sensitive_political",
+            "religion": "sensitive_religious",
+            "ethni": "sensitive_ethnic",
+            "sexual": "sensitive_sexual",
+            "kind": "children_data",
+            "tracking": "behavioral_tracking",
+            "profiling": "automated_profiling",
+        }
+
+        for dtype in raw_data_types:
+            dtype_lower = str(dtype).lower()
+            for key, category in type_mapping.items():
+                if key in dtype_lower and category not in data_categories:
+                    data_categories.append(category)
+
+        # Add profiling if automated decisions
+        if briefing.get("automatisierte_entscheidungen"):
+            if "automated_profiling" not in data_categories:
+                data_categories.append("automated_profiling")
+
+    # Use LLM response if provided
+    if llm_response:
+        return RiskReportV3.from_dict(llm_response)
+
+    # Determine if DPIA is required
+    dpia_required, dpia_reason = _determine_dpia_required(
+        ai_act_class=base.ai_act_class,
+        dsgvo_risk_level=base.dsgvo_risk_level,
+        data_categories=data_categories,
+        briefing=briefing,
+    )
+
+    # Get use cases from briefing
+    use_cases: List[str] = []
+    if briefing:
+        ki_anwendung = briefing.get("ki_anwendung", "")
+        if ki_anwendung:
+            use_cases.append(ki_anwendung)
+        use_cases_raw = briefing.get("use_cases", [])
+        if isinstance(use_cases_raw, list):
+            use_cases.extend(use_cases_raw)
+
+    # Generate DPIA entries if required
+    dpia_entries: List[DPIAEntry] = []
+    if dpia_required:
+        dpia_entries = _generate_dpia_entries(
+            ai_act_class=base.ai_act_class,
+            dsgvo_risk_level=base.dsgvo_risk_level,
+            data_categories=data_categories,
+            use_cases=use_cases,
+            briefing=briefing,
+            size_label=size_label,
+        )
+
+    # Determine AI Act conformity
+    ai_act_conformity = _determine_ai_act_controls(
+        ai_act_class=base.ai_act_class,
+        tools_data=tools_data,
+        strategy_data=strategy_data,
+    )
+
+    # Generate mitigation plan
+    mitigation_plan, mitigation_timeline = _generate_mitigation_plan(
+        dpia_entries=dpia_entries,
+        ai_act_conformity=ai_act_conformity,
+        strategy_data=strategy_data,
+    )
+
+    # Calculate residual risk score
+    residual_risk_score = _calculate_residual_risk_score(
+        base_score=base.consolidated_score,
+        dpia_entries=dpia_entries,
+        ai_act_conformity=ai_act_conformity,
+        mitigation_plan=mitigation_plan,
+    )
+
+    # Determine compliance status
+    compliance_status, compliance_gaps = _determine_compliance_status(
+        residual_risk_score=residual_risk_score,
+        ai_act_conformity=ai_act_conformity,
+        dpia_entries=dpia_entries,
+    )
+
+    report = RiskReportV3(
+        base=base,
+        dpia_required=dpia_required,
+        dpia_reason=dpia_reason,
+        dpia_entries=dpia_entries,
+        ai_act_conformity=ai_act_conformity,
+        mitigation_plan=mitigation_plan,
+        mitigation_timeline=mitigation_timeline,
+        residual_risk_score=residual_risk_score,
+        residual_risk_grade=_score_to_grade(residual_risk_score),
+        compliance_status=compliance_status,
+        compliance_gaps=compliance_gaps,
+    )
+
+    log.info(
+        "[G33] Risk Report V3 generated: DPIA=%s, AI Act Conformity=%.0f%%, "
+        "Residual Risk=%s (%s), Compliance=%s",
+        "Required" if dpia_required else "Not Required",
+        ai_act_conformity.conformity_score * 100,
+        report.residual_risk_grade,
+        f"{residual_risk_score:.0f}/100",
+        compliance_status,
+    )
+
+    return report
+
+
+# =============================================================================
+# HTML RENDERING
+# =============================================================================
+
+def risk_report_v3_to_html(
+    report: RiskReportV3,
+    lang: str = "de",
+) -> str:
+    """
+    Generate HTML section for Risk Report V3.
+
+    Includes:
+    - DPIA Overview
+    - AI Act Conformity Block
+    - Vendor Risk Deep Dive
+    - Data Categories & Legal Basis
+    - Mitigation Plan
+    - Residual Risk Score
+    - Compliance Summary
+
+    Args:
+        report: RiskReportV3 object
+        lang: Language code ("de" or "en")
+
+    Returns:
+        HTML string for PDF template
+    """
+    # Labels
+    if lang == "en":
+        labels = {
+            "title": "DPIA & AI Act Conformity",
+            "dpia_required": "DPIA Required",
+            "dpia_not_required": "DPIA Not Required",
+            "yes": "Yes",
+            "no": "No",
+            "reason": "Reason",
+            "ai_act_conformity": "AI Act Conformity",
+            "required_controls": "Required Controls",
+            "implemented": "Implemented",
+            "missing": "Missing",
+            "conformity_score": "Conformity Score",
+            "risk_implications": "Risk Implications",
+            "dpia_entries": "DPIA Analysis",
+            "legal_basis": "Legal Basis",
+            "data_categories": "Data Categories",
+            "rights_risks": "Rights at Risk",
+            "mitigations": "Mitigations",
+            "residual_risk": "Residual Risk",
+            "mitigation_plan": "Mitigation Plan",
+            "compliance_summary": "Compliance Summary",
+            "compliance_gaps": "Compliance Gaps",
+            "combined_score": "Combined Risk Score",
+            "phase_1": "Phase 1 (Immediate)",
+            "phase_2": "Phase 2 (Short-term)",
+            "phase_3": "Phase 3 (Long-term)",
+            "compliant": "Compliant",
+            "partial": "Partially Compliant",
+            "non_compliant": "Non-Compliant",
+        }
+        legal_basis_labels = {
+            "consent": "Consent (Art. 6(1)(a))",
+            "contract": "Contract (Art. 6(1)(b))",
+            "legal_obligation": "Legal Obligation (Art. 6(1)(c))",
+            "vital_interests": "Vital Interests (Art. 6(1)(d))",
+            "public_task": "Public Task (Art. 6(1)(e))",
+            "legitimate_interest": "Legitimate Interest (Art. 6(1)(f))",
+        }
+    else:
+        labels = {
+            "title": "DPIA & AI Act Konformität",
+            "dpia_required": "DPIA Erforderlich",
+            "dpia_not_required": "DPIA Nicht Erforderlich",
+            "yes": "Ja",
+            "no": "Nein",
+            "reason": "Begründung",
+            "ai_act_conformity": "AI Act Konformität",
+            "required_controls": "Erforderliche Kontrollen",
+            "implemented": "Implementiert",
+            "missing": "Fehlend",
+            "conformity_score": "Konformitäts-Score",
+            "risk_implications": "Risiko-Implikationen",
+            "dpia_entries": "DPIA-Analyse",
+            "legal_basis": "Rechtsgrundlage",
+            "data_categories": "Datenkategorien",
+            "rights_risks": "Gefährdete Rechte",
+            "mitigations": "Schutzmaßnahmen",
+            "residual_risk": "Restrisiko",
+            "mitigation_plan": "Maßnahmenplan",
+            "compliance_summary": "Compliance-Status",
+            "compliance_gaps": "Compliance-Lücken",
+            "combined_score": "Kombinierter Risiko-Score",
+            "phase_1": "Phase 1 (Sofort)",
+            "phase_2": "Phase 2 (Kurzfristig)",
+            "phase_3": "Phase 3 (Langfristig)",
+            "compliant": "Konform",
+            "partial": "Teilweise Konform",
+            "non_compliant": "Nicht Konform",
+        }
+        legal_basis_labels = {
+            "consent": "Einwilligung (Art. 6(1)(a))",
+            "contract": "Vertragserfüllung (Art. 6(1)(b))",
+            "legal_obligation": "Rechtliche Verpflichtung (Art. 6(1)(c))",
+            "vital_interests": "Lebenswichtige Interessen (Art. 6(1)(d))",
+            "public_task": "Öffentliche Aufgabe (Art. 6(1)(e))",
+            "legitimate_interest": "Berechtigtes Interesse (Art. 6(1)(f))",
+        }
+
+    # Colors
+    status_colors = {
+        "compliant": "#22c55e",
+        "partial": "#f59e0b",
+        "non_compliant": "#dc2626",
+    }
+    risk_colors = {
+        "low": "#22c55e",
+        "medium": "#f59e0b",
+        "high": "#f97316",
+        "critical": "#dc2626",
+    }
+    grade_colors = {
+        "A": "#22c55e",
+        "B": "#84cc16",
+        "C": "#f59e0b",
+        "D": "#f97316",
+        "F": "#dc2626",
+    }
+
+    html_parts = [f'''
+    <div class="risk-engine-v3" style="font-size:11pt;">
+        <div style="display:flex;align-items:center;gap:10px;margin-bottom:16px;">
+            <span style="font-size:20px;">🛡️</span>
+            <span style="font-size:11px;padding:2px 8px;background:#dc2626;color:#fff;border-radius:4px;font-weight:600;">G33</span>
+        </div>
+    ''']
+
+    # DPIA Status Block
+    dpia_color = "#dc2626" if report.dpia_required else "#22c55e"
+    dpia_status = labels["dpia_required"] if report.dpia_required else labels["dpia_not_required"]
+
+    html_parts.append(f'''
+        <div class="dpia-status-block" style="padding:16px;background:linear-gradient(135deg,#fff 0%,#fef2f2 100%);border-radius:12px;border:2px solid {dpia_color};margin-bottom:20px;">
+            <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:8px;">
+                <span style="font-weight:700;font-size:13pt;color:#1e293b;">📋 {dpia_status}</span>
+                <span style="font-size:11px;padding:4px 12px;background:{dpia_color};color:#fff;border-radius:20px;">{labels["yes"] if report.dpia_required else labels["no"]}</span>
+            </div>
+            <p style="margin:0;color:#64748b;font-size:10pt;">{labels["reason"]}: {report.dpia_reason}</p>
+        </div>
+    ''')
+
+    # AI Act Conformity Block
+    conformity = report.ai_act_conformity
+    conformity_color = grade_colors.get(conformity.conformity_grade, "#f59e0b")
+
+    html_parts.append(f'''
+        <div class="ai-act-conformity-block" style="padding:16px;background:#f8fafc;border-radius:12px;border:1px solid #e2e8f0;margin-bottom:20px;">
+            <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:12px;">
+                <span style="font-weight:700;font-size:12pt;color:#1e293b;">⚖️ {labels["ai_act_conformity"]}</span>
+                <div style="text-align:right;">
+                    <span style="font-size:24px;font-weight:700;color:{conformity_color};">{conformity.conformity_score*100:.0f}%</span>
+                    <span style="font-size:11px;padding:2px 8px;background:{conformity_color};color:#fff;border-radius:4px;margin-left:8px;">{conformity.conformity_grade}</span>
+                </div>
+            </div>
+
+            <div style="display:flex;gap:12px;margin-bottom:12px;">
+                <div style="flex:1;padding:12px;background:#dcfce7;border-radius:8px;">
+                    <span style="font-size:10px;color:#166534;font-weight:600;">{labels["implemented"]}</span>
+                    <div style="font-size:18px;font-weight:700;color:#166534;">{len(conformity.implemented_controls)}</div>
+                </div>
+                <div style="flex:1;padding:12px;background:#fef2f2;border-radius:8px;">
+                    <span style="font-size:10px;color:#dc2626;font-weight:600;">{labels["missing"]}</span>
+                    <div style="font-size:18px;font-weight:700;color:#dc2626;">{len(conformity.missing_controls)}</div>
+                </div>
+            </div>
+    ''')
+
+    # Missing controls list
+    if conformity.missing_controls:
+        html_parts.append(f'''
+            <div style="margin-top:12px;">
+                <span style="font-size:10px;color:#64748b;font-weight:600;">{labels["missing"]}:</span>
+                <div style="display:flex;flex-wrap:wrap;gap:6px;margin-top:6px;">
+        ''')
+        for ctrl in conformity.missing_controls[:5]:
+            ctrl_name = ctrl.replace("_", " ").title()
+            html_parts.append(f'''
+                    <span style="font-size:9px;padding:2px 8px;background:#dc262622;color:#dc2626;border-radius:4px;border:1px solid #dc262644;">{ctrl_name}</span>
+            ''')
+        html_parts.append('</div></div>')
+
+    # Risk implications
+    if conformity.risk_implications:
+        html_parts.append(f'''
+            <div style="margin-top:12px;padding:12px;background:#fef9c3;border-radius:8px;border:1px solid #fde04744;">
+                <span style="font-size:10px;color:#854d0e;font-weight:600;">⚠️ {labels["risk_implications"]}:</span>
+                <ul style="margin:8px 0 0 16px;padding:0;font-size:9pt;color:#854d0e;">
+        ''')
+        for impl in conformity.risk_implications[:3]:
+            html_parts.append(f'<li style="margin-bottom:4px;">{impl}</li>')
+        html_parts.append('</ul></div>')
+
+    html_parts.append('</div>')
+
+    # DPIA Entries
+    if report.dpia_entries:
+        html_parts.append(f'''
+            <div class="dpia-entries-section" style="margin-bottom:20px;">
+                <p style="font-weight:700;font-size:12pt;color:#1e293b;margin:0 0 12px 0;">📝 {labels["dpia_entries"]}</p>
+                <div style="display:flex;flex-direction:column;gap:12px;">
+        ''')
+
+        for entry in report.dpia_entries:
+            entry_risk_color = risk_colors.get(entry.residual_risk, "#f59e0b")
+            legal_basis_label = legal_basis_labels.get(entry.legal_basis, entry.legal_basis)
+
+            html_parts.append(f'''
+                <div class="dpia-entry-card" style="padding:16px;background:#fff;border-radius:8px;border:1px solid #e2e8f0;border-left:4px solid {entry_risk_color};">
+                    <div style="display:flex;justify-content:space-between;align-items:flex-start;margin-bottom:8px;">
+                        <h4 style="margin:0;font-size:11pt;color:#1e293b;font-weight:600;">{entry.title}</h4>
+                        <span style="font-size:9px;padding:2px 8px;background:{entry_risk_color};color:#fff;border-radius:4px;">{entry.residual_risk.upper()}</span>
+                    </div>
+
+                    <p style="margin:0 0 8px 0;color:#64748b;font-size:10pt;">{entry.description}</p>
+
+                    <div style="display:flex;flex-wrap:wrap;gap:8px;margin-bottom:8px;">
+                        <span style="font-size:9px;padding:2px 8px;background:#3b82f622;color:#3b82f6;border-radius:4px;">📜 {legal_basis_label}</span>
+            ''')
+
+            # Data categories
+            for cat in entry.data_categories[:3]:
+                cat_name = cat.replace("_", " ").title()
+                html_parts.append(f'''
+                        <span style="font-size:8px;padding:2px 6px;background:#8b5cf622;color:#8b5cf6;border-radius:3px;">{cat_name}</span>
+                ''')
+
+            html_parts.append('</div>')
+
+            # Mitigation measures
+            if entry.mitigation_measures:
+                html_parts.append(f'''
+                    <div style="margin-top:8px;font-size:9pt;color:#64748b;">
+                        <span style="font-weight:600;">{labels["mitigations"]}:</span> {", ".join(entry.mitigation_measures[:3])}
+                    </div>
+                ''')
+
+            html_parts.append('</div>')
+
+        html_parts.append('</div></div>')
+
+    # Mitigation Plan & Timeline
+    if report.mitigation_plan:
+        html_parts.append(f'''
+            <div class="mitigation-plan-section" style="padding:16px;background:#f0fdf4;border-radius:12px;border:1px solid #22c55e44;margin-bottom:20px;">
+                <p style="font-weight:700;font-size:12pt;color:#166534;margin:0 0 12px 0;">🎯 {labels["mitigation_plan"]}</p>
+        ''')
+
+        # Phase-wise timeline
+        for phase_key, phase_label in [("phase_1", labels["phase_1"]), ("phase_2", labels["phase_2"]), ("phase_3", labels["phase_3"])]:
+            phase_items = report.mitigation_timeline.get(phase_key, [])
+            if phase_items:
+                phase_colors = {"phase_1": "#dc2626", "phase_2": "#f59e0b", "phase_3": "#22c55e"}
+                html_parts.append(f'''
+                    <div style="margin-bottom:8px;">
+                        <span style="font-size:10px;padding:2px 8px;background:{phase_colors[phase_key]};color:#fff;border-radius:4px;">{phase_label}</span>
+                        <ul style="margin:6px 0 0 16px;padding:0;font-size:9pt;color:#1e293b;">
+                ''')
+                for item in phase_items[:3]:
+                    html_parts.append(f'<li style="margin-bottom:2px;">{item}</li>')
+                html_parts.append('</ul></div>')
+
+        html_parts.append('</div>')
+
+    # Compliance Summary
+    status_color = status_colors.get(report.compliance_status, "#f59e0b")
+    status_label = labels.get(report.compliance_status, report.compliance_status)
+    combined_grade_color = grade_colors.get(report.combined_grade, "#f59e0b")
+
+    html_parts.append(f'''
+        <div class="compliance-summary" style="padding:16px;background:linear-gradient(135deg,#f8fafc 0%,#fff 100%);border-radius:12px;border:2px solid {status_color};">
+            <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:12px;">
+                <span style="font-weight:700;font-size:12pt;color:#1e293b;">✅ {labels["compliance_summary"]}</span>
+                <span style="font-size:11px;padding:4px 12px;background:{status_color};color:#fff;border-radius:20px;font-weight:600;">{status_label}</span>
+            </div>
+
+            <div style="display:flex;gap:12px;">
+                <div style="flex:1;padding:12px;background:#fff;border-radius:8px;border:1px solid #e2e8f0;text-align:center;">
+                    <span style="font-size:9px;color:#64748b;">{labels["combined_score"]}</span>
+                    <div style="font-size:20px;font-weight:700;color:{combined_grade_color};">{report.combined_risk_score:.0f}</div>
+                    <span style="font-size:11px;padding:2px 6px;background:{combined_grade_color};color:#fff;border-radius:3px;">{report.combined_grade}</span>
+                </div>
+                <div style="flex:1;padding:12px;background:#fff;border-radius:8px;border:1px solid #e2e8f0;text-align:center;">
+                    <span style="font-size:9px;color:#64748b;">{labels["residual_risk"]}</span>
+                    <div style="font-size:20px;font-weight:700;color:{grade_colors.get(report.residual_risk_grade, '#f59e0b')};">{report.residual_risk_score:.0f}</div>
+                    <span style="font-size:11px;padding:2px 6px;background:{grade_colors.get(report.residual_risk_grade, '#f59e0b')};color:#fff;border-radius:3px;">{report.residual_risk_grade}</span>
+                </div>
+            </div>
+    ''')
+
+    # Compliance gaps
+    if report.compliance_gaps:
+        html_parts.append(f'''
+            <div style="margin-top:12px;">
+                <span style="font-size:10px;color:#64748b;font-weight:600;">{labels["compliance_gaps"]}:</span>
+                <ul style="margin:6px 0 0 16px;padding:0;font-size:9pt;color:#dc2626;">
+        ''')
+        for gap in report.compliance_gaps[:4]:
+            html_parts.append(f'<li style="margin-bottom:2px;">{gap}</li>')
+        html_parts.append('</ul></div>')
+
+    html_parts.append('</div></div>')
+
+    return '\n'.join(html_parts)
+
+
+# =============================================================================
+# VALIDATION HELPERS (for Consistency Engine)
+# =============================================================================
+
+def validate_dpia_required(
+    report: RiskReportV3,
+    strategy_data: Optional[Any] = None,
+) -> Tuple[bool, List[str]]:
+    """
+    Validate DPIA requirements are met in strategy.
+
+    RISK3_001: If DPIA required, Strategy Engine must contain measures.
+
+    Returns:
+        Tuple of (is_valid, list of error messages)
+    """
+    errors: List[str] = []
+
+    if not report.dpia_required:
+        return True, []
+
+    if not strategy_data:
+        errors.append("DPIA erforderlich, aber keine Strategy-Daten vorhanden")
+        return False, errors
+
+    # Check strategy for DPIA-related measures
+    strategy_text = ""
+    if hasattr(strategy_data, "phases"):
+        for phase in strategy_data.phases:
+            strategy_text += str(getattr(phase, "focus", "")) + " "
+    elif isinstance(strategy_data, dict):
+        for phase in strategy_data.get("phases", []):
+            strategy_text += str(phase.get("focus", "")) + " "
+
+    strategy_lower = strategy_text.lower()
+    dpia_keywords = ["dpia", "datenschutz", "privacy", "dsgvo", "gdpr", "folgenabschätzung"]
+
+    if not any(kw in strategy_lower for kw in dpia_keywords):
+        errors.append("DPIA erforderlich, aber keine DPIA-Maßnahmen im Strategy Plan")
+
+    return len(errors) == 0, errors
+
+
+def validate_ai_act_conformity(
+    report: RiskReportV3,
+    strategy_data: Optional[Any] = None,
+) -> Tuple[bool, List[str]]:
+    """
+    Validate AI Act conformity gaps are addressed in strategy.
+
+    RISK3_002: Missing controls must be in Strategy Phase 1 or 2.
+
+    Returns:
+        Tuple of (is_valid, list of error messages)
+    """
+    errors: List[str] = []
+
+    missing_controls = report.ai_act_conformity.missing_controls
+    if not missing_controls:
+        return True, []
+
+    if not strategy_data:
+        errors.append(f"AI Act Controls fehlen ({len(missing_controls)}), aber keine Strategy-Daten")
+        return False, errors
+
+    # Check strategy for control implementations
+    strategy_text = ""
+    if hasattr(strategy_data, "phases"):
+        for phase in strategy_data.phases:
+            strategy_text += str(getattr(phase, "focus", "")) + " "
+    elif isinstance(strategy_data, dict):
+        for phase in strategy_data.get("phases", []):
+            strategy_text += str(phase.get("focus", "")) + " "
+
+    strategy_lower = strategy_text.lower()
+
+    for ctrl in missing_controls:
+        ctrl_keywords = ctrl.replace("_", " ").split()
+        if not any(kw in strategy_lower for kw in ctrl_keywords):
+            errors.append(f"Missing AI Act Control '{ctrl}' nicht im Strategy Plan adressiert")
+
+    return len(errors) == 0, errors
+
+
+# =============================================================================
+# MODULE INITIALIZATION
+# =============================================================================
+
+log.info("[G33] Risk Engine V3 loaded")

--- a/templates/pdf_template.html
+++ b/templates/pdf_template.html
@@ -2539,6 +2539,24 @@
                     </div>
                 </section>
                 {% endif %}
+                <!-- G33: Risk Engine 3.0 – DPIA & AI Act Conformity -->
+                {% if RISK_ENGINE_V3_HTML %}
+                <section class="section chapter" id="risk-engine-v3">
+                    <div class="section-header">
+                        <div class="section-title">
+                            <span class="section-kicker">DPIA &amp; Compliance</span>
+                            <h2>DPIA-Analyse &amp; AI Act Konformität</h2>
+                        </div>
+                        <span class="section-pill">
+                            <span class="pill-dot"></span>
+                            DSGVO Art. 35 • AI Act Annex III
+                        </span>
+                    </div>
+                    <div class="section-body">
+                        {{ RISK_ENGINE_V3_HTML|safe }}
+                    </div>
+                </section>
+                {% endif %}
                 <!-- G30: Business Case Engine 2.0 – ROI-Simulation & Szenarien -->
                 {% if BUSINESS_CASE_ENGINE_HTML %}
                 <section class="section chapter" id="business-case-engine">

--- a/templates/pdf_template_en.html
+++ b/templates/pdf_template_en.html
@@ -2056,6 +2056,24 @@
                     </div>
                 </section>
                 {% endif %}
+                <!-- G33: Risk Engine 3.0 – DPIA & AI Act Conformity -->
+                {% if RISK_ENGINE_V3_HTML %}
+                <section class="section chapter" id="risk-engine-v3">
+                    <div class="section-header">
+                        <div class="section-title">
+                            <span class="section-kicker">DPIA &amp; Compliance</span>
+                            <h2>DPIA Analysis &amp; AI Act Conformity</h2>
+                        </div>
+                        <span class="section-pill">
+                            <span class="pill-dot"></span>
+                            GDPR Art. 35 • AI Act Annex III
+                        </span>
+                    </div>
+                    <div class="section-body">
+                        {{ RISK_ENGINE_V3_HTML|safe }}
+                    </div>
+                </section>
+                {% endif %}
                 <!-- G30: Business Case Engine 2.0 – ROI Simulation & Scenarios -->
                 {% if BUSINESS_CASE_ENGINE_HTML %}
                 <section class="section chapter" id="business-case-engine">

--- a/tests/test_g33_risk_engine_v3.py
+++ b/tests/test_g33_risk_engine_v3.py
@@ -1,0 +1,906 @@
+# -*- coding: utf-8 -*-
+"""
+Sprint G33: Risk Engine 3.0 Tests
+=================================
+
+Comprehensive test suite for Risk Engine 3.0 with 60+ tests covering:
+- Data structures (DPIAEntry, AIActConformity, RiskReportV3)
+- DPIA determination logic
+- AI Act conformity mapping
+- Mitigation plan generation
+- Residual risk calculation
+- HTML generation
+- Consistency Engine integration (RISK3_001-RISK3_008)
+
+Version: 1.0.0 (Sprint G33)
+"""
+from __future__ import annotations
+
+import pytest
+from typing import Dict, Any, List, Optional
+
+
+# =============================================================================
+# TEST: Data Structures - DPIAEntry
+# =============================================================================
+
+class TestDPIAEntry:
+    """Tests for DPIAEntry dataclass."""
+
+    def test_basic_creation(self) -> None:
+        """Test DPIAEntry can be instantiated with basic values."""
+        from services.risk_engine_v3 import DPIAEntry
+
+        entry = DPIAEntry(
+            id="dpia_001",
+            title="DPIA: Customer Service",
+            description="DPIA for customer service chatbot",
+            legal_basis="legitimate_interest",
+            data_categories=["personal_basic", "personal_contact"],
+            rights_risks=["Right to access", "Right to erasure"],
+            mitigation_measures=["Data minimization", "Pseudonymization"],
+            residual_risk="medium",
+        )
+
+        assert entry.id == "dpia_001"
+        assert entry.title == "DPIA: Customer Service"
+        assert entry.legal_basis == "legitimate_interest"
+        assert entry.residual_risk == "medium"
+
+    def test_invalid_legal_basis_normalized(self) -> None:
+        """Test invalid legal_basis is normalized."""
+        from services.risk_engine_v3 import DPIAEntry
+
+        entry = DPIAEntry(
+            id="dpia_001",
+            title="Test",
+            description="Test",
+            legal_basis="invalid_basis",
+        )
+
+        assert entry.legal_basis == "legitimate_interest"
+
+    def test_invalid_residual_risk_normalized(self) -> None:
+        """Test invalid residual_risk is normalized."""
+        from services.risk_engine_v3 import DPIAEntry
+
+        entry = DPIAEntry(
+            id="dpia_001",
+            title="Test",
+            description="Test",
+            legal_basis="consent",
+            residual_risk="extreme",
+        )
+
+        assert entry.residual_risk == "medium"
+
+    def test_valid_residual_risks(self) -> None:
+        """Test all valid residual_risk values."""
+        from services.risk_engine_v3 import DPIAEntry, RESIDUAL_RISK_LEVELS
+
+        for risk_level in RESIDUAL_RISK_LEVELS:
+            entry = DPIAEntry(
+                id="dpia_001",
+                title="Test",
+                description="Test",
+                legal_basis="consent",
+                residual_risk=risk_level,
+            )
+            assert entry.residual_risk == risk_level
+
+    def test_has_sensitive_data_true(self) -> None:
+        """Test has_sensitive_data property returns True for sensitive data."""
+        from services.risk_engine_v3 import DPIAEntry
+
+        entry = DPIAEntry(
+            id="dpia_001",
+            title="Test",
+            description="Test",
+            legal_basis="consent",
+            data_categories=["sensitive_health", "personal_basic"],
+        )
+
+        assert entry.has_sensitive_data is True
+
+    def test_has_sensitive_data_false(self) -> None:
+        """Test has_sensitive_data property returns False for non-sensitive data."""
+        from services.risk_engine_v3 import DPIAEntry
+
+        entry = DPIAEntry(
+            id="dpia_001",
+            title="Test",
+            description="Test",
+            legal_basis="contract",
+            data_categories=["personal_basic", "personal_contact"],
+        )
+
+        assert entry.has_sensitive_data is False
+
+    def test_risk_score_calculation(self) -> None:
+        """Test risk_score property calculation."""
+        from services.risk_engine_v3 import DPIAEntry
+
+        entry = DPIAEntry(
+            id="dpia_001",
+            title="Test",
+            description="Test",
+            legal_basis="consent",
+            data_categories=["personal_basic"],
+            rights_risks=["Risk 1", "Risk 2", "Risk 3", "Risk 4"],
+            residual_risk="high",
+        )
+
+        # Base score for high is 3, plus 2 for 4 rights_risks (4//2=2)
+        assert entry.risk_score >= 3
+
+    def test_to_dict_serialization(self) -> None:
+        """Test DPIAEntry serialization to dict."""
+        from services.risk_engine_v3 import DPIAEntry
+
+        entry = DPIAEntry(
+            id="dpia_001",
+            title="Test",
+            description="Description",
+            legal_basis="consent",
+            data_categories=["personal_basic"],
+            rights_risks=["Risk 1"],
+            mitigation_measures=["Measure 1"],
+            residual_risk="low",
+        )
+
+        data = entry.to_dict()
+
+        assert data["id"] == "dpia_001"
+        assert data["legal_basis"] == "consent"
+        assert data["residual_risk"] == "low"
+        assert "has_sensitive_data" in data
+        assert "risk_score" in data
+
+    def test_from_dict_deserialization(self) -> None:
+        """Test DPIAEntry creation from dict."""
+        from services.risk_engine_v3 import DPIAEntry
+
+        data = {
+            "id": "dpia_002",
+            "title": "From Dict",
+            "description": "Description",
+            "legal_basis": "contract",
+            "data_categories": ["personal_financial"],
+            "rights_risks": ["Risk A"],
+            "mitigation_measures": ["Measure A"],
+            "residual_risk": "high",
+        }
+
+        entry = DPIAEntry.from_dict(data)
+
+        assert entry.id == "dpia_002"
+        assert entry.legal_basis == "contract"
+        assert entry.residual_risk == "high"
+
+
+# =============================================================================
+# TEST: Data Structures - AIActConformity
+# =============================================================================
+
+class TestAIActConformity:
+    """Tests for AIActConformity dataclass."""
+
+    def test_basic_creation(self) -> None:
+        """Test AIActConformity can be instantiated."""
+        from services.risk_engine_v3 import AIActConformity
+
+        conformity = AIActConformity(
+            required_controls=["transparency_provision", "human_oversight"],
+            implemented_controls=["transparency_provision"],
+            missing_controls=["human_oversight"],
+            conformity_score=0.5,
+            risk_implications=["Missing human oversight"],
+            remediation_timeline="phase_2",
+        )
+
+        assert len(conformity.required_controls) == 2
+        assert len(conformity.implemented_controls) == 1
+        assert len(conformity.missing_controls) == 1
+        assert conformity.conformity_score == 0.5
+
+    def test_conformity_score_clamped(self) -> None:
+        """Test conformity_score is clamped to 0-1."""
+        from services.risk_engine_v3 import AIActConformity
+
+        conformity_high = AIActConformity(conformity_score=1.5)
+        conformity_low = AIActConformity(conformity_score=-0.5)
+
+        assert conformity_high.conformity_score == 1.0
+        assert conformity_low.conformity_score == 0.0
+
+    def test_auto_calculate_missing_controls(self) -> None:
+        """Test missing_controls is auto-calculated if not provided."""
+        from services.risk_engine_v3 import AIActConformity
+
+        conformity = AIActConformity(
+            required_controls=["control_a", "control_b", "control_c"],
+            implemented_controls=["control_a"],
+            missing_controls=[],  # Should be auto-calculated
+        )
+
+        assert "control_b" in conformity.missing_controls
+        assert "control_c" in conformity.missing_controls
+        assert "control_a" not in conformity.missing_controls
+
+    def test_auto_calculate_conformity_score(self) -> None:
+        """Test conformity_score is auto-calculated if zero."""
+        from services.risk_engine_v3 import AIActConformity
+
+        conformity = AIActConformity(
+            required_controls=["control_a", "control_b", "control_c", "control_d"],
+            implemented_controls=["control_a", "control_b"],
+            conformity_score=0.0,  # Should be auto-calculated
+        )
+
+        assert conformity.conformity_score == 0.5  # 2/4
+
+    def test_is_compliant_true(self) -> None:
+        """Test is_compliant property returns True when score >= 0.8."""
+        from services.risk_engine_v3 import AIActConformity
+
+        conformity = AIActConformity(conformity_score=0.85)
+
+        assert conformity.is_compliant is True
+
+    def test_is_compliant_false(self) -> None:
+        """Test is_compliant property returns False when score < 0.8."""
+        from services.risk_engine_v3 import AIActConformity
+
+        conformity = AIActConformity(conformity_score=0.7)
+
+        assert conformity.is_compliant is False
+
+    def test_conformity_grade_a(self) -> None:
+        """Test conformity_grade returns A for score >= 0.9."""
+        from services.risk_engine_v3 import AIActConformity
+
+        conformity = AIActConformity(conformity_score=0.95)
+
+        assert conformity.conformity_grade == "A"
+
+    def test_conformity_grade_f(self) -> None:
+        """Test conformity_grade returns F for score < 0.4."""
+        from services.risk_engine_v3 import AIActConformity
+
+        conformity = AIActConformity(conformity_score=0.3)
+
+        assert conformity.conformity_grade == "F"
+
+    def test_to_dict_serialization(self) -> None:
+        """Test AIActConformity serialization to dict."""
+        from services.risk_engine_v3 import AIActConformity
+
+        conformity = AIActConformity(
+            required_controls=["ctrl_a", "ctrl_b"],
+            implemented_controls=["ctrl_a"],
+            conformity_score=0.5,
+        )
+
+        data = conformity.to_dict()
+
+        assert "required_controls" in data
+        assert "implemented_controls" in data
+        assert "missing_controls" in data
+        assert "conformity_score" in data
+        assert "conformity_grade" in data
+        assert "is_compliant" in data
+
+    def test_from_dict_deserialization(self) -> None:
+        """Test AIActConformity creation from dict."""
+        from services.risk_engine_v3 import AIActConformity
+
+        data = {
+            "required_controls": ["ctrl_a", "ctrl_b"],
+            "implemented_controls": ["ctrl_a"],
+            "missing_controls": ["ctrl_b"],
+            "conformity_score": 0.5,
+            "risk_implications": ["Risk 1"],
+            "remediation_timeline": "phase_1",
+        }
+
+        conformity = AIActConformity.from_dict(data)
+
+        assert len(conformity.required_controls) == 2
+        assert conformity.conformity_score == 0.5
+        assert conformity.remediation_timeline == "phase_1"
+
+
+# =============================================================================
+# TEST: Data Structures - RiskReportV3
+# =============================================================================
+
+class TestRiskReportV3:
+    """Tests for RiskReportV3 dataclass."""
+
+    def test_basic_creation(self) -> None:
+        """Test RiskReportV3 can be instantiated."""
+        from services.risk_engine_v3 import RiskReportV3, DPIAEntry, AIActConformity
+        from services.risk_engine_v2 import RiskReport
+
+        base = RiskReport(ai_act_class="high_risk")
+        conformity = AIActConformity(conformity_score=0.7)
+        dpia_entry = DPIAEntry(
+            id="dpia_001",
+            title="Test",
+            description="Test",
+            legal_basis="consent",
+        )
+
+        report = RiskReportV3(
+            base=base,
+            dpia_required=True,
+            dpia_reason="High Risk AI",
+            dpia_entries=[dpia_entry],
+            ai_act_conformity=conformity,
+            residual_risk_score=65.0,
+        )
+
+        assert report.dpia_required is True
+        assert len(report.dpia_entries) == 1
+        assert report.residual_risk_score == 65.0
+
+    def test_residual_risk_score_clamped(self) -> None:
+        """Test residual_risk_score is clamped to 0-100."""
+        from services.risk_engine_v3 import RiskReportV3
+
+        report_high = RiskReportV3(residual_risk_score=150.0)
+        report_low = RiskReportV3(residual_risk_score=-50.0)
+
+        assert report_high.residual_risk_score == 100.0
+        assert report_low.residual_risk_score == 0.0
+
+    def test_grade_auto_calculated(self) -> None:
+        """Test residual_risk_grade is auto-calculated when invalid."""
+        from services.risk_engine_v3 import RiskReportV3
+
+        # Provide an invalid grade to trigger recalculation
+        report = RiskReportV3(residual_risk_score=85.0, residual_risk_grade="X")
+
+        assert report.residual_risk_grade == "A"
+
+    def test_total_dpia_entries_property(self) -> None:
+        """Test total_dpia_entries property."""
+        from services.risk_engine_v3 import RiskReportV3, DPIAEntry
+
+        entries = [
+            DPIAEntry(id=f"dpia_{i}", title=f"Test {i}", description="D", legal_basis="consent")
+            for i in range(3)
+        ]
+
+        report = RiskReportV3(dpia_entries=entries)
+
+        assert report.total_dpia_entries == 3
+
+    def test_high_risk_dpia_entries_property(self) -> None:
+        """Test high_risk_dpia_entries property."""
+        from services.risk_engine_v3 import RiskReportV3, DPIAEntry
+
+        entries = [
+            DPIAEntry(id="dpia_1", title="Low", description="D", legal_basis="consent", residual_risk="low"),
+            DPIAEntry(id="dpia_2", title="High", description="D", legal_basis="consent", residual_risk="high"),
+            DPIAEntry(id="dpia_3", title="Critical", description="D", legal_basis="consent", residual_risk="critical"),
+        ]
+
+        report = RiskReportV3(dpia_entries=entries)
+
+        high_risk = report.high_risk_dpia_entries
+        assert len(high_risk) == 2
+
+    def test_sensitive_data_entries_property(self) -> None:
+        """Test sensitive_data_entries property."""
+        from services.risk_engine_v3 import RiskReportV3, DPIAEntry
+
+        entries = [
+            DPIAEntry(id="dpia_1", title="Normal", description="D", legal_basis="consent",
+                     data_categories=["personal_basic"]),
+            DPIAEntry(id="dpia_2", title="Sensitive", description="D", legal_basis="consent",
+                     data_categories=["sensitive_health"]),
+        ]
+
+        report = RiskReportV3(dpia_entries=entries)
+
+        sensitive = report.sensitive_data_entries
+        assert len(sensitive) == 1
+        assert sensitive[0].id == "dpia_2"
+
+    def test_combined_risk_score_property(self) -> None:
+        """Test combined_risk_score property calculation."""
+        from services.risk_engine_v3 import RiskReportV3, AIActConformity
+        from services.risk_engine_v2 import RiskReport
+
+        base = RiskReport(ai_act_class="minimal", consolidated_score=70.0)
+        conformity = AIActConformity(conformity_score=0.8)
+
+        report = RiskReportV3(
+            base=base,
+            ai_act_conformity=conformity,
+            residual_risk_score=60.0,
+        )
+
+        # Combined: 70*0.4 + 60*0.4 + 80*0.2 = 28 + 24 + 16 = 68
+        assert 65 <= report.combined_risk_score <= 70
+
+    def test_get_dpia_entry(self) -> None:
+        """Test get_dpia_entry method."""
+        from services.risk_engine_v3 import RiskReportV3, DPIAEntry
+
+        entries = [
+            DPIAEntry(id="dpia_1", title="Entry 1", description="D", legal_basis="consent"),
+            DPIAEntry(id="dpia_2", title="Entry 2", description="D", legal_basis="contract"),
+        ]
+
+        report = RiskReportV3(dpia_entries=entries)
+
+        assert report.get_dpia_entry("dpia_1").title == "Entry 1"
+        assert report.get_dpia_entry("dpia_2").title == "Entry 2"
+        assert report.get_dpia_entry("dpia_invalid") is None
+
+    def test_to_dict_serialization(self) -> None:
+        """Test RiskReportV3 serialization to dict."""
+        from services.risk_engine_v3 import RiskReportV3
+
+        report = RiskReportV3(
+            dpia_required=True,
+            dpia_reason="Test reason",
+            residual_risk_score=65.0,
+            compliance_status="partial",
+        )
+
+        data = report.to_dict()
+
+        assert data["dpia_required"] is True
+        assert data["dpia_reason"] == "Test reason"
+        assert data["residual_risk_score"] == 65.0
+        assert "combined_risk_score" in data
+        assert "combined_grade" in data
+
+    def test_from_dict_deserialization(self) -> None:
+        """Test RiskReportV3 creation from dict."""
+        from services.risk_engine_v3 import RiskReportV3
+
+        data = {
+            "base": {"ai_act_class": "high_risk"},
+            "dpia_required": True,
+            "dpia_reason": "High Risk",
+            "dpia_entries": [],
+            "ai_act_conformity": {"conformity_score": 0.6},
+            "residual_risk_score": 55.0,
+            "compliance_status": "partial",
+        }
+
+        report = RiskReportV3.from_dict(data)
+
+        assert report.dpia_required is True
+        assert report.residual_risk_score == 55.0
+
+
+# =============================================================================
+# TEST: Constants and Configuration
+# =============================================================================
+
+class TestConstants:
+    """Tests for module constants."""
+
+    def test_ai_act_controls_exist(self) -> None:
+        """Test AI_ACT_ANNEX_III_CONTROLS are defined."""
+        from services.risk_engine_v3 import AI_ACT_ANNEX_III_CONTROLS
+
+        assert len(AI_ACT_ANNEX_III_CONTROLS) == 7
+        assert "human_oversight" in AI_ACT_ANNEX_III_CONTROLS
+        assert "transparency_provision" in AI_ACT_ANNEX_III_CONTROLS
+
+    def test_data_categories_exist(self) -> None:
+        """Test DSGVO_DATA_CATEGORIES are defined."""
+        from services.risk_engine_v3 import DSGVO_DATA_CATEGORIES
+
+        assert "personal_basic" in DSGVO_DATA_CATEGORIES
+        assert "sensitive_health" in DSGVO_DATA_CATEGORIES
+        assert "children_data" in DSGVO_DATA_CATEGORIES
+
+    def test_legal_basis_options_exist(self) -> None:
+        """Test LEGAL_BASIS_OPTIONS are defined."""
+        from services.risk_engine_v3 import LEGAL_BASIS_OPTIONS
+
+        assert "consent" in LEGAL_BASIS_OPTIONS
+        assert "contract" in LEGAL_BASIS_OPTIONS
+        assert "legitimate_interest" in LEGAL_BASIS_OPTIONS
+
+    def test_size_constraints_exist(self) -> None:
+        """Test SIZE_DPIA_LIMITS are defined."""
+        from services.risk_engine_v3 import SIZE_DPIA_LIMITS
+
+        assert "solo" in SIZE_DPIA_LIMITS
+        assert "team" in SIZE_DPIA_LIMITS
+        assert "kmu" in SIZE_DPIA_LIMITS
+
+    def test_solo_constraints(self) -> None:
+        """Test Solo size constraints."""
+        from services.risk_engine_v3 import SIZE_DPIA_LIMITS
+
+        solo = SIZE_DPIA_LIMITS["solo"]
+        assert solo["max_dpia_entries"] == 3
+        assert solo["max_controls"] == 4
+
+
+# =============================================================================
+# TEST: Report Generation
+# =============================================================================
+
+class TestReportGeneration:
+    """Tests for report generation function."""
+
+    def test_generate_with_empty_input(self) -> None:
+        """Test report generation with minimal input."""
+        from services.risk_engine_v3 import generate_risk_report_v3
+
+        report = generate_risk_report_v3(
+            briefing={"unternehmensgroesse": "Team", "branche": "IT"}
+        )
+
+        assert report is not None
+        assert isinstance(report.dpia_required, bool)
+        assert isinstance(report.residual_risk_score, float)
+
+    def test_generate_with_high_risk_ai_act(self) -> None:
+        """Test report generation with high-risk AI Act classification."""
+        from services.risk_engine_v3 import generate_risk_report_v3
+        from services.risk_engine_v2 import RiskReport
+
+        base = RiskReport(ai_act_class="high_risk")
+
+        report = generate_risk_report_v3(
+            base_risk_report=base,
+            briefing={"unternehmensgroesse": "KMU", "branche": "Gesundheit"}
+        )
+
+        # High-risk classification should require DPIA
+        assert report.dpia_required is True
+
+    def test_generate_with_sensitive_data(self) -> None:
+        """Test report generation with sensitive data categories."""
+        from services.risk_engine_v3 import generate_risk_report_v3
+
+        report = generate_risk_report_v3(
+            briefing={
+                "unternehmensgroesse": "Team",
+                "branche": "Gesundheitswesen",
+                "datentypen": ["Gesundheitsdaten", "Patientenakte"],
+            }
+        )
+
+        # Sensitive data should trigger DPIA
+        assert report.dpia_required is True
+
+    def test_generate_with_automated_decisions(self) -> None:
+        """Test report generation with automated decisions."""
+        from services.risk_engine_v3 import generate_risk_report_v3
+
+        report = generate_risk_report_v3(
+            briefing={
+                "unternehmensgroesse": "KMU",
+                "branche": "Finanzen",
+                "automatisierte_entscheidungen": True,
+            }
+        )
+
+        # Automated decisions should trigger DPIA
+        assert report.dpia_required is True
+
+    def test_generate_respects_size_limits(self) -> None:
+        """Test generated DPIA entries respect size limits."""
+        from services.risk_engine_v3 import generate_risk_report_v3
+        from services.risk_engine_v2 import RiskReport
+
+        base = RiskReport(ai_act_class="high_risk", dsgvo_risk_level="hoch")
+
+        report = generate_risk_report_v3(
+            base_risk_report=base,
+            briefing={
+                "unternehmensgroesse": "Solo/Freelancer",
+                "branche": "IT",
+                "automatisierte_entscheidungen": True,
+            }
+        )
+
+        # Solo should have max 3 DPIA entries
+        assert len(report.dpia_entries) <= 3
+
+    def test_generate_creates_mitigation_plan(self) -> None:
+        """Test mitigation plan is generated."""
+        from services.risk_engine_v3 import generate_risk_report_v3
+        from services.risk_engine_v2 import RiskReport
+
+        base = RiskReport(ai_act_class="high_risk")
+
+        report = generate_risk_report_v3(
+            base_risk_report=base,
+            briefing={"unternehmensgroesse": "KMU", "branche": "IT"}
+        )
+
+        assert len(report.mitigation_plan) > 0
+
+    def test_generate_calculates_compliance_status(self) -> None:
+        """Test compliance status is calculated."""
+        from services.risk_engine_v3 import generate_risk_report_v3
+
+        report = generate_risk_report_v3(
+            briefing={"unternehmensgroesse": "Team", "branche": "Handel"}
+        )
+
+        assert report.compliance_status in ["compliant", "partial", "non_compliant"]
+
+
+# =============================================================================
+# TEST: HTML Generation
+# =============================================================================
+
+class TestHTMLGeneration:
+    """Tests for HTML rendering function."""
+
+    def test_html_contains_dpia_status(self) -> None:
+        """Test HTML includes DPIA status."""
+        from services.risk_engine_v3 import RiskReportV3, risk_report_v3_to_html
+
+        report = RiskReportV3(dpia_required=True, dpia_reason="Test reason")
+        html = risk_report_v3_to_html(report, lang="de")
+
+        assert "DPIA" in html
+        assert "Test reason" in html
+
+    def test_html_contains_conformity_score(self) -> None:
+        """Test HTML includes conformity score."""
+        from services.risk_engine_v3 import RiskReportV3, AIActConformity, risk_report_v3_to_html
+
+        conformity = AIActConformity(conformity_score=0.75)
+        report = RiskReportV3(ai_act_conformity=conformity)
+        html = risk_report_v3_to_html(report, lang="de")
+
+        assert "75" in html  # 75%
+
+    def test_html_german_labels(self) -> None:
+        """Test HTML uses German labels."""
+        from services.risk_engine_v3 import RiskReportV3, risk_report_v3_to_html
+
+        report = RiskReportV3(dpia_required=True)
+        html = risk_report_v3_to_html(report, lang="de")
+
+        assert "Konformität" in html or "DPIA" in html
+
+    def test_html_english_labels(self) -> None:
+        """Test HTML uses English labels."""
+        from services.risk_engine_v3 import RiskReportV3, risk_report_v3_to_html
+
+        report = RiskReportV3(dpia_required=True)
+        html = risk_report_v3_to_html(report, lang="en")
+
+        assert "Conformity" in html or "DPIA" in html
+
+    def test_html_includes_dpia_entries(self) -> None:
+        """Test HTML includes DPIA entries."""
+        from services.risk_engine_v3 import RiskReportV3, DPIAEntry, risk_report_v3_to_html
+
+        entry = DPIAEntry(
+            id="dpia_001",
+            title="Customer Data Processing",
+            description="Processing of customer data",
+            legal_basis="consent",
+        )
+        report = RiskReportV3(dpia_entries=[entry])
+        html = risk_report_v3_to_html(report, lang="de")
+
+        assert "Customer Data Processing" in html
+
+    def test_html_includes_missing_controls(self) -> None:
+        """Test HTML includes missing controls."""
+        from services.risk_engine_v3 import RiskReportV3, AIActConformity, risk_report_v3_to_html
+
+        conformity = AIActConformity(
+            required_controls=["human_oversight", "transparency_provision"],
+            implemented_controls=[],
+            missing_controls=["human_oversight", "transparency_provision"],
+        )
+        report = RiskReportV3(ai_act_conformity=conformity)
+        html = risk_report_v3_to_html(report, lang="de")
+
+        # Should show missing count or controls
+        assert "2" in html or "Fehlend" in html or "Missing" in html
+
+    def test_html_includes_compliance_status(self) -> None:
+        """Test HTML includes compliance status."""
+        from services.risk_engine_v3 import RiskReportV3, risk_report_v3_to_html
+
+        report = RiskReportV3(compliance_status="partial")
+        html = risk_report_v3_to_html(report, lang="de")
+
+        assert "Konform" in html or "Compliance" in html
+
+    def test_html_g33_badge(self) -> None:
+        """Test HTML includes G33 sprint badge."""
+        from services.risk_engine_v3 import RiskReportV3, risk_report_v3_to_html
+
+        report = RiskReportV3()
+        html = risk_report_v3_to_html(report, lang="de")
+
+        assert "G33" in html
+
+
+# =============================================================================
+# TEST: Validation Functions
+# =============================================================================
+
+class TestValidationFunctions:
+    """Tests for validation helper functions."""
+
+    def test_validate_dpia_required_with_strategy(self) -> None:
+        """Test DPIA validation passes when strategy has measures."""
+        from services.risk_engine_v3 import RiskReportV3, validate_dpia_required
+
+        report = RiskReportV3(dpia_required=True)
+
+        # Mock strategy data with DPIA keywords
+        class MockStrategy:
+            phases = [type('obj', (object,), {'focus': 'Implement DPIA measures'})()]
+
+        is_valid, errors = validate_dpia_required(report, MockStrategy())
+
+        assert is_valid is True
+
+    def test_validate_dpia_required_without_strategy(self) -> None:
+        """Test DPIA validation fails when strategy missing."""
+        from services.risk_engine_v3 import RiskReportV3, validate_dpia_required
+
+        report = RiskReportV3(dpia_required=True)
+
+        is_valid, errors = validate_dpia_required(report, None)
+
+        assert is_valid is False
+        assert len(errors) >= 1
+
+    def test_validate_ai_act_conformity_with_strategy(self) -> None:
+        """Test AI Act conformity validation."""
+        from services.risk_engine_v3 import RiskReportV3, AIActConformity, validate_ai_act_conformity
+
+        conformity = AIActConformity(missing_controls=["human_oversight"])
+        report = RiskReportV3(ai_act_conformity=conformity)
+
+        # Mock strategy with control implementation
+        class MockStrategy:
+            phases = [type('obj', (object,), {'focus': 'Implement human oversight'})()]
+
+        is_valid, errors = validate_ai_act_conformity(report, MockStrategy())
+
+        assert is_valid is True
+
+
+# =============================================================================
+# TEST: Consistency Engine Integration
+# =============================================================================
+
+class TestConsistencyEngineIntegration:
+    """Tests for consistency engine RISK3_001-RISK3_008 rules."""
+
+    def test_risk3_domain_in_consistency_engine(self) -> None:
+        """Test 'risk_engine_v3' domain exists in consistency engine."""
+        from services.consistency_engine import ConsistencyEngine
+
+        sections = {"RISK_ENGINE_V3_HTML": "<div>test</div>"}
+        briefing = {"unternehmensgroesse": "Team"}
+
+        engine = ConsistencyEngine(sections, briefing)
+        report = engine.check_all()
+
+        assert "risk_engine_v3" in report.domain_scores
+
+    def test_consistency_skips_without_v3_html(self) -> None:
+        """Test consistency check skips when no risk_v3 HTML."""
+        from services.consistency_engine import ConsistencyEngine
+
+        sections = {}
+        briefing = {"unternehmensgroesse": "Team"}
+
+        engine = ConsistencyEngine(sections, briefing)
+        report = engine.check_all()
+
+        # No RISK3 issues when section missing
+        risk3_issues = [i for i in report.issues if i.rule_id.startswith("RISK3_")]
+        assert len(risk3_issues) == 0
+
+
+# =============================================================================
+# TEST: Edge Cases
+# =============================================================================
+
+class TestEdgeCases:
+    """Tests for edge cases and error handling."""
+
+    def test_empty_dpia_entries_list(self) -> None:
+        """Test report with empty DPIA entries list."""
+        from services.risk_engine_v3 import RiskReportV3
+
+        report = RiskReportV3(dpia_entries=[])
+
+        assert report.total_dpia_entries == 0
+        assert len(report.high_risk_dpia_entries) == 0
+
+    def test_none_values_in_dpia_entry(self) -> None:
+        """Test DPIAEntry handles None values in lists."""
+        from services.risk_engine_v3 import DPIAEntry
+
+        entry = DPIAEntry(
+            id="dpia_001",
+            title="Test",
+            description="Test",
+            legal_basis="consent",
+            data_categories=None,  # type: ignore
+            rights_risks=None,  # type: ignore
+            mitigation_measures=None,  # type: ignore
+        )
+
+        assert entry.data_categories == []
+        assert entry.rights_risks == []
+        assert entry.mitigation_measures == []
+
+    def test_empty_ai_act_conformity(self) -> None:
+        """Test AIActConformity with empty controls."""
+        from services.risk_engine_v3 import AIActConformity
+
+        conformity = AIActConformity(
+            required_controls=[],
+            implemented_controls=[],
+        )
+
+        assert conformity.conformity_score == 0.0
+        assert len(conformity.missing_controls) == 0
+
+    def test_determine_size_label(self) -> None:
+        """Test _determine_size_label function."""
+        from services.risk_engine_v3 import _determine_size_label
+
+        assert _determine_size_label({"unternehmensgroesse": "Solo/Freelancer"}) == "solo"
+        assert _determine_size_label({"unternehmensgroesse": "Freiberufler"}) == "solo"
+        assert _determine_size_label({"unternehmensgroesse": "Team (2-10 MA)"}) == "team"
+        assert _determine_size_label({"unternehmensgroesse": "KMU (>10 Mitarbeiter)"}) == "kmu"
+        assert _determine_size_label({}) == "team"
+        assert _determine_size_label(None) == "team"
+
+
+# =============================================================================
+# TEST: Module Loading
+# =============================================================================
+
+class TestModuleLoading:
+    """Tests for module loading and exports."""
+
+    def test_module_exports(self) -> None:
+        """Test all expected exports are available."""
+        from services.risk_engine_v3 import (
+            DPIAEntry,
+            AIActConformity,
+            RiskReportV3,
+            generate_risk_report_v3,
+            risk_report_v3_to_html,
+            RISK_ENGINE_V3_ENABLED,
+        )
+
+        assert DPIAEntry is not None
+        assert AIActConformity is not None
+        assert RiskReportV3 is not None
+        assert generate_risk_report_v3 is not None
+        assert risk_report_v3_to_html is not None
+        assert RISK_ENGINE_V3_ENABLED is True
+
+    def test_imports_from_risk_engine_v2(self) -> None:
+        """Test Risk Engine V3 properly imports from V2."""
+        from services.risk_engine_v3 import (
+            RiskReport,
+            RiskMatrixEntry,
+        )
+
+        # These should be re-exported from v2
+        assert RiskReport is not None
+        assert RiskMatrixEntry is not None


### PR DESCRIPTION
…mity

- Add services/risk_engine_v3.py with DPIAEntry, AIActConformity, and RiskReportV3 dataclasses extending Risk Engine 2.0 (G29)
- Add DPIA analysis per GDPR Art. 35 with automated requirement checks
- Add AI Act Annex III Controls mapping (7 controls: risk_management, data_governance, technical_documentation, record_keeping, transparency_provision, human_oversight, accuracy_robustness_security)
- Add mitigation planning with phased timelines
- Add residual risk calculation with A-F grading
- Add prompts/de/risk_engine_v3.md and prompts/en/risk_engine_v3.md
- Add consistency rules RISK3_001-RISK3_008 to consistency_engine.py
- Integrate into gpt_analyze.py after G29
- Update PDF templates with DPIA section
- Add 60 comprehensive tests