### PR TITLE
feat(G34): add Monte Carlo ROI Simulation & Uncertainty Model

### DIFF
--- a/prompts/de/business_case_simulation.md
+++ b/prompts/de/business_case_simulation.md
@@ -1,0 +1,276 @@
+# Business Case Simulation – Monte-Carlo Unsicherheitsmodell (G34)
+
+Du generierst Simulationsannahmen fuer eine Monte-Carlo-Analyse des Business Case.
+Die eigentliche Simulation findet in Python statt – du lieferst nur die Verteilungsparameter.
+
+## Kontext
+
+**Unternehmen:** {{COMPANY_NAME}}
+**Branche:** {{BRANCH_LABEL}} ({{BRANCH_SHORT_LABEL}})
+**Groesse:** {{SIZE_LABEL}}
+**Reifegrad:** {{MATURITY_LEVEL}}
+**Region:** {{BUNDESLAND}}
+
+### Business Case Engine v2 (G30) Baseline
+
+**Realistisches Szenario:**
+- ROI (12M): {{BC_REALISTIC_ROI}}%
+- Payback: {{BC_REALISTIC_PAYBACK}} Monate
+- Monatliche Ersparnis: {{BC_REALISTIC_SAVINGS}} EUR
+- Investment: {{BC_INVESTMENT_TOTAL}} EUR
+
+**Szenario-Bandbreite:**
+- Optimistisch: ROI {{BC_OPTIMISTIC_ROI}}%, Payback {{BC_OPTIMISTIC_PAYBACK}} Monate
+- Konservativ: ROI {{BC_CONSERVATIVE_ROI}}%, Payback {{BC_CONSERVATIVE_PAYBACK}} Monate
+
+### Risk Engine v3 (G33) Ergebnisse
+
+**Risikoprofil:**
+- Residual Risk Score: {{RISK_RESIDUAL_SCORE}}/100
+- Residual Risk Grade: {{RISK_RESIDUAL_GRADE}}
+- Compliance Status: {{COMPLIANCE_STATUS}}
+- DPIA erforderlich: {{DPIA_REQUIRED}}
+
+**AI Act Konformitaet:**
+- Konformitaets-Score: {{AI_ACT_CONFORMITY}}%
+- Fehlende Controls: {{AI_ACT_MISSING_CONTROLS}}
+
+### Automation Roadmap (G36) Ergebnisse
+
+**Prozessautomation:**
+- Identifizierte Prozesse: {{AUTO_PROCESS_COUNT}}
+- Quick Wins: {{AUTO_QUICK_WINS}}
+- Durchschnittliches Automationspotenzial: {{AUTO_AVG_POTENTIAL}}%
+- Phase 1 Prozesse: {{AUTO_PHASE_1_COUNT}}
+
+### Tools & Funding Kontext
+
+**Tools Engine (G25):**
+{{TOOLS_SUMMARY}}
+
+**Funding Engine (G26):**
+{{FUNDING_SUMMARY}}
+
+## Anforderungen
+
+Erstelle realistische Verteilungsannahmen fuer die Monte-Carlo-Simulation.
+Beruecksichtige dabei:
+
+1. **Unternehmensgröße ({{SIZE_LABEL}})**:
+   - **Solo/Freelancer**: Hoehere Varianz bei Umsetzungsgeschwindigkeit, kleinere Bandbreiten bei Kosten
+   - **Team (2-10 MA)**: Mittlere Varianz, moderate Bandbreiten
+   - **KMU (>10 MA)**: Niedrigere relative Varianz, strukturiertere Umsetzung
+
+2. **Risikoprofil (Grade: {{RISK_RESIDUAL_GRADE}})**:
+   - Grade A/B: Engere Bandbreiten (niedrige Unsicherheit)
+   - Grade C: Mittlere Bandbreiten (Standard)
+   - Grade D/F: Breitere Bandbreiten (hohe Unsicherheit)
+
+3. **G30 Szenarien als Ankerpunkte**:
+   - Konservatives Szenario ≈ Min-Werte
+   - Realistisches Szenario ≈ Mode-Werte (wahrscheinlichster Fall)
+   - Optimistisches Szenario ≈ Max-Werte
+
+4. **Foerdererfolgswahrscheinlichkeit**:
+   - Basierend auf Match-Scores und Programmverfuegbarkeit
+   - Solo: 30-50%
+   - Team: 40-60%
+   - KMU: 50-70%
+
+## Output-Format
+
+Du MUSST exakt dieses JSON-Schema ausgeben – keine weiteren Texte, nur JSON:
+
+```json
+{
+  "assumptions": {
+    "monthly_savings": {
+      "min": 3000,
+      "mode": 5000,
+      "max": 8000
+    },
+    "investment_total": {
+      "min": 20000,
+      "mode": 25000,
+      "max": 35000
+    },
+    "speed_factor": {
+      "min": 0.7,
+      "mode": 1.0,
+      "max": 1.2
+    },
+    "risk_factor": {
+      "min": 0.8,
+      "mode": 1.0,
+      "max": 1.1
+    },
+    "funding_success_probability": 0.5
+  }
+}
+```
+
+## Feldspezifikationen
+
+### monthly_savings (Dreiecksverteilung: min/mode/max)
+
+Monatliche Ersparnis in EUR.
+
+**Orientierung an G30:**
+- `min`: Konservatives Szenario Ersparnis (oder 60-70% des realistischen)
+- `mode`: Realistisches Szenario Ersparnis
+- `max`: Optimistisches Szenario Ersparnis (oder 130-150% des realistischen)
+
+**Groessenanpassung:**
+- Solo: min 200-2.000€, mode 500-3.000€, max 1.000-5.000€
+- Team: min 500-5.000€, mode 1.500-8.000€, max 3.000-12.000€
+- KMU: min 2.000-15.000€, mode 5.000-25.000€, max 10.000-40.000€
+
+### investment_total (Dreiecksverteilung: min/mode/max)
+
+Gesamtinvestition in EUR.
+
+**Orientierung an G30:**
+- `min`: Optimistisches Szenario Investment (guenstigster Fall)
+- `mode`: Realistisches Szenario Investment
+- `max`: Konservatives Szenario Investment (+ Risikopuffer)
+
+**Groessenanpassung:**
+- Solo: min 300-3.000€, mode 500-5.000€, max 1.000-8.000€
+- Team: min 1.500-15.000€, mode 3.000-25.000€, max 5.000-40.000€
+- KMU: min 8.000-60.000€, mode 15.000-80.000€, max 25.000-120.000€
+
+### speed_factor (Dreiecksverteilung: min/mode/max)
+
+Umsetzungsgeschwindigkeitsfaktor (1.0 = wie geplant).
+
+**Bedeutung:**
+- `< 1.0`: Langsamer als geplant (reduziert effektive Einsparungen)
+- `= 1.0`: Planmaessige Umsetzung
+- `> 1.0`: Schneller als geplant (beschleunigt Einsparungen)
+
+**Risikoanpassung:**
+- Grade A/B: min 0.85, mode 1.0, max 1.15
+- Grade C: min 0.75, mode 1.0, max 1.15
+- Grade D/F: min 0.60, mode 0.9, max 1.1
+
+### risk_factor (Dreiecksverteilung: min/mode/max)
+
+Risikoadjustierungsfaktor basierend auf G33 (1.0 = neutral).
+
+**Bedeutung:**
+- `< 1.0`: Risiken reduzieren erwartete Ertraege
+- `= 1.0`: Neutrale Risikoposition
+- `> 1.0`: Guenstige Risikosituation
+
+**Berechnung aus G33:**
+- Mode = min(1.0, Residual_Risk_Score/100 + 0.5)
+- Grade A/B: min 0.9, mode 1.0, max 1.1
+- Grade C: min 0.8, mode 0.95, max 1.05
+- Grade D/F: min 0.6, mode 0.8, max 0.95
+
+### funding_success_probability
+
+Wahrscheinlichkeit, dass Foerderung erfolgreich beantragt wird (0.0-1.0).
+
+**Orientierung:**
+- Keine Foerderoptionen: 0.0
+- 1-2 passende Programme (Match < 70%): 0.3-0.4
+- 2-3 passende Programme (Match 70-85%): 0.5-0.6
+- 3+ passende Programme (Match > 85%): 0.6-0.8
+
+## Validierungsregeln
+
+### Konsistenz mit G30
+1. `monthly_savings.mode` ≈ G30 realistic.monthly_savings (±15%)
+2. `investment_total.mode` ≈ G30 investment_total (±15%)
+3. `monthly_savings.min` ≈ G30 conservative.monthly_savings (±20%)
+4. `monthly_savings.max` ≈ G30 optimistic.monthly_savings (±20%)
+
+### Verteilungslogik
+1. Fuer alle Parameter: min ≤ mode ≤ max
+2. monthly_savings: min ≥ 0, max ≤ 100.000
+3. investment_total: min ≥ 100, max ≤ 500.000
+4. speed_factor: min ≥ 0.3, max ≤ 1.5
+5. risk_factor: min ≥ 0.3, max ≤ 1.3
+6. funding_success_probability: 0.0 ≤ x ≤ 1.0
+
+### Risikoanpassung
+1. Hoeherer Risiko-Grade → breitere Verteilungen (hoehere Varianz)
+2. Hoeherer Risiko-Grade → niedrigere risk_factor Werte
+3. Niedrigerer AI Act Conformity Score → niedrigere speed_factor
+
+### Groessenkonsistenz
+1. Solo: Kleinere absolute Werte, hoehere relative Varianz
+2. Team: Mittlere Werte, moderate Varianz
+3. KMU: Groessere absolute Werte, niedrigere relative Varianz
+
+## Beispiel-Outputs
+
+### Solo-Freelancer, niedriges Risiko (Grade B)
+
+```json
+{
+  "assumptions": {
+    "monthly_savings": {
+      "min": 400,
+      "mode": 800,
+      "max": 1200
+    },
+    "investment_total": {
+      "min": 1500,
+      "mode": 2000,
+      "max": 2800
+    },
+    "speed_factor": {
+      "min": 0.85,
+      "mode": 1.0,
+      "max": 1.15
+    },
+    "risk_factor": {
+      "min": 0.9,
+      "mode": 1.0,
+      "max": 1.05
+    },
+    "funding_success_probability": 0.35
+  }
+}
+```
+
+### KMU, hohes Risiko (Grade D)
+
+```json
+{
+  "assumptions": {
+    "monthly_savings": {
+      "min": 3000,
+      "mode": 8000,
+      "max": 15000
+    },
+    "investment_total": {
+      "min": 25000,
+      "mode": 45000,
+      "max": 70000
+    },
+    "speed_factor": {
+      "min": 0.55,
+      "mode": 0.85,
+      "max": 1.05
+    },
+    "risk_factor": {
+      "min": 0.55,
+      "mode": 0.75,
+      "max": 0.9
+    },
+    "funding_success_probability": 0.55
+  }
+}
+```
+
+## Wichtig
+
+- Nur JSON ausgeben, keine Erklaerungen oder Markdown
+- Alle Felder muessen vorhanden sein
+- Werte muessen realistisch und konsistent mit G30/G33 sein
+- Verteilungen muessen min ≤ mode ≤ max erfuellen
+- Groessenanpassung beachten
+- Risikoanpassung aus G33 einbeziehen

--- a/prompts/en/business_case_simulation.md
+++ b/prompts/en/business_case_simulation.md
@@ -1,0 +1,276 @@
+# Business Case Simulation – Monte Carlo Uncertainty Model (G34)
+
+You generate simulation assumptions for a Monte Carlo analysis of the Business Case.
+The actual simulation runs in Python – you only provide the distribution parameters.
+
+## Context
+
+**Company:** {{COMPANY_NAME}}
+**Industry:** {{BRANCH_LABEL}} ({{BRANCH_SHORT_LABEL}})
+**Size:** {{SIZE_LABEL}}
+**Maturity:** {{MATURITY_LEVEL}}
+**Region:** {{BUNDESLAND}}
+
+### Business Case Engine v2 (G30) Baseline
+
+**Realistic Scenario:**
+- ROI (12M): {{BC_REALISTIC_ROI}}%
+- Payback: {{BC_REALISTIC_PAYBACK}} months
+- Monthly Savings: {{BC_REALISTIC_SAVINGS}} EUR
+- Investment: {{BC_INVESTMENT_TOTAL}} EUR
+
+**Scenario Range:**
+- Optimistic: ROI {{BC_OPTIMISTIC_ROI}}%, Payback {{BC_OPTIMISTIC_PAYBACK}} months
+- Conservative: ROI {{BC_CONSERVATIVE_ROI}}%, Payback {{BC_CONSERVATIVE_PAYBACK}} months
+
+### Risk Engine v3 (G33) Results
+
+**Risk Profile:**
+- Residual Risk Score: {{RISK_RESIDUAL_SCORE}}/100
+- Residual Risk Grade: {{RISK_RESIDUAL_GRADE}}
+- Compliance Status: {{COMPLIANCE_STATUS}}
+- DPIA Required: {{DPIA_REQUIRED}}
+
+**AI Act Conformity:**
+- Conformity Score: {{AI_ACT_CONFORMITY}}%
+- Missing Controls: {{AI_ACT_MISSING_CONTROLS}}
+
+### Automation Roadmap (G36) Results
+
+**Process Automation:**
+- Identified Processes: {{AUTO_PROCESS_COUNT}}
+- Quick Wins: {{AUTO_QUICK_WINS}}
+- Average Automation Potential: {{AUTO_AVG_POTENTIAL}}%
+- Phase 1 Processes: {{AUTO_PHASE_1_COUNT}}
+
+### Tools & Funding Context
+
+**Tools Engine (G25):**
+{{TOOLS_SUMMARY}}
+
+**Funding Engine (G26):**
+{{FUNDING_SUMMARY}}
+
+## Requirements
+
+Create realistic distribution assumptions for the Monte Carlo simulation.
+Consider:
+
+1. **Company Size ({{SIZE_LABEL}})**:
+   - **Solo/Freelancer**: Higher variance in implementation speed, smaller cost ranges
+   - **Team (2-10 employees)**: Medium variance, moderate ranges
+   - **SME (>10 employees)**: Lower relative variance, more structured implementation
+
+2. **Risk Profile (Grade: {{RISK_RESIDUAL_GRADE}})**:
+   - Grade A/B: Narrower ranges (low uncertainty)
+   - Grade C: Medium ranges (standard)
+   - Grade D/F: Wider ranges (high uncertainty)
+
+3. **G30 Scenarios as Anchor Points**:
+   - Conservative scenario ≈ Min values
+   - Realistic scenario ≈ Mode values (most likely case)
+   - Optimistic scenario ≈ Max values
+
+4. **Funding Success Probability**:
+   - Based on match scores and program availability
+   - Solo: 30-50%
+   - Team: 40-60%
+   - SME: 50-70%
+
+## Output Format
+
+You MUST output exactly this JSON schema – no additional text, only JSON:
+
+```json
+{
+  "assumptions": {
+    "monthly_savings": {
+      "min": 3000,
+      "mode": 5000,
+      "max": 8000
+    },
+    "investment_total": {
+      "min": 20000,
+      "mode": 25000,
+      "max": 35000
+    },
+    "speed_factor": {
+      "min": 0.7,
+      "mode": 1.0,
+      "max": 1.2
+    },
+    "risk_factor": {
+      "min": 0.8,
+      "mode": 1.0,
+      "max": 1.1
+    },
+    "funding_success_probability": 0.5
+  }
+}
+```
+
+## Field Specifications
+
+### monthly_savings (Triangular Distribution: min/mode/max)
+
+Monthly savings in EUR.
+
+**Guidance from G30:**
+- `min`: Conservative scenario savings (or 60-70% of realistic)
+- `mode`: Realistic scenario savings
+- `max`: Optimistic scenario savings (or 130-150% of realistic)
+
+**Size Adjustment:**
+- Solo: min 200-2,000€, mode 500-3,000€, max 1,000-5,000€
+- Team: min 500-5,000€, mode 1,500-8,000€, max 3,000-12,000€
+- SME: min 2,000-15,000€, mode 5,000-25,000€, max 10,000-40,000€
+
+### investment_total (Triangular Distribution: min/mode/max)
+
+Total investment in EUR.
+
+**Guidance from G30:**
+- `min`: Optimistic scenario investment (best case)
+- `mode`: Realistic scenario investment
+- `max`: Conservative scenario investment (+ risk buffer)
+
+**Size Adjustment:**
+- Solo: min 300-3,000€, mode 500-5,000€, max 1,000-8,000€
+- Team: min 1,500-15,000€, mode 3,000-25,000€, max 5,000-40,000€
+- SME: min 8,000-60,000€, mode 15,000-80,000€, max 25,000-120,000€
+
+### speed_factor (Triangular Distribution: min/mode/max)
+
+Implementation speed factor (1.0 = as planned).
+
+**Meaning:**
+- `< 1.0`: Slower than planned (reduces effective savings)
+- `= 1.0`: On-schedule implementation
+- `> 1.0`: Faster than planned (accelerates savings)
+
+**Risk Adjustment:**
+- Grade A/B: min 0.85, mode 1.0, max 1.15
+- Grade C: min 0.75, mode 1.0, max 1.15
+- Grade D/F: min 0.60, mode 0.9, max 1.1
+
+### risk_factor (Triangular Distribution: min/mode/max)
+
+Risk adjustment factor based on G33 (1.0 = neutral).
+
+**Meaning:**
+- `< 1.0`: Risks reduce expected returns
+- `= 1.0`: Neutral risk position
+- `> 1.0`: Favorable risk situation
+
+**Calculation from G33:**
+- Mode = min(1.0, Residual_Risk_Score/100 + 0.5)
+- Grade A/B: min 0.9, mode 1.0, max 1.1
+- Grade C: min 0.8, mode 0.95, max 1.05
+- Grade D/F: min 0.6, mode 0.8, max 0.95
+
+### funding_success_probability
+
+Probability that funding will be successfully applied for (0.0-1.0).
+
+**Guidance:**
+- No funding options: 0.0
+- 1-2 matching programs (Match < 70%): 0.3-0.4
+- 2-3 matching programs (Match 70-85%): 0.5-0.6
+- 3+ matching programs (Match > 85%): 0.6-0.8
+
+## Validation Rules
+
+### Consistency with G30
+1. `monthly_savings.mode` ≈ G30 realistic.monthly_savings (±15%)
+2. `investment_total.mode` ≈ G30 investment_total (±15%)
+3. `monthly_savings.min` ≈ G30 conservative.monthly_savings (±20%)
+4. `monthly_savings.max` ≈ G30 optimistic.monthly_savings (±20%)
+
+### Distribution Logic
+1. For all parameters: min ≤ mode ≤ max
+2. monthly_savings: min ≥ 0, max ≤ 100,000
+3. investment_total: min ≥ 100, max ≤ 500,000
+4. speed_factor: min ≥ 0.3, max ≤ 1.5
+5. risk_factor: min ≥ 0.3, max ≤ 1.3
+6. funding_success_probability: 0.0 ≤ x ≤ 1.0
+
+### Risk Adjustment
+1. Higher risk grade → wider distributions (higher variance)
+2. Higher risk grade → lower risk_factor values
+3. Lower AI Act Conformity Score → lower speed_factor
+
+### Size Consistency
+1. Solo: Smaller absolute values, higher relative variance
+2. Team: Medium values, moderate variance
+3. SME: Larger absolute values, lower relative variance
+
+## Example Outputs
+
+### Solo Freelancer, Low Risk (Grade B)
+
+```json
+{
+  "assumptions": {
+    "monthly_savings": {
+      "min": 400,
+      "mode": 800,
+      "max": 1200
+    },
+    "investment_total": {
+      "min": 1500,
+      "mode": 2000,
+      "max": 2800
+    },
+    "speed_factor": {
+      "min": 0.85,
+      "mode": 1.0,
+      "max": 1.15
+    },
+    "risk_factor": {
+      "min": 0.9,
+      "mode": 1.0,
+      "max": 1.05
+    },
+    "funding_success_probability": 0.35
+  }
+}
+```
+
+### SME, High Risk (Grade D)
+
+```json
+{
+  "assumptions": {
+    "monthly_savings": {
+      "min": 3000,
+      "mode": 8000,
+      "max": 15000
+    },
+    "investment_total": {
+      "min": 25000,
+      "mode": 45000,
+      "max": 70000
+    },
+    "speed_factor": {
+      "min": 0.55,
+      "mode": 0.85,
+      "max": 1.05
+    },
+    "risk_factor": {
+      "min": 0.55,
+      "mode": 0.75,
+      "max": 0.9
+    },
+    "funding_success_probability": 0.55
+  }
+}
+```
+
+## Important
+
+- Only output JSON, no explanations or Markdown
+- All fields must be present
+- Values must be realistic and consistent with G30/G33
+- Distributions must satisfy min ≤ mode ≤ max
+- Apply size adjustments
+- Incorporate risk adjustments from G33

--- a/services/business_case_simulation.py
+++ b/services/business_case_simulation.py
@@ -1,0 +1,1248 @@
+# -*- coding: utf-8 -*-
+"""
+Sprint G34: Business Case Monte Carlo Simulation & Uncertainty Model
+======================================================================
+
+Extends Business Case Engine 2.0 (G30) with:
+- Monte Carlo Simulation for ROI & Payback
+- Probability distributions for uncertain inputs
+- P50/P80/P90 risk-adjusted metrics
+- Integration with Risk Engine V3 for risk-adjusted factors
+- Size-aware & branch-aware simulations
+- Dedicated report section: BUSINESS_CASE_SIM_HTML
+
+This module provides the uncertainty and risk modeling layer on top of
+the deterministic G30 Business Case calculations.
+
+Version: 1.0.0 (Sprint G34)
+Author: Claude + Wolf
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import math
+import random
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Tuple
+
+# Import G30 Business Case Engine
+from services.business_case_engine_v2 import (
+    BusinessCaseReport,
+    ScenarioKPIs,
+    calculate_roi,
+    calculate_payback,
+    MIN_ROI,
+    MAX_ROI,
+    MIN_PAYBACK_MONTHS,
+    MAX_PAYBACK_MONTHS,
+)
+
+log = logging.getLogger(__name__)
+
+__all__ = [
+    "SimulationDistribution",
+    "SimulationAssumptions",
+    "BusinessCaseSimulationReport",
+    "generate_business_case_simulation",
+    "business_case_simulation_to_html",
+    "BUSINESS_CASE_SIMULATION_ENABLED",
+]
+
+
+# =============================================================================
+# CONFIGURATION
+# =============================================================================
+
+BUSINESS_CASE_SIMULATION_ENABLED = True
+
+# Default simulation settings
+DEFAULT_SIMULATION_RUNS = 1000
+MIN_SIMULATION_RUNS = 100
+MAX_SIMULATION_RUNS = 5000
+
+# Percentile definitions
+PERCENTILE_P50 = 50
+PERCENTILE_P80 = 80
+PERCENTILE_P90 = 90
+PERCENTILE_P20 = 20
+
+# Distribution types
+DISTRIBUTION_UNIFORM = "uniform"
+DISTRIBUTION_TRIANGULAR = "triangular"
+DISTRIBUTION_NORMAL = "normal"
+
+# Size-specific variance multipliers
+SIZE_VARIANCE_MULTIPLIERS = {
+    "solo": 1.3,   # Higher variance for solo entrepreneurs
+    "team": 1.0,   # Base variance
+    "kmu": 0.85,   # Lower variance for established KMUs
+}
+
+# Risk-adjusted variance factors
+RISK_VARIANCE_FACTORS = {
+    "A": 0.7,   # Low risk = lower variance
+    "B": 0.85,
+    "C": 1.0,   # Medium risk = base variance
+    "D": 1.2,
+    "F": 1.5,   # High risk = higher variance
+}
+
+# Default assumption ranges (percentage of base value)
+DEFAULT_SAVINGS_RANGE = {"min_pct": 0.6, "mode_pct": 1.0, "max_pct": 1.4}
+DEFAULT_INVESTMENT_RANGE = {"min_pct": 0.8, "mode_pct": 1.0, "max_pct": 1.3}
+DEFAULT_IMPLEMENTATION_SPEED_RANGE = {"min_pct": 0.7, "mode_pct": 1.0, "max_pct": 1.2}
+
+
+# =============================================================================
+# DATA STRUCTURES
+# =============================================================================
+
+@dataclass
+class SimulationAssumptions:
+    """
+    Assumptions for Monte Carlo simulation distributions.
+
+    Defines min/mode/max ranges for each uncertain input.
+    Uses triangular distribution by default.
+    """
+    # Monthly savings distribution
+    monthly_savings_min: float = 0.0
+    monthly_savings_mode: float = 0.0
+    monthly_savings_max: float = 0.0
+
+    # Investment total distribution
+    investment_min: float = 0.0
+    investment_mode: float = 0.0
+    investment_max: float = 0.0
+
+    # Implementation speed factor (1.0 = as planned)
+    speed_factor_min: float = 0.7
+    speed_factor_mode: float = 1.0
+    speed_factor_max: float = 1.2
+
+    # Risk adjustment factor (1.0 = neutral)
+    risk_factor_min: float = 0.8
+    risk_factor_mode: float = 1.0
+    risk_factor_max: float = 1.0
+
+    # Funding success probability (0.0-1.0)
+    funding_success_probability: float = 0.5
+
+    # Distribution type
+    distribution_type: str = DISTRIBUTION_TRIANGULAR
+
+    def __post_init__(self) -> None:
+        """Validate and normalize values."""
+        # Ensure min <= mode <= max for all parameters
+        if self.monthly_savings_min > self.monthly_savings_mode:
+            self.monthly_savings_min = self.monthly_savings_mode
+        if self.monthly_savings_mode > self.monthly_savings_max:
+            self.monthly_savings_max = self.monthly_savings_mode
+
+        if self.investment_min > self.investment_mode:
+            self.investment_min = self.investment_mode
+        if self.investment_mode > self.investment_max:
+            self.investment_max = self.investment_mode
+
+        # Clamp funding probability
+        self.funding_success_probability = max(0.0, min(1.0, self.funding_success_probability))
+
+        # Validate distribution type
+        if self.distribution_type not in [DISTRIBUTION_UNIFORM, DISTRIBUTION_TRIANGULAR, DISTRIBUTION_NORMAL]:
+            self.distribution_type = DISTRIBUTION_TRIANGULAR
+
+    @property
+    def is_valid(self) -> bool:
+        """Check if assumptions are valid for simulation."""
+        return (
+            self.monthly_savings_max > 0 and
+            self.investment_max > 0 and
+            self.monthly_savings_min <= self.monthly_savings_max and
+            self.investment_min <= self.investment_max
+        )
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert to dictionary for JSON serialization."""
+        return {
+            "monthly_savings": {
+                "min": round(self.monthly_savings_min, 2),
+                "mode": round(self.monthly_savings_mode, 2),
+                "max": round(self.monthly_savings_max, 2),
+            },
+            "investment_total": {
+                "min": round(self.investment_min, 2),
+                "mode": round(self.investment_mode, 2),
+                "max": round(self.investment_max, 2),
+            },
+            "speed_factor": {
+                "min": round(self.speed_factor_min, 2),
+                "mode": round(self.speed_factor_mode, 2),
+                "max": round(self.speed_factor_max, 2),
+            },
+            "risk_factor": {
+                "min": round(self.risk_factor_min, 2),
+                "mode": round(self.risk_factor_mode, 2),
+                "max": round(self.risk_factor_max, 2),
+            },
+            "funding_success_probability": round(self.funding_success_probability, 2),
+            "distribution_type": self.distribution_type,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "SimulationAssumptions":
+        """Create from dictionary."""
+        monthly = data.get("monthly_savings", {})
+        investment = data.get("investment_total", {})
+        speed = data.get("speed_factor", {})
+        risk = data.get("risk_factor", {})
+
+        return cls(
+            monthly_savings_min=float(monthly.get("min", 0)),
+            monthly_savings_mode=float(monthly.get("mode", 0)),
+            monthly_savings_max=float(monthly.get("max", 0)),
+            investment_min=float(investment.get("min", 0)),
+            investment_mode=float(investment.get("mode", 0)),
+            investment_max=float(investment.get("max", 0)),
+            speed_factor_min=float(speed.get("min", 0.7)),
+            speed_factor_mode=float(speed.get("mode", 1.0)),
+            speed_factor_max=float(speed.get("max", 1.2)),
+            risk_factor_min=float(risk.get("min", 0.8)),
+            risk_factor_mode=float(risk.get("mode", 1.0)),
+            risk_factor_max=float(risk.get("max", 1.0)),
+            funding_success_probability=float(data.get("funding_success_probability", 0.5)),
+            distribution_type=data.get("distribution_type", DISTRIBUTION_TRIANGULAR),
+        )
+
+
+@dataclass
+class SimulationDistribution:
+    """
+    Results of Monte Carlo simulation.
+
+    Contains all sample values and calculated percentiles.
+    """
+    # Raw samples
+    roi_samples: List[float] = field(default_factory=list)
+    payback_samples: List[float] = field(default_factory=list)
+    monthly_savings_samples: List[float] = field(default_factory=list)
+
+    # ROI percentiles
+    roi_p50: float = 0.0
+    roi_p80: float = 0.0
+    roi_p90: float = 0.0
+    roi_p20: float = 0.0
+
+    # Payback percentiles
+    payback_p50: float = 0.0
+    payback_p80: float = 0.0
+    payback_p90: float = 0.0
+    payback_p20: float = 0.0
+
+    # Ranges
+    roi_min: float = 0.0
+    roi_max: float = 0.0
+    roi_mean: float = 0.0
+    roi_std: float = 0.0
+
+    payback_min: float = 0.0
+    payback_max: float = 0.0
+    payback_mean: float = 0.0
+    payback_std: float = 0.0
+
+    # Sample count
+    simulation_runs: int = 0
+
+    def __post_init__(self) -> None:
+        """Calculate statistics if samples provided."""
+        if self.roi_samples and not self.roi_p50:
+            self._calculate_statistics()
+
+    def _calculate_statistics(self) -> None:
+        """Calculate all statistics from samples."""
+        if not self.roi_samples:
+            return
+
+        self.simulation_runs = len(self.roi_samples)
+
+        # ROI statistics
+        sorted_roi = sorted(self.roi_samples)
+        self.roi_min = min(sorted_roi)
+        self.roi_max = max(sorted_roi)
+        self.roi_mean = sum(sorted_roi) / len(sorted_roi)
+        self.roi_std = _calculate_std(sorted_roi, self.roi_mean)
+
+        self.roi_p20 = _percentile(sorted_roi, PERCENTILE_P20)
+        self.roi_p50 = _percentile(sorted_roi, PERCENTILE_P50)
+        self.roi_p80 = _percentile(sorted_roi, PERCENTILE_P80)
+        self.roi_p90 = _percentile(sorted_roi, PERCENTILE_P90)
+
+        # Payback statistics
+        if self.payback_samples:
+            sorted_payback = sorted(self.payback_samples)
+            self.payback_min = min(sorted_payback)
+            self.payback_max = max(sorted_payback)
+            self.payback_mean = sum(sorted_payback) / len(sorted_payback)
+            self.payback_std = _calculate_std(sorted_payback, self.payback_mean)
+
+            self.payback_p20 = _percentile(sorted_payback, PERCENTILE_P20)
+            self.payback_p50 = _percentile(sorted_payback, PERCENTILE_P50)
+            self.payback_p80 = _percentile(sorted_payback, PERCENTILE_P80)
+            self.payback_p90 = _percentile(sorted_payback, PERCENTILE_P90)
+
+    @property
+    def roi_confidence_interval_80(self) -> Tuple[float, float]:
+        """Get 80% confidence interval for ROI (P10 to P90)."""
+        if not self.roi_samples:
+            return (0.0, 0.0)
+        sorted_roi = sorted(self.roi_samples)
+        return (_percentile(sorted_roi, 10), _percentile(sorted_roi, 90))
+
+    @property
+    def payback_confidence_interval_80(self) -> Tuple[float, float]:
+        """Get 80% confidence interval for Payback (P10 to P90)."""
+        if not self.payback_samples:
+            return (0.0, 0.0)
+        sorted_payback = sorted(self.payback_samples)
+        return (_percentile(sorted_payback, 10), _percentile(sorted_payback, 90))
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert to dictionary for JSON serialization."""
+        return {
+            "simulation_runs": self.simulation_runs,
+            "roi": {
+                "p20": round(self.roi_p20, 1),
+                "p50": round(self.roi_p50, 1),
+                "p80": round(self.roi_p80, 1),
+                "p90": round(self.roi_p90, 1),
+                "min": round(self.roi_min, 1),
+                "max": round(self.roi_max, 1),
+                "mean": round(self.roi_mean, 1),
+                "std": round(self.roi_std, 1),
+            },
+            "payback": {
+                "p20": round(self.payback_p20, 1),
+                "p50": round(self.payback_p50, 1),
+                "p80": round(self.payback_p80, 1),
+                "p90": round(self.payback_p90, 1),
+                "min": round(self.payback_min, 1),
+                "max": round(self.payback_max, 1),
+                "mean": round(self.payback_mean, 1),
+                "std": round(self.payback_std, 1),
+            },
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "SimulationDistribution":
+        """Create from dictionary."""
+        roi = data.get("roi", {})
+        payback = data.get("payback", {})
+
+        return cls(
+            roi_samples=[],  # Samples not serialized
+            payback_samples=[],
+            monthly_savings_samples=[],
+            roi_p50=float(roi.get("p50", 0)),
+            roi_p80=float(roi.get("p80", 0)),
+            roi_p90=float(roi.get("p90", 0)),
+            roi_p20=float(roi.get("p20", 0)),
+            payback_p50=float(payback.get("p50", 0)),
+            payback_p80=float(payback.get("p80", 0)),
+            payback_p90=float(payback.get("p90", 0)),
+            payback_p20=float(payback.get("p20", 0)),
+            roi_min=float(roi.get("min", 0)),
+            roi_max=float(roi.get("max", 0)),
+            roi_mean=float(roi.get("mean", 0)),
+            roi_std=float(roi.get("std", 0)),
+            payback_min=float(payback.get("min", 0)),
+            payback_max=float(payback.get("max", 0)),
+            payback_mean=float(payback.get("mean", 0)),
+            payback_std=float(payback.get("std", 0)),
+            simulation_runs=data.get("simulation_runs", 0),
+        )
+
+
+@dataclass
+class BusinessCaseSimulationReport:
+    """
+    Complete Business Case Simulation Report.
+
+    Combines G30 deterministic baseline with Monte Carlo simulation results.
+    """
+    # G30 baseline report
+    baseline_report: Optional[BusinessCaseReport] = None
+
+    # Simulation results
+    distribution: SimulationDistribution = field(default_factory=SimulationDistribution)
+
+    # Assumptions used
+    assumptions: SimulationAssumptions = field(default_factory=SimulationAssumptions)
+
+    # Narrative summary
+    narrative_summary: str = ""
+
+    # Metadata
+    size_label: str = "team"
+    risk_grade: str = "C"
+    simulation_runs: int = DEFAULT_SIMULATION_RUNS
+
+    def __post_init__(self) -> None:
+        """Validate and normalize."""
+        if self.baseline_report is None:
+            self.baseline_report = BusinessCaseReport()
+        if not isinstance(self.distribution, SimulationDistribution):
+            self.distribution = SimulationDistribution()
+        if not isinstance(self.assumptions, SimulationAssumptions):
+            self.assumptions = SimulationAssumptions()
+
+    @property
+    def realistic_scenario(self) -> Optional[ScenarioKPIs]:
+        """Get realistic scenario from baseline."""
+        if self.baseline_report:
+            return self.baseline_report.realistic_scenario
+        return None
+
+    @property
+    def is_simulation_valid(self) -> bool:
+        """Check if simulation produced valid results."""
+        return (
+            self.distribution.simulation_runs > 0 and
+            self.distribution.roi_p50 != 0
+        )
+
+    @property
+    def roi_p50_vs_realistic_deviation(self) -> float:
+        """Calculate deviation between P50 ROI and realistic scenario ROI."""
+        realistic = self.realistic_scenario
+        if not realistic:
+            return 0.0
+        if realistic.roi_12m == 0:
+            return 0.0
+        return abs(self.distribution.roi_p50 - realistic.roi_12m) / abs(realistic.roi_12m) * 100
+
+    @property
+    def variance_level(self) -> str:
+        """Determine variance level (low/medium/high)."""
+        if self.distribution.roi_std == 0:
+            return "low"
+        cv = abs(self.distribution.roi_std / self.distribution.roi_mean) if self.distribution.roi_mean != 0 else 0
+        if cv < 0.2:
+            return "low"
+        elif cv < 0.5:
+            return "medium"
+        else:
+            return "high"
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert to dictionary for JSON serialization."""
+        return {
+            "baseline_report": self.baseline_report.to_dict() if self.baseline_report else {},
+            "distribution": self.distribution.to_dict(),
+            "assumptions": self.assumptions.to_dict(),
+            "narrative_summary": self.narrative_summary,
+            "size_label": self.size_label,
+            "risk_grade": self.risk_grade,
+            "simulation_runs": self.simulation_runs,
+            "is_valid": self.is_simulation_valid,
+            "variance_level": self.variance_level,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "BusinessCaseSimulationReport":
+        """Create from dictionary."""
+        baseline_data = data.get("baseline_report", {})
+        baseline = BusinessCaseReport.from_dict(baseline_data) if baseline_data else None
+
+        dist_data = data.get("distribution", {})
+        distribution = SimulationDistribution.from_dict(dist_data) if dist_data else SimulationDistribution()
+
+        assumptions_data = data.get("assumptions", {})
+        assumptions = SimulationAssumptions.from_dict(assumptions_data) if assumptions_data else SimulationAssumptions()
+
+        return cls(
+            baseline_report=baseline,
+            distribution=distribution,
+            assumptions=assumptions,
+            narrative_summary=data.get("narrative_summary", ""),
+            size_label=data.get("size_label", "team"),
+            risk_grade=data.get("risk_grade", "C"),
+            simulation_runs=data.get("simulation_runs", DEFAULT_SIMULATION_RUNS),
+        )
+
+
+# =============================================================================
+# HELPER FUNCTIONS
+# =============================================================================
+
+def _percentile(sorted_data: List[float], p: int) -> float:
+    """Calculate percentile from sorted data."""
+    if not sorted_data:
+        return 0.0
+    n = len(sorted_data)
+    if n == 1:
+        return sorted_data[0]
+
+    k = (n - 1) * p / 100
+    f = math.floor(k)
+    c = math.ceil(k)
+
+    if f == c:
+        return sorted_data[int(k)]
+
+    return sorted_data[int(f)] * (c - k) + sorted_data[int(c)] * (k - f)
+
+
+def _calculate_std(data: List[float], mean: float) -> float:
+    """Calculate standard deviation."""
+    if len(data) < 2:
+        return 0.0
+    variance = sum((x - mean) ** 2 for x in data) / (len(data) - 1)
+    return math.sqrt(variance)
+
+
+def _triangular_sample(min_val: float, mode_val: float, max_val: float) -> float:
+    """Sample from triangular distribution."""
+    if min_val >= max_val:
+        return mode_val
+    return random.triangular(min_val, max_val, mode_val)
+
+
+def _uniform_sample(min_val: float, max_val: float) -> float:
+    """Sample from uniform distribution."""
+    if min_val >= max_val:
+        return min_val
+    return random.uniform(min_val, max_val)
+
+
+def _normal_sample(mean: float, std: float, min_val: float, max_val: float) -> float:
+    """Sample from truncated normal distribution."""
+    value = random.gauss(mean, std)
+    return max(min_val, min(max_val, value))
+
+
+def _sample_from_distribution(
+    min_val: float,
+    mode_val: float,
+    max_val: float,
+    distribution_type: str,
+) -> float:
+    """Sample a value based on distribution type."""
+    if distribution_type == DISTRIBUTION_UNIFORM:
+        return _uniform_sample(min_val, max_val)
+    elif distribution_type == DISTRIBUTION_NORMAL:
+        mean = mode_val
+        std = (max_val - min_val) / 4  # Approximate std
+        return _normal_sample(mean, std, min_val, max_val)
+    else:  # Default: triangular
+        return _triangular_sample(min_val, mode_val, max_val)
+
+
+def _determine_size_label(briefing: Optional[Dict[str, Any]]) -> str:
+    """Determine company size label from briefing."""
+    if not briefing:
+        return "team"
+
+    size = str(briefing.get("unternehmensgroesse", "")).lower()
+
+    if "solo" in size or "freiberuf" in size or "einzelunternehm" in size:
+        return "solo"
+    elif "kmu" in size or "mittel" in size or ">10" in size:
+        return "kmu"
+    else:
+        return "team"
+
+
+def _extract_risk_grade(risk_report_v3: Any) -> str:
+    """Extract risk grade from Risk Engine V3 report."""
+    if not risk_report_v3:
+        return "C"
+
+    if hasattr(risk_report_v3, "residual_risk_grade"):
+        return risk_report_v3.residual_risk_grade
+    elif isinstance(risk_report_v3, dict):
+        return risk_report_v3.get("residual_risk_grade", "C")
+
+    return "C"
+
+
+def _extract_residual_risk_score(risk_report_v3: Any) -> float:
+    """Extract residual risk score from Risk Engine V3 report."""
+    if not risk_report_v3:
+        return 50.0
+
+    if hasattr(risk_report_v3, "residual_risk_score"):
+        return risk_report_v3.residual_risk_score
+    elif isinstance(risk_report_v3, dict):
+        return float(risk_report_v3.get("residual_risk_score", 50.0))
+
+    return 50.0
+
+
+# =============================================================================
+# ASSUMPTION GENERATION
+# =============================================================================
+
+def generate_default_assumptions(
+    business_case: BusinessCaseReport,
+    risk_report_v3: Any = None,
+    auto_report: Any = None,
+    size_label: str = "team",
+) -> SimulationAssumptions:
+    """
+    Generate default simulation assumptions from business case baseline.
+
+    Uses G30 scenarios to derive reasonable ranges:
+    - Conservative scenario values as min
+    - Realistic scenario values as mode
+    - Optimistic scenario values as max
+
+    Risk adjustment based on G33 residual risk score.
+    """
+    # Get scenarios
+    optimistic = business_case.get_scenario("optimistic")
+    realistic = business_case.get_scenario("realistic")
+    conservative = business_case.get_scenario("conservative")
+
+    # Default values if scenarios missing
+    base_savings = realistic.monthly_savings if realistic else 500.0
+    base_investment = business_case.investment_total or 5000.0
+
+    # Size-based variance multiplier
+    variance_mult = SIZE_VARIANCE_MULTIPLIERS.get(size_label, 1.0)
+
+    # Risk-based variance factor
+    risk_grade = _extract_risk_grade(risk_report_v3)
+    risk_variance = RISK_VARIANCE_FACTORS.get(risk_grade, 1.0)
+
+    # Combined variance factor
+    combined_variance = variance_mult * risk_variance
+
+    # Monthly savings range
+    if conservative and optimistic:
+        savings_min = conservative.monthly_savings
+        savings_max = optimistic.monthly_savings
+    else:
+        savings_min = base_savings * DEFAULT_SAVINGS_RANGE["min_pct"] * combined_variance
+        savings_max = base_savings * DEFAULT_SAVINGS_RANGE["max_pct"] * combined_variance
+
+    # Investment range
+    if conservative and optimistic:
+        # Conservative = higher investment, optimistic = lower
+        invest_min = optimistic.investment_total
+        invest_max = conservative.investment_total
+    else:
+        invest_min = base_investment * DEFAULT_INVESTMENT_RANGE["min_pct"]
+        invest_max = base_investment * DEFAULT_INVESTMENT_RANGE["max_pct"] * combined_variance
+
+    # Speed factor based on risk
+    speed_min = DEFAULT_IMPLEMENTATION_SPEED_RANGE["min_pct"]
+    speed_max = DEFAULT_IMPLEMENTATION_SPEED_RANGE["max_pct"]
+    if risk_grade in ["D", "F"]:
+        speed_min *= 0.9  # Higher risk = potentially slower
+        speed_max *= 0.95
+
+    # Risk adjustment factor
+    risk_score = _extract_residual_risk_score(risk_report_v3)
+    risk_factor_mode = min(1.0, risk_score / 100 + 0.5)  # 50% score = 1.0 factor
+    risk_factor_min = max(0.5, risk_factor_mode - 0.2 * combined_variance)
+    risk_factor_max = min(1.2, risk_factor_mode + 0.1)
+
+    # Funding success probability
+    funding_prob = 0.5
+    if business_case.funding_programmes_used:
+        funding_prob = min(0.8, 0.4 + len(business_case.funding_programmes_used) * 0.15)
+
+    return SimulationAssumptions(
+        monthly_savings_min=max(0, savings_min),
+        monthly_savings_mode=base_savings,
+        monthly_savings_max=savings_max,
+        investment_min=max(100, invest_min),
+        investment_mode=base_investment,
+        investment_max=invest_max,
+        speed_factor_min=speed_min,
+        speed_factor_mode=1.0,
+        speed_factor_max=speed_max,
+        risk_factor_min=risk_factor_min,
+        risk_factor_mode=risk_factor_mode,
+        risk_factor_max=risk_factor_max,
+        funding_success_probability=funding_prob,
+        distribution_type=DISTRIBUTION_TRIANGULAR,
+    )
+
+
+def parse_llm_assumptions(llm_response: str) -> Optional[SimulationAssumptions]:
+    """
+    Parse LLM response containing assumption JSON.
+
+    Expected format:
+    {
+        "assumptions": {
+            "monthly_savings": {"min": 3000, "mode": 5000, "max": 8000},
+            "investment_total": {"min": 20000, "mode": 25000, "max": 30000},
+            "speed_factor": {"min": 0.7, "mode": 1.0, "max": 1.2},
+            "risk_factor": {"min": 0.8, "mode": 1.0, "max": 1.1},
+            "funding_success_probability": 0.6
+        }
+    }
+    """
+    if not llm_response:
+        return None
+
+    try:
+        data = json.loads(llm_response)
+        if "assumptions" in data:
+            return SimulationAssumptions.from_dict(data["assumptions"])
+        return SimulationAssumptions.from_dict(data)
+    except (json.JSONDecodeError, TypeError, KeyError) as e:
+        log.warning("[G34] Failed to parse LLM assumptions: %s", e)
+        return None
+
+
+# =============================================================================
+# MONTE CARLO SIMULATION
+# =============================================================================
+
+def run_monte_carlo_simulation(
+    assumptions: SimulationAssumptions,
+    funding_effect_base: float = 0.0,
+    runs: int = DEFAULT_SIMULATION_RUNS,
+) -> SimulationDistribution:
+    """
+    Run Monte Carlo simulation for ROI and Payback.
+
+    For each simulation:
+    1. Sample monthly_savings from distribution
+    2. Sample investment_total from distribution
+    3. Sample risk_factor for adjustment
+    4. Apply funding effect probabilistically
+    5. Calculate ROI and Payback
+
+    Returns distribution with all percentiles calculated.
+    """
+    runs = max(MIN_SIMULATION_RUNS, min(MAX_SIMULATION_RUNS, runs))
+
+    roi_samples: List[float] = []
+    payback_samples: List[float] = []
+    savings_samples: List[float] = []
+
+    dist_type = assumptions.distribution_type
+
+    for _ in range(runs):
+        # Sample monthly savings
+        monthly_savings = _sample_from_distribution(
+            assumptions.monthly_savings_min,
+            assumptions.monthly_savings_mode,
+            assumptions.monthly_savings_max,
+            dist_type,
+        )
+
+        # Sample investment
+        investment = _sample_from_distribution(
+            assumptions.investment_min,
+            assumptions.investment_mode,
+            assumptions.investment_max,
+            dist_type,
+        )
+
+        # Sample risk factor
+        risk_factor = _sample_from_distribution(
+            assumptions.risk_factor_min,
+            assumptions.risk_factor_mode,
+            assumptions.risk_factor_max,
+            dist_type,
+        )
+
+        # Sample speed factor
+        speed_factor = _sample_from_distribution(
+            assumptions.speed_factor_min,
+            assumptions.speed_factor_mode,
+            assumptions.speed_factor_max,
+            dist_type,
+        )
+
+        # Apply funding effect probabilistically
+        funding_effect = 0.0
+        if random.random() < assumptions.funding_success_probability:
+            funding_effect = funding_effect_base
+
+        # Adjust values
+        effective_savings = monthly_savings * risk_factor * speed_factor
+        effective_investment = max(100, investment - funding_effect)
+
+        # Calculate annual savings
+        annual_savings = effective_savings * 12
+
+        # Calculate ROI
+        roi = calculate_roi(annual_savings, effective_investment)
+        roi = max(MIN_ROI, min(MAX_ROI, roi))
+
+        # Calculate Payback
+        if effective_savings > 0:
+            payback = effective_investment / effective_savings
+            payback = max(MIN_PAYBACK_MONTHS, min(MAX_PAYBACK_MONTHS, payback))
+        else:
+            payback = MAX_PAYBACK_MONTHS
+
+        roi_samples.append(roi)
+        payback_samples.append(payback)
+        savings_samples.append(effective_savings)
+
+    distribution = SimulationDistribution(
+        roi_samples=roi_samples,
+        payback_samples=payback_samples,
+        monthly_savings_samples=savings_samples,
+    )
+    distribution._calculate_statistics()
+
+    return distribution
+
+
+# =============================================================================
+# NARRATIVE GENERATION
+# =============================================================================
+
+def generate_narrative_summary(
+    distribution: SimulationDistribution,
+    baseline: BusinessCaseReport,
+    assumptions: SimulationAssumptions,
+    lang: str = "de",
+) -> str:
+    """Generate narrative summary for simulation results."""
+    realistic = baseline.realistic_scenario
+
+    if lang == "en":
+        parts = []
+
+        # P50 vs realistic comparison
+        if realistic:
+            deviation = abs(distribution.roi_p50 - realistic.roi_12m)
+            if deviation < 10:
+                parts.append(f"The Monte Carlo simulation confirms the realistic scenario with a median ROI of {distribution.roi_p50:.0f}%.")
+            elif distribution.roi_p50 > realistic.roi_12m:
+                parts.append(f"The simulation indicates potential upside: median ROI of {distribution.roi_p50:.0f}% vs. {realistic.roi_12m:.0f}% planned.")
+            else:
+                parts.append(f"The simulation suggests conservative planning may be prudent: median ROI of {distribution.roi_p50:.0f}%.")
+
+        # Confidence interval
+        roi_ci = distribution.roi_confidence_interval_80
+        parts.append(f"With 80% probability, ROI will fall between {roi_ci[0]:.0f}% and {roi_ci[1]:.0f}%.")
+
+        # Payback
+        pb_ci = distribution.payback_confidence_interval_80
+        parts.append(f"Payback period: {distribution.payback_p50:.1f} months (80% CI: {pb_ci[0]:.1f}-{pb_ci[1]:.1f} months).")
+
+        # Risk assessment
+        if distribution.roi_std > 50:
+            parts.append("High variance indicates significant uncertainty - consider risk mitigation.")
+        elif distribution.roi_std < 20:
+            parts.append("Low variance suggests reliable outcome expectations.")
+
+    else:  # German
+        parts = []
+
+        # P50 vs realistic comparison
+        if realistic:
+            deviation = abs(distribution.roi_p50 - realistic.roi_12m)
+            if deviation < 10:
+                parts.append(f"Die Monte-Carlo-Simulation bestaetigt das realistische Szenario mit einem Median-ROI von {distribution.roi_p50:.0f}%.")
+            elif distribution.roi_p50 > realistic.roi_12m:
+                parts.append(f"Die Simulation zeigt Potenzial nach oben: Median-ROI von {distribution.roi_p50:.0f}% vs. {realistic.roi_12m:.0f}% geplant.")
+            else:
+                parts.append(f"Die Simulation empfiehlt konservative Planung: Median-ROI von {distribution.roi_p50:.0f}%.")
+
+        # Confidence interval
+        roi_ci = distribution.roi_confidence_interval_80
+        parts.append(f"Mit 80% Wahrscheinlichkeit liegt der ROI zwischen {roi_ci[0]:.0f}% und {roi_ci[1]:.0f}%.")
+
+        # Payback
+        pb_ci = distribution.payback_confidence_interval_80
+        parts.append(f"Amortisation: {distribution.payback_p50:.1f} Monate (80% KI: {pb_ci[0]:.1f}-{pb_ci[1]:.1f} Monate).")
+
+        # Risk assessment
+        if distribution.roi_std > 50:
+            parts.append("Hohe Varianz zeigt erhebliche Unsicherheit - Risikominderung empfohlen.")
+        elif distribution.roi_std < 20:
+            parts.append("Niedrige Varianz deutet auf zuverlaessige Ergebniserwartungen hin.")
+
+    return " ".join(parts)
+
+
+# =============================================================================
+# MAIN GENERATION FUNCTION
+# =============================================================================
+
+def generate_business_case_simulation(
+    context: Any = None,
+    business_case: Optional[BusinessCaseReport] = None,
+    risk_report_v3: Any = None,
+    auto_report: Any = None,
+    tools_data: Any = None,
+    funding_data: Any = None,
+    briefing: Optional[Dict[str, Any]] = None,
+    llm_response: Optional[str] = None,
+    runs: int = DEFAULT_SIMULATION_RUNS,
+) -> BusinessCaseSimulationReport:
+    """
+    Generate Business Case Simulation Report with Monte Carlo analysis.
+
+    This function:
+    1. Takes G30 BusinessCaseReport as baseline
+    2. Extracts or generates simulation assumptions
+    3. Adjusts variance based on G33 risk score and company size
+    4. Runs Monte Carlo simulation
+    5. Calculates P50/P80/P90 percentiles
+    6. Generates narrative summary
+
+    Args:
+        context: ReportContext object (optional)
+        business_case: G30 BusinessCaseReport (required)
+        risk_report_v3: G33 RiskReportV3 for risk adjustment
+        auto_report: G36 AutomationRoadmapReport for context
+        tools_data: G25 Tools Engine data
+        funding_data: G26 Funding Engine data
+        briefing: Original briefing/answers dict
+        llm_response: Optional LLM response with assumptions JSON
+        runs: Number of simulation runs (default 1000)
+
+    Returns:
+        BusinessCaseSimulationReport with simulation results
+    """
+    log.info("[G34] Starting Business Case Monte Carlo Simulation...")
+
+    # Ensure we have a baseline
+    if business_case is None:
+        log.warning("[G34] No business case provided, creating empty baseline")
+        business_case = BusinessCaseReport()
+
+    # Determine size label
+    size_label = _determine_size_label(briefing)
+
+    # Extract risk grade
+    risk_grade = _extract_risk_grade(risk_report_v3)
+
+    # Get language
+    lang = "de"
+    if briefing:
+        lang = briefing.get("language", briefing.get("sprache", "de"))
+
+    # Parse LLM assumptions or generate defaults
+    assumptions: Optional[SimulationAssumptions] = None
+    if llm_response:
+        assumptions = parse_llm_assumptions(llm_response)
+
+    if not assumptions or not assumptions.is_valid:
+        log.info("[G34] Generating default assumptions from business case")
+        assumptions = generate_default_assumptions(
+            business_case=business_case,
+            risk_report_v3=risk_report_v3,
+            auto_report=auto_report,
+            size_label=size_label,
+        )
+
+    # Get funding effect from baseline
+    funding_effect_base = business_case.funding_effect
+
+    # Run Monte Carlo simulation
+    log.info("[G34] Running Monte Carlo simulation with %d runs...", runs)
+    distribution = run_monte_carlo_simulation(
+        assumptions=assumptions,
+        funding_effect_base=funding_effect_base,
+        runs=runs,
+    )
+
+    # Generate narrative
+    narrative = generate_narrative_summary(
+        distribution=distribution,
+        baseline=business_case,
+        assumptions=assumptions,
+        lang=lang,
+    )
+
+    report = BusinessCaseSimulationReport(
+        baseline_report=business_case,
+        distribution=distribution,
+        assumptions=assumptions,
+        narrative_summary=narrative,
+        size_label=size_label,
+        risk_grade=risk_grade,
+        simulation_runs=runs,
+    )
+
+    log.info(
+        "[G34] Business Case Simulation complete: ROI P50=%.1f%%, P80=%.1f%%, P90=%.1f%%, "
+        "Payback P50=%.1f months, runs=%d",
+        distribution.roi_p50,
+        distribution.roi_p80,
+        distribution.roi_p90,
+        distribution.payback_p50,
+        runs,
+    )
+
+    return report
+
+
+# =============================================================================
+# HTML RENDERING
+# =============================================================================
+
+def business_case_simulation_to_html(
+    report: BusinessCaseSimulationReport,
+    lang: str = "de",
+) -> str:
+    """
+    Generate HTML section for Business Case Simulation.
+
+    Renders:
+    - P50/P80/P90 percentile table for ROI & Payback
+    - Min/Max ranges
+    - Confidence interval visualization
+    - Narrative summary
+    - Comparison to G30 deterministic scenarios
+
+    Uses only allowed tags: div, p, ul, li, strong, span, table, tr, td, th
+
+    Args:
+        report: BusinessCaseSimulationReport object
+        lang: Language code ("de" or "en")
+
+    Returns:
+        HTML string for PDF template
+    """
+    # Labels
+    if lang == "en":
+        labels = {
+            "title": "Risk-Adjusted Business Case",
+            "subtitle": "Monte Carlo Simulation Analysis",
+            "roi_label": "ROI (12 months)",
+            "payback_label": "Payback Period",
+            "percentile": "Percentile",
+            "p50": "P50 (Median)",
+            "p80": "P80",
+            "p90": "P90",
+            "p20": "P20",
+            "min": "Min",
+            "max": "Max",
+            "mean": "Mean",
+            "std": "Std Dev",
+            "months": "months",
+            "runs": "Simulation Runs",
+            "confidence_80": "80% Confidence Interval",
+            "assumptions": "Simulation Assumptions",
+            "monthly_savings": "Monthly Savings",
+            "investment": "Investment",
+            "assessment": "Assessment",
+            "vs_realistic": "vs. Realistic Scenario",
+            "variance": "Variance Level",
+            "low": "Low",
+            "medium": "Medium",
+            "high": "High",
+        }
+    else:
+        labels = {
+            "title": "Risikoadjustierter Business Case",
+            "subtitle": "Monte-Carlo Simulationsanalyse",
+            "roi_label": "ROI (12 Monate)",
+            "payback_label": "Amortisationszeit",
+            "percentile": "Perzentil",
+            "p50": "P50 (Median)",
+            "p80": "P80",
+            "p90": "P90",
+            "p20": "P20",
+            "min": "Min",
+            "max": "Max",
+            "mean": "Mittelwert",
+            "std": "Std-Abw.",
+            "months": "Monate",
+            "runs": "Simulationslaeufe",
+            "confidence_80": "80% Konfidenzintervall",
+            "assumptions": "Simulationsannahmen",
+            "monthly_savings": "Monatl. Ersparnis",
+            "investment": "Investment",
+            "assessment": "Bewertung",
+            "vs_realistic": "vs. Realistisches Szenario",
+            "variance": "Varianz-Level",
+            "low": "Niedrig",
+            "medium": "Mittel",
+            "high": "Hoch",
+        }
+
+    dist = report.distribution
+    assumptions = report.assumptions
+    realistic = report.realistic_scenario
+
+    # Colors
+    colors = {
+        "primary": "#6366f1",      # Indigo
+        "primary_light": "#a5b4fc",
+        "primary_bg": "#eef2ff",
+        "green": "#22c55e",
+        "green_bg": "#f0fdf4",
+        "yellow": "#f59e0b",
+        "yellow_bg": "#fffbeb",
+        "red": "#dc2626",
+        "red_bg": "#fef2f2",
+        "blue": "#3b82f6",
+        "blue_bg": "#eff6ff",
+        "gray": "#64748b",
+        "gray_light": "#f1f5f9",
+        "gray_border": "#e2e8f0",
+        "text_primary": "#1e293b",
+        "text_secondary": "#64748b",
+    }
+
+    # Variance level color
+    variance_color = colors["green"] if report.variance_level == "low" else (
+        colors["yellow"] if report.variance_level == "medium" else colors["red"]
+    )
+    variance_label = labels.get(report.variance_level, report.variance_level)
+
+    html_parts: List[str] = []
+
+    # Main container
+    html_parts.append(f'''
+<div class="business-case-simulation" style="font-size:11pt;color:{colors["text_primary"]};">
+    <!-- Header -->
+    <div style="display:flex;align-items:center;gap:10px;margin-bottom:16px;">
+        <span style="font-size:20px;">🎲</span>
+        <span style="font-size:11px;padding:2px 8px;background:{colors["primary"]};color:#fff;border-radius:4px;font-weight:600;">G34</span>
+        <span style="font-size:10pt;color:{colors["text_secondary"]};">{labels["subtitle"]} ({dist.simulation_runs} {labels["runs"]})</span>
+    </div>
+''')
+
+    # Main KPI Cards - ROI and Payback P50
+    html_parts.append(f'''
+    <!-- Key Metrics -->
+    <div style="display:flex;gap:16px;margin-bottom:20px;">
+        <!-- ROI P50 Card -->
+        <div style="flex:1;padding:20px;background:linear-gradient(135deg,{colors["primary_bg"]} 0%,#fff 100%);border-radius:12px;border:2px solid {colors["primary_light"]};text-align:center;">
+            <span style="font-size:10px;color:{colors["text_secondary"]};font-weight:600;">{labels["roi_label"]} {labels["p50"]}</span>
+            <div style="font-size:36px;font-weight:700;color:{colors["primary"]};margin:8px 0;">{dist.roi_p50:.0f}%</div>
+            <div style="font-size:9pt;color:{colors["text_secondary"]};">
+                {labels["confidence_80"]}: {dist.roi_confidence_interval_80[0]:.0f}% - {dist.roi_confidence_interval_80[1]:.0f}%
+            </div>
+        </div>
+
+        <!-- Payback P50 Card -->
+        <div style="flex:1;padding:20px;background:linear-gradient(135deg,{colors["blue_bg"]} 0%,#fff 100%);border-radius:12px;border:2px solid #93c5fd;text-align:center;">
+            <span style="font-size:10px;color:{colors["text_secondary"]};font-weight:600;">{labels["payback_label"]} {labels["p50"]}</span>
+            <div style="font-size:36px;font-weight:700;color:{colors["blue"]};margin:8px 0;">{dist.payback_p50:.1f}</div>
+            <div style="font-size:9pt;color:{colors["text_secondary"]};">
+                {labels["months"]} ({labels["confidence_80"]}: {dist.payback_confidence_interval_80[0]:.1f}-{dist.payback_confidence_interval_80[1]:.1f})
+            </div>
+        </div>
+
+        <!-- Variance Card -->
+        <div style="flex:0.6;padding:20px;background:{colors["gray_light"]};border-radius:12px;border:1px solid {colors["gray_border"]};text-align:center;">
+            <span style="font-size:10px;color:{colors["text_secondary"]};font-weight:600;">{labels["variance"]}</span>
+            <div style="font-size:24px;font-weight:700;color:{variance_color};margin:8px 0;">{variance_label}</div>
+            <div style="font-size:9pt;color:{colors["text_secondary"]};">
+                Std: {dist.roi_std:.1f}%
+            </div>
+        </div>
+    </div>
+''')
+
+    # Percentile Table
+    html_parts.append(f'''
+    <!-- Percentile Table -->
+    <div style="margin-bottom:20px;">
+        <table style="width:100%;border-collapse:collapse;font-size:10pt;">
+            <tr style="background:{colors["gray_light"]};">
+                <th style="padding:10px;text-align:left;border:1px solid {colors["gray_border"]};">{labels["percentile"]}</th>
+                <th style="padding:10px;text-align:right;border:1px solid {colors["gray_border"]};">{labels["roi_label"]}</th>
+                <th style="padding:10px;text-align:right;border:1px solid {colors["gray_border"]};">{labels["payback_label"]}</th>
+            </tr>
+            <tr>
+                <td style="padding:8px;border:1px solid {colors["gray_border"]};font-weight:600;color:{colors["red"]};">{labels["p20"]}</td>
+                <td style="padding:8px;text-align:right;border:1px solid {colors["gray_border"]};">{dist.roi_p20:.1f}%</td>
+                <td style="padding:8px;text-align:right;border:1px solid {colors["gray_border"]};">{dist.payback_p20:.1f} {labels["months"]}</td>
+            </tr>
+            <tr style="background:{colors["primary_bg"]};">
+                <td style="padding:8px;border:1px solid {colors["gray_border"]};font-weight:600;color:{colors["primary"]};">{labels["p50"]}</td>
+                <td style="padding:8px;text-align:right;border:1px solid {colors["gray_border"]};font-weight:700;color:{colors["primary"]};">{dist.roi_p50:.1f}%</td>
+                <td style="padding:8px;text-align:right;border:1px solid {colors["gray_border"]};font-weight:700;color:{colors["primary"]};">{dist.payback_p50:.1f} {labels["months"]}</td>
+            </tr>
+            <tr>
+                <td style="padding:8px;border:1px solid {colors["gray_border"]};font-weight:600;color:{colors["yellow"]};">{labels["p80"]}</td>
+                <td style="padding:8px;text-align:right;border:1px solid {colors["gray_border"]};">{dist.roi_p80:.1f}%</td>
+                <td style="padding:8px;text-align:right;border:1px solid {colors["gray_border"]};">{dist.payback_p80:.1f} {labels["months"]}</td>
+            </tr>
+            <tr style="background:{colors["green_bg"]};">
+                <td style="padding:8px;border:1px solid {colors["gray_border"]};font-weight:600;color:{colors["green"]};">{labels["p90"]}</td>
+                <td style="padding:8px;text-align:right;border:1px solid {colors["gray_border"]};">{dist.roi_p90:.1f}%</td>
+                <td style="padding:8px;text-align:right;border:1px solid {colors["gray_border"]};">{dist.payback_p90:.1f} {labels["months"]}</td>
+            </tr>
+            <tr style="background:{colors["gray_light"]};">
+                <td style="padding:8px;border:1px solid {colors["gray_border"]};font-size:9pt;">{labels["min"]} / {labels["max"]}</td>
+                <td style="padding:8px;text-align:right;border:1px solid {colors["gray_border"]};font-size:9pt;">{dist.roi_min:.1f}% / {dist.roi_max:.1f}%</td>
+                <td style="padding:8px;text-align:right;border:1px solid {colors["gray_border"]};font-size:9pt;">{dist.payback_min:.1f} / {dist.payback_max:.1f} {labels["months"]}</td>
+            </tr>
+        </table>
+    </div>
+''')
+
+    # Comparison to G30 realistic scenario
+    if realistic:
+        deviation_pct = report.roi_p50_vs_realistic_deviation
+        comparison_color = colors["green"] if deviation_pct < 15 else (colors["yellow"] if deviation_pct < 30 else colors["red"])
+
+        html_parts.append(f'''
+    <!-- Comparison to G30 -->
+    <div style="padding:16px;background:{colors["yellow_bg"]};border-radius:12px;border:1px solid #fcd34d;margin-bottom:20px;">
+        <div style="display:flex;justify-content:space-between;align-items:center;">
+            <div>
+                <span style="font-size:10px;font-weight:600;color:{colors["yellow"]};">📊 {labels["vs_realistic"]}</span>
+                <div style="font-size:10pt;color:{colors["text_primary"]};margin-top:4px;">
+                    G30 Realistic: <strong>{realistic.roi_12m:.0f}%</strong> ROI, <strong>{realistic.payback_months:.1f}</strong> {labels["months"]} Payback
+                </div>
+            </div>
+            <div style="text-align:right;">
+                <span style="font-size:9px;color:{colors["text_secondary"]};">Abweichung</span>
+                <div style="font-size:16px;font-weight:700;color:{comparison_color};">{deviation_pct:.0f}%</div>
+            </div>
+        </div>
+    </div>
+''')
+
+    # Assumptions summary
+    html_parts.append(f'''
+    <!-- Assumptions -->
+    <div style="padding:16px;background:{colors["gray_light"]};border-radius:12px;margin-bottom:20px;">
+        <span style="font-size:10px;font-weight:600;color:{colors["text_secondary"]};">⚙️ {labels["assumptions"]}</span>
+        <div style="display:flex;gap:16px;margin-top:8px;">
+            <div style="flex:1;">
+                <span style="font-size:9px;color:{colors["text_secondary"]};">{labels["monthly_savings"]}</span>
+                <div style="font-size:10pt;">{assumptions.monthly_savings_min:,.0f} - {assumptions.monthly_savings_mode:,.0f} - {assumptions.monthly_savings_max:,.0f} EUR</div>
+            </div>
+            <div style="flex:1;">
+                <span style="font-size:9px;color:{colors["text_secondary"]};">{labels["investment"]}</span>
+                <div style="font-size:10pt;">{assumptions.investment_min:,.0f} - {assumptions.investment_mode:,.0f} - {assumptions.investment_max:,.0f} EUR</div>
+            </div>
+        </div>
+    </div>
+''')
+
+    # Narrative summary
+    if report.narrative_summary:
+        html_parts.append(f'''
+    <!-- Narrative -->
+    <div style="padding:16px;background:#fff;border-radius:12px;border:1px solid {colors["gray_border"]};">
+        <span style="font-size:10px;font-weight:600;color:{colors["text_secondary"]};">📝 {labels["assessment"]}</span>
+        <p style="margin:8px 0 0 0;font-size:10pt;color:{colors["text_primary"]};line-height:1.6;">
+            {report.narrative_summary}
+        </p>
+    </div>
+''')
+
+    # Close container
+    html_parts.append('</div>')
+
+    return '\n'.join(html_parts)
+
+
+# =============================================================================
+# MODULE INITIALIZATION
+# =============================================================================
+
+log.info("[G34] Business Case Simulation Engine loaded")

--- a/services/consistency_engine.py
+++ b/services/consistency_engine.py
@@ -454,6 +454,7 @@ class ConsistencyEngine:
         self._check_risk_engine_v3_consistency()  # G33
         self._check_vendor_audit_consistency()  # G35
         self._check_automation_roadmap_consistency()  # G36
+        self._check_business_case_simulation_consistency()  # G34
 
         # Calculate domain scores
         self._calculate_domain_scores()
@@ -3425,12 +3426,389 @@ class ConsistencyEngine:
                 ))
 
     # -------------------------------------------------------------------------
+    # DOMAIN 14: Business Case Simulation Consistency (G34)
+    # -------------------------------------------------------------------------
+
+    def _check_business_case_simulation_consistency(self) -> None:
+        """
+        G34: Check Business Case Simulation consistency with G30 deterministic baseline.
+
+        Rules BCSIM_001-BCSIM_006:
+        - BCSIM_001: P50 ROI must be near realistic scenario ROI (±20%)
+        - BCSIM_002: P80 ROI must not be below conservative scenario
+        - BCSIM_003: P20 ROI must be plausible (near conservative/realistic)
+        - BCSIM_004: Payback P50 cannot be < 0 or < best deterministic payback
+        - BCSIM_005: High residual risk must result in wider distributions
+        - BCSIM_006: Strategy cannot be too optimistic if P80 ROI << optimistic
+        """
+        self.report.checked_rules += 6
+
+        # Get simulation HTML and report data
+        sim_html = self.sections.get("BUSINESS_CASE_SIM_HTML", "")
+        sim_report = self.sections.get("_business_case_simulation_report")
+
+        # Get G30 baseline
+        bc_html = self.sections.get("BUSINESS_CASE_ENGINE_HTML", "")
+        bc_report = self.sections.get("_business_case_report")
+
+        if not sim_html and not sim_report:
+            log.debug("[G34] Business Case Simulation consistency: Skipping (no simulation data)")
+            return
+
+        # Extract simulation metrics from HTML or report
+        sim_metrics = self._extract_simulation_metrics(sim_html, sim_report)
+
+        if not sim_metrics:
+            log.debug("[G34] Business Case Simulation consistency: Could not extract metrics")
+            return
+
+        # Extract G30 baseline scenarios
+        scenario_rois = self._extract_scenario_rois(bc_html)
+        if not scenario_rois and bc_report:
+            scenario_rois = self._extract_scenario_rois_from_report(bc_report)
+
+        if not scenario_rois:
+            log.debug("[G34] Business Case Simulation consistency: No G30 baseline scenarios")
+            return
+
+        opt_roi = scenario_rois.get("optimistic", 0)
+        real_roi = scenario_rois.get("realistic", 0)
+        cons_roi = scenario_rois.get("conservative", 0)
+
+        # Rule BCSIM_001: P50 ROI must be near realistic scenario ROI (±20%)
+        p50_roi = sim_metrics.get("roi_p50", 0)
+        if real_roi > 0 and p50_roi > 0:
+            deviation = abs(p50_roi - real_roi) / real_roi * 100
+            if deviation > 25:
+                self.report.add_issue(ConsistencyIssue(
+                    rule_id="BCSIM_001",
+                    severity="WARNING",
+                    domain="business_case_sim",
+                    source_section="business_case_simulation",
+                    target_section="business_case_engine",
+                    message="P50 ROI weicht stark vom realistischen Szenario ab",
+                    expected=f"P50 ROI nahe realistic ROI (±25%): {real_roi:.1f}%",
+                    actual=f"P50 ROI: {p50_roi:.1f}% (Abweichung: {deviation:.0f}%)",
+                    suggestion="Pruefe Simulationsannahmen oder passe G30 Szenarien an",
+                ))
+
+        # Rule BCSIM_002: P80 ROI must not be below conservative scenario
+        p80_roi = sim_metrics.get("roi_p80", 0)
+        if cons_roi > 0 and p80_roi < cons_roi * 0.8:
+            self.report.add_issue(ConsistencyIssue(
+                rule_id="BCSIM_002",
+                severity="WARNING",
+                domain="business_case_sim",
+                source_section="business_case_simulation",
+                target_section="business_case_engine",
+                message="P80 ROI liegt unter dem konservativen Szenario",
+                expected=f"P80 ROI >= conservative ROI ({cons_roi:.1f}%)",
+                actual=f"P80 ROI: {p80_roi:.1f}%",
+                suggestion="Simulationsverteilung ist pessimistischer als G30 conservative",
+            ))
+
+        # Rule BCSIM_003: P20 ROI must be plausible
+        p20_roi = sim_metrics.get("roi_p20", 0)
+        # P20 should be somewhere between 50% of conservative and conservative
+        lower_bound = cons_roi * 0.4
+        if p20_roi < lower_bound and cons_roi > 0:
+            self.report.add_issue(ConsistencyIssue(
+                rule_id="BCSIM_003",
+                severity="INFO",
+                domain="business_case_sim",
+                source_section="business_case_simulation",
+                target_section="business_case_engine",
+                message="P20 ROI liegt sehr deutlich unter conservative Szenario",
+                expected=f"P20 ROI >= {lower_bound:.1f}% (40% von conservative)",
+                actual=f"P20 ROI: {p20_roi:.1f}%",
+                suggestion="Hohe Worst-Case-Varianz - pruefen ob realistisch",
+            ))
+
+        # Rule BCSIM_004: Payback P50 must be valid
+        payback_p50 = sim_metrics.get("payback_p50", 0)
+        scenario_paybacks = self._extract_scenario_paybacks(bc_html)
+        if not scenario_paybacks and bc_report:
+            scenario_paybacks = self._extract_scenario_paybacks_from_report(bc_report)
+
+        if payback_p50 < 0:
+            self.report.add_issue(ConsistencyIssue(
+                rule_id="BCSIM_004",
+                severity="ERROR",
+                domain="business_case_sim",
+                source_section="business_case_simulation",
+                target_section="business_case_simulation",
+                message="Payback P50 ist negativ",
+                expected="Payback P50 >= 0",
+                actual=f"Payback P50: {payback_p50:.1f} Monate",
+                suggestion="Pruefe Simulationslogik fuer Payback-Berechnung",
+            ))
+
+        opt_payback = scenario_paybacks.get("optimistic", 0) if scenario_paybacks else 0
+        if payback_p50 > 0 and opt_payback > 0 and payback_p50 < opt_payback * 0.5:
+            self.report.add_issue(ConsistencyIssue(
+                rule_id="BCSIM_004",
+                severity="INFO",
+                domain="business_case_sim",
+                source_section="business_case_simulation",
+                target_section="business_case_engine",
+                message="Payback P50 besser als optimistisches Szenario",
+                expected=f"Payback P50 >= optimistic Payback * 0.5 ({opt_payback * 0.5:.1f} Mo.)",
+                actual=f"Payback P50: {payback_p50:.1f} Monate",
+                suggestion="Simulation zeigt zu optimistische Payback-Erwartung",
+            ))
+
+        # Rule BCSIM_005: High risk must result in wider distributions
+        risk_grade = self._extract_risk_grade_from_sections()
+        roi_std = sim_metrics.get("roi_std", 0)
+        roi_mean = sim_metrics.get("roi_mean", 1)
+
+        if roi_mean != 0:
+            cv = abs(roi_std / roi_mean) if roi_mean else 0  # Coefficient of variation
+
+            if risk_grade in ["D", "F"]:
+                # High risk should have high variance (CV > 0.3)
+                if cv < 0.2:
+                    self.report.add_issue(ConsistencyIssue(
+                        rule_id="BCSIM_005",
+                        severity="WARNING",
+                        domain="business_case_sim",
+                        source_section="business_case_simulation",
+                        target_section="risk_engine_v3",
+                        message=f"Niedrige Varianz trotz hohem Risiko-Grade ({risk_grade})",
+                        expected=f"Bei Risk-Grade {risk_grade}: CV > 0.2",
+                        actual=f"Coefficient of Variation: {cv:.2f}",
+                        suggestion="Erhoehe Verteilungs-Bandbreiten bei hohem Risiko",
+                    ))
+            elif risk_grade in ["A", "B"]:
+                # Low risk should have lower variance (CV < 0.5)
+                if cv > 0.6:
+                    self.report.add_issue(ConsistencyIssue(
+                        rule_id="BCSIM_005",
+                        severity="INFO",
+                        domain="business_case_sim",
+                        source_section="business_case_simulation",
+                        target_section="risk_engine_v3",
+                        message=f"Hohe Varianz trotz niedrigem Risiko-Grade ({risk_grade})",
+                        expected=f"Bei Risk-Grade {risk_grade}: CV < 0.6",
+                        actual=f"Coefficient of Variation: {cv:.2f}",
+                        suggestion="Engere Verteilungen bei niedrigem Risiko erwarten",
+                    ))
+
+        # Rule BCSIM_006: Strategy cannot be too optimistic if P80 ROI << optimistic
+        strategy_html = self.sections.get("STRATEGIE_GOVERNANCE_HTML", "") or self.sections.get("EXECUTIVE_SUMMARY_HTML", "")
+
+        if strategy_html and p80_roi > 0 and opt_roi > 0:
+            # Check if strategy is optimistic
+            optimistic_terms = ["hervorragend", "excellent", "outstanding", "massiv", "enorm",
+                               "schnell amortisier", "hohe rendite", "high return"]
+            strategy_lower = strategy_html.lower()
+            is_optimistic_strategy = any(term in strategy_lower for term in optimistic_terms)
+
+            # P80 ROI significantly below optimistic (more than 50% gap)
+            gap_pct = (opt_roi - p80_roi) / opt_roi * 100 if opt_roi else 0
+
+            if is_optimistic_strategy and gap_pct > 40:
+                self.report.add_issue(ConsistencyIssue(
+                    rule_id="BCSIM_006",
+                    severity="WARNING",
+                    domain="business_case_sim",
+                    source_section="strategy",
+                    target_section="business_case_simulation",
+                    message="Strategy-Narrativ zu optimistisch im Vergleich zu P80 ROI",
+                    expected=f"P80 ROI ({p80_roi:.1f}%) sollte naeher an optimistic ({opt_roi:.1f}%) liegen",
+                    actual=f"Gap zwischen P80 und optimistic: {gap_pct:.0f}%",
+                    suggestion="Passe Strategy-Narrativ an realistische Simulation an",
+                ))
+
+    def _extract_simulation_metrics(
+        self,
+        html: str,
+        report: Any
+    ) -> Dict[str, float]:
+        """Extract simulation metrics from HTML or report object."""
+        import re
+
+        metrics: Dict[str, float] = {}
+
+        # Try from report object first
+        if report:
+            if hasattr(report, "distribution"):
+                dist = report.distribution
+                if hasattr(dist, "roi_p50"):
+                    metrics["roi_p50"] = dist.roi_p50
+                if hasattr(dist, "roi_p80"):
+                    metrics["roi_p80"] = dist.roi_p80
+                if hasattr(dist, "roi_p90"):
+                    metrics["roi_p90"] = dist.roi_p90
+                if hasattr(dist, "roi_p20"):
+                    metrics["roi_p20"] = dist.roi_p20
+                if hasattr(dist, "roi_std"):
+                    metrics["roi_std"] = dist.roi_std
+                if hasattr(dist, "roi_mean"):
+                    metrics["roi_mean"] = dist.roi_mean
+                if hasattr(dist, "payback_p50"):
+                    metrics["payback_p50"] = dist.payback_p50
+
+            if metrics:
+                return metrics
+
+        # Fall back to HTML parsing
+        if not html:
+            return metrics
+
+        # Extract P50 ROI
+        p50_patterns = [
+            r'P50.*?ROI.*?(\d+(?:\.\d+)?)\s*%',
+            r'ROI.*?P50.*?(\d+(?:\.\d+)?)\s*%',
+            r'Median.*?ROI.*?(\d+(?:\.\d+)?)\s*%',
+            r'roi_p50.*?(\d+(?:\.\d+)?)',
+        ]
+        for pattern in p50_patterns:
+            match = re.search(pattern, html, re.IGNORECASE)
+            if match:
+                metrics["roi_p50"] = float(match.group(1))
+                break
+
+        # Extract P80 ROI
+        p80_patterns = [
+            r'P80.*?ROI.*?(\d+(?:\.\d+)?)\s*%',
+            r'ROI.*?P80.*?(\d+(?:\.\d+)?)\s*%',
+            r'roi_p80.*?(\d+(?:\.\d+)?)',
+        ]
+        for pattern in p80_patterns:
+            match = re.search(pattern, html, re.IGNORECASE)
+            if match:
+                metrics["roi_p80"] = float(match.group(1))
+                break
+
+        # Extract P20 ROI
+        p20_patterns = [
+            r'P20.*?ROI.*?(\d+(?:\.\d+)?)\s*%',
+            r'ROI.*?P20.*?(\d+(?:\.\d+)?)\s*%',
+            r'roi_p20.*?(\d+(?:\.\d+)?)',
+        ]
+        for pattern in p20_patterns:
+            match = re.search(pattern, html, re.IGNORECASE)
+            if match:
+                metrics["roi_p20"] = float(match.group(1))
+                break
+
+        # Extract Payback P50
+        payback_patterns = [
+            r'P50.*?Payback.*?(\d+(?:\.\d+)?)',
+            r'Payback.*?P50.*?(\d+(?:\.\d+)?)',
+            r'payback_p50.*?(\d+(?:\.\d+)?)',
+        ]
+        for pattern in payback_patterns:
+            match = re.search(pattern, html, re.IGNORECASE)
+            if match:
+                metrics["payback_p50"] = float(match.group(1))
+                break
+
+        # Extract std deviation
+        std_patterns = [
+            r'Std.*?(\d+(?:\.\d+)?)\s*%',
+            r'roi_std.*?(\d+(?:\.\d+)?)',
+            r'Standard.*?(\d+(?:\.\d+)?)',
+        ]
+        for pattern in std_patterns:
+            match = re.search(pattern, html, re.IGNORECASE)
+            if match:
+                metrics["roi_std"] = float(match.group(1))
+                break
+
+        return metrics
+
+    def _extract_scenario_rois_from_report(self, report: Any) -> Dict[str, float]:
+        """Extract scenario ROIs from G30 report object."""
+        rois: Dict[str, float] = {}
+
+        if not report:
+            return rois
+
+        scenarios = getattr(report, "scenarios", [])
+        for scenario in scenarios:
+            name = getattr(scenario, "name", "")
+            roi = getattr(scenario, "roi_12m", 0)
+            if name in ["optimistic", "realistic", "conservative"]:
+                rois[name] = roi
+
+        return rois
+
+    def _extract_scenario_paybacks(self, html: str) -> Dict[str, float]:
+        """Extract scenario payback periods from HTML."""
+        import re
+
+        paybacks: Dict[str, float] = {}
+
+        if not html:
+            return paybacks
+
+        scenario_names = ["optimistic", "realistic", "conservative"]
+
+        for scenario in scenario_names:
+            # Look for payback near scenario name
+            patterns = [
+                rf'{scenario}.*?payback.*?(\d+(?:\.\d+)?)',
+                rf'{scenario}.*?amortis.*?(\d+(?:\.\d+)?)',
+                rf'payback.*?{scenario}.*?(\d+(?:\.\d+)?)',
+            ]
+
+            for pattern in patterns:
+                match = re.search(pattern, html, re.IGNORECASE)
+                if match:
+                    paybacks[scenario] = float(match.group(1))
+                    break
+
+        return paybacks
+
+    def _extract_scenario_paybacks_from_report(self, report: Any) -> Dict[str, float]:
+        """Extract scenario paybacks from G30 report object."""
+        paybacks: Dict[str, float] = {}
+
+        if not report:
+            return paybacks
+
+        scenarios = getattr(report, "scenarios", [])
+        for scenario in scenarios:
+            name = getattr(scenario, "name", "")
+            payback = getattr(scenario, "payback_months", 0)
+            if name in ["optimistic", "realistic", "conservative"]:
+                paybacks[name] = payback
+
+        return paybacks
+
+    def _extract_risk_grade_from_sections(self) -> str:
+        """Extract risk grade from Risk Engine V3 section."""
+        risk_v3_html = self.sections.get("RISK_ENGINE_V3_HTML", "")
+        risk_report = self.sections.get("_risk_report_v3")
+
+        if risk_report:
+            if hasattr(risk_report, "residual_risk_grade"):
+                return risk_report.residual_risk_grade
+
+        if risk_v3_html:
+            # Look for grade indicators
+            import re
+            grade_patterns = [
+                r'Grade[:\s]*([A-F])',
+                r'Risk.*?Grade[:\s]*([A-F])',
+                r'residual.*?grade[:\s]*([A-F])',
+            ]
+            for pattern in grade_patterns:
+                match = re.search(pattern, risk_v3_html, re.IGNORECASE)
+                if match:
+                    return match.group(1).upper()
+
+        return "C"  # Default medium risk
+
+    # -------------------------------------------------------------------------
     # SCORING
     # -------------------------------------------------------------------------
 
     def _calculate_domain_scores(self) -> None:
         """Calculate scores per domain."""
-        domains = ["tools", "funding", "kpi", "risk", "roadmap", "narrative", "snapshot", "risk_engine", "business_case", "recommendations", "risk_engine_v3", "vendor_audit", "automation_roadmap"]
+        domains = ["tools", "funding", "kpi", "risk", "roadmap", "narrative", "snapshot", "risk_engine", "business_case", "recommendations", "risk_engine_v3", "vendor_audit", "automation_roadmap", "business_case_sim"]
 
         for domain in domains:
             domain_issues = [i for i in self.report.issues if i.domain == domain]

--- a/templates/pdf_template.html
+++ b/templates/pdf_template.html
@@ -2611,6 +2611,24 @@
                     </div>
                 </section>
                 {% endif %}
+                <!-- G34: Business Case Simulation – Monte Carlo ROI & Payback Analysis -->
+                {% if BUSINESS_CASE_SIM_HTML %}
+                <section class="section chapter" id="business-case-simulation">
+                    <div class="section-header">
+                        <div class="section-title">
+                            <span class="section-kicker">Monte-Carlo Simulation</span>
+                            <h2>Risiko- und Szenarioanalyse</h2>
+                        </div>
+                        <span class="section-pill">
+                            <span class="pill-dot"></span>
+                            P50/P80/P90 • Unsicherheitsmodell
+                        </span>
+                    </div>
+                    <div class="section-body">
+                        {{ BUSINESS_CASE_SIM_HTML|safe }}
+                    </div>
+                </section>
+                {% endif %}
                 <!-- G32: Recommendations Engine – Priorisierte Handlungsempfehlungen -->
                 {% if RECOMMENDATIONS_ENGINE_HTML %}
                 <section class="section chapter" id="recommendations-engine">

--- a/templates/pdf_template_en.html
+++ b/templates/pdf_template_en.html
@@ -2128,6 +2128,24 @@
                     </div>
                 </section>
                 {% endif %}
+                <!-- G34: Business Case Simulation – Monte Carlo ROI & Payback Analysis -->
+                {% if BUSINESS_CASE_SIM_HTML %}
+                <section class="section chapter" id="business-case-simulation">
+                    <div class="section-header">
+                        <div class="section-title">
+                            <span class="section-kicker">Monte Carlo Simulation</span>
+                            <h2>Risk & Scenario Analysis</h2>
+                        </div>
+                        <span class="section-pill">
+                            <span class="pill-dot"></span>
+                            P50/P80/P90 • Uncertainty Model
+                        </span>
+                    </div>
+                    <div class="section-body">
+                        {{ BUSINESS_CASE_SIM_HTML|safe }}
+                    </div>
+                </section>
+                {% endif %}
                 <!-- G32: Recommendations Engine – Prioritized Action Recommendations -->
                 {% if RECOMMENDATIONS_ENGINE_HTML %}
                 <section class="section chapter" id="recommendations-engine">

--- a/tests/test_g34_business_case_simulation.py
+++ b/tests/test_g34_business_case_simulation.py
@@ -1,0 +1,1246 @@
+# -*- coding: utf-8 -*-
+"""
+Sprint G34: Business Case Monte Carlo Simulation Tests
+=======================================================
+
+Comprehensive test suite for Business Case Simulation Engine with 50+ tests covering:
+- Data structures (SimulationAssumptions, SimulationDistribution, BusinessCaseSimulationReport)
+- Monte Carlo simulation logic
+- Percentile calculations
+- Assumption generation from G30 baseline
+- LLM response parsing
+- HTML generation
+- G22 Consistency Engine integration (BCSIM_001-BCSIM_006)
+- Size-awareness
+- Risk adjustment
+
+Version: 1.0.0 (Sprint G34)
+"""
+from __future__ import annotations
+
+import json
+import math
+import pytest
+from typing import Any, Dict, List, Optional
+
+
+# =============================================================================
+# TEST: Data Structures - SimulationAssumptions
+# =============================================================================
+
+class TestSimulationAssumptions:
+    """Tests for SimulationAssumptions dataclass."""
+
+    def test_basic_creation(self) -> None:
+        """Test SimulationAssumptions can be instantiated with basic values."""
+        from services.business_case_simulation import SimulationAssumptions
+
+        assumptions = SimulationAssumptions(
+            monthly_savings_min=1000.0,
+            monthly_savings_mode=2000.0,
+            monthly_savings_max=3000.0,
+            investment_min=5000.0,
+            investment_mode=8000.0,
+            investment_max=12000.0,
+        )
+
+        assert assumptions.monthly_savings_min == 1000.0
+        assert assumptions.monthly_savings_mode == 2000.0
+        assert assumptions.monthly_savings_max == 3000.0
+        assert assumptions.investment_min == 5000.0
+        assert assumptions.investment_mode == 8000.0
+        assert assumptions.investment_max == 12000.0
+
+    def test_default_values(self) -> None:
+        """Test SimulationAssumptions has sensible defaults."""
+        from services.business_case_simulation import SimulationAssumptions
+
+        assumptions = SimulationAssumptions()
+
+        assert assumptions.speed_factor_min == 0.7
+        assert assumptions.speed_factor_mode == 1.0
+        assert assumptions.speed_factor_max == 1.2
+        assert assumptions.risk_factor_mode == 1.0
+
+    def test_min_mode_max_validation(self) -> None:
+        """Test min <= mode <= max is enforced."""
+        from services.business_case_simulation import SimulationAssumptions
+
+        # Create with invalid ordering (min > mode)
+        assumptions = SimulationAssumptions(
+            monthly_savings_min=5000.0,  # Greater than mode
+            monthly_savings_mode=2000.0,
+            monthly_savings_max=3000.0,
+        )
+
+        # Should be normalized so min <= mode
+        assert assumptions.monthly_savings_min <= assumptions.monthly_savings_mode
+
+    def test_funding_probability_clamped(self) -> None:
+        """Test funding probability is clamped to [0, 1]."""
+        from services.business_case_simulation import SimulationAssumptions
+
+        assumptions = SimulationAssumptions(
+            funding_success_probability=1.5,  # Above 1
+        )
+
+        assert assumptions.funding_success_probability == 1.0
+
+        assumptions2 = SimulationAssumptions(
+            funding_success_probability=-0.5,  # Below 0
+        )
+
+        assert assumptions2.funding_success_probability == 0.0
+
+    def test_is_valid_property(self) -> None:
+        """Test is_valid returns True for valid assumptions."""
+        from services.business_case_simulation import SimulationAssumptions
+
+        assumptions = SimulationAssumptions(
+            monthly_savings_min=1000.0,
+            monthly_savings_mode=2000.0,
+            monthly_savings_max=3000.0,
+            investment_min=5000.0,
+            investment_mode=8000.0,
+            investment_max=12000.0,
+        )
+
+        assert assumptions.is_valid is True
+
+    def test_is_valid_false_for_zero_max(self) -> None:
+        """Test is_valid returns False when max values are zero."""
+        from services.business_case_simulation import SimulationAssumptions
+
+        assumptions = SimulationAssumptions(
+            monthly_savings_max=0.0,
+            investment_max=0.0,
+        )
+
+        assert assumptions.is_valid is False
+
+    def test_to_dict_serialization(self) -> None:
+        """Test SimulationAssumptions serialization to dict."""
+        from services.business_case_simulation import SimulationAssumptions
+
+        assumptions = SimulationAssumptions(
+            monthly_savings_min=1000.0,
+            monthly_savings_mode=2000.0,
+            monthly_savings_max=3000.0,
+            funding_success_probability=0.6,
+        )
+
+        result = assumptions.to_dict()
+
+        assert isinstance(result, dict)
+        assert "monthly_savings" in result
+        assert result["monthly_savings"]["min"] == 1000.0
+        assert result["monthly_savings"]["mode"] == 2000.0
+        assert result["monthly_savings"]["max"] == 3000.0
+        assert result["funding_success_probability"] == 0.6
+
+    def test_from_dict_deserialization(self) -> None:
+        """Test SimulationAssumptions deserialization from dict."""
+        from services.business_case_simulation import SimulationAssumptions
+
+        data = {
+            "monthly_savings": {"min": 500, "mode": 1000, "max": 1500},
+            "investment_total": {"min": 3000, "mode": 5000, "max": 7000},
+            "speed_factor": {"min": 0.8, "mode": 1.0, "max": 1.1},
+            "funding_success_probability": 0.5,
+        }
+
+        assumptions = SimulationAssumptions.from_dict(data)
+
+        assert assumptions.monthly_savings_min == 500.0
+        assert assumptions.monthly_savings_mode == 1000.0
+        assert assumptions.monthly_savings_max == 1500.0
+        assert assumptions.funding_success_probability == 0.5
+
+
+# =============================================================================
+# TEST: Data Structures - SimulationDistribution
+# =============================================================================
+
+class TestSimulationDistribution:
+    """Tests for SimulationDistribution dataclass."""
+
+    def test_basic_creation_with_samples(self) -> None:
+        """Test SimulationDistribution calculates statistics from samples."""
+        from services.business_case_simulation import SimulationDistribution
+
+        roi_samples = [100.0, 120.0, 140.0, 160.0, 180.0]
+        payback_samples = [4.0, 5.0, 6.0, 7.0, 8.0]
+
+        dist = SimulationDistribution(
+            roi_samples=roi_samples,
+            payback_samples=payback_samples,
+        )
+
+        # Should calculate statistics
+        dist._calculate_statistics()
+
+        assert dist.simulation_runs == 5
+        assert dist.roi_min == 100.0
+        assert dist.roi_max == 180.0
+        assert dist.payback_min == 4.0
+        assert dist.payback_max == 8.0
+
+    def test_percentile_calculation_p50(self) -> None:
+        """Test P50 (median) calculation."""
+        from services.business_case_simulation import SimulationDistribution
+
+        # With 5 samples, P50 should be the middle value
+        roi_samples = [100.0, 120.0, 140.0, 160.0, 180.0]
+
+        dist = SimulationDistribution(roi_samples=roi_samples)
+        dist._calculate_statistics()
+
+        # P50 of [100, 120, 140, 160, 180] = 140
+        assert dist.roi_p50 == 140.0
+
+    def test_percentile_calculation_p80(self) -> None:
+        """Test P80 calculation."""
+        from services.business_case_simulation import SimulationDistribution
+
+        roi_samples = list(range(0, 101, 10))  # [0, 10, 20, ..., 100]
+
+        dist = SimulationDistribution(roi_samples=[float(x) for x in roi_samples])
+        dist._calculate_statistics()
+
+        # P80 should be around 80
+        assert 75.0 <= dist.roi_p80 <= 85.0
+
+    def test_mean_calculation(self) -> None:
+        """Test mean calculation."""
+        from services.business_case_simulation import SimulationDistribution
+
+        roi_samples = [100.0, 200.0, 300.0]
+
+        dist = SimulationDistribution(roi_samples=roi_samples)
+        dist._calculate_statistics()
+
+        assert dist.roi_mean == 200.0
+
+    def test_std_calculation(self) -> None:
+        """Test standard deviation calculation."""
+        from services.business_case_simulation import SimulationDistribution
+
+        # Known std for [2, 4, 4, 4, 5, 5, 7, 9] = 2.138...
+        roi_samples = [2.0, 4.0, 4.0, 4.0, 5.0, 5.0, 7.0, 9.0]
+
+        dist = SimulationDistribution(roi_samples=roi_samples)
+        dist._calculate_statistics()
+
+        assert 2.0 <= dist.roi_std <= 2.5
+
+    def test_confidence_interval_80(self) -> None:
+        """Test 80% confidence interval calculation."""
+        from services.business_case_simulation import SimulationDistribution
+
+        roi_samples = list(range(0, 101))  # 0 to 100
+
+        dist = SimulationDistribution(roi_samples=[float(x) for x in roi_samples])
+        dist._calculate_statistics()
+
+        ci = dist.roi_confidence_interval_80
+        assert ci[0] < ci[1]  # Lower < Upper
+        assert 5.0 <= ci[0] <= 15.0  # P10 around 10
+        assert 85.0 <= ci[1] <= 95.0  # P90 around 90
+
+    def test_to_dict_serialization(self) -> None:
+        """Test SimulationDistribution serialization."""
+        from services.business_case_simulation import SimulationDistribution
+
+        dist = SimulationDistribution(
+            roi_samples=[100.0, 150.0, 200.0],
+            payback_samples=[3.0, 4.0, 5.0],
+        )
+        dist._calculate_statistics()
+
+        result = dist.to_dict()
+
+        assert "roi" in result
+        assert "payback" in result
+        assert result["simulation_runs"] == 3
+
+    def test_from_dict_deserialization(self) -> None:
+        """Test SimulationDistribution deserialization."""
+        from services.business_case_simulation import SimulationDistribution
+
+        data = {
+            "roi": {"p50": 150.0, "p80": 180.0, "p90": 200.0, "min": 100.0, "max": 250.0, "mean": 155.0, "std": 30.0, "p20": 120.0},
+            "payback": {"p50": 5.0, "p80": 6.0, "p90": 7.0, "min": 3.0, "max": 10.0, "mean": 5.5, "std": 1.5, "p20": 4.0},
+            "simulation_runs": 1000,
+        }
+
+        dist = SimulationDistribution.from_dict(data)
+
+        assert dist.roi_p50 == 150.0
+        assert dist.roi_p80 == 180.0
+        assert dist.payback_p50 == 5.0
+        assert dist.simulation_runs == 1000
+
+
+# =============================================================================
+# TEST: Data Structures - BusinessCaseSimulationReport
+# =============================================================================
+
+class TestBusinessCaseSimulationReport:
+    """Tests for BusinessCaseSimulationReport dataclass."""
+
+    def test_basic_creation(self) -> None:
+        """Test BusinessCaseSimulationReport can be created."""
+        from services.business_case_simulation import BusinessCaseSimulationReport
+
+        report = BusinessCaseSimulationReport(
+            size_label="team",
+            risk_grade="C",
+            simulation_runs=1000,
+        )
+
+        assert report.size_label == "team"
+        assert report.risk_grade == "C"
+        assert report.simulation_runs == 1000
+
+    def test_is_simulation_valid_property(self) -> None:
+        """Test is_simulation_valid property."""
+        from services.business_case_simulation import (
+            BusinessCaseSimulationReport,
+            SimulationDistribution,
+        )
+
+        dist = SimulationDistribution(
+            roi_samples=[100.0, 150.0, 200.0],
+        )
+        dist._calculate_statistics()
+
+        report = BusinessCaseSimulationReport(distribution=dist)
+
+        assert report.is_simulation_valid is True
+
+    def test_variance_level_low(self) -> None:
+        """Test variance_level returns 'low' for low CV."""
+        from services.business_case_simulation import (
+            BusinessCaseSimulationReport,
+            SimulationDistribution,
+        )
+
+        # Low variance: std / mean < 0.2
+        dist = SimulationDistribution()
+        dist.roi_mean = 100.0
+        dist.roi_std = 10.0  # CV = 0.1
+
+        report = BusinessCaseSimulationReport(distribution=dist)
+
+        assert report.variance_level == "low"
+
+    def test_variance_level_medium(self) -> None:
+        """Test variance_level returns 'medium' for medium CV."""
+        from services.business_case_simulation import (
+            BusinessCaseSimulationReport,
+            SimulationDistribution,
+        )
+
+        dist = SimulationDistribution()
+        dist.roi_mean = 100.0
+        dist.roi_std = 35.0  # CV = 0.35
+
+        report = BusinessCaseSimulationReport(distribution=dist)
+
+        assert report.variance_level == "medium"
+
+    def test_variance_level_high(self) -> None:
+        """Test variance_level returns 'high' for high CV."""
+        from services.business_case_simulation import (
+            BusinessCaseSimulationReport,
+            SimulationDistribution,
+        )
+
+        dist = SimulationDistribution()
+        dist.roi_mean = 100.0
+        dist.roi_std = 60.0  # CV = 0.6
+
+        report = BusinessCaseSimulationReport(distribution=dist)
+
+        assert report.variance_level == "high"
+
+    def test_to_dict_serialization(self) -> None:
+        """Test BusinessCaseSimulationReport serialization."""
+        from services.business_case_simulation import BusinessCaseSimulationReport
+
+        report = BusinessCaseSimulationReport(
+            size_label="kmu",
+            risk_grade="B",
+            simulation_runs=500,
+        )
+
+        result = report.to_dict()
+
+        assert result["size_label"] == "kmu"
+        assert result["risk_grade"] == "B"
+        assert result["simulation_runs"] == 500
+
+
+# =============================================================================
+# TEST: Helper Functions
+# =============================================================================
+
+class TestHelperFunctions:
+    """Tests for helper functions."""
+
+    def test_percentile_calculation(self) -> None:
+        """Test _percentile function."""
+        from services.business_case_simulation import _percentile
+
+        data = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0]
+
+        p50 = _percentile(data, 50)
+        assert 5.0 <= p50 <= 6.0
+
+        p0 = _percentile(data, 0)
+        assert p0 == 1.0
+
+        p100 = _percentile(data, 100)
+        assert p100 == 10.0
+
+    def test_percentile_empty_list(self) -> None:
+        """Test _percentile with empty list."""
+        from services.business_case_simulation import _percentile
+
+        result = _percentile([], 50)
+        assert result == 0.0
+
+    def test_percentile_single_element(self) -> None:
+        """Test _percentile with single element."""
+        from services.business_case_simulation import _percentile
+
+        result = _percentile([42.0], 50)
+        assert result == 42.0
+
+    def test_calculate_std(self) -> None:
+        """Test _calculate_std function."""
+        from services.business_case_simulation import _calculate_std
+
+        data = [2.0, 4.0, 4.0, 4.0, 5.0, 5.0, 7.0, 9.0]
+        mean = sum(data) / len(data)
+
+        std = _calculate_std(data, mean)
+        assert 2.0 <= std <= 2.2  # Known std ≈ 2.138
+
+    def test_calculate_std_single_element(self) -> None:
+        """Test _calculate_std with single element."""
+        from services.business_case_simulation import _calculate_std
+
+        result = _calculate_std([5.0], 5.0)
+        assert result == 0.0
+
+    def test_triangular_sample(self) -> None:
+        """Test _triangular_sample returns values in range."""
+        from services.business_case_simulation import _triangular_sample
+
+        for _ in range(100):
+            result = _triangular_sample(10.0, 50.0, 100.0)
+            assert 10.0 <= result <= 100.0
+
+    def test_triangular_sample_equal_bounds(self) -> None:
+        """Test _triangular_sample with equal min/max."""
+        from services.business_case_simulation import _triangular_sample
+
+        result = _triangular_sample(50.0, 50.0, 50.0)
+        assert result == 50.0
+
+    def test_uniform_sample(self) -> None:
+        """Test _uniform_sample returns values in range."""
+        from services.business_case_simulation import _uniform_sample
+
+        for _ in range(100):
+            result = _uniform_sample(0.0, 100.0)
+            assert 0.0 <= result <= 100.0
+
+    def test_determine_size_label(self) -> None:
+        """Test _determine_size_label function."""
+        from services.business_case_simulation import _determine_size_label
+
+        assert _determine_size_label({"unternehmensgroesse": "solo"}) == "solo"
+        assert _determine_size_label({"unternehmensgroesse": "freiberufler"}) == "solo"
+        assert _determine_size_label({"unternehmensgroesse": "team"}) == "team"
+        assert _determine_size_label({"unternehmensgroesse": "kmu"}) == "kmu"
+        assert _determine_size_label(None) == "team"  # Default
+
+
+# =============================================================================
+# TEST: Assumption Generation
+# =============================================================================
+
+class TestAssumptionGeneration:
+    """Tests for assumption generation from G30 baseline."""
+
+    def test_generate_default_assumptions_basic(self) -> None:
+        """Test generate_default_assumptions with basic business case."""
+        from services.business_case_simulation import generate_default_assumptions
+        from services.business_case_engine_v2 import BusinessCaseReport, ScenarioKPIs
+
+        bc = BusinessCaseReport(
+            investment_total=10000.0,
+            scenarios=[
+                ScenarioKPIs(name="optimistic", roi_12m=200.0, payback_months=4.0,
+                            monthly_savings=3500.0, annual_savings=42000.0, investment_total=8000.0),
+                ScenarioKPIs(name="realistic", roi_12m=150.0, payback_months=6.0,
+                            monthly_savings=2500.0, annual_savings=30000.0, investment_total=10000.0),
+                ScenarioKPIs(name="conservative", roi_12m=80.0, payback_months=10.0,
+                            monthly_savings=1500.0, annual_savings=18000.0, investment_total=12000.0),
+            ],
+        )
+
+        assumptions = generate_default_assumptions(bc)
+
+        assert assumptions.is_valid
+        assert assumptions.monthly_savings_mode == 2500.0  # From realistic
+        assert assumptions.monthly_savings_min == 1500.0  # From conservative
+        assert assumptions.monthly_savings_max == 3500.0  # From optimistic
+
+    def test_generate_default_assumptions_risk_adjustment(self) -> None:
+        """Test assumptions are adjusted based on risk grade."""
+        from services.business_case_simulation import generate_default_assumptions
+        from services.business_case_engine_v2 import BusinessCaseReport, ScenarioKPIs
+        from dataclasses import dataclass
+
+        @dataclass
+        class MockRiskReport:
+            residual_risk_grade: str = "D"
+            residual_risk_score: float = 75.0
+
+        bc = BusinessCaseReport(
+            investment_total=10000.0,
+            scenarios=[
+                ScenarioKPIs(name="optimistic", roi_12m=200.0, payback_months=4.0,
+                            monthly_savings=3000.0, annual_savings=36000.0, investment_total=8000.0),
+                ScenarioKPIs(name="realistic", roi_12m=150.0, payback_months=6.0,
+                            monthly_savings=2000.0, annual_savings=24000.0, investment_total=10000.0),
+                ScenarioKPIs(name="conservative", roi_12m=80.0, payback_months=10.0,
+                            monthly_savings=1000.0, annual_savings=12000.0, investment_total=12000.0),
+            ],
+        )
+
+        assumptions = generate_default_assumptions(bc, risk_report_v3=MockRiskReport())
+
+        # High risk should result in lower risk_factor
+        assert assumptions.risk_factor_mode < 1.0
+
+    def test_generate_default_assumptions_size_solo(self) -> None:
+        """Test assumptions adjusted for solo company size."""
+        from services.business_case_simulation import generate_default_assumptions
+        from services.business_case_engine_v2 import BusinessCaseReport, ScenarioKPIs
+
+        bc = BusinessCaseReport(
+            investment_total=2000.0,
+            scenarios=[
+                ScenarioKPIs(name="optimistic", roi_12m=180.0, payback_months=3.0,
+                            monthly_savings=1000.0, annual_savings=12000.0, investment_total=1500.0),
+                ScenarioKPIs(name="realistic", roi_12m=120.0, payback_months=5.0,
+                            monthly_savings=600.0, annual_savings=7200.0, investment_total=2000.0),
+                ScenarioKPIs(name="conservative", roi_12m=60.0, payback_months=8.0,
+                            monthly_savings=400.0, annual_savings=4800.0, investment_total=2500.0),
+            ],
+        )
+
+        assumptions = generate_default_assumptions(bc, size_label="solo")
+
+        # Solo should have wider variance
+        assert assumptions.is_valid
+
+
+# =============================================================================
+# TEST: LLM Response Parsing
+# =============================================================================
+
+class TestLLMResponseParsing:
+    """Tests for LLM response parsing."""
+
+    def test_parse_llm_assumptions_valid_json(self) -> None:
+        """Test parsing valid LLM JSON response."""
+        from services.business_case_simulation import parse_llm_assumptions
+
+        json_str = json.dumps({
+            "assumptions": {
+                "monthly_savings": {"min": 1000, "mode": 2000, "max": 3000},
+                "investment_total": {"min": 5000, "mode": 8000, "max": 12000},
+                "speed_factor": {"min": 0.7, "mode": 1.0, "max": 1.2},
+                "risk_factor": {"min": 0.8, "mode": 1.0, "max": 1.1},
+                "funding_success_probability": 0.5,
+            }
+        })
+
+        result = parse_llm_assumptions(json_str)
+
+        assert result is not None
+        assert result.monthly_savings_min == 1000.0
+        assert result.monthly_savings_mode == 2000.0
+        assert result.monthly_savings_max == 3000.0
+
+    def test_parse_llm_assumptions_without_wrapper(self) -> None:
+        """Test parsing JSON without 'assumptions' wrapper."""
+        from services.business_case_simulation import parse_llm_assumptions
+
+        json_str = json.dumps({
+            "monthly_savings": {"min": 500, "mode": 1000, "max": 1500},
+            "investment_total": {"min": 2000, "mode": 3000, "max": 4000},
+        })
+
+        result = parse_llm_assumptions(json_str)
+
+        assert result is not None
+        assert result.monthly_savings_mode == 1000.0
+
+    def test_parse_llm_assumptions_invalid_json(self) -> None:
+        """Test parsing invalid JSON returns None."""
+        from services.business_case_simulation import parse_llm_assumptions
+
+        result = parse_llm_assumptions("not valid json {")
+
+        assert result is None
+
+    def test_parse_llm_assumptions_empty_string(self) -> None:
+        """Test parsing empty string returns None."""
+        from services.business_case_simulation import parse_llm_assumptions
+
+        result = parse_llm_assumptions("")
+
+        assert result is None
+
+    def test_parse_llm_assumptions_none(self) -> None:
+        """Test parsing None returns None."""
+        from services.business_case_simulation import parse_llm_assumptions
+
+        result = parse_llm_assumptions(None)  # type: ignore
+
+        assert result is None
+
+
+# =============================================================================
+# TEST: Monte Carlo Simulation
+# =============================================================================
+
+class TestMonteCarloSimulation:
+    """Tests for Monte Carlo simulation logic."""
+
+    def test_run_simulation_basic(self) -> None:
+        """Test basic Monte Carlo simulation runs correctly."""
+        from services.business_case_simulation import (
+            run_monte_carlo_simulation,
+            SimulationAssumptions,
+        )
+
+        assumptions = SimulationAssumptions(
+            monthly_savings_min=1000.0,
+            monthly_savings_mode=2000.0,
+            monthly_savings_max=3000.0,
+            investment_min=8000.0,
+            investment_mode=10000.0,
+            investment_max=12000.0,
+        )
+
+        result = run_monte_carlo_simulation(assumptions, runs=100)
+
+        assert result.simulation_runs == 100
+        assert len(result.roi_samples) == 100
+        assert len(result.payback_samples) == 100
+
+    def test_run_simulation_roi_within_bounds(self) -> None:
+        """Test simulation ROI values are within expected bounds."""
+        from services.business_case_simulation import (
+            run_monte_carlo_simulation,
+            SimulationAssumptions,
+            MIN_ROI,
+            MAX_ROI,
+        )
+
+        assumptions = SimulationAssumptions(
+            monthly_savings_min=500.0,
+            monthly_savings_mode=1000.0,
+            monthly_savings_max=2000.0,
+            investment_min=5000.0,
+            investment_mode=8000.0,
+            investment_max=10000.0,
+        )
+
+        result = run_monte_carlo_simulation(assumptions, runs=500)
+
+        # All ROI values should be within bounds
+        for roi in result.roi_samples:
+            assert MIN_ROI <= roi <= MAX_ROI
+
+    def test_run_simulation_payback_positive(self) -> None:
+        """Test simulation payback values are positive."""
+        from services.business_case_simulation import (
+            run_monte_carlo_simulation,
+            SimulationAssumptions,
+        )
+
+        assumptions = SimulationAssumptions(
+            monthly_savings_min=1000.0,
+            monthly_savings_mode=2000.0,
+            monthly_savings_max=3000.0,
+            investment_min=5000.0,
+            investment_mode=8000.0,
+            investment_max=10000.0,
+        )
+
+        result = run_monte_carlo_simulation(assumptions, runs=200)
+
+        # All payback values should be positive
+        for payback in result.payback_samples:
+            assert payback > 0
+
+    def test_run_simulation_with_funding_effect(self) -> None:
+        """Test simulation with funding effect applied."""
+        from services.business_case_simulation import (
+            run_monte_carlo_simulation,
+            SimulationAssumptions,
+        )
+
+        assumptions = SimulationAssumptions(
+            monthly_savings_min=1000.0,
+            monthly_savings_mode=2000.0,
+            monthly_savings_max=3000.0,
+            investment_min=10000.0,
+            investment_mode=15000.0,
+            investment_max=20000.0,
+            funding_success_probability=1.0,  # Always apply funding
+        )
+
+        result_with_funding = run_monte_carlo_simulation(
+            assumptions, funding_effect_base=5000.0, runs=100
+        )
+
+        # With 100% funding success, effective investment should be lower
+        # resulting in higher ROI on average
+        assert result_with_funding.roi_mean > 0
+
+    def test_run_simulation_min_runs_enforced(self) -> None:
+        """Test minimum simulation runs is enforced."""
+        from services.business_case_simulation import (
+            run_monte_carlo_simulation,
+            SimulationAssumptions,
+            MIN_SIMULATION_RUNS,
+        )
+
+        assumptions = SimulationAssumptions(
+            monthly_savings_min=1000.0,
+            monthly_savings_mode=2000.0,
+            monthly_savings_max=3000.0,
+            investment_min=5000.0,
+            investment_mode=8000.0,
+            investment_max=10000.0,
+        )
+
+        result = run_monte_carlo_simulation(assumptions, runs=10)  # Below minimum
+
+        assert result.simulation_runs >= MIN_SIMULATION_RUNS
+
+    def test_run_simulation_max_runs_enforced(self) -> None:
+        """Test maximum simulation runs is enforced."""
+        from services.business_case_simulation import (
+            run_monte_carlo_simulation,
+            SimulationAssumptions,
+            MAX_SIMULATION_RUNS,
+        )
+
+        assumptions = SimulationAssumptions(
+            monthly_savings_min=1000.0,
+            monthly_savings_mode=2000.0,
+            monthly_savings_max=3000.0,
+            investment_min=5000.0,
+            investment_mode=8000.0,
+            investment_max=10000.0,
+        )
+
+        result = run_monte_carlo_simulation(assumptions, runs=100000)  # Above max
+
+        assert result.simulation_runs <= MAX_SIMULATION_RUNS
+
+
+# =============================================================================
+# TEST: Main Generation Function
+# =============================================================================
+
+class TestGenerateBusinessCaseSimulation:
+    """Tests for main simulation generation function."""
+
+    def test_generate_simulation_basic(self) -> None:
+        """Test basic simulation generation."""
+        from services.business_case_simulation import generate_business_case_simulation
+        from services.business_case_engine_v2 import BusinessCaseReport, ScenarioKPIs
+
+        bc = BusinessCaseReport(
+            investment_total=10000.0,
+            scenarios=[
+                ScenarioKPIs(name="optimistic", roi_12m=200.0, payback_months=4.0,
+                            monthly_savings=3000.0, annual_savings=36000.0, investment_total=8000.0),
+                ScenarioKPIs(name="realistic", roi_12m=150.0, payback_months=6.0,
+                            monthly_savings=2000.0, annual_savings=24000.0, investment_total=10000.0),
+                ScenarioKPIs(name="conservative", roi_12m=80.0, payback_months=10.0,
+                            monthly_savings=1000.0, annual_savings=12000.0, investment_total=12000.0),
+            ],
+        )
+
+        result = generate_business_case_simulation(business_case=bc, runs=100)
+
+        assert result.is_simulation_valid
+        assert result.distribution.simulation_runs == 100
+        assert result.baseline_report == bc
+
+    def test_generate_simulation_without_baseline(self) -> None:
+        """Test simulation generation without baseline creates empty report."""
+        from services.business_case_simulation import generate_business_case_simulation
+
+        result = generate_business_case_simulation(runs=100)
+
+        # Should still work but with default assumptions
+        assert result is not None
+
+    def test_generate_simulation_with_briefing(self) -> None:
+        """Test simulation uses briefing data."""
+        from services.business_case_simulation import generate_business_case_simulation
+        from services.business_case_engine_v2 import BusinessCaseReport, ScenarioKPIs
+
+        bc = BusinessCaseReport(
+            investment_total=5000.0,
+            scenarios=[
+                ScenarioKPIs(name="optimistic", roi_12m=180.0, payback_months=3.0,
+                            monthly_savings=2000.0, annual_savings=24000.0, investment_total=4000.0),
+                ScenarioKPIs(name="realistic", roi_12m=120.0, payback_months=5.0,
+                            monthly_savings=1500.0, annual_savings=18000.0, investment_total=5000.0),
+                ScenarioKPIs(name="conservative", roi_12m=60.0, payback_months=8.0,
+                            monthly_savings=1000.0, annual_savings=12000.0, investment_total=6000.0),
+            ],
+        )
+
+        briefing = {"unternehmensgroesse": "solo", "language": "en"}
+
+        result = generate_business_case_simulation(
+            business_case=bc,
+            briefing=briefing,
+            runs=100,
+        )
+
+        assert result.size_label == "solo"
+
+    def test_generate_simulation_narrative_generated(self) -> None:
+        """Test simulation generates narrative summary."""
+        from services.business_case_simulation import generate_business_case_simulation
+        from services.business_case_engine_v2 import BusinessCaseReport, ScenarioKPIs
+
+        bc = BusinessCaseReport(
+            investment_total=10000.0,
+            scenarios=[
+                ScenarioKPIs(name="optimistic", roi_12m=200.0, payback_months=4.0,
+                            monthly_savings=3000.0, annual_savings=36000.0, investment_total=8000.0),
+                ScenarioKPIs(name="realistic", roi_12m=150.0, payback_months=6.0,
+                            monthly_savings=2000.0, annual_savings=24000.0, investment_total=10000.0),
+                ScenarioKPIs(name="conservative", roi_12m=80.0, payback_months=10.0,
+                            monthly_savings=1000.0, annual_savings=12000.0, investment_total=12000.0),
+            ],
+        )
+
+        result = generate_business_case_simulation(business_case=bc, runs=100)
+
+        assert len(result.narrative_summary) > 0
+
+
+# =============================================================================
+# TEST: HTML Generation
+# =============================================================================
+
+class TestHTMLGeneration:
+    """Tests for HTML generation."""
+
+    def test_html_generation_basic(self) -> None:
+        """Test basic HTML generation."""
+        from services.business_case_simulation import (
+            business_case_simulation_to_html,
+            BusinessCaseSimulationReport,
+            SimulationDistribution,
+            SimulationAssumptions,
+        )
+        from services.business_case_engine_v2 import BusinessCaseReport, ScenarioKPIs
+
+        dist = SimulationDistribution()
+        dist.roi_p50 = 150.0
+        dist.roi_p80 = 180.0
+        dist.roi_p90 = 200.0
+        dist.roi_p20 = 100.0
+        dist.roi_min = 80.0
+        dist.roi_max = 250.0
+        dist.roi_std = 30.0
+        dist.payback_p50 = 6.0
+        dist.payback_p80 = 7.0
+        dist.payback_p90 = 8.0
+        dist.payback_p20 = 5.0
+        dist.payback_min = 3.0
+        dist.payback_max = 12.0
+        dist.simulation_runs = 1000
+
+        bc = BusinessCaseReport(
+            scenarios=[
+                ScenarioKPIs(name="realistic", roi_12m=150.0, payback_months=6.0,
+                            monthly_savings=2000.0, annual_savings=24000.0, investment_total=10000.0),
+            ]
+        )
+
+        report = BusinessCaseSimulationReport(
+            baseline_report=bc,
+            distribution=dist,
+            assumptions=SimulationAssumptions(
+                monthly_savings_min=1000.0,
+                monthly_savings_mode=2000.0,
+                monthly_savings_max=3000.0,
+            ),
+            narrative_summary="Test narrative",
+        )
+
+        html = business_case_simulation_to_html(report, lang="de")
+
+        assert "150" in html  # P50 ROI
+        assert "P50" in html or "Median" in html
+        assert "P80" in html
+        assert "P90" in html
+        assert "business-case-simulation" in html
+
+    def test_html_generation_english(self) -> None:
+        """Test HTML generation in English."""
+        from services.business_case_simulation import (
+            business_case_simulation_to_html,
+            BusinessCaseSimulationReport,
+            SimulationDistribution,
+        )
+
+        dist = SimulationDistribution()
+        dist.roi_p50 = 120.0
+        dist.payback_p50 = 5.0
+        dist.simulation_runs = 500
+
+        report = BusinessCaseSimulationReport(distribution=dist)
+
+        html = business_case_simulation_to_html(report, lang="en")
+
+        # Check for English labels
+        assert "months" in html or "Months" in html
+
+    def test_html_contains_percentile_table(self) -> None:
+        """Test HTML contains percentile table."""
+        from services.business_case_simulation import (
+            business_case_simulation_to_html,
+            BusinessCaseSimulationReport,
+            SimulationDistribution,
+        )
+
+        dist = SimulationDistribution()
+        dist.roi_p50 = 150.0
+        dist.roi_p80 = 180.0
+        dist.roi_p90 = 200.0
+        dist.roi_p20 = 100.0
+        dist.payback_p50 = 6.0
+        dist.payback_p80 = 7.0
+        dist.payback_p90 = 8.0
+        dist.payback_p20 = 5.0
+        dist.simulation_runs = 1000
+
+        report = BusinessCaseSimulationReport(distribution=dist)
+
+        html = business_case_simulation_to_html(report)
+
+        assert "<table" in html
+        assert "</table>" in html
+
+    def test_html_contains_assumptions_section(self) -> None:
+        """Test HTML contains assumptions section."""
+        from services.business_case_simulation import (
+            business_case_simulation_to_html,
+            BusinessCaseSimulationReport,
+            SimulationAssumptions,
+        )
+
+        report = BusinessCaseSimulationReport(
+            assumptions=SimulationAssumptions(
+                monthly_savings_min=1000.0,
+                monthly_savings_mode=2000.0,
+                monthly_savings_max=3000.0,
+            )
+        )
+
+        html = business_case_simulation_to_html(report)
+
+        # Should mention assumptions values
+        assert "1.000" in html or "1,000" in html or "1000" in html
+
+
+# =============================================================================
+# TEST: Consistency Rules Integration
+# =============================================================================
+
+class TestConsistencyRules:
+    """Tests for BCSIM_001-BCSIM_006 consistency rules."""
+
+    def test_bcsim_001_p50_near_realistic(self) -> None:
+        """Test BCSIM_001: P50 ROI should be near realistic scenario."""
+        from services.consistency_engine import ConsistencyEngine
+        from services.business_case_simulation import (
+            BusinessCaseSimulationReport,
+            SimulationDistribution,
+        )
+
+        dist = SimulationDistribution()
+        dist.roi_p50 = 100.0  # 33% deviation from 150
+        dist.roi_p80 = 120.0
+        dist.simulation_runs = 1000
+
+        sections = {
+            "BUSINESS_CASE_SIM_HTML": "<div>P50 ROI: 100%</div>",
+            "BUSINESS_CASE_ENGINE_HTML": """
+                <div>optimistic ROI: 200%</div>
+                <div>realistic ROI: 150%</div>
+                <div>conservative ROI: 80%</div>
+            """,
+            "_business_case_simulation_report": BusinessCaseSimulationReport(distribution=dist),
+        }
+
+        engine = ConsistencyEngine(sections, {})
+        engine._check_business_case_simulation_consistency()
+
+        # Should find BCSIM_001 issue due to >25% deviation
+        bcsim_001_issues = [i for i in engine.report.issues if i.rule_id == "BCSIM_001"]
+        assert len(bcsim_001_issues) >= 1
+
+    def test_bcsim_002_p80_above_conservative(self) -> None:
+        """Test BCSIM_002: P80 ROI should not be below conservative."""
+        from services.consistency_engine import ConsistencyEngine
+        from services.business_case_simulation import (
+            BusinessCaseSimulationReport,
+            SimulationDistribution,
+        )
+
+        dist = SimulationDistribution()
+        dist.roi_p50 = 150.0
+        dist.roi_p80 = 50.0  # Below conservative (80)
+        dist.simulation_runs = 1000
+
+        sections = {
+            "BUSINESS_CASE_SIM_HTML": "<div>P80 ROI: 50%</div>",
+            "BUSINESS_CASE_ENGINE_HTML": """
+                <div>optimistic ROI: 200%</div>
+                <div>realistic ROI: 150%</div>
+                <div>conservative ROI: 80%</div>
+            """,
+            "_business_case_simulation_report": BusinessCaseSimulationReport(distribution=dist),
+        }
+
+        engine = ConsistencyEngine(sections, {})
+        engine._check_business_case_simulation_consistency()
+
+        bcsim_002_issues = [i for i in engine.report.issues if i.rule_id == "BCSIM_002"]
+        assert len(bcsim_002_issues) >= 1
+
+    def test_bcsim_004_negative_payback_error(self) -> None:
+        """Test BCSIM_004: Negative payback should trigger error."""
+        from services.consistency_engine import ConsistencyEngine
+        from services.business_case_simulation import (
+            BusinessCaseSimulationReport,
+            SimulationDistribution,
+        )
+
+        dist = SimulationDistribution()
+        dist.roi_p50 = 150.0
+        dist.roi_p80 = 180.0
+        dist.payback_p50 = -5.0  # Negative!
+        dist.simulation_runs = 1000
+
+        sections = {
+            "BUSINESS_CASE_SIM_HTML": "<div>Payback P50: -5 months</div>",
+            "BUSINESS_CASE_ENGINE_HTML": "<div>realistic ROI: 150%</div>",
+            "_business_case_simulation_report": BusinessCaseSimulationReport(distribution=dist),
+        }
+
+        engine = ConsistencyEngine(sections, {})
+        engine._check_business_case_simulation_consistency()
+
+        bcsim_004_issues = [i for i in engine.report.issues if i.rule_id == "BCSIM_004"]
+        assert any(i.severity == "ERROR" for i in bcsim_004_issues)
+
+    def test_bcsim_005_high_risk_variance(self) -> None:
+        """Test BCSIM_005: High risk should have wider variance."""
+        from services.consistency_engine import ConsistencyEngine
+        from services.business_case_simulation import (
+            BusinessCaseSimulationReport,
+            SimulationDistribution,
+        )
+
+        dist = SimulationDistribution()
+        dist.roi_p50 = 150.0
+        dist.roi_p80 = 180.0
+        dist.roi_mean = 150.0
+        dist.roi_std = 10.0  # Very low variance (CV = 0.067)
+        dist.simulation_runs = 1000
+
+        sections = {
+            "BUSINESS_CASE_SIM_HTML": "<div>ROI: 150%</div>",
+            "BUSINESS_CASE_ENGINE_HTML": "<div>realistic ROI: 150%</div>",
+            "RISK_ENGINE_V3_HTML": "<div>Risk Grade: D</div>",  # High risk
+            "_business_case_simulation_report": BusinessCaseSimulationReport(distribution=dist),
+        }
+
+        engine = ConsistencyEngine(sections, {})
+        engine._check_business_case_simulation_consistency()
+
+        bcsim_005_issues = [i for i in engine.report.issues if i.rule_id == "BCSIM_005"]
+        assert len(bcsim_005_issues) >= 1
+
+    def test_consistency_rules_pass_valid_data(self) -> None:
+        """Test consistency rules pass with valid, consistent data."""
+        from services.consistency_engine import ConsistencyEngine
+        from services.business_case_simulation import (
+            BusinessCaseSimulationReport,
+            SimulationDistribution,
+        )
+
+        dist = SimulationDistribution()
+        dist.roi_p50 = 150.0  # Close to realistic (150)
+        dist.roi_p80 = 180.0
+        dist.roi_p90 = 200.0
+        dist.roi_p20 = 100.0
+        dist.payback_p50 = 6.0
+        dist.roi_mean = 155.0
+        dist.roi_std = 45.0  # Medium variance (CV ≈ 0.29)
+        dist.simulation_runs = 1000
+
+        sections = {
+            "BUSINESS_CASE_SIM_HTML": "<div>P50 ROI: 150%</div>",
+            "BUSINESS_CASE_ENGINE_HTML": """
+                <div>optimistic ROI: 200%</div>
+                <div>realistic ROI: 150%</div>
+                <div>conservative ROI: 80%</div>
+            """,
+            "RISK_ENGINE_V3_HTML": "<div>Risk Grade: C</div>",
+            "_business_case_simulation_report": BusinessCaseSimulationReport(distribution=dist),
+        }
+
+        engine = ConsistencyEngine(sections, {})
+        engine._check_business_case_simulation_consistency()
+
+        # Should have no or few issues
+        error_issues = [i for i in engine.report.issues if i.severity == "ERROR"]
+        assert len(error_issues) == 0
+
+
+# =============================================================================
+# TEST: Edge Cases
+# =============================================================================
+
+class TestEdgeCases:
+    """Tests for edge cases and error handling."""
+
+    def test_simulation_with_zero_savings(self) -> None:
+        """Test simulation handles zero savings gracefully."""
+        from services.business_case_simulation import (
+            run_monte_carlo_simulation,
+            SimulationAssumptions,
+        )
+
+        assumptions = SimulationAssumptions(
+            monthly_savings_min=0.0,
+            monthly_savings_mode=0.0,
+            monthly_savings_max=0.0,
+            investment_min=5000.0,
+            investment_mode=8000.0,
+            investment_max=10000.0,
+        )
+
+        # Should not crash
+        result = run_monte_carlo_simulation(assumptions, runs=100)
+        assert result is not None
+
+    def test_simulation_with_very_high_investment(self) -> None:
+        """Test simulation with very high investment values."""
+        from services.business_case_simulation import (
+            run_monte_carlo_simulation,
+            SimulationAssumptions,
+        )
+
+        assumptions = SimulationAssumptions(
+            monthly_savings_min=5000.0,
+            monthly_savings_mode=10000.0,
+            monthly_savings_max=20000.0,
+            investment_min=500000.0,
+            investment_mode=1000000.0,
+            investment_max=2000000.0,
+        )
+
+        result = run_monte_carlo_simulation(assumptions, runs=100)
+
+        # Should calculate negative ROI (investment > savings)
+        assert result.roi_min < 0
+
+    def test_html_generation_empty_report(self) -> None:
+        """Test HTML generation with empty report."""
+        from services.business_case_simulation import (
+            business_case_simulation_to_html,
+            BusinessCaseSimulationReport,
+        )
+
+        report = BusinessCaseSimulationReport()
+
+        # Should not crash
+        html = business_case_simulation_to_html(report)
+        assert "business-case-simulation" in html
+
+    def test_generate_narrative_german(self) -> None:
+        """Test narrative generation in German."""
+        from services.business_case_simulation import (
+            generate_narrative_summary,
+            SimulationDistribution,
+            SimulationAssumptions,
+        )
+        from services.business_case_engine_v2 import BusinessCaseReport, ScenarioKPIs
+
+        dist = SimulationDistribution()
+        dist.roi_p50 = 150.0
+        dist.roi_std = 30.0
+        dist.payback_p50 = 6.0
+
+        bc = BusinessCaseReport(
+            scenarios=[
+                ScenarioKPIs(name="realistic", roi_12m=150.0, payback_months=6.0,
+                            monthly_savings=2000.0, annual_savings=24000.0, investment_total=10000.0),
+            ]
+        )
+
+        narrative = generate_narrative_summary(dist, bc, SimulationAssumptions(), lang="de")
+
+        # Should contain German text
+        assert "Monte-Carlo" in narrative or "Simulation" in narrative
+
+    def test_generate_narrative_english(self) -> None:
+        """Test narrative generation in English."""
+        from services.business_case_simulation import (
+            generate_narrative_summary,
+            SimulationDistribution,
+            SimulationAssumptions,
+        )
+        from services.business_case_engine_v2 import BusinessCaseReport, ScenarioKPIs
+
+        dist = SimulationDistribution()
+        dist.roi_p50 = 150.0
+        dist.roi_std = 30.0
+        dist.payback_p50 = 6.0
+
+        bc = BusinessCaseReport(
+            scenarios=[
+                ScenarioKPIs(name="realistic", roi_12m=150.0, payback_months=6.0,
+                            monthly_savings=2000.0, annual_savings=24000.0, investment_total=10000.0),
+            ]
+        )
+
+        narrative = generate_narrative_summary(dist, bc, SimulationAssumptions(), lang="en")
+
+        # Should contain English text
+        assert "Monte Carlo" in narrative or "simulation" in narrative


### PR DESCRIPTION
- Add services/business_case_simulation.py with:
  - SimulationAssumptions dataclass for distribution parameters
  - SimulationDistribution dataclass for simulation results
  - BusinessCaseSimulationReport combining baseline + simulation
  - Monte Carlo simulation with triangular/uniform distributions
  - P50/P80/P90 percentile calculations
  - Risk-adjusted variance based on G33 residual risk
  - Size-aware variance multipliers (solo/team/kmu)
  - HTML rendering for PDF reports

- Add prompts/de/business_case_simulation.md & prompts/en/business_case_simulation.md for LLM-based assumption generation

- Add consistency rules BCSIM_001-BCSIM_006 to consistency_engine.py:
  - BCSIM_001: P50 ROI near realistic scenario (±25%)
  - BCSIM_002: P80 ROI above conservative scenario
  - BCSIM_003: P20 ROI plausibility check
  - BCSIM_004: Payback validation (positive, reasonable)
  - BCSIM_005: Variance aligned with risk grade
  - BCSIM_006: Strategy narrative consistency

- Update PDF templates with BUSINESS_CASE_SIM_HTML section

- Add tests/test_g34_business_case_simulation.py with 50+ tests