### PR TITLE
feat(G37): add Benchmark Engine for industry comparison and SWOT anal…

### DIFF
--- a/gpt_analyze.py
+++ b/gpt_analyze.py
@@ -5295,6 +5295,92 @@ def analyze_briefing(db: Session, briefing_id: int, run_id: str) -> tuple[int, s
         log.warning("[%s] ⚠️ G32 Recommendations Engine failed: %s", run_id, e)
         sections.setdefault("RECOMMENDATIONS_ENGINE_HTML", "")
 
+    # =========================================================================
+    # SPRINT G34: Business Case Simulation – Monte Carlo ROI & Payback Analysis
+    # =========================================================================
+    try:
+        from services.business_case_simulation import (
+            generate_business_case_simulation,
+            business_case_simulation_to_html,
+        )
+
+        bc_simulation = generate_business_case_simulation(
+            context=None,
+            sections=sections,
+            business_case=sections.get("_bc_report"),
+            risk_report_v3=sections.get("_risk_report_v3"),
+            auto_report=sections.get("_automation_roadmap_report"),
+            briefing=answers,
+            llm_response=None,
+        )
+
+        sections["BUSINESS_CASE_SIM_HTML"] = business_case_simulation_to_html(bc_simulation, lang=report_lang)
+        sections["_business_case_simulation_report"] = bc_simulation
+
+        # Extract key values for template usage
+        if bc_simulation.roi_distribution:
+            sections["ROI_P50"] = bc_simulation.roi_distribution.p50
+            sections["ROI_P80"] = bc_simulation.roi_distribution.p80
+            sections["ROI_P90"] = bc_simulation.roi_distribution.p90
+        if bc_simulation.payback_distribution:
+            sections["PAYBACK_P50"] = bc_simulation.payback_distribution.p50
+
+        log.info("[%s] ✅ G34 Business Case Simulation generated: P50 ROI=%.1f%%, P80 ROI=%.1f%%",
+                 run_id,
+                 bc_simulation.roi_distribution.p50 if bc_simulation.roi_distribution else 0,
+                 bc_simulation.roi_distribution.p80 if bc_simulation.roi_distribution else 0)
+    except ImportError:
+        log.debug("[%s] G34 business_case_simulation not available", run_id)
+        sections.setdefault("BUSINESS_CASE_SIM_HTML", "")
+    except Exception as e:
+        log.warning("[%s] ⚠️ G34 Business Case Simulation failed: %s", run_id, e)
+        sections.setdefault("BUSINESS_CASE_SIM_HTML", "")
+
+    # =========================================================================
+    # SPRINT G37: Benchmark Engine – Branchenvergleich & Wettbewerbsposition
+    # =========================================================================
+    try:
+        from services.benchmark_engine import (
+            generate_benchmark_report,
+            benchmark_report_to_html,
+        )
+
+        benchmark_report = generate_benchmark_report(
+            context=None,
+            sections=sections,
+            kpi_data=sections.get("_business_case_simulation_report"),
+            tools_data=sections.get("_tools_data"),
+            funding_data=sections.get("_funding_data"),
+            risk_report_v3=sections.get("_risk_report_v3"),
+            auto_report=sections.get("_automation_roadmap_report"),
+            strategy_plan=sections.get("_strategy_plan"),
+            business_case=sections.get("_bc_report"),
+            briefing=answers,
+            llm_response=None,
+            lang=report_lang,
+        )
+
+        sections["BENCHMARK_ENGINE_HTML"] = benchmark_report_to_html(benchmark_report, lang=report_lang)
+        sections["_benchmark_report"] = benchmark_report
+
+        # Extract key values for template usage
+        sections["BENCHMARK_MATURITY_SCORE"] = benchmark_report.maturity_score
+        sections["BENCHMARK_GRADE"] = benchmark_report.competitiveness_grade
+        sections["BENCHMARK_ABOVE_MEDIAN"] = benchmark_report.above_median_count
+
+        log.info("[%s] ✅ G37 Benchmark Engine generated: maturity=%.0f%%, grade=%s, above_median=%d/%d",
+                 run_id,
+                 benchmark_report.maturity_score,
+                 benchmark_report.competitiveness_grade,
+                 benchmark_report.above_median_count,
+                 len(benchmark_report.positions))
+    except ImportError:
+        log.debug("[%s] G37 benchmark_engine not available", run_id)
+        sections.setdefault("BENCHMARK_ENGINE_HTML", "")
+    except Exception as e:
+        log.warning("[%s] ⚠️ G37 Benchmark Engine failed: %s", run_id, e)
+        sections.setdefault("BENCHMARK_ENGINE_HTML", "")
+
     log.info("[%s] 🎨 Rendering final HTML...", run_id)
     # --- Sanitize dynamic sections to prevent HTML leaks (z. B. eingebettetes <html> im Pilot-Plan) ---
     try:

--- a/gpt_analyze.py
+++ b/gpt_analyze.py
@@ -5306,7 +5306,6 @@ def analyze_briefing(db: Session, briefing_id: int, run_id: str) -> tuple[int, s
 
         bc_simulation = generate_business_case_simulation(
             context=None,
-            sections=sections,
             business_case=sections.get("_bc_report"),
             risk_report_v3=sections.get("_risk_report_v3"),
             auto_report=sections.get("_automation_roadmap_report"),
@@ -5318,17 +5317,16 @@ def analyze_briefing(db: Session, briefing_id: int, run_id: str) -> tuple[int, s
         sections["_business_case_simulation_report"] = bc_simulation
 
         # Extract key values for template usage
-        if bc_simulation.roi_distribution:
-            sections["ROI_P50"] = bc_simulation.roi_distribution.p50
-            sections["ROI_P80"] = bc_simulation.roi_distribution.p80
-            sections["ROI_P90"] = bc_simulation.roi_distribution.p90
-        if bc_simulation.payback_distribution:
-            sections["PAYBACK_P50"] = bc_simulation.payback_distribution.p50
+        if bc_simulation.distribution:
+            sections["ROI_P50"] = bc_simulation.distribution.roi_p50
+            sections["ROI_P80"] = bc_simulation.distribution.roi_p80
+            sections["ROI_P90"] = bc_simulation.distribution.roi_p90
+            sections["PAYBACK_P50"] = bc_simulation.distribution.payback_p50
 
         log.info("[%s] ✅ G34 Business Case Simulation generated: P50 ROI=%.1f%%, P80 ROI=%.1f%%",
                  run_id,
-                 bc_simulation.roi_distribution.p50 if bc_simulation.roi_distribution else 0,
-                 bc_simulation.roi_distribution.p80 if bc_simulation.roi_distribution else 0)
+                 bc_simulation.distribution.roi_p50 if bc_simulation.distribution else 0,
+                 bc_simulation.distribution.roi_p80 if bc_simulation.distribution else 0)
     except ImportError:
         log.debug("[%s] G34 business_case_simulation not available", run_id)
         sections.setdefault("BUSINESS_CASE_SIM_HTML", "")

--- a/prompts/de/benchmark_engine.md
+++ b/prompts/de/benchmark_engine.md
@@ -1,0 +1,201 @@
+# Benchmark Engine – Branchenvergleich & Wettbewerbsposition
+
+## Rolle
+Du bist ein KI-Strategieberater und Marktanalyst. Deine Aufgabe ist es, das Unternehmen mit Branchenbenchmarks zu vergleichen, die KI-Reife zu quantifizieren und eine wettbewerbsorientierte Perspektive zu liefern.
+
+## Kontext
+- **Unternehmensgroesse**: {{unternehmensgroesse}}
+- **Branche**: {{branche}}
+- **KI-Anwendung**: {{ki_anwendung}}
+- **KI-Reifegrad**: {{ki_reifegrad}}
+- **Hauptherausforderungen**: {{hauptherausforderungen}}
+
+## Business Case Simulation Daten (G34)
+{{kpi_data}}
+
+## Tools Engine 4.0 Daten (G25)
+{{tools_data}}
+
+## Funding Engine v2 Daten (G26)
+{{funding_data}}
+
+## Risk Engine 3.0 Daten (G33)
+{{risk_report_v3}}
+
+## Automation Roadmap Daten (G36)
+{{auto_report}}
+
+## Strategy Plan Daten (G28)
+{{strategy_plan}}
+
+## Aufgabe
+Erstelle eine umfassende Benchmark-Analyse mit:
+
+1. **KPI-Benchmarking**: ROI P50/P80/P90 im Branchenvergleich
+2. **Risk-Benchmarking**: Risiko-Score vs. branchenuebliches Risiko
+3. **Tools-Benchmarking**: Tool-Fit, Vendor-Risk-Verteilung
+4. **Funding-Benchmarking**: Foerderquote/Summe vs. Branchenniveau
+5. **Automation-Benchmarking**: Prozesse, Impact x Machbarkeit
+6. **Strategy-Benchmarking**: Phasen-Fortschritt im Branchenvergleich
+
+## Bewertungskriterien
+
+### score_percentile (0-100)
+- **75-100**: Top-Quartil der Branche
+- **50-75**: Ueber Branchenmedian
+- **25-50**: Unter Branchenmedian
+- **0-25**: Unteres Quartil
+
+### company_value
+Normalisierter Wert (typisch 0.0-1.5):
+- KPI/ROI: Prozentsatz als Dezimal (z.B. 1.2 = 120%)
+- Tools: Fit-Score 0.0-1.0
+- Risk: Score 0.0-1.0 (niedriger ist besser)
+- Automation: Potenzial 0.0-1.0
+- Funding: Quote 0.0-1.0
+- Strategy: Reife 0.0-1.0
+
+### industry_median / industry_top_quartile
+Branchentypische Referenzwerte basierend auf:
+- Branche: {{branche}}
+- Unternehmensgroesse: {{unternehmensgroesse}}
+
+## Groessen-Constraints
+
+### Solo (Einzelunternehmer)
+- Niedrigere Median-Erwartungen bei Tools/Automation
+- Hoehere relative Varianz bei KPIs
+- Limitierte Foerder-Optionen
+
+### Team (kleines Team)
+- Standard-Branchenbenchmarks
+- Fokus auf Quick Wins und Effizienz
+
+### KMU (kleine/mittlere Unternehmen)
+- Hoehere Erwartungen an Governance/Strategie
+- Mehr Foerder-Potenzial
+- Komplexere Automationspfade
+
+## Fehlervermeidungs-Regeln
+
+1. **BENCH_001**: score_percentile muss zwischen 0 und 100 liegen
+2. **BENCH_002**: company_value darf nicht > 10x industry_median sein (Outlier-Schutz)
+3. **BENCH_003**: Bei hohem RiskScore darf risk_percentile nicht im Top-Quartil sein
+4. **BENCH_004**: Radar scores muessen der Berechnung entsprechen (Normalization Check)
+5. **BENCH_005**: Strengths duerfen nicht im Widerspruch zu RiskReport stehen
+6. **BENCH_006**: Weaknesses duerfen nicht "none" sein - immer Verbesserungspotenzial identifizieren
+7. **BENCH_007**: Opportunities muessen mit Funding Engine uebereinstimmen
+8. **BENCH_008**: Summary muss die BenchmarkPositionen korrekt widerspiegeln
+
+## SWOT-Perspektive
+
+### Strengths (Staerken)
+- Bereiche mit score_percentile >= 65
+- Wettbewerbsvorteile gegenueber Branche
+- Positive Abweichungen vom Median
+
+### Weaknesses (Schwaechen)
+- Bereiche mit score_percentile <= 35
+- Rueckstand gegenueber Branche
+- Verbesserungspotenziale
+
+### Opportunities (Chancen)
+- Ungenutzte Foerderprogramme
+- Automationspotenziale
+- Marktchancen durch KI
+
+### Threats (Risiken)
+- Wettbewerbsdruck durch KI-Adoption
+- Regulatorische Herausforderungen
+- Technologische Disruption
+
+## Output-Format (JSON)
+
+```json
+{
+  "positions": [
+    {
+      "domain": "kpi",
+      "company_value": 1.2,
+      "industry_median": 0.8,
+      "industry_top_quartile": 1.4,
+      "score_percentile": 75,
+      "narrative": "Ihre ROI-Leistung liegt im Top-Quartil der Branche."
+    },
+    {
+      "domain": "tools",
+      "company_value": 0.65,
+      "industry_median": 0.5,
+      "industry_top_quartile": 0.75,
+      "score_percentile": 68,
+      "narrative": "Tool-Reife ueber Branchenmedian."
+    },
+    {
+      "domain": "risk",
+      "company_value": 0.45,
+      "industry_median": 0.6,
+      "industry_top_quartile": 0.35,
+      "score_percentile": 72,
+      "narrative": "Risikomanagement besser als Branchendurchschnitt."
+    },
+    {
+      "domain": "automation",
+      "company_value": 0.52,
+      "industry_median": 0.4,
+      "industry_top_quartile": 0.65,
+      "score_percentile": 65,
+      "narrative": "Automationsgrad ueber Median."
+    },
+    {
+      "domain": "funding",
+      "company_value": 0.35,
+      "industry_median": 0.3,
+      "industry_top_quartile": 0.55,
+      "score_percentile": 58,
+      "narrative": "Foerder-Ausschoepfung leicht ueber Durchschnitt."
+    },
+    {
+      "domain": "strategy",
+      "company_value": 0.6,
+      "industry_median": 0.5,
+      "industry_top_quartile": 0.75,
+      "score_percentile": 62,
+      "narrative": "Strategische KI-Reife auf gutem Niveau."
+    }
+  ],
+  "radar": {
+    "categories": ["ROI", "Risiko", "Tools", "Automation", "Foerderung", "Strategie"],
+    "scores": [0.75, 0.72, 0.68, 0.65, 0.58, 0.62]
+  },
+  "summary": "Ihre KI-Wettbewerbsposition ist gut (Note B). Mit einem Reifegrad von 67% liegen Sie in 5 von 6 Benchmark-Kategorien ueber dem Branchenmedian. Als Team in der Technologie-Branche haben Sie eine gute Ausgangsposition fuer weitere KI-Transformation.",
+  "strengths": [
+    "Starke ROI-Kennzahlen im Branchenvergleich",
+    "Solides Risikomanagement",
+    "Fortschrittlicher Tool-Stack"
+  ],
+  "weaknesses": [
+    "Foerder-Ausschoepfung ausbaufaehig",
+    "Strategische Planung noch nicht voll ausgereift"
+  ],
+  "opportunities": [
+    "Weitere Foerderprogramme nutzen",
+    "Automationspotenzial skalieren",
+    "Strategische Positionierung als KI-Leader"
+  ],
+  "threats": [
+    "Wettbewerber holen bei KI-Adoption auf",
+    "Regulatorische Anforderungen (AI Act) steigen",
+    "Technologische Disruption durch neue Tools"
+  ]
+}
+```
+
+## Wichtige Hinweise
+
+1. **Branchenspezifisch**: Benchmarks muessen zur angegebenen Branche passen
+2. **Groessen-aware**: Erwartungen an Solo vs. KMU unterscheiden
+3. **Konsistent**: Alle Werte muessen zueinander passen
+4. **Realistisch**: Keine uebertrieben positiven oder negativen Bewertungen
+5. **Actionable**: SWOT muss konkrete Handlungsoptionen aufzeigen
+
+Erstelle jetzt die Benchmark-Analyse basierend auf den bereitgestellten Daten.

--- a/prompts/en/benchmark_engine.md
+++ b/prompts/en/benchmark_engine.md
@@ -1,0 +1,201 @@
+# Benchmark Engine – Industry Comparison & Competitive Position
+
+## Role
+You are an AI strategy consultant and market analyst. Your task is to compare the company with industry benchmarks, quantify AI maturity, and provide a competitive perspective.
+
+## Context
+- **Company Size**: {{company_size}}
+- **Industry**: {{industry}}
+- **AI Application**: {{ai_application}}
+- **AI Maturity Level**: {{ai_maturity}}
+- **Main Challenges**: {{main_challenges}}
+
+## Business Case Simulation Data (G34)
+{{kpi_data}}
+
+## Tools Engine 4.0 Data (G25)
+{{tools_data}}
+
+## Funding Engine v2 Data (G26)
+{{funding_data}}
+
+## Risk Engine 3.0 Data (G33)
+{{risk_report_v3}}
+
+## Automation Roadmap Data (G36)
+{{auto_report}}
+
+## Strategy Plan Data (G28)
+{{strategy_plan}}
+
+## Task
+Create a comprehensive benchmark analysis with:
+
+1. **KPI Benchmarking**: ROI P50/P80/P90 compared to industry
+2. **Risk Benchmarking**: Risk score vs. typical industry risk
+3. **Tools Benchmarking**: Tool fit, vendor risk distribution
+4. **Funding Benchmarking**: Funding rate/amount vs. industry level
+5. **Automation Benchmarking**: Processes, Impact x Feasibility
+6. **Strategy Benchmarking**: Phase progress compared to industry
+
+## Evaluation Criteria
+
+### score_percentile (0-100)
+- **75-100**: Top quartile of industry
+- **50-75**: Above industry median
+- **25-50**: Below industry median
+- **0-25**: Bottom quartile
+
+### company_value
+Normalized value (typically 0.0-1.5):
+- KPI/ROI: Percentage as decimal (e.g., 1.2 = 120%)
+- Tools: Fit score 0.0-1.0
+- Risk: Score 0.0-1.0 (lower is better)
+- Automation: Potential 0.0-1.0
+- Funding: Rate 0.0-1.0
+- Strategy: Maturity 0.0-1.0
+
+### industry_median / industry_top_quartile
+Industry-typical reference values based on:
+- Industry: {{industry}}
+- Company Size: {{company_size}}
+
+## Size Constraints
+
+### Solo (Solo Entrepreneur)
+- Lower median expectations for Tools/Automation
+- Higher relative variance in KPIs
+- Limited funding options
+
+### Team (Small Team)
+- Standard industry benchmarks
+- Focus on quick wins and efficiency
+
+### SME (Small/Medium Enterprise)
+- Higher expectations for governance/strategy
+- More funding potential
+- More complex automation paths
+
+## Error Prevention Rules
+
+1. **BENCH_001**: score_percentile must be between 0 and 100
+2. **BENCH_002**: company_value must not be > 10x industry_median (outlier protection)
+3. **BENCH_003**: With high RiskScore, risk_percentile cannot be in top quartile
+4. **BENCH_004**: Radar scores must match the calculation (normalization check)
+5. **BENCH_005**: Strengths must not contradict RiskReport
+6. **BENCH_006**: Weaknesses must not be "none" - always identify improvement potential
+7. **BENCH_007**: Opportunities must align with Funding Engine
+8. **BENCH_008**: Summary must correctly reflect BenchmarkPositions
+
+## SWOT Perspective
+
+### Strengths
+- Areas with score_percentile >= 65
+- Competitive advantages vs. industry
+- Positive deviations from median
+
+### Weaknesses
+- Areas with score_percentile <= 35
+- Gap vs. industry
+- Improvement potentials
+
+### Opportunities
+- Unused funding programs
+- Automation potentials
+- Market opportunities through AI
+
+### Threats
+- Competitive pressure from AI adoption
+- Regulatory challenges
+- Technological disruption
+
+## Output Format (JSON)
+
+```json
+{
+  "positions": [
+    {
+      "domain": "kpi",
+      "company_value": 1.2,
+      "industry_median": 0.8,
+      "industry_top_quartile": 1.4,
+      "score_percentile": 75,
+      "narrative": "Your ROI performance is in the top quartile of the industry."
+    },
+    {
+      "domain": "tools",
+      "company_value": 0.65,
+      "industry_median": 0.5,
+      "industry_top_quartile": 0.75,
+      "score_percentile": 68,
+      "narrative": "Tool maturity above industry median."
+    },
+    {
+      "domain": "risk",
+      "company_value": 0.45,
+      "industry_median": 0.6,
+      "industry_top_quartile": 0.35,
+      "score_percentile": 72,
+      "narrative": "Risk management better than industry average."
+    },
+    {
+      "domain": "automation",
+      "company_value": 0.52,
+      "industry_median": 0.4,
+      "industry_top_quartile": 0.65,
+      "score_percentile": 65,
+      "narrative": "Automation level above median."
+    },
+    {
+      "domain": "funding",
+      "company_value": 0.35,
+      "industry_median": 0.3,
+      "industry_top_quartile": 0.55,
+      "score_percentile": 58,
+      "narrative": "Funding utilization slightly above average."
+    },
+    {
+      "domain": "strategy",
+      "company_value": 0.6,
+      "industry_median": 0.5,
+      "industry_top_quartile": 0.75,
+      "score_percentile": 62,
+      "narrative": "Strategic AI maturity at good level."
+    }
+  ],
+  "radar": {
+    "categories": ["ROI", "Risk", "Tools", "Automation", "Funding", "Strategy"],
+    "scores": [0.75, 0.72, 0.68, 0.65, 0.58, 0.62]
+  },
+  "summary": "Your AI competitive position is good (grade B). With a maturity score of 67%, you are above the industry median in 5 out of 6 benchmark categories. As a team in the technology industry, you have a good starting position for further AI transformation.",
+  "strengths": [
+    "Strong ROI metrics compared to industry",
+    "Solid risk management",
+    "Advanced tool stack"
+  ],
+  "weaknesses": [
+    "Funding utilization could be improved",
+    "Strategic planning not yet fully mature"
+  ],
+  "opportunities": [
+    "Utilize additional funding programs",
+    "Scale automation potential",
+    "Strategic positioning as AI leader"
+  ],
+  "threats": [
+    "Competitors catching up on AI adoption",
+    "Regulatory requirements (AI Act) increasing",
+    "Technological disruption from new tools"
+  ]
+}
+```
+
+## Important Notes
+
+1. **Industry-specific**: Benchmarks must match the specified industry
+2. **Size-aware**: Expectations for Solo vs. SME differ
+3. **Consistent**: All values must be coherent
+4. **Realistic**: No overly positive or negative assessments
+5. **Actionable**: SWOT must show concrete action options
+
+Now create the benchmark analysis based on the provided data.

--- a/services/benchmark_engine.py
+++ b/services/benchmark_engine.py
@@ -1,0 +1,1613 @@
+# -*- coding: utf-8 -*-
+"""
+Sprint G37: Benchmark Engine – Wettbewerb, Branchenmedian, Reifegradvergleich
+=============================================================================
+
+A comprehensive Benchmark Engine that:
+
+- Compares the company with industry median values
+- Integrates competitive and market perspectives
+- Quantifies internal maturity (Readiness Score)
+- Embeds KPI, Tool, Risk, Automation, Strategy, and Funding values in a benchmark model
+- Generates a new report chapter: BENCHMARK_ENGINE_HTML
+
+This module elevates the Decision Suite to a full AI Maturity & Competitiveness Framework.
+
+Version: 1.0.0 (Sprint G37)
+Author: Claude + Wolf
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Tuple, Union
+
+log = logging.getLogger(__name__)
+
+__all__ = [
+    "BenchmarkPosition",
+    "BenchmarkRadar",
+    "BenchmarkReport",
+    "generate_benchmark_report",
+    "benchmark_report_to_html",
+    "BENCHMARK_ENGINE_ENABLED",
+]
+
+
+# =============================================================================
+# CONFIGURATION
+# =============================================================================
+
+BENCHMARK_ENGINE_ENABLED = True
+
+# Benchmark domains
+BENCHMARK_DOMAINS = ["kpi", "tools", "risk", "automation", "funding", "strategy"]
+
+# Industry benchmark values by branch (median and top quartile)
+# These are baseline values that get adjusted based on actual data
+INDUSTRY_BENCHMARKS: Dict[str, Dict[str, Dict[str, float]]] = {
+    # Default benchmarks (used when branch not found)
+    "default": {
+        "kpi": {"median": 0.8, "top_quartile": 1.4, "floor": 0.3},
+        "tools": {"median": 0.5, "top_quartile": 0.75, "floor": 0.2},
+        "risk": {"median": 0.6, "top_quartile": 0.35, "floor": 0.1},  # Lower is better for risk
+        "automation": {"median": 0.4, "top_quartile": 0.65, "floor": 0.1},
+        "funding": {"median": 0.3, "top_quartile": 0.55, "floor": 0.05},
+        "strategy": {"median": 0.5, "top_quartile": 0.75, "floor": 0.2},
+    },
+    # Technology / IT
+    "technologie": {
+        "kpi": {"median": 1.0, "top_quartile": 1.8, "floor": 0.4},
+        "tools": {"median": 0.65, "top_quartile": 0.85, "floor": 0.3},
+        "risk": {"median": 0.5, "top_quartile": 0.3, "floor": 0.1},
+        "automation": {"median": 0.55, "top_quartile": 0.8, "floor": 0.2},
+        "funding": {"median": 0.35, "top_quartile": 0.6, "floor": 0.1},
+        "strategy": {"median": 0.6, "top_quartile": 0.85, "floor": 0.3},
+    },
+    "it": {
+        "kpi": {"median": 1.0, "top_quartile": 1.8, "floor": 0.4},
+        "tools": {"median": 0.65, "top_quartile": 0.85, "floor": 0.3},
+        "risk": {"median": 0.5, "top_quartile": 0.3, "floor": 0.1},
+        "automation": {"median": 0.55, "top_quartile": 0.8, "floor": 0.2},
+        "funding": {"median": 0.35, "top_quartile": 0.6, "floor": 0.1},
+        "strategy": {"median": 0.6, "top_quartile": 0.85, "floor": 0.3},
+    },
+    "software": {
+        "kpi": {"median": 1.2, "top_quartile": 2.0, "floor": 0.5},
+        "tools": {"median": 0.7, "top_quartile": 0.9, "floor": 0.35},
+        "risk": {"median": 0.45, "top_quartile": 0.25, "floor": 0.1},
+        "automation": {"median": 0.6, "top_quartile": 0.85, "floor": 0.25},
+        "funding": {"median": 0.4, "top_quartile": 0.65, "floor": 0.1},
+        "strategy": {"median": 0.65, "top_quartile": 0.88, "floor": 0.35},
+    },
+    # Finance / Banking
+    "finanzen": {
+        "kpi": {"median": 0.9, "top_quartile": 1.5, "floor": 0.35},
+        "tools": {"median": 0.55, "top_quartile": 0.78, "floor": 0.25},
+        "risk": {"median": 0.65, "top_quartile": 0.4, "floor": 0.15},
+        "automation": {"median": 0.45, "top_quartile": 0.7, "floor": 0.15},
+        "funding": {"median": 0.25, "top_quartile": 0.45, "floor": 0.05},
+        "strategy": {"median": 0.55, "top_quartile": 0.8, "floor": 0.25},
+    },
+    "banking": {
+        "kpi": {"median": 0.9, "top_quartile": 1.5, "floor": 0.35},
+        "tools": {"median": 0.55, "top_quartile": 0.78, "floor": 0.25},
+        "risk": {"median": 0.65, "top_quartile": 0.4, "floor": 0.15},
+        "automation": {"median": 0.45, "top_quartile": 0.7, "floor": 0.15},
+        "funding": {"median": 0.25, "top_quartile": 0.45, "floor": 0.05},
+        "strategy": {"median": 0.55, "top_quartile": 0.8, "floor": 0.25},
+    },
+    # Healthcare
+    "healthcare": {
+        "kpi": {"median": 0.7, "top_quartile": 1.2, "floor": 0.3},
+        "tools": {"median": 0.45, "top_quartile": 0.68, "floor": 0.2},
+        "risk": {"median": 0.7, "top_quartile": 0.45, "floor": 0.2},
+        "automation": {"median": 0.35, "top_quartile": 0.55, "floor": 0.1},
+        "funding": {"median": 0.35, "top_quartile": 0.6, "floor": 0.1},
+        "strategy": {"median": 0.45, "top_quartile": 0.7, "floor": 0.2},
+    },
+    "gesundheit": {
+        "kpi": {"median": 0.7, "top_quartile": 1.2, "floor": 0.3},
+        "tools": {"median": 0.45, "top_quartile": 0.68, "floor": 0.2},
+        "risk": {"median": 0.7, "top_quartile": 0.45, "floor": 0.2},
+        "automation": {"median": 0.35, "top_quartile": 0.55, "floor": 0.1},
+        "funding": {"median": 0.35, "top_quartile": 0.6, "floor": 0.1},
+        "strategy": {"median": 0.45, "top_quartile": 0.7, "floor": 0.2},
+    },
+    # Manufacturing / Production
+    "produktion": {
+        "kpi": {"median": 0.85, "top_quartile": 1.4, "floor": 0.35},
+        "tools": {"median": 0.5, "top_quartile": 0.72, "floor": 0.2},
+        "risk": {"median": 0.55, "top_quartile": 0.35, "floor": 0.12},
+        "automation": {"median": 0.5, "top_quartile": 0.75, "floor": 0.2},
+        "funding": {"median": 0.4, "top_quartile": 0.65, "floor": 0.15},
+        "strategy": {"median": 0.5, "top_quartile": 0.75, "floor": 0.25},
+    },
+    "manufacturing": {
+        "kpi": {"median": 0.85, "top_quartile": 1.4, "floor": 0.35},
+        "tools": {"median": 0.5, "top_quartile": 0.72, "floor": 0.2},
+        "risk": {"median": 0.55, "top_quartile": 0.35, "floor": 0.12},
+        "automation": {"median": 0.5, "top_quartile": 0.75, "floor": 0.2},
+        "funding": {"median": 0.4, "top_quartile": 0.65, "floor": 0.15},
+        "strategy": {"median": 0.5, "top_quartile": 0.75, "floor": 0.25},
+    },
+    # Retail / E-commerce
+    "retail": {
+        "kpi": {"median": 0.75, "top_quartile": 1.3, "floor": 0.3},
+        "tools": {"median": 0.55, "top_quartile": 0.75, "floor": 0.25},
+        "risk": {"median": 0.5, "top_quartile": 0.32, "floor": 0.1},
+        "automation": {"median": 0.45, "top_quartile": 0.68, "floor": 0.15},
+        "funding": {"median": 0.3, "top_quartile": 0.5, "floor": 0.08},
+        "strategy": {"median": 0.5, "top_quartile": 0.73, "floor": 0.22},
+    },
+    "handel": {
+        "kpi": {"median": 0.75, "top_quartile": 1.3, "floor": 0.3},
+        "tools": {"median": 0.55, "top_quartile": 0.75, "floor": 0.25},
+        "risk": {"median": 0.5, "top_quartile": 0.32, "floor": 0.1},
+        "automation": {"median": 0.45, "top_quartile": 0.68, "floor": 0.15},
+        "funding": {"median": 0.3, "top_quartile": 0.5, "floor": 0.08},
+        "strategy": {"median": 0.5, "top_quartile": 0.73, "floor": 0.22},
+    },
+    "e-commerce": {
+        "kpi": {"median": 0.9, "top_quartile": 1.5, "floor": 0.4},
+        "tools": {"median": 0.6, "top_quartile": 0.82, "floor": 0.28},
+        "risk": {"median": 0.48, "top_quartile": 0.3, "floor": 0.1},
+        "automation": {"median": 0.52, "top_quartile": 0.75, "floor": 0.2},
+        "funding": {"median": 0.32, "top_quartile": 0.55, "floor": 0.1},
+        "strategy": {"median": 0.55, "top_quartile": 0.78, "floor": 0.25},
+    },
+    # Professional Services / Consulting
+    "beratung": {
+        "kpi": {"median": 0.95, "top_quartile": 1.6, "floor": 0.4},
+        "tools": {"median": 0.6, "top_quartile": 0.8, "floor": 0.3},
+        "risk": {"median": 0.45, "top_quartile": 0.28, "floor": 0.1},
+        "automation": {"median": 0.48, "top_quartile": 0.7, "floor": 0.2},
+        "funding": {"median": 0.28, "top_quartile": 0.48, "floor": 0.08},
+        "strategy": {"median": 0.58, "top_quartile": 0.82, "floor": 0.28},
+    },
+    "consulting": {
+        "kpi": {"median": 0.95, "top_quartile": 1.6, "floor": 0.4},
+        "tools": {"median": 0.6, "top_quartile": 0.8, "floor": 0.3},
+        "risk": {"median": 0.45, "top_quartile": 0.28, "floor": 0.1},
+        "automation": {"median": 0.48, "top_quartile": 0.7, "floor": 0.2},
+        "funding": {"median": 0.28, "top_quartile": 0.48, "floor": 0.08},
+        "strategy": {"median": 0.58, "top_quartile": 0.82, "floor": 0.28},
+    },
+    # Education
+    "bildung": {
+        "kpi": {"median": 0.65, "top_quartile": 1.1, "floor": 0.25},
+        "tools": {"median": 0.45, "top_quartile": 0.65, "floor": 0.2},
+        "risk": {"median": 0.55, "top_quartile": 0.35, "floor": 0.12},
+        "automation": {"median": 0.35, "top_quartile": 0.55, "floor": 0.12},
+        "funding": {"median": 0.45, "top_quartile": 0.7, "floor": 0.15},
+        "strategy": {"median": 0.42, "top_quartile": 0.65, "floor": 0.18},
+    },
+    "education": {
+        "kpi": {"median": 0.65, "top_quartile": 1.1, "floor": 0.25},
+        "tools": {"median": 0.45, "top_quartile": 0.65, "floor": 0.2},
+        "risk": {"median": 0.55, "top_quartile": 0.35, "floor": 0.12},
+        "automation": {"median": 0.35, "top_quartile": 0.55, "floor": 0.12},
+        "funding": {"median": 0.45, "top_quartile": 0.7, "floor": 0.15},
+        "strategy": {"median": 0.42, "top_quartile": 0.65, "floor": 0.18},
+    },
+    # Marketing / Media
+    "marketing": {
+        "kpi": {"median": 0.85, "top_quartile": 1.45, "floor": 0.35},
+        "tools": {"median": 0.62, "top_quartile": 0.82, "floor": 0.3},
+        "risk": {"median": 0.42, "top_quartile": 0.25, "floor": 0.08},
+        "automation": {"median": 0.55, "top_quartile": 0.78, "floor": 0.22},
+        "funding": {"median": 0.25, "top_quartile": 0.42, "floor": 0.05},
+        "strategy": {"median": 0.55, "top_quartile": 0.78, "floor": 0.25},
+    },
+    "media": {
+        "kpi": {"median": 0.82, "top_quartile": 1.4, "floor": 0.32},
+        "tools": {"median": 0.58, "top_quartile": 0.78, "floor": 0.28},
+        "risk": {"median": 0.45, "top_quartile": 0.28, "floor": 0.1},
+        "automation": {"median": 0.5, "top_quartile": 0.72, "floor": 0.2},
+        "funding": {"median": 0.28, "top_quartile": 0.48, "floor": 0.08},
+        "strategy": {"median": 0.52, "top_quartile": 0.75, "floor": 0.22},
+    },
+    # Legal
+    "recht": {
+        "kpi": {"median": 0.7, "top_quartile": 1.2, "floor": 0.3},
+        "tools": {"median": 0.4, "top_quartile": 0.62, "floor": 0.18},
+        "risk": {"median": 0.6, "top_quartile": 0.38, "floor": 0.15},
+        "automation": {"median": 0.32, "top_quartile": 0.52, "floor": 0.12},
+        "funding": {"median": 0.2, "top_quartile": 0.38, "floor": 0.05},
+        "strategy": {"median": 0.42, "top_quartile": 0.65, "floor": 0.18},
+    },
+    "legal": {
+        "kpi": {"median": 0.7, "top_quartile": 1.2, "floor": 0.3},
+        "tools": {"median": 0.4, "top_quartile": 0.62, "floor": 0.18},
+        "risk": {"median": 0.6, "top_quartile": 0.38, "floor": 0.15},
+        "automation": {"median": 0.32, "top_quartile": 0.52, "floor": 0.12},
+        "funding": {"median": 0.2, "top_quartile": 0.38, "floor": 0.05},
+        "strategy": {"median": 0.42, "top_quartile": 0.65, "floor": 0.18},
+    },
+}
+
+# Size multipliers for benchmarks
+SIZE_BENCHMARK_MULTIPLIERS = {
+    "solo": {"kpi": 0.85, "tools": 0.75, "risk": 1.1, "automation": 0.7, "funding": 0.6, "strategy": 0.75},
+    "team": {"kpi": 1.0, "tools": 1.0, "risk": 1.0, "automation": 1.0, "funding": 1.0, "strategy": 1.0},
+    "kmu": {"kpi": 1.15, "tools": 1.1, "risk": 0.9, "automation": 1.15, "funding": 1.2, "strategy": 1.15},
+}
+
+# Radar categories for visualization
+RADAR_CATEGORIES_DE = ["ROI", "Risiko", "Tools", "Automation", "Foerderung", "Strategie"]
+RADAR_CATEGORIES_EN = ["ROI", "Risk", "Tools", "Automation", "Funding", "Strategy"]
+
+# Percentile thresholds
+PERCENTILE_TOP_QUARTILE = 75
+PERCENTILE_MEDIAN = 50
+PERCENTILE_BOTTOM_QUARTILE = 25
+
+
+# =============================================================================
+# DATA STRUCTURES
+# =============================================================================
+
+@dataclass
+class BenchmarkPosition:
+    """
+    A single benchmark position for a specific domain.
+
+    Compares company value against industry median and top quartile.
+    """
+    domain: str  # e.g. "kpi", "tools", "risk", "automation", "funding", "strategy"
+    company_value: float
+    industry_median: float
+    industry_top_quartile: float
+    score_percentile: float  # 0-100
+    narrative: str
+
+    def __post_init__(self) -> None:
+        """Validate and normalize values."""
+        # Validate domain
+        if self.domain not in BENCHMARK_DOMAINS:
+            log.warning(
+                "[G37] Invalid benchmark domain: %s, defaulting to 'kpi'",
+                self.domain
+            )
+            self.domain = "kpi"
+
+        # Clamp percentile
+        self.score_percentile = max(0.0, min(100.0, self.score_percentile))
+
+        # Ensure non-negative values
+        self.company_value = max(0.0, self.company_value)
+        self.industry_median = max(0.01, self.industry_median)  # Avoid division by zero
+        self.industry_top_quartile = max(0.01, self.industry_top_quartile)
+
+    @property
+    def is_above_median(self) -> bool:
+        """Check if company is above industry median."""
+        if self.domain == "risk":
+            # For risk, lower is better
+            return self.company_value < self.industry_median
+        return self.company_value > self.industry_median
+
+    @property
+    def is_top_quartile(self) -> bool:
+        """Check if company is in top quartile."""
+        if self.domain == "risk":
+            # For risk, lower is better
+            return self.company_value <= self.industry_top_quartile
+        return self.company_value >= self.industry_top_quartile
+
+    @property
+    def deviation_from_median(self) -> float:
+        """Calculate percentage deviation from median."""
+        if self.industry_median == 0:
+            return 0.0
+        deviation = ((self.company_value - self.industry_median) / self.industry_median) * 100
+        if self.domain == "risk":
+            # Invert for risk (negative deviation = good)
+            deviation = -deviation
+        return round(deviation, 1)
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert to dictionary for JSON serialization."""
+        return {
+            "domain": self.domain,
+            "company_value": round(self.company_value, 3),
+            "industry_median": round(self.industry_median, 3),
+            "industry_top_quartile": round(self.industry_top_quartile, 3),
+            "score_percentile": round(self.score_percentile, 1),
+            "narrative": self.narrative,
+            "is_above_median": self.is_above_median,
+            "is_top_quartile": self.is_top_quartile,
+            "deviation_from_median": self.deviation_from_median,
+        }
+
+
+@dataclass
+class BenchmarkRadar:
+    """
+    Radar/Radial chart data for benchmark visualization.
+
+    All scores are normalized to 0-1 for consistent display.
+    """
+    categories: List[str] = field(default_factory=list)
+    scores: List[float] = field(default_factory=list)
+
+    def __post_init__(self) -> None:
+        """Validate and normalize values."""
+        # Ensure lists are the same length
+        if len(self.categories) != len(self.scores):
+            log.warning(
+                "[G37] Radar categories/scores length mismatch: %d vs %d",
+                len(self.categories), len(self.scores)
+            )
+            # Truncate to shorter length
+            min_len = min(len(self.categories), len(self.scores))
+            self.categories = self.categories[:min_len]
+            self.scores = self.scores[:min_len]
+
+        # Normalize scores to 0-1
+        self.scores = [max(0.0, min(1.0, s)) for s in self.scores]
+
+    @property
+    def is_valid(self) -> bool:
+        """Check if radar has valid data."""
+        return len(self.categories) >= 3 and len(self.scores) >= 3
+
+    @property
+    def average_score(self) -> float:
+        """Calculate average of all radar scores."""
+        if not self.scores:
+            return 0.0
+        return sum(self.scores) / len(self.scores)
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert to dictionary for JSON serialization."""
+        return {
+            "categories": self.categories,
+            "scores": [round(s, 3) for s in self.scores],
+            "average_score": round(self.average_score, 3),
+        }
+
+
+@dataclass
+class BenchmarkReport:
+    """
+    Complete benchmark report with positions, radar, and SWOT analysis.
+    """
+    positions: List[BenchmarkPosition] = field(default_factory=list)
+    radar: BenchmarkRadar = field(default_factory=BenchmarkRadar)
+    summary: str = ""
+    strengths: List[str] = field(default_factory=list)
+    weaknesses: List[str] = field(default_factory=list)
+    opportunities: List[str] = field(default_factory=list)
+    threats: List[str] = field(default_factory=list)
+    maturity_score: float = 0.0  # Overall AI maturity score (0-100)
+    competitiveness_grade: str = "C"  # A-F grade
+
+    def __post_init__(self) -> None:
+        """Validate and normalize values."""
+        # Ensure lists
+        if not isinstance(self.positions, list):
+            self.positions = []
+        if not isinstance(self.strengths, list):
+            self.strengths = []
+        if not isinstance(self.weaknesses, list):
+            self.weaknesses = []
+        if not isinstance(self.opportunities, list):
+            self.opportunities = []
+        if not isinstance(self.threats, list):
+            self.threats = []
+
+        # Clamp maturity score
+        self.maturity_score = max(0.0, min(100.0, self.maturity_score))
+
+        # Validate grade
+        if self.competitiveness_grade not in ["A", "B", "C", "D", "F"]:
+            self.competitiveness_grade = "C"
+
+        # Recalculate if positions exist
+        if self.positions:
+            self._recalculate_scores()
+
+    def _recalculate_scores(self) -> None:
+        """Recalculate maturity score and grade from positions."""
+        if not self.positions:
+            return
+
+        # Calculate maturity score as weighted average of percentiles
+        weights = {"kpi": 0.25, "tools": 0.15, "risk": 0.2, "automation": 0.15, "funding": 0.1, "strategy": 0.15}
+        total_weight = 0.0
+        weighted_sum = 0.0
+
+        for pos in self.positions:
+            weight = weights.get(pos.domain, 0.1)
+            weighted_sum += pos.score_percentile * weight
+            total_weight += weight
+
+        if total_weight > 0:
+            self.maturity_score = weighted_sum / total_weight
+
+        # Determine grade
+        if self.maturity_score >= 80:
+            self.competitiveness_grade = "A"
+        elif self.maturity_score >= 65:
+            self.competitiveness_grade = "B"
+        elif self.maturity_score >= 50:
+            self.competitiveness_grade = "C"
+        elif self.maturity_score >= 35:
+            self.competitiveness_grade = "D"
+        else:
+            self.competitiveness_grade = "F"
+
+    @property
+    def is_valid(self) -> bool:
+        """Check if report has valid data."""
+        return len(self.positions) >= 3 and self.radar.is_valid
+
+    @property
+    def above_median_count(self) -> int:
+        """Count positions above industry median."""
+        return sum(1 for p in self.positions if p.is_above_median)
+
+    @property
+    def top_quartile_count(self) -> int:
+        """Count positions in top quartile."""
+        return sum(1 for p in self.positions if p.is_top_quartile)
+
+    def get_position(self, domain: str) -> Optional[BenchmarkPosition]:
+        """Get position for a specific domain."""
+        for pos in self.positions:
+            if pos.domain == domain:
+                return pos
+        return None
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert to dictionary for JSON serialization."""
+        return {
+            "positions": [p.to_dict() for p in self.positions],
+            "radar": self.radar.to_dict(),
+            "summary": self.summary,
+            "strengths": self.strengths,
+            "weaknesses": self.weaknesses,
+            "opportunities": self.opportunities,
+            "threats": self.threats,
+            "maturity_score": round(self.maturity_score, 1),
+            "competitiveness_grade": self.competitiveness_grade,
+            "above_median_count": self.above_median_count,
+            "top_quartile_count": self.top_quartile_count,
+        }
+
+
+# =============================================================================
+# HELPER FUNCTIONS
+# =============================================================================
+
+def _normalize_branch(branch: str) -> str:
+    """Normalize branch name for benchmark lookup."""
+    if not branch:
+        return "default"
+
+    branch_lower = branch.lower().strip()
+
+    # Direct mapping
+    branch_mappings = {
+        "technology": "technologie",
+        "tech": "technologie",
+        "information technology": "it",
+        "finance": "finanzen",
+        "finanzdienstleistungen": "finanzen",
+        "bank": "banking",
+        "versicherung": "finanzen",
+        "insurance": "finanzen",
+        "health": "healthcare",
+        "medical": "healthcare",
+        "pharma": "healthcare",
+        "produktion": "manufacturing",
+        "industrie": "manufacturing",
+        "industry": "manufacturing",
+        "fertigung": "manufacturing",
+        "einzelhandel": "retail",
+        "commerce": "e-commerce",
+        "ecommerce": "e-commerce",
+        "onlinehandel": "e-commerce",
+        "dienstleistung": "beratung",
+        "service": "beratung",
+        "professional services": "consulting",
+        "unternehmensberatung": "consulting",
+        "ausbildung": "education",
+        "schule": "education",
+        "hochschule": "education",
+        "werbung": "marketing",
+        "agentur": "marketing",
+        "medien": "media",
+        "verlag": "media",
+        "publishing": "media",
+        "rechtsanwalt": "legal",
+        "anwalt": "legal",
+        "kanzlei": "legal",
+    }
+
+    # Check direct mappings
+    for key, value in branch_mappings.items():
+        if key in branch_lower:
+            return value
+
+    # Check if branch exists in benchmarks
+    if branch_lower in INDUSTRY_BENCHMARKS:
+        return branch_lower
+
+    return "default"
+
+
+def _get_industry_benchmarks(branch: str, domain: str) -> Dict[str, float]:
+    """Get industry benchmark values for branch and domain."""
+    normalized_branch = _normalize_branch(branch)
+    benchmarks = INDUSTRY_BENCHMARKS.get(normalized_branch, INDUSTRY_BENCHMARKS["default"])
+    return benchmarks.get(domain, INDUSTRY_BENCHMARKS["default"][domain])
+
+
+def _calculate_percentile(
+    company_value: float,
+    median: float,
+    top_quartile: float,
+    floor: float,
+    is_inverse: bool = False
+) -> float:
+    """
+    Calculate percentile position based on value relative to benchmarks.
+
+    For inverse metrics (like risk), lower is better.
+    """
+    if is_inverse:
+        # Invert the logic for risk-like metrics
+        if company_value <= top_quartile:
+            # Top quartile (75-100)
+            range_size = top_quartile - floor if top_quartile > floor else 0.1
+            position = (top_quartile - company_value) / range_size
+            return 75 + min(25, position * 25)
+        elif company_value <= median:
+            # Above median (50-75)
+            range_size = median - top_quartile if median > top_quartile else 0.1
+            position = (median - company_value) / range_size
+            return 50 + position * 25
+        else:
+            # Below median (0-50)
+            # Use a reasonable ceiling (2x median)
+            ceiling = median * 2
+            range_size = ceiling - median if ceiling > median else median
+            position = (ceiling - company_value) / range_size
+            return max(0, min(50, position * 50))
+    else:
+        # Normal metrics (higher is better)
+        if company_value >= top_quartile:
+            # Top quartile (75-100)
+            # Extrapolate beyond top quartile
+            range_size = top_quartile - median if top_quartile > median else 0.1
+            overshoot = (company_value - top_quartile) / range_size
+            return min(100, 75 + overshoot * 25)
+        elif company_value >= median:
+            # Above median (50-75)
+            range_size = top_quartile - median if top_quartile > median else 0.1
+            position = (company_value - median) / range_size
+            return 50 + position * 25
+        elif company_value >= floor:
+            # Below median but above floor (25-50)
+            range_size = median - floor if median > floor else 0.1
+            position = (company_value - floor) / range_size
+            return 25 + position * 25
+        else:
+            # Below floor (0-25)
+            if floor > 0:
+                position = company_value / floor
+                return position * 25
+            return 0
+
+
+def _extract_kpi_value(
+    kpi_data: Any,
+    business_case: Any,
+    sections: Dict[str, str]
+) -> float:
+    """Extract normalized KPI value (ROI-based)."""
+    # Try business case simulation P50 ROI
+    if kpi_data:
+        if hasattr(kpi_data, "roi_p50"):
+            return float(kpi_data.roi_p50) / 100  # Convert percentage to ratio
+        if hasattr(kpi_data, "roi_distribution") and kpi_data.roi_distribution:
+            if hasattr(kpi_data.roi_distribution, "p50"):
+                return float(kpi_data.roi_distribution.p50) / 100
+
+    # Try business case report
+    if business_case:
+        if hasattr(business_case, "get_scenario"):
+            realistic = business_case.get_scenario("realistic")
+            if realistic and hasattr(realistic, "roi_12m"):
+                return float(realistic.roi_12m) / 100
+        if hasattr(business_case, "scenarios"):
+            for scenario in business_case.scenarios:
+                if hasattr(scenario, "name") and scenario.name == "realistic":
+                    if hasattr(scenario, "roi_12m"):
+                        return float(scenario.roi_12m) / 100
+
+    # Try sections
+    roi_val = sections.get("ROI_P50") or sections.get("ROI_12M")
+    if roi_val:
+        try:
+            return float(str(roi_val).replace("%", "").replace(",", ".")) / 100
+        except (ValueError, TypeError):
+            pass
+
+    return 0.8  # Default to median
+
+
+def _extract_tools_value(tools_data: Any, sections: Dict[str, str]) -> float:
+    """Extract normalized tools maturity value."""
+    if tools_data:
+        # Try avg_fit_score
+        if hasattr(tools_data, "avg_fit_score"):
+            return float(tools_data.avg_fit_score)
+        if hasattr(tools_data, "summary") and hasattr(tools_data.summary, "avg_fit"):
+            return float(tools_data.summary.avg_fit)
+        if isinstance(tools_data, dict):
+            if "avg_fit_score" in tools_data:
+                return float(tools_data["avg_fit_score"])
+            if "summary" in tools_data and "avg_fit" in tools_data["summary"]:
+                return float(tools_data["summary"]["avg_fit"])
+
+    # Try sections
+    tools_fit = sections.get("TOOLS_AVG_FIT") or sections.get("AVG_FIT_SCORE")
+    if tools_fit:
+        try:
+            return float(str(tools_fit).replace(",", "."))
+        except (ValueError, TypeError):
+            pass
+
+    return 0.5  # Default to median
+
+
+def _extract_risk_value(risk_report_v3: Any, sections: Dict[str, str]) -> float:
+    """Extract normalized risk value (0-1, lower is better)."""
+    if risk_report_v3:
+        # Try residual risk score
+        if hasattr(risk_report_v3, "residual_risk_score"):
+            return float(risk_report_v3.residual_risk_score) / 100
+        if isinstance(risk_report_v3, dict) and "residual_risk_score" in risk_report_v3:
+            return float(risk_report_v3["residual_risk_score"]) / 100
+
+    # Try sections
+    risk_score = sections.get("RESIDUAL_RISK_SCORE")
+    if risk_score:
+        try:
+            score = float(str(risk_score).replace(",", "."))
+            if score > 1:
+                score = score / 100
+            return score
+        except (ValueError, TypeError):
+            pass
+
+    return 0.6  # Default to median
+
+
+def _extract_automation_value(auto_report: Any, sections: Dict[str, str]) -> float:
+    """Extract normalized automation potential value."""
+    if auto_report:
+        if hasattr(auto_report, "avg_automation_potential"):
+            return float(auto_report.avg_automation_potential)
+        if isinstance(auto_report, dict) and "avg_automation_potential" in auto_report:
+            return float(auto_report["avg_automation_potential"])
+
+    # Try sections
+    auto_potential = sections.get("AUTO_AVG_POTENTIAL")
+    if auto_potential:
+        try:
+            val = float(str(auto_potential).replace("%", "").replace(",", "."))
+            return val if val <= 1 else val / 100
+        except (ValueError, TypeError):
+            pass
+
+    return 0.4  # Default to median
+
+
+def _extract_funding_value(funding_data: Any, sections: Dict[str, str]) -> float:
+    """Extract normalized funding success/coverage value."""
+    if funding_data:
+        # Try funding coverage or success rate
+        if hasattr(funding_data, "coverage_ratio"):
+            return float(funding_data.coverage_ratio)
+        if hasattr(funding_data, "summary") and hasattr(funding_data.summary, "coverage"):
+            return float(funding_data.summary.coverage)
+        if isinstance(funding_data, dict):
+            if "coverage_ratio" in funding_data:
+                return float(funding_data["coverage_ratio"])
+            if "success_probability" in funding_data:
+                return float(funding_data["success_probability"])
+
+    # Try sections
+    funding_coverage = sections.get("FUNDING_COVERAGE") or sections.get("FUNDING_SUCCESS_RATE")
+    if funding_coverage:
+        try:
+            val = float(str(funding_coverage).replace("%", "").replace(",", "."))
+            return val if val <= 1 else val / 100
+        except (ValueError, TypeError):
+            pass
+
+    return 0.3  # Default to median
+
+
+def _extract_strategy_value(strategy_plan: Any, sections: Dict[str, str]) -> float:
+    """Extract normalized strategy maturity value."""
+    if strategy_plan:
+        # Try strategy readiness or maturity score
+        if hasattr(strategy_plan, "readiness_score"):
+            return float(strategy_plan.readiness_score)
+        if hasattr(strategy_plan, "maturity_level"):
+            # Map maturity level to score
+            maturity_map = {"low": 0.3, "medium": 0.5, "high": 0.75, "advanced": 0.9}
+            return maturity_map.get(str(strategy_plan.maturity_level).lower(), 0.5)
+        if isinstance(strategy_plan, dict):
+            if "readiness_score" in strategy_plan:
+                return float(strategy_plan["readiness_score"])
+
+    # Try sections
+    strategy_score = sections.get("STRATEGY_READINESS") or sections.get("STRATEGY_SCORE")
+    if strategy_score:
+        try:
+            val = float(str(strategy_score).replace("%", "").replace(",", "."))
+            return val if val <= 1 else val / 100
+        except (ValueError, TypeError):
+            pass
+
+    return 0.5  # Default to median
+
+
+def _generate_position_narrative(
+    domain: str,
+    company_value: float,
+    median: float,
+    percentile: float,
+    lang: str = "de"
+) -> str:
+    """Generate narrative for a benchmark position."""
+    is_inverse = domain == "risk"
+
+    if percentile >= 75:
+        position = "Top-Quartil" if lang == "de" else "top quartile"
+        trend = "unterdurchschnittlich (positiv)" if is_inverse and lang == "de" else \
+                "below average (positive)" if is_inverse else \
+                "ueberdurchschnittlich" if lang == "de" else "above average"
+    elif percentile >= 50:
+        position = "obere Haelfte" if lang == "de" else "upper half"
+        trend = "unter Median (positiv)" if is_inverse and lang == "de" else \
+                "below median (positive)" if is_inverse else \
+                "ueber Median" if lang == "de" else "above median"
+    elif percentile >= 25:
+        position = "untere Haelfte" if lang == "de" else "lower half"
+        trend = "ueber Median (negativ)" if is_inverse and lang == "de" else \
+                "above median (negative)" if is_inverse else \
+                "unter Median" if lang == "de" else "below median"
+    else:
+        position = "unterste Quartil" if lang == "de" else "bottom quartile"
+        trend = "ueberdurchschnittlich (negativ)" if is_inverse and lang == "de" else \
+                "above average (negative)" if is_inverse else \
+                "unterdurchschnittlich" if lang == "de" else "below average"
+
+    domain_names_de = {
+        "kpi": "KPI/ROI-Leistung",
+        "tools": "Tool-Reife",
+        "risk": "Risiko-Management",
+        "automation": "Automationsgrad",
+        "funding": "Foerder-Ausschoepfung",
+        "strategy": "Strategie-Reife"
+    }
+    domain_names_en = {
+        "kpi": "KPI/ROI performance",
+        "tools": "tool maturity",
+        "risk": "risk management",
+        "automation": "automation level",
+        "funding": "funding utilization",
+        "strategy": "strategy maturity"
+    }
+
+    domain_name = domain_names_de.get(domain, domain) if lang == "de" else domain_names_en.get(domain, domain)
+
+    if lang == "de":
+        return f"{domain_name}: {position} der Branche ({trend}, Perzentil: {percentile:.0f})"
+    else:
+        return f"{domain_name}: {position} of industry ({trend}, percentile: {percentile:.0f})"
+
+
+def _generate_swot_from_positions(
+    positions: List[BenchmarkPosition],
+    lang: str = "de"
+) -> Tuple[List[str], List[str], List[str], List[str]]:
+    """Generate SWOT analysis from benchmark positions."""
+    strengths: List[str] = []
+    weaknesses: List[str] = []
+    opportunities: List[str] = []
+    threats: List[str] = []
+
+    domain_labels_de = {
+        "kpi": "Starke ROI-Kennzahlen",
+        "tools": "Fortschrittlicher Tool-Stack",
+        "risk": "Gutes Risikomanagement",
+        "automation": "Hoher Automationsgrad",
+        "funding": "Gute Foerder-Ausschoepfung",
+        "strategy": "Klare KI-Strategie"
+    }
+    domain_labels_en = {
+        "kpi": "Strong ROI metrics",
+        "tools": "Advanced tool stack",
+        "risk": "Good risk management",
+        "automation": "High automation level",
+        "funding": "Good funding utilization",
+        "strategy": "Clear AI strategy"
+    }
+
+    weakness_labels_de = {
+        "kpi": "ROI-Potenzial noch nicht ausgeschoepft",
+        "tools": "Tool-Stack ausbaufaehig",
+        "risk": "Risikomanagement verbesserungswuerdig",
+        "automation": "Automationspotenzial ungenutzt",
+        "funding": "Foerdermittel unterbeansprucht",
+        "strategy": "KI-Strategie unklar definiert"
+    }
+    weakness_labels_en = {
+        "kpi": "ROI potential not fully realized",
+        "tools": "Tool stack needs improvement",
+        "risk": "Risk management needs attention",
+        "automation": "Automation potential untapped",
+        "funding": "Funding underutilized",
+        "strategy": "AI strategy unclear"
+    }
+
+    opportunity_labels_de = {
+        "kpi": "Weitere ROI-Steigerung durch KI-Optimierung",
+        "tools": "Neue KI-Tools koennen Effizienz steigern",
+        "risk": "Compliance-Vorsprung als Wettbewerbsvorteil",
+        "automation": "Skalierung durch weitere Automatisierung",
+        "funding": "Zusaetzliche Foerderprogramme verfuegbar",
+        "strategy": "Strategische Positionierung als KI-Leader"
+    }
+    opportunity_labels_en = {
+        "kpi": "Further ROI increase through AI optimization",
+        "tools": "New AI tools can boost efficiency",
+        "risk": "Compliance lead as competitive advantage",
+        "automation": "Scaling through further automation",
+        "funding": "Additional funding programs available",
+        "strategy": "Strategic positioning as AI leader"
+    }
+
+    threat_labels_de = {
+        "kpi": "Wettbewerber holen bei ROI auf",
+        "tools": "Technologische Disruption durch neue Tools",
+        "risk": "Regulatorische Verschaerfungen (AI Act)",
+        "automation": "Wettbewerber automatisieren schneller",
+        "funding": "Foerderbudgets werden kompetitiver",
+        "strategy": "Strategielucke gegenueber Wettbewerbern"
+    }
+    threat_labels_en = {
+        "kpi": "Competitors catching up on ROI",
+        "tools": "Technological disruption from new tools",
+        "risk": "Regulatory tightening (AI Act)",
+        "automation": "Competitors automating faster",
+        "funding": "Funding budgets becoming more competitive",
+        "strategy": "Strategy gap vs competitors"
+    }
+
+    labels = domain_labels_de if lang == "de" else domain_labels_en
+    weak_labels = weakness_labels_de if lang == "de" else weakness_labels_en
+    opp_labels = opportunity_labels_de if lang == "de" else opportunity_labels_en
+    threat_labels = threat_labels_de if lang == "de" else threat_labels_en
+
+    for pos in positions:
+        if pos.score_percentile >= 65:
+            # Strength
+            strengths.append(labels.get(pos.domain, f"Strong in {pos.domain}"))
+            # Opportunity to leverage
+            opportunities.append(opp_labels.get(pos.domain, f"Opportunity in {pos.domain}"))
+        elif pos.score_percentile <= 35:
+            # Weakness
+            weaknesses.append(weak_labels.get(pos.domain, f"Weak in {pos.domain}"))
+            # Threat from gap
+            threats.append(threat_labels.get(pos.domain, f"Threat in {pos.domain}"))
+        else:
+            # Middle ground - opportunity for improvement
+            if pos.score_percentile >= 50:
+                opportunities.append(opp_labels.get(pos.domain, f"Opportunity in {pos.domain}"))
+            else:
+                weaknesses.append(weak_labels.get(pos.domain, f"Needs work in {pos.domain}"))
+
+    # Ensure at least one item in each category
+    if not strengths:
+        strengths.append(
+            "Solide Grundlage fuer KI-Transformation" if lang == "de"
+            else "Solid foundation for AI transformation"
+        )
+    if not weaknesses:
+        weaknesses.append(
+            "Keine kritischen Schwaechen identifiziert" if lang == "de"
+            else "No critical weaknesses identified"
+        )
+    if not opportunities:
+        opportunities.append(
+            "Potenzial zur Branchenfuehrerschaft" if lang == "de"
+            else "Potential for industry leadership"
+        )
+    if not threats:
+        threats.append(
+            "Allgemeiner Wettbewerbsdruck im KI-Bereich" if lang == "de"
+            else "General competitive pressure in AI"
+        )
+
+    return strengths[:4], weaknesses[:4], opportunities[:4], threats[:4]
+
+
+def _generate_summary(
+    report: BenchmarkReport,
+    branch: str,
+    size_label: str,
+    lang: str = "de"
+) -> str:
+    """Generate executive summary for benchmark report."""
+    grade = report.competitiveness_grade
+    maturity = report.maturity_score
+    above_median = report.above_median_count
+    total = len(report.positions)
+
+    if lang == "de":
+        grade_labels = {
+            "A": "exzellent",
+            "B": "gut",
+            "C": "durchschnittlich",
+            "D": "unter dem Durchschnitt",
+            "F": "verbesserungswuerdig"
+        }
+        size_labels = {"solo": "Einzelunternehmer", "team": "Team", "kmu": "KMU"}
+
+        return (
+            f"Ihre KI-Wettbewerbsposition ist {grade_labels.get(grade, 'solide')} (Note {grade}). "
+            f"Mit einem Reifegrad von {maturity:.0f}% liegen Sie in {above_median} von {total} "
+            f"Benchmark-Kategorien ueber dem Branchenmedian. "
+            f"Als {size_labels.get(size_label, 'Unternehmen')} in der Branche {branch} "
+            f"haben Sie eine {_get_position_phrase_de(maturity)} Ausgangsposition."
+        )
+    else:
+        grade_labels = {
+            "A": "excellent",
+            "B": "good",
+            "C": "average",
+            "D": "below average",
+            "F": "needs improvement"
+        }
+        size_labels = {"solo": "solo entrepreneur", "team": "team", "kmu": "SME"}
+
+        return (
+            f"Your AI competitive position is {grade_labels.get(grade, 'solid')} (grade {grade}). "
+            f"With a maturity score of {maturity:.0f}%, you are above the industry median in "
+            f"{above_median} out of {total} benchmark categories. "
+            f"As a {size_labels.get(size_label, 'company')} in the {branch} industry, "
+            f"you have a {_get_position_phrase_en(maturity)} starting position."
+        )
+
+
+def _get_position_phrase_de(maturity: float) -> str:
+    """Get German position phrase based on maturity."""
+    if maturity >= 80:
+        return "hervorragende"
+    elif maturity >= 65:
+        return "gute"
+    elif maturity >= 50:
+        return "solide"
+    elif maturity >= 35:
+        return "ausbaufaehige"
+    else:
+        return "herausfordernde"
+
+
+def _get_position_phrase_en(maturity: float) -> str:
+    """Get English position phrase based on maturity."""
+    if maturity >= 80:
+        return "excellent"
+    elif maturity >= 65:
+        return "good"
+    elif maturity >= 50:
+        return "solid"
+    elif maturity >= 35:
+        return "developing"
+    else:
+        return "challenging"
+
+
+def _parse_llm_benchmark_response(response: Optional[str]) -> Optional[Dict[str, Any]]:
+    """Parse LLM response JSON for benchmark data."""
+    if not response:
+        return None
+
+    try:
+        # Try direct JSON parse
+        data = json.loads(response)
+        return dict(data) if isinstance(data, dict) else None
+    except json.JSONDecodeError:
+        pass
+
+    # Try to extract JSON from markdown code block
+    json_match = re.search(r'```(?:json)?\s*(\{.*?\})\s*```', response, re.DOTALL)
+    if json_match:
+        try:
+            parsed = json.loads(json_match.group(1))
+            return dict(parsed) if isinstance(parsed, dict) else None
+        except json.JSONDecodeError:
+            pass
+
+    # Try to find JSON object in response
+    brace_match = re.search(r'\{[^{}]*"positions"[^{}]*\}', response, re.DOTALL)
+    if brace_match:
+        try:
+            parsed = json.loads(brace_match.group(0))
+            return dict(parsed) if isinstance(parsed, dict) else None
+        except json.JSONDecodeError:
+            pass
+
+    log.warning("[G37] Failed to parse LLM benchmark response")
+    return None
+
+
+# =============================================================================
+# MAIN FUNCTIONS
+# =============================================================================
+
+def generate_benchmark_report(
+    context: Any,
+    sections: Dict[str, str],
+    kpi_data: Any = None,
+    tools_data: Any = None,
+    funding_data: Any = None,
+    risk_report_v3: Any = None,
+    auto_report: Any = None,
+    strategy_plan: Any = None,
+    business_case: Any = None,
+    briefing: Optional[Dict[str, Any]] = None,
+    llm_response: Optional[str] = None,
+    lang: str = "de",
+) -> BenchmarkReport:
+    """
+    Generate comprehensive benchmark report comparing company to industry.
+
+    Integrates data from:
+    - Business Case Simulation (G34) for KPI benchmarks
+    - Tools Engine 4.0 (G25) for tool maturity
+    - Funding Engine v2 (G26) for funding utilization
+    - Risk Engine V3 (G33) for risk benchmarks
+    - Automation Roadmap (G36) for automation benchmarks
+    - Strategy Plan for strategy maturity
+
+    Args:
+        context: Report context (optional)
+        sections: Dictionary of report sections
+        kpi_data: Business Case Simulation data (G34)
+        tools_data: Tools Engine data (G25)
+        funding_data: Funding Engine data (G26)
+        risk_report_v3: Risk Engine V3 data (G33)
+        auto_report: Automation Roadmap data (G36)
+        strategy_plan: Strategy plan data
+        business_case: Business Case data (G30)
+        briefing: User briefing/questionnaire data
+        llm_response: Optional LLM response for narrative enhancement
+        lang: Language code ("de" or "en")
+
+    Returns:
+        BenchmarkReport with positions, radar, SWOT, and summary
+    """
+    if not BENCHMARK_ENGINE_ENABLED:
+        log.debug("[G37] Benchmark Engine is disabled")
+        return BenchmarkReport()
+
+    # Extract context from briefing
+    briefing = briefing or {}
+    branch = str(briefing.get("branche", briefing.get("industry", "default"))).lower()
+    size_label = _normalize_size(briefing.get("unternehmensgroesse", briefing.get("company_size", "team")))
+
+    log.info("[G37] Generating benchmark report for branch=%s, size=%s", branch, size_label)
+
+    # Parse LLM response if provided
+    llm_data = _parse_llm_benchmark_response(llm_response)
+
+    # Get size multipliers
+    size_mult = SIZE_BENCHMARK_MULTIPLIERS.get(size_label, SIZE_BENCHMARK_MULTIPLIERS["team"])
+
+    # Generate positions for each domain
+    positions: List[BenchmarkPosition] = []
+
+    # KPI Benchmark
+    kpi_value = _extract_kpi_value(kpi_data, business_case, sections)
+    kpi_benchmarks = _get_industry_benchmarks(branch, "kpi")
+    kpi_median = kpi_benchmarks["median"] * size_mult["kpi"]
+    kpi_tq = kpi_benchmarks["top_quartile"] * size_mult["kpi"]
+    kpi_floor = kpi_benchmarks["floor"] * size_mult["kpi"]
+    kpi_percentile = _calculate_percentile(kpi_value, kpi_median, kpi_tq, kpi_floor)
+    positions.append(BenchmarkPosition(
+        domain="kpi",
+        company_value=kpi_value,
+        industry_median=kpi_median,
+        industry_top_quartile=kpi_tq,
+        score_percentile=kpi_percentile,
+        narrative=_generate_position_narrative("kpi", kpi_value, kpi_median, kpi_percentile, lang)
+    ))
+
+    # Tools Benchmark
+    tools_value = _extract_tools_value(tools_data, sections)
+    tools_benchmarks = _get_industry_benchmarks(branch, "tools")
+    tools_median = tools_benchmarks["median"] * size_mult["tools"]
+    tools_tq = tools_benchmarks["top_quartile"] * size_mult["tools"]
+    tools_floor = tools_benchmarks["floor"] * size_mult["tools"]
+    tools_percentile = _calculate_percentile(tools_value, tools_median, tools_tq, tools_floor)
+    positions.append(BenchmarkPosition(
+        domain="tools",
+        company_value=tools_value,
+        industry_median=tools_median,
+        industry_top_quartile=tools_tq,
+        score_percentile=tools_percentile,
+        narrative=_generate_position_narrative("tools", tools_value, tools_median, tools_percentile, lang)
+    ))
+
+    # Risk Benchmark (inverse - lower is better)
+    risk_value = _extract_risk_value(risk_report_v3, sections)
+    risk_benchmarks = _get_industry_benchmarks(branch, "risk")
+    risk_median = risk_benchmarks["median"] * size_mult["risk"]
+    risk_tq = risk_benchmarks["top_quartile"] * size_mult["risk"]
+    risk_floor = risk_benchmarks["floor"] * size_mult["risk"]
+    risk_percentile = _calculate_percentile(risk_value, risk_median, risk_tq, risk_floor, is_inverse=True)
+    positions.append(BenchmarkPosition(
+        domain="risk",
+        company_value=risk_value,
+        industry_median=risk_median,
+        industry_top_quartile=risk_tq,
+        score_percentile=risk_percentile,
+        narrative=_generate_position_narrative("risk", risk_value, risk_median, risk_percentile, lang)
+    ))
+
+    # Automation Benchmark
+    auto_value = _extract_automation_value(auto_report, sections)
+    auto_benchmarks = _get_industry_benchmarks(branch, "automation")
+    auto_median = auto_benchmarks["median"] * size_mult["automation"]
+    auto_tq = auto_benchmarks["top_quartile"] * size_mult["automation"]
+    auto_floor = auto_benchmarks["floor"] * size_mult["automation"]
+    auto_percentile = _calculate_percentile(auto_value, auto_median, auto_tq, auto_floor)
+    positions.append(BenchmarkPosition(
+        domain="automation",
+        company_value=auto_value,
+        industry_median=auto_median,
+        industry_top_quartile=auto_tq,
+        score_percentile=auto_percentile,
+        narrative=_generate_position_narrative("automation", auto_value, auto_median, auto_percentile, lang)
+    ))
+
+    # Funding Benchmark
+    funding_value = _extract_funding_value(funding_data, sections)
+    funding_benchmarks = _get_industry_benchmarks(branch, "funding")
+    funding_median = funding_benchmarks["median"] * size_mult["funding"]
+    funding_tq = funding_benchmarks["top_quartile"] * size_mult["funding"]
+    funding_floor = funding_benchmarks["floor"] * size_mult["funding"]
+    funding_percentile = _calculate_percentile(funding_value, funding_median, funding_tq, funding_floor)
+    positions.append(BenchmarkPosition(
+        domain="funding",
+        company_value=funding_value,
+        industry_median=funding_median,
+        industry_top_quartile=funding_tq,
+        score_percentile=funding_percentile,
+        narrative=_generate_position_narrative("funding", funding_value, funding_median, funding_percentile, lang)
+    ))
+
+    # Strategy Benchmark
+    strategy_value = _extract_strategy_value(strategy_plan, sections)
+    strategy_benchmarks = _get_industry_benchmarks(branch, "strategy")
+    strategy_median = strategy_benchmarks["median"] * size_mult["strategy"]
+    strategy_tq = strategy_benchmarks["top_quartile"] * size_mult["strategy"]
+    strategy_floor = strategy_benchmarks["floor"] * size_mult["strategy"]
+    strategy_percentile = _calculate_percentile(strategy_value, strategy_median, strategy_tq, strategy_floor)
+    positions.append(BenchmarkPosition(
+        domain="strategy",
+        company_value=strategy_value,
+        industry_median=strategy_median,
+        industry_top_quartile=strategy_tq,
+        score_percentile=strategy_percentile,
+        narrative=_generate_position_narrative("strategy", strategy_value, strategy_median, strategy_percentile, lang)
+    ))
+
+    # Generate radar data
+    radar_categories = RADAR_CATEGORIES_DE if lang == "de" else RADAR_CATEGORIES_EN
+    radar_scores = [
+        kpi_percentile / 100,
+        risk_percentile / 100,
+        tools_percentile / 100,
+        auto_percentile / 100,
+        funding_percentile / 100,
+        strategy_percentile / 100,
+    ]
+    radar = BenchmarkRadar(categories=radar_categories, scores=radar_scores)
+
+    # Generate SWOT
+    strengths, weaknesses, opportunities, threats = _generate_swot_from_positions(positions, lang)
+
+    # Use LLM data to enhance if available
+    if llm_data:
+        if llm_data.get("strengths"):
+            strengths = llm_data["strengths"][:4]
+        if llm_data.get("weaknesses"):
+            weaknesses = llm_data["weaknesses"][:4]
+        if llm_data.get("opportunities"):
+            opportunities = llm_data["opportunities"][:4]
+        if llm_data.get("threats"):
+            threats = llm_data["threats"][:4]
+
+    # Create report
+    report = BenchmarkReport(
+        positions=positions,
+        radar=radar,
+        strengths=strengths,
+        weaknesses=weaknesses,
+        opportunities=opportunities,
+        threats=threats,
+    )
+
+    # Generate summary
+    report.summary = llm_data.get("summary") if llm_data and llm_data.get("summary") else \
+        _generate_summary(report, branch, size_label, lang)
+
+    log.info(
+        "[G37] Benchmark report generated: maturity=%.1f%%, grade=%s, above_median=%d/%d",
+        report.maturity_score,
+        report.competitiveness_grade,
+        report.above_median_count,
+        len(positions)
+    )
+
+    return report
+
+
+def _normalize_size(size: Any) -> str:
+    """Normalize company size to standard labels."""
+    if not size:
+        return "team"
+
+    size_str = str(size).lower().strip()
+
+    solo_keywords = ["solo", "einzelunternehmer", "freelancer", "selbststaendig", "1", "one"]
+    team_keywords = ["team", "klein", "small", "startup", "2-10", "5"]
+    kmu_keywords = ["kmu", "sme", "mittel", "medium", "10-50", "50", "enterprise"]
+
+    for kw in solo_keywords:
+        if kw in size_str:
+            return "solo"
+
+    for kw in kmu_keywords:
+        if kw in size_str:
+            return "kmu"
+
+    for kw in team_keywords:
+        if kw in size_str:
+            return "team"
+
+    return "team"
+
+
+# =============================================================================
+# HTML GENERATION
+# =============================================================================
+
+def benchmark_report_to_html(
+    report: BenchmarkReport,
+    lang: str = "de"
+) -> str:
+    """
+    Generate HTML output for benchmark report.
+
+    Creates PLATIN++ compliant HTML with:
+    - Comparison tables
+    - Color coding (good: blue/green, neutral: gray, weak: red)
+    - Radar representation (table-based)
+    - Mini-SWOT from benchmark perspective
+    - Position in industry field
+
+    Args:
+        report: BenchmarkReport to render
+        lang: Language code ("de" or "en")
+
+    Returns:
+        HTML string for BENCHMARK_ENGINE_HTML section
+    """
+    if not report or not report.is_valid:
+        return _get_empty_benchmark_html(lang)
+
+    html_parts: List[str] = []
+
+    # Header with maturity score
+    html_parts.append(_generate_header_html(report, lang))
+
+    # Benchmark positions table
+    html_parts.append(_generate_positions_table_html(report.positions, lang))
+
+    # Radar visualization (table-based)
+    html_parts.append(_generate_radar_table_html(report.radar, lang))
+
+    # SWOT analysis
+    html_parts.append(_generate_swot_html(report, lang))
+
+    # Summary
+    html_parts.append(_generate_summary_html(report, lang))
+
+    return "\n".join(html_parts)
+
+
+def _get_empty_benchmark_html(lang: str) -> str:
+    """Return empty state HTML for benchmark section."""
+    if lang == "de":
+        return """
+<div class="benchmark-empty">
+    <p class="text-muted">Benchmark-Daten werden berechnet...</p>
+</div>
+"""
+    return """
+<div class="benchmark-empty">
+    <p class="text-muted">Benchmark data is being calculated...</p>
+</div>
+"""
+
+
+def _generate_header_html(report: BenchmarkReport, lang: str) -> str:
+    """Generate header HTML with maturity score and grade."""
+    grade_colors = {
+        "A": "#22c55e",  # Green
+        "B": "#3b82f6",  # Blue
+        "C": "#f59e0b",  # Amber
+        "D": "#f97316",  # Orange
+        "F": "#dc2626",  # Red
+    }
+    grade_color = grade_colors.get(report.competitiveness_grade, "#64748b")
+
+    maturity_label = "KI-Reifegrad" if lang == "de" else "AI Maturity"
+    grade_label = "Wettbewerbsnote" if lang == "de" else "Competitiveness Grade"
+    above_median_label = "ueber Branchenmedian" if lang == "de" else "above industry median"
+
+    return f"""
+<div class="benchmark-header" style="display: flex; gap: 24px; margin-bottom: 24px; flex-wrap: wrap;">
+    <div class="benchmark-score-card" style="flex: 1; min-width: 200px; padding: 20px; background: var(--color-bg-surface, #f8fafc); border-radius: 10px; border: 1px solid var(--color-border, #e2e8f0);">
+        <div class="score-label" style="font-size: 11pt; color: var(--color-text-muted, #64748b); margin-bottom: 8px;">{maturity_label}</div>
+        <div class="score-value" style="font-size: 32pt; font-weight: 700; color: var(--color-text-strong, #0f172a);">{report.maturity_score:.0f}%</div>
+        <div class="score-bar" style="margin-top: 12px; height: 8px; background: var(--color-border, #e2e8f0); border-radius: 4px; overflow: hidden;">
+            <div style="width: {report.maturity_score}%; height: 100%; background: {grade_color}; border-radius: 4px;"></div>
+        </div>
+    </div>
+    <div class="benchmark-grade-card" style="flex: 1; min-width: 200px; padding: 20px; background: var(--color-bg-surface, #f8fafc); border-radius: 10px; border: 1px solid var(--color-border, #e2e8f0); text-align: center;">
+        <div class="grade-label" style="font-size: 11pt; color: var(--color-text-muted, #64748b); margin-bottom: 8px;">{grade_label}</div>
+        <div class="grade-value" style="font-size: 48pt; font-weight: 700; color: {grade_color};">{report.competitiveness_grade}</div>
+    </div>
+    <div class="benchmark-summary-card" style="flex: 1; min-width: 200px; padding: 20px; background: var(--color-bg-surface, #f8fafc); border-radius: 10px; border: 1px solid var(--color-border, #e2e8f0);">
+        <div class="summary-stat" style="font-size: 11pt; color: var(--color-text-muted, #64748b); margin-bottom: 8px;">{above_median_label}</div>
+        <div class="summary-value" style="font-size: 28pt; font-weight: 700; color: var(--color-text-strong, #0f172a);">{report.above_median_count}/{len(report.positions)}</div>
+        <div class="summary-detail" style="margin-top: 8px; font-size: 10pt; color: var(--color-text-muted, #64748b);">
+            {"Top-Quartil" if lang == "de" else "Top quartile"}: {report.top_quartile_count}
+        </div>
+    </div>
+</div>
+"""
+
+
+def _generate_positions_table_html(positions: List[BenchmarkPosition], lang: str) -> str:
+    """Generate benchmark positions comparison table."""
+    domain_labels_de = {
+        "kpi": "ROI / KPIs",
+        "tools": "Tool-Reife",
+        "risk": "Risiko-Management",
+        "automation": "Automationsgrad",
+        "funding": "Foerder-Ausschoepfung",
+        "strategy": "Strategie-Reife"
+    }
+    domain_labels_en = {
+        "kpi": "ROI / KPIs",
+        "tools": "Tool Maturity",
+        "risk": "Risk Management",
+        "automation": "Automation Level",
+        "funding": "Funding Utilization",
+        "strategy": "Strategy Maturity"
+    }
+    labels = domain_labels_de if lang == "de" else domain_labels_en
+
+    header_company = "Ihr Wert" if lang == "de" else "Your Value"
+    header_median = "Branchenmedian" if lang == "de" else "Industry Median"
+    header_tq = "Top-Quartil" if lang == "de" else "Top Quartile"
+    header_percentile = "Perzentil" if lang == "de" else "Percentile"
+    header_position = "Position" if lang == "de" else "Position"
+    title = "Branchenvergleich" if lang == "de" else "Industry Comparison"
+
+    rows: List[str] = []
+    for pos in positions:
+        # Color coding based on percentile
+        if pos.score_percentile >= 75:
+            color = "#22c55e"  # Green
+            bg = "rgba(34, 197, 94, 0.08)"
+        elif pos.score_percentile >= 50:
+            color = "#3b82f6"  # Blue
+            bg = "rgba(59, 130, 246, 0.08)"
+        elif pos.score_percentile >= 25:
+            color = "#f59e0b"  # Amber
+            bg = "rgba(245, 158, 11, 0.08)"
+        else:
+            color = "#dc2626"  # Red
+            bg = "rgba(220, 38, 38, 0.08)"
+
+        # Format values based on domain
+        if pos.domain in ["kpi"]:
+            company_fmt = f"{pos.company_value * 100:.0f}%"
+            median_fmt = f"{pos.industry_median * 100:.0f}%"
+            tq_fmt = f"{pos.industry_top_quartile * 100:.0f}%"
+        else:
+            company_fmt = f"{pos.company_value:.2f}"
+            median_fmt = f"{pos.industry_median:.2f}"
+            tq_fmt = f"{pos.industry_top_quartile:.2f}"
+
+        # Position indicator
+        if pos.is_top_quartile:
+            position_icon = "&#9733;"  # Star
+            position_text = "Top" if lang == "en" else "Top"
+        elif pos.is_above_median:
+            position_icon = "&#9650;"  # Up triangle
+            position_text = "Above" if lang == "en" else "Ueber"
+        else:
+            position_icon = "&#9660;"  # Down triangle
+            position_text = "Below" if lang == "en" else "Unter"
+
+        rows.append(f"""
+        <tr style="background: {bg};">
+            <td style="padding: 12px; font-weight: 600; border-bottom: 1px solid var(--color-border, #e2e8f0);">{labels.get(pos.domain, pos.domain)}</td>
+            <td style="padding: 12px; border-bottom: 1px solid var(--color-border, #e2e8f0); text-align: right; font-weight: 600; color: {color};">{company_fmt}</td>
+            <td style="padding: 12px; border-bottom: 1px solid var(--color-border, #e2e8f0); text-align: right; color: var(--color-text-muted, #64748b);">{median_fmt}</td>
+            <td style="padding: 12px; border-bottom: 1px solid var(--color-border, #e2e8f0); text-align: right; color: var(--color-text-muted, #64748b);">{tq_fmt}</td>
+            <td style="padding: 12px; border-bottom: 1px solid var(--color-border, #e2e8f0); text-align: right;">
+                <span style="display: inline-block; padding: 4px 12px; background: {color}; color: white; border-radius: 12px; font-size: 10pt; font-weight: 600;">P{pos.score_percentile:.0f}</span>
+            </td>
+            <td style="padding: 12px; border-bottom: 1px solid var(--color-border, #e2e8f0); text-align: center; color: {color};">
+                <span style="font-size: 14pt;">{position_icon}</span> {position_text}
+            </td>
+        </tr>
+        """)
+
+    return f"""
+<div class="benchmark-positions" style="margin-bottom: 24px;">
+    <h3 style="font-size: 14pt; font-weight: 600; color: var(--color-text-strong, #0f172a); margin-bottom: 16px;">{title}</h3>
+    <table style="width: 100%; border-collapse: collapse; background: var(--color-bg-card, #ffffff); border-radius: 8px; overflow: hidden; border: 1px solid var(--color-border, #e2e8f0);">
+        <thead>
+            <tr style="background: var(--color-bg-surface, #f8fafc);">
+                <th style="padding: 12px; text-align: left; font-weight: 600; font-size: 10pt; color: var(--color-text-muted, #64748b); border-bottom: 1px solid var(--color-border, #e2e8f0);">Domain</th>
+                <th style="padding: 12px; text-align: right; font-weight: 600; font-size: 10pt; color: var(--color-text-muted, #64748b); border-bottom: 1px solid var(--color-border, #e2e8f0);">{header_company}</th>
+                <th style="padding: 12px; text-align: right; font-weight: 600; font-size: 10pt; color: var(--color-text-muted, #64748b); border-bottom: 1px solid var(--color-border, #e2e8f0);">{header_median}</th>
+                <th style="padding: 12px; text-align: right; font-weight: 600; font-size: 10pt; color: var(--color-text-muted, #64748b); border-bottom: 1px solid var(--color-border, #e2e8f0);">{header_tq}</th>
+                <th style="padding: 12px; text-align: right; font-weight: 600; font-size: 10pt; color: var(--color-text-muted, #64748b); border-bottom: 1px solid var(--color-border, #e2e8f0);">{header_percentile}</th>
+                <th style="padding: 12px; text-align: center; font-weight: 600; font-size: 10pt; color: var(--color-text-muted, #64748b); border-bottom: 1px solid var(--color-border, #e2e8f0);">{header_position}</th>
+            </tr>
+        </thead>
+        <tbody>
+            {"".join(rows)}
+        </tbody>
+    </table>
+</div>
+"""
+
+
+def _generate_radar_table_html(radar: BenchmarkRadar, lang: str) -> str:
+    """Generate radar visualization as a table (PDF-friendly, no SVG filters)."""
+    title = "KI-Reifeprofil" if lang == "de" else "AI Maturity Profile"
+
+    rows: List[str] = []
+    for i, (cat, score) in enumerate(zip(radar.categories, radar.scores)):
+        percentage = score * 100
+        # Color gradient from red to green
+        if percentage >= 75:
+            color = "#22c55e"
+        elif percentage >= 50:
+            color = "#3b82f6"
+        elif percentage >= 25:
+            color = "#f59e0b"
+        else:
+            color = "#dc2626"
+
+        rows.append(f"""
+        <tr>
+            <td style="padding: 10px 12px; border-bottom: 1px solid var(--color-border, #e2e8f0); font-weight: 500;">{cat}</td>
+            <td style="padding: 10px 12px; border-bottom: 1px solid var(--color-border, #e2e8f0); width: 60%;">
+                <div style="display: flex; align-items: center; gap: 12px;">
+                    <div style="flex: 1; height: 12px; background: var(--color-border, #e2e8f0); border-radius: 6px; overflow: hidden;">
+                        <div style="width: {percentage}%; height: 100%; background: {color}; border-radius: 6px;"></div>
+                    </div>
+                    <span style="min-width: 45px; text-align: right; font-weight: 600; color: {color};">{percentage:.0f}%</span>
+                </div>
+            </td>
+        </tr>
+        """)
+
+    avg_score = radar.average_score * 100
+    avg_label = "Durchschnitt" if lang == "de" else "Average"
+
+    return f"""
+<div class="benchmark-radar" style="margin-bottom: 24px;">
+    <h3 style="font-size: 14pt; font-weight: 600; color: var(--color-text-strong, #0f172a); margin-bottom: 16px;">{title}</h3>
+    <table style="width: 100%; border-collapse: collapse; background: var(--color-bg-card, #ffffff); border-radius: 8px; overflow: hidden; border: 1px solid var(--color-border, #e2e8f0);">
+        <tbody>
+            {"".join(rows)}
+        </tbody>
+        <tfoot>
+            <tr style="background: var(--color-bg-surface, #f8fafc);">
+                <td style="padding: 12px; font-weight: 700;">{avg_label}</td>
+                <td style="padding: 12px;">
+                    <span style="font-weight: 700; font-size: 14pt; color: var(--color-text-strong, #0f172a);">{avg_score:.0f}%</span>
+                </td>
+            </tr>
+        </tfoot>
+    </table>
+</div>
+"""
+
+
+def _generate_swot_html(report: BenchmarkReport, lang: str) -> str:
+    """Generate SWOT analysis HTML."""
+    title = "Mini-SWOT Analyse" if lang == "de" else "Mini-SWOT Analysis"
+    labels = {
+        "strengths": "Staerken" if lang == "de" else "Strengths",
+        "weaknesses": "Schwaechen" if lang == "de" else "Weaknesses",
+        "opportunities": "Chancen" if lang == "de" else "Opportunities",
+        "threats": "Risiken" if lang == "de" else "Threats",
+    }
+
+    def render_items(items: List[str], color: str, bg: str) -> str:
+        return "".join([
+            f'<li style="padding: 6px 0; border-bottom: 1px solid {bg};">{item}</li>'
+            for item in items
+        ])
+
+    return f"""
+<div class="benchmark-swot" style="margin-bottom: 24px;">
+    <h3 style="font-size: 14pt; font-weight: 600; color: var(--color-text-strong, #0f172a); margin-bottom: 16px;">{title}</h3>
+    <div style="display: grid; grid-template-columns: repeat(2, 1fr); gap: 16px;">
+        <div style="padding: 16px; background: rgba(34, 197, 94, 0.08); border-radius: 8px; border-left: 4px solid #22c55e;">
+            <h4 style="margin: 0 0 12px 0; font-size: 12pt; font-weight: 600; color: #22c55e;">{labels["strengths"]}</h4>
+            <ul style="margin: 0; padding: 0 0 0 16px; font-size: 10pt; color: var(--color-text-normal, #1e293b);">
+                {render_items(report.strengths, "#22c55e", "rgba(34, 197, 94, 0.2)")}
+            </ul>
+        </div>
+        <div style="padding: 16px; background: rgba(239, 68, 68, 0.08); border-radius: 8px; border-left: 4px solid #ef4444;">
+            <h4 style="margin: 0 0 12px 0; font-size: 12pt; font-weight: 600; color: #ef4444;">{labels["weaknesses"]}</h4>
+            <ul style="margin: 0; padding: 0 0 0 16px; font-size: 10pt; color: var(--color-text-normal, #1e293b);">
+                {render_items(report.weaknesses, "#ef4444", "rgba(239, 68, 68, 0.2)")}
+            </ul>
+        </div>
+        <div style="padding: 16px; background: rgba(59, 130, 246, 0.08); border-radius: 8px; border-left: 4px solid #3b82f6;">
+            <h4 style="margin: 0 0 12px 0; font-size: 12pt; font-weight: 600; color: #3b82f6;">{labels["opportunities"]}</h4>
+            <ul style="margin: 0; padding: 0 0 0 16px; font-size: 10pt; color: var(--color-text-normal, #1e293b);">
+                {render_items(report.opportunities, "#3b82f6", "rgba(59, 130, 246, 0.2)")}
+            </ul>
+        </div>
+        <div style="padding: 16px; background: rgba(245, 158, 11, 0.08); border-radius: 8px; border-left: 4px solid #f59e0b;">
+            <h4 style="margin: 0 0 12px 0; font-size: 12pt; font-weight: 600; color: #f59e0b;">{labels["threats"]}</h4>
+            <ul style="margin: 0; padding: 0 0 0 16px; font-size: 10pt; color: var(--color-text-normal, #1e293b);">
+                {render_items(report.threats, "#f59e0b", "rgba(245, 158, 11, 0.2)")}
+            </ul>
+        </div>
+    </div>
+</div>
+"""
+
+
+def _generate_summary_html(report: BenchmarkReport, lang: str) -> str:
+    """Generate summary section HTML."""
+    title = "Zusammenfassung" if lang == "de" else "Summary"
+
+    return f"""
+<div class="benchmark-summary" style="padding: 20px; background: var(--color-bg-surface, #f8fafc); border-radius: 10px; border: 1px solid var(--color-border, #e2e8f0);">
+    <h3 style="font-size: 14pt; font-weight: 600; color: var(--color-text-strong, #0f172a); margin: 0 0 12px 0;">{title}</h3>
+    <p style="margin: 0; font-size: 11pt; line-height: 1.6; color: var(--color-text-normal, #1e293b);">
+        {report.summary}
+    </p>
+</div>
+"""

--- a/services/consistency_engine.py
+++ b/services/consistency_engine.py
@@ -455,6 +455,7 @@ class ConsistencyEngine:
         self._check_vendor_audit_consistency()  # G35
         self._check_automation_roadmap_consistency()  # G36
         self._check_business_case_simulation_consistency()  # G34
+        self._check_benchmark_consistency()  # G37
 
         # Calculate domain scores
         self._calculate_domain_scores()
@@ -3803,12 +3804,297 @@ class ConsistencyEngine:
         return "C"  # Default medium risk
 
     # -------------------------------------------------------------------------
+    # DOMAIN 15: Benchmark Engine Consistency (G37)
+    # -------------------------------------------------------------------------
+
+    def _check_benchmark_consistency(self) -> None:
+        """
+        G37: Check Benchmark Engine consistency with other engines.
+
+        Rules BENCH_001-BENCH_008:
+        - BENCH_001: score_percentile must be 0-100
+        - BENCH_002: company_value cannot be > 10x industry_median (outlier protection)
+        - BENCH_003: If RiskScore high, risk_percentile cannot be in top quartile
+        - BENCH_004: Radar scores must match calculation (normalization check)
+        - BENCH_005: Strengths must not contradict RiskReport
+        - BENCH_006: Weaknesses cannot be "none" - always improvement potential
+        - BENCH_007: Opportunities must align with Funding Engine
+        - BENCH_008: Summary must correctly reflect BenchmarkPositions
+        """
+        self.report.checked_rules += 8
+
+        # Get benchmark HTML and report data
+        bench_html = self.sections.get("BENCHMARK_ENGINE_HTML", "")
+        bench_report = self.sections.get("_benchmark_report")
+
+        if not bench_html and not bench_report:
+            log.debug("[G37] Benchmark consistency: Skipping (no benchmark data)")
+            return
+
+        # Extract benchmark metrics
+        positions = self._extract_benchmark_positions(bench_html, bench_report)
+        radar_scores = self._extract_benchmark_radar(bench_html, bench_report)
+        swot = self._extract_benchmark_swot(bench_html, bench_report)
+
+        # Rule BENCH_001: score_percentile must be 0-100
+        for pos in positions:
+            percentile = pos.get("score_percentile", 0)
+            if percentile < 0 or percentile > 100:
+                self.report.add_issue(ConsistencyIssue(
+                    rule_id="BENCH_001",
+                    severity="ERROR",
+                    domain="benchmark",
+                    source_section="benchmark_engine",
+                    target_section="benchmark_engine",
+                    message=f"score_percentile ausserhalb des gueltigen Bereichs fuer {pos.get('domain', 'unknown')}",
+                    expected="score_percentile zwischen 0 und 100",
+                    actual=f"score_percentile: {percentile}",
+                    suggestion="Korrigiere die Perzentil-Berechnung",
+                ))
+
+        # Rule BENCH_002: company_value cannot be > 10x industry_median
+        for pos in positions:
+            company_val = pos.get("company_value", 0)
+            median = pos.get("industry_median", 1)
+            if median > 0 and company_val > median * 10:
+                self.report.add_issue(ConsistencyIssue(
+                    rule_id="BENCH_002",
+                    severity="ERROR",
+                    domain="benchmark",
+                    source_section="benchmark_engine",
+                    target_section="benchmark_engine",
+                    message=f"company_value ist ein extremer Outlier fuer {pos.get('domain', 'unknown')}",
+                    expected=f"company_value <= 10x industry_median ({median * 10:.2f})",
+                    actual=f"company_value: {company_val:.2f}",
+                    suggestion="Pruefe die Eingabedaten auf Fehler",
+                ))
+
+        # Rule BENCH_003: If RiskScore high, risk_percentile cannot be in top quartile
+        risk_score = self._extract_risk_score_for_benchmark()
+        risk_position = next((p for p in positions if p.get("domain") == "risk"), None)
+        if risk_position and risk_score > 70:  # High risk
+            risk_percentile = risk_position.get("score_percentile", 50)
+            if risk_percentile >= 75:
+                self.report.add_issue(ConsistencyIssue(
+                    rule_id="BENCH_003",
+                    severity="WARNING",
+                    domain="benchmark",
+                    source_section="benchmark_engine",
+                    target_section="risk_engine_v3",
+                    message="Risiko-Perzentil im Top-Quartil trotz hohem Risiko-Score",
+                    expected=f"Bei Risk Score {risk_score:.0f}% sollte Perzentil < 75 sein",
+                    actual=f"risk_percentile: {risk_percentile:.0f}%",
+                    suggestion="Pruefe Konsistenz zwischen Benchmark und Risk Engine",
+                ))
+
+        # Rule BENCH_004: Radar scores must match positions (normalization check)
+        if radar_scores and positions:
+            for i, pos in enumerate(positions):
+                if i < len(radar_scores):
+                    expected_radar = pos.get("score_percentile", 0) / 100
+                    actual_radar = radar_scores[i]
+                    if abs(expected_radar - actual_radar) > 0.1:
+                        self.report.add_issue(ConsistencyIssue(
+                            rule_id="BENCH_004",
+                            severity="WARNING",
+                            domain="benchmark",
+                            source_section="benchmark_engine",
+                            target_section="benchmark_engine",
+                            message=f"Radar-Score stimmt nicht mit Position fuer {pos.get('domain', 'unknown')} ueberein",
+                            expected=f"Radar score nahe {expected_radar:.2f}",
+                            actual=f"Radar score: {actual_radar:.2f}",
+                            suggestion="Synchronisiere Radar mit Positions-Daten",
+                        ))
+
+        # Rule BENCH_005: Strengths must not contradict RiskReport
+        strengths = swot.get("strengths", [])
+        risk_grade = self._extract_risk_grade_from_sections()
+        if risk_grade in ["D", "F"]:
+            risk_strength_keywords = ["risiko", "risk", "sicher", "secure", "compliance"]
+            for strength in strengths:
+                if any(kw in strength.lower() for kw in risk_strength_keywords):
+                    self.report.add_issue(ConsistencyIssue(
+                        rule_id="BENCH_005",
+                        severity="WARNING",
+                        domain="benchmark",
+                        source_section="benchmark_engine",
+                        target_section="risk_engine_v3",
+                        message="Staerke 'Risikomanagement' widerspricht hohem Risiko-Grade",
+                        expected=f"Bei Risk Grade {risk_grade} keine Risiko-Staerke",
+                        actual=f"Staerke: {strength}",
+                        suggestion="Entferne widerspruchliche Staerken oder korrigiere Risk Assessment",
+                    ))
+
+        # Rule BENCH_006: Weaknesses cannot be empty or "none"
+        weaknesses = swot.get("weaknesses", [])
+        if not weaknesses or all(w.lower() in ["none", "keine", "-", ""] for w in weaknesses):
+            self.report.add_issue(ConsistencyIssue(
+                rule_id="BENCH_006",
+                severity="WARNING",
+                domain="benchmark",
+                source_section="benchmark_engine",
+                target_section="benchmark_engine",
+                message="Keine Schwaechen identifiziert - unrealistisch",
+                expected="Mindestens 1 konkrete Schwaeche",
+                actual=f"Schwaechen: {weaknesses}",
+                suggestion="Identifiziere Verbesserungspotenziale auch bei guter Performance",
+            ))
+
+        # Rule BENCH_007: Opportunities must align with Funding Engine
+        opportunities = swot.get("opportunities", [])
+        funding_html = self.sections.get("FUNDING_ENGINE_V2_HTML", "") or self.sections.get("FOERDERPROGRAMME_HTML", "")
+        funding_keywords = ["foerder", "funding", "programm", "zuschuss", "grant"]
+        funding_opportunities = [o for o in opportunities if any(kw in o.lower() for kw in funding_keywords)]
+        if funding_opportunities and not funding_html:
+            self.report.add_issue(ConsistencyIssue(
+                rule_id="BENCH_007",
+                severity="INFO",
+                domain="benchmark",
+                source_section="benchmark_engine",
+                target_section="funding_engine",
+                message="Foerder-Chancen genannt aber keine Funding Engine Daten",
+                expected="Funding-Opportunities sollten von Funding Engine gestuetzt werden",
+                actual=f"Opportunities: {funding_opportunities[:2]}",
+                suggestion="Aktiviere Funding Engine fuer konsistente Empfehlungen",
+            ))
+
+        # Rule BENCH_008: Summary must reflect positions
+        summary = self._extract_benchmark_summary(bench_html, bench_report)
+        if summary:
+            above_median_count = sum(1 for p in positions if p.get("score_percentile", 0) >= 50)
+            total_positions = len(positions)
+
+            # Check if summary mentions being above/below median correctly
+            above_keywords = ["ueber", "above", "besser", "better", "fuehrend", "leading"]
+            below_keywords = ["unter", "below", "schlechter", "worse", "nachholbedarf"]
+
+            summary_positive = any(kw in summary.lower() for kw in above_keywords)
+            summary_negative = any(kw in summary.lower() for kw in below_keywords)
+
+            majority_above = above_median_count > total_positions / 2
+
+            if majority_above and summary_negative and not summary_positive:
+                self.report.add_issue(ConsistencyIssue(
+                    rule_id="BENCH_008",
+                    severity="WARNING",
+                    domain="benchmark",
+                    source_section="benchmark_engine",
+                    target_section="benchmark_engine",
+                    message="Summary ist negativ aber Mehrheit der Positionen ueber Median",
+                    expected=f"{above_median_count}/{total_positions} Positionen ueber Median - positive Summary",
+                    actual="Summary betont Schwaechen",
+                    suggestion="Passe Summary an die tatsaechliche Benchmark-Performance an",
+                ))
+            elif not majority_above and summary_positive and not summary_negative:
+                self.report.add_issue(ConsistencyIssue(
+                    rule_id="BENCH_008",
+                    severity="WARNING",
+                    domain="benchmark",
+                    source_section="benchmark_engine",
+                    target_section="benchmark_engine",
+                    message="Summary ist positiv aber Mehrheit der Positionen unter Median",
+                    expected=f"{above_median_count}/{total_positions} Positionen ueber Median - ausgewogene Summary",
+                    actual="Summary betont nur Staerken",
+                    suggestion="Erwaehne auch Verbesserungspotenziale in der Summary",
+                ))
+
+    def _extract_benchmark_positions(self, html: str, report: Any) -> List[Dict[str, Any]]:
+        """Extract benchmark positions from HTML or report."""
+        positions: List[Dict[str, Any]] = []
+
+        if report:
+            if hasattr(report, "positions"):
+                for pos in report.positions:
+                    positions.append({
+                        "domain": getattr(pos, "domain", ""),
+                        "company_value": getattr(pos, "company_value", 0),
+                        "industry_median": getattr(pos, "industry_median", 1),
+                        "industry_top_quartile": getattr(pos, "industry_top_quartile", 1),
+                        "score_percentile": getattr(pos, "score_percentile", 50),
+                    })
+                return positions
+            if isinstance(report, dict) and "positions" in report:
+                return list(report["positions"])
+
+        if html:
+            # Try to extract from HTML table
+            percentile_pattern = r'P(\d+(?:\.\d+)?)'
+            for match in re.finditer(percentile_pattern, html):
+                try:
+                    percentile = float(match.group(1))
+                    positions.append({"score_percentile": percentile, "domain": "unknown"})
+                except ValueError:
+                    pass
+
+        return positions
+
+    def _extract_benchmark_radar(self, html: str, report: Any) -> List[float]:
+        """Extract radar scores from HTML or report."""
+        if report:
+            if hasattr(report, "radar") and hasattr(report.radar, "scores"):
+                return list(report.radar.scores)
+            if isinstance(report, dict) and "radar" in report:
+                return list(report["radar"].get("scores", []))
+
+        return []
+
+    def _extract_benchmark_swot(self, html: str, report: Any) -> Dict[str, List[str]]:
+        """Extract SWOT elements from HTML or report."""
+        swot: Dict[str, List[str]] = {
+            "strengths": [],
+            "weaknesses": [],
+            "opportunities": [],
+            "threats": [],
+        }
+
+        if report:
+            if hasattr(report, "strengths"):
+                swot["strengths"] = list(report.strengths)
+            if hasattr(report, "weaknesses"):
+                swot["weaknesses"] = list(report.weaknesses)
+            if hasattr(report, "opportunities"):
+                swot["opportunities"] = list(report.opportunities)
+            if hasattr(report, "threats"):
+                swot["threats"] = list(report.threats)
+            return swot
+
+        if isinstance(report, dict):
+            swot["strengths"] = report.get("strengths", [])
+            swot["weaknesses"] = report.get("weaknesses", [])
+            swot["opportunities"] = report.get("opportunities", [])
+            swot["threats"] = report.get("threats", [])
+
+        return swot
+
+    def _extract_benchmark_summary(self, html: str, report: Any) -> str:
+        """Extract summary from HTML or report."""
+        if report:
+            if hasattr(report, "summary"):
+                return str(report.summary)
+            if isinstance(report, dict) and "summary" in report:
+                return str(report["summary"])
+
+        return ""
+
+    def _extract_risk_score_for_benchmark(self) -> float:
+        """Extract risk score for benchmark validation."""
+        risk_report = self.sections.get("_risk_report_v3")
+        if risk_report and hasattr(risk_report, "residual_risk_score"):
+            return float(risk_report.residual_risk_score)
+
+        risk_score_str = self.sections.get("RESIDUAL_RISK_SCORE", "50")
+        try:
+            return float(str(risk_score_str).replace(",", "."))
+        except ValueError:
+            return 50.0
+
+    # -------------------------------------------------------------------------
     # SCORING
     # -------------------------------------------------------------------------
 
     def _calculate_domain_scores(self) -> None:
         """Calculate scores per domain."""
-        domains = ["tools", "funding", "kpi", "risk", "roadmap", "narrative", "snapshot", "risk_engine", "business_case", "recommendations", "risk_engine_v3", "vendor_audit", "automation_roadmap", "business_case_sim"]
+        domains = ["tools", "funding", "kpi", "risk", "roadmap", "narrative", "snapshot", "risk_engine", "business_case", "recommendations", "risk_engine_v3", "vendor_audit", "automation_roadmap", "business_case_sim", "benchmark"]
 
         for domain in domains:
             domain_issues = [i for i in self.report.issues if i.domain == domain]

--- a/templates/pdf_template.html
+++ b/templates/pdf_template.html
@@ -2629,6 +2629,24 @@
                     </div>
                 </section>
                 {% endif %}
+                <!-- G37: Benchmark Engine – Branchenvergleich & Wettbewerbsposition -->
+                {% if BENCHMARK_ENGINE_HTML %}
+                <section class="section chapter" id="benchmark-engine">
+                    <div class="section-header">
+                        <div class="section-title">
+                            <span class="section-kicker">Benchmarking</span>
+                            <h2>Branchenvergleich & Wettbewerbsposition</h2>
+                        </div>
+                        <span class="section-pill">
+                            <span class="pill-dot"></span>
+                            KI-Reife • Branchenmedian • SWOT
+                        </span>
+                    </div>
+                    <div class="section-body">
+                        {{ BENCHMARK_ENGINE_HTML|safe }}
+                    </div>
+                </section>
+                {% endif %}
                 <!-- G32: Recommendations Engine – Priorisierte Handlungsempfehlungen -->
                 {% if RECOMMENDATIONS_ENGINE_HTML %}
                 <section class="section chapter" id="recommendations-engine">

--- a/templates/pdf_template_en.html
+++ b/templates/pdf_template_en.html
@@ -2146,6 +2146,24 @@
                     </div>
                 </section>
                 {% endif %}
+                <!-- G37: Benchmark Engine – Industry Comparison & Competitive Position -->
+                {% if BENCHMARK_ENGINE_HTML %}
+                <section class="section chapter" id="benchmark-engine">
+                    <div class="section-header">
+                        <div class="section-title">
+                            <span class="section-kicker">Benchmarking</span>
+                            <h2>Industry Comparison & Competitive Position</h2>
+                        </div>
+                        <span class="section-pill">
+                            <span class="pill-dot"></span>
+                            AI Maturity • Industry Median • SWOT
+                        </span>
+                    </div>
+                    <div class="section-body">
+                        {{ BENCHMARK_ENGINE_HTML|safe }}
+                    </div>
+                </section>
+                {% endif %}
                 <!-- G32: Recommendations Engine – Prioritized Action Recommendations -->
                 {% if RECOMMENDATIONS_ENGINE_HTML %}
                 <section class="section chapter" id="recommendations-engine">

--- a/tests/test_g37_benchmark_engine.py
+++ b/tests/test_g37_benchmark_engine.py
@@ -1,0 +1,1076 @@
+# -*- coding: utf-8 -*-
+"""
+Sprint G37: Benchmark Engine Tests
+===================================
+
+Comprehensive test suite covering:
+- BenchmarkPosition dataclass
+- BenchmarkRadar dataclass
+- BenchmarkReport dataclass
+- Report generation
+- HTML rendering
+- Consistency rules BENCH_001-BENCH_008
+- Size awareness (solo/team/kmu)
+- Branch awareness
+- Industry benchmarks
+- SWOT generation
+- Edge cases
+
+Version: 1.0.0 (Sprint G37)
+"""
+from __future__ import annotations
+
+import pytest
+from typing import Dict, Any, List, Optional
+
+
+# =============================================================================
+# TEST: BenchmarkPosition Dataclass
+# =============================================================================
+
+class TestBenchmarkPosition:
+    """Tests for BenchmarkPosition dataclass."""
+
+    def test_basic_creation(self) -> None:
+        """Test BenchmarkPosition can be instantiated with basic values."""
+        from services.benchmark_engine import BenchmarkPosition
+
+        pos = BenchmarkPosition(
+            domain="kpi",
+            company_value=1.2,
+            industry_median=0.8,
+            industry_top_quartile=1.4,
+            score_percentile=75.0,
+            narrative="Test narrative",
+        )
+
+        assert pos.domain == "kpi"
+        assert pos.company_value == 1.2
+        assert pos.industry_median == 0.8
+        assert pos.industry_top_quartile == 1.4
+        assert pos.score_percentile == 75.0
+        assert pos.narrative == "Test narrative"
+
+    def test_percentile_clamped_high(self) -> None:
+        """Test score_percentile is clamped to max 100."""
+        from services.benchmark_engine import BenchmarkPosition
+
+        pos = BenchmarkPosition(
+            domain="kpi",
+            company_value=1.0,
+            industry_median=0.8,
+            industry_top_quartile=1.4,
+            score_percentile=150.0,
+            narrative="Test",
+        )
+
+        assert pos.score_percentile == 100.0
+
+    def test_percentile_clamped_low(self) -> None:
+        """Test score_percentile is clamped to min 0."""
+        from services.benchmark_engine import BenchmarkPosition
+
+        pos = BenchmarkPosition(
+            domain="kpi",
+            company_value=1.0,
+            industry_median=0.8,
+            industry_top_quartile=1.4,
+            score_percentile=-20.0,
+            narrative="Test",
+        )
+
+        assert pos.score_percentile == 0.0
+
+    def test_invalid_domain_normalized(self) -> None:
+        """Test invalid domain is normalized to 'kpi'."""
+        from services.benchmark_engine import BenchmarkPosition
+
+        pos = BenchmarkPosition(
+            domain="invalid_domain",
+            company_value=1.0,
+            industry_median=0.8,
+            industry_top_quartile=1.4,
+            score_percentile=50.0,
+            narrative="Test",
+        )
+
+        assert pos.domain == "kpi"
+
+    def test_valid_domains(self) -> None:
+        """Test all valid domain values."""
+        from services.benchmark_engine import BenchmarkPosition, BENCHMARK_DOMAINS
+
+        for domain in BENCHMARK_DOMAINS:
+            pos = BenchmarkPosition(
+                domain=domain,
+                company_value=1.0,
+                industry_median=0.8,
+                industry_top_quartile=1.4,
+                score_percentile=50.0,
+                narrative="Test",
+            )
+            assert pos.domain == domain
+
+    def test_is_above_median_true(self) -> None:
+        """Test is_above_median returns True when company value exceeds median."""
+        from services.benchmark_engine import BenchmarkPosition
+
+        pos = BenchmarkPosition(
+            domain="kpi",
+            company_value=1.0,
+            industry_median=0.8,
+            industry_top_quartile=1.4,
+            score_percentile=60.0,
+            narrative="Test",
+        )
+
+        assert pos.is_above_median is True
+
+    def test_is_above_median_false(self) -> None:
+        """Test is_above_median returns False when company value below median."""
+        from services.benchmark_engine import BenchmarkPosition
+
+        pos = BenchmarkPosition(
+            domain="kpi",
+            company_value=0.5,
+            industry_median=0.8,
+            industry_top_quartile=1.4,
+            score_percentile=30.0,
+            narrative="Test",
+        )
+
+        assert pos.is_above_median is False
+
+    def test_is_above_median_risk_inverse(self) -> None:
+        """Test is_above_median is inverse for risk domain (lower is better)."""
+        from services.benchmark_engine import BenchmarkPosition
+
+        pos = BenchmarkPosition(
+            domain="risk",
+            company_value=0.4,
+            industry_median=0.6,
+            industry_top_quartile=0.35,
+            score_percentile=70.0,
+            narrative="Test",
+        )
+
+        # For risk, company_value 0.4 < median 0.6 means above median (good)
+        assert pos.is_above_median is True
+
+    def test_is_top_quartile_true(self) -> None:
+        """Test is_top_quartile returns True when in top quartile."""
+        from services.benchmark_engine import BenchmarkPosition
+
+        pos = BenchmarkPosition(
+            domain="kpi",
+            company_value=1.5,
+            industry_median=0.8,
+            industry_top_quartile=1.4,
+            score_percentile=80.0,
+            narrative="Test",
+        )
+
+        assert pos.is_top_quartile is True
+
+    def test_is_top_quartile_false(self) -> None:
+        """Test is_top_quartile returns False when not in top quartile."""
+        from services.benchmark_engine import BenchmarkPosition
+
+        pos = BenchmarkPosition(
+            domain="kpi",
+            company_value=1.0,
+            industry_median=0.8,
+            industry_top_quartile=1.4,
+            score_percentile=60.0,
+            narrative="Test",
+        )
+
+        assert pos.is_top_quartile is False
+
+    def test_deviation_from_median_positive(self) -> None:
+        """Test deviation_from_median is positive when above median."""
+        from services.benchmark_engine import BenchmarkPosition
+
+        pos = BenchmarkPosition(
+            domain="kpi",
+            company_value=1.0,
+            industry_median=0.8,
+            industry_top_quartile=1.4,
+            score_percentile=60.0,
+            narrative="Test",
+        )
+
+        # (1.0 - 0.8) / 0.8 * 100 = 25%
+        assert pos.deviation_from_median == 25.0
+
+    def test_deviation_from_median_negative(self) -> None:
+        """Test deviation_from_median is negative when below median."""
+        from services.benchmark_engine import BenchmarkPosition
+
+        pos = BenchmarkPosition(
+            domain="kpi",
+            company_value=0.6,
+            industry_median=0.8,
+            industry_top_quartile=1.4,
+            score_percentile=40.0,
+            narrative="Test",
+        )
+
+        # (0.6 - 0.8) / 0.8 * 100 = -25%
+        assert pos.deviation_from_median == -25.0
+
+    def test_to_dict_serialization(self) -> None:
+        """Test to_dict serialization includes all fields."""
+        from services.benchmark_engine import BenchmarkPosition
+
+        pos = BenchmarkPosition(
+            domain="kpi",
+            company_value=1.2,
+            industry_median=0.8,
+            industry_top_quartile=1.4,
+            score_percentile=75.0,
+            narrative="Test narrative",
+        )
+
+        d = pos.to_dict()
+        assert d["domain"] == "kpi"
+        assert d["company_value"] == 1.2
+        assert d["industry_median"] == 0.8
+        assert d["industry_top_quartile"] == 1.4
+        assert d["score_percentile"] == 75.0
+        assert d["narrative"] == "Test narrative"
+        assert "is_above_median" in d
+        assert "is_top_quartile" in d
+        assert "deviation_from_median" in d
+
+
+# =============================================================================
+# TEST: BenchmarkRadar Dataclass
+# =============================================================================
+
+class TestBenchmarkRadar:
+    """Tests for BenchmarkRadar dataclass."""
+
+    def test_basic_creation(self) -> None:
+        """Test BenchmarkRadar can be instantiated with basic values."""
+        from services.benchmark_engine import BenchmarkRadar
+
+        radar = BenchmarkRadar(
+            categories=["ROI", "Risk", "Tools"],
+            scores=[0.7, 0.5, 0.8],
+        )
+
+        assert radar.categories == ["ROI", "Risk", "Tools"]
+        assert radar.scores == [0.7, 0.5, 0.8]
+
+    def test_scores_normalized_high(self) -> None:
+        """Test scores are clamped to max 1.0."""
+        from services.benchmark_engine import BenchmarkRadar
+
+        radar = BenchmarkRadar(
+            categories=["A", "B", "C"],
+            scores=[1.5, 2.0, 0.8],
+        )
+
+        assert radar.scores == [1.0, 1.0, 0.8]
+
+    def test_scores_normalized_low(self) -> None:
+        """Test scores are clamped to min 0.0."""
+        from services.benchmark_engine import BenchmarkRadar
+
+        radar = BenchmarkRadar(
+            categories=["A", "B", "C"],
+            scores=[-0.5, 0.5, -1.0],
+        )
+
+        assert radar.scores == [0.0, 0.5, 0.0]
+
+    def test_mismatched_lengths_truncated(self) -> None:
+        """Test mismatched categories/scores lengths are truncated."""
+        from services.benchmark_engine import BenchmarkRadar
+
+        radar = BenchmarkRadar(
+            categories=["A", "B", "C", "D", "E"],
+            scores=[0.5, 0.6],
+        )
+
+        assert len(radar.categories) == 2
+        assert len(radar.scores) == 2
+
+    def test_is_valid_true(self) -> None:
+        """Test is_valid returns True with 3+ categories."""
+        from services.benchmark_engine import BenchmarkRadar
+
+        radar = BenchmarkRadar(
+            categories=["A", "B", "C"],
+            scores=[0.5, 0.6, 0.7],
+        )
+
+        assert radar.is_valid is True
+
+    def test_is_valid_false_insufficient_categories(self) -> None:
+        """Test is_valid returns False with < 3 categories."""
+        from services.benchmark_engine import BenchmarkRadar
+
+        radar = BenchmarkRadar(
+            categories=["A", "B"],
+            scores=[0.5, 0.6],
+        )
+
+        assert radar.is_valid is False
+
+    def test_average_score(self) -> None:
+        """Test average_score calculation."""
+        from services.benchmark_engine import BenchmarkRadar
+
+        radar = BenchmarkRadar(
+            categories=["A", "B", "C"],
+            scores=[0.6, 0.8, 1.0],
+        )
+
+        expected = (0.6 + 0.8 + 1.0) / 3
+        assert abs(radar.average_score - expected) < 0.001
+
+    def test_average_score_empty(self) -> None:
+        """Test average_score returns 0 for empty scores."""
+        from services.benchmark_engine import BenchmarkRadar
+
+        radar = BenchmarkRadar(categories=[], scores=[])
+        assert radar.average_score == 0.0
+
+    def test_to_dict_serialization(self) -> None:
+        """Test to_dict serialization."""
+        from services.benchmark_engine import BenchmarkRadar
+
+        radar = BenchmarkRadar(
+            categories=["A", "B", "C"],
+            scores=[0.6, 0.8, 1.0],
+        )
+
+        d = radar.to_dict()
+        assert d["categories"] == ["A", "B", "C"]
+        assert len(d["scores"]) == 3
+        assert "average_score" in d
+
+
+# =============================================================================
+# TEST: BenchmarkReport Dataclass
+# =============================================================================
+
+class TestBenchmarkReport:
+    """Tests for BenchmarkReport dataclass."""
+
+    def test_basic_creation(self) -> None:
+        """Test BenchmarkReport can be instantiated with basic values."""
+        from services.benchmark_engine import BenchmarkReport, BenchmarkPosition, BenchmarkRadar
+
+        pos = BenchmarkPosition(
+            domain="kpi",
+            company_value=1.0,
+            industry_median=0.8,
+            industry_top_quartile=1.4,
+            score_percentile=60.0,
+            narrative="Test",
+        )
+        radar = BenchmarkRadar(
+            categories=["ROI", "Risk", "Tools"],
+            scores=[0.6, 0.5, 0.7],
+        )
+
+        report = BenchmarkReport(
+            positions=[pos],
+            radar=radar,
+            summary="Test summary",
+            strengths=["Strength 1"],
+            weaknesses=["Weakness 1"],
+            opportunities=["Opportunity 1"],
+            threats=["Threat 1"],
+        )
+
+        assert len(report.positions) == 1
+        assert report.summary == "Test summary"
+        assert len(report.strengths) == 1
+
+    def test_maturity_score_clamped(self) -> None:
+        """Test maturity_score is clamped to 0-100."""
+        from services.benchmark_engine import BenchmarkReport
+
+        report_high = BenchmarkReport(maturity_score=150.0)
+        assert report_high.maturity_score == 100.0
+
+        report_low = BenchmarkReport(maturity_score=-20.0)
+        assert report_low.maturity_score == 0.0
+
+    def test_invalid_grade_normalized(self) -> None:
+        """Test invalid competitiveness_grade is normalized to 'C'."""
+        from services.benchmark_engine import BenchmarkReport
+
+        report = BenchmarkReport(competitiveness_grade="X")
+        assert report.competitiveness_grade == "C"
+
+    def test_valid_grades(self) -> None:
+        """Test all valid grade values."""
+        from services.benchmark_engine import BenchmarkReport
+
+        for grade in ["A", "B", "C", "D", "F"]:
+            report = BenchmarkReport(competitiveness_grade=grade)
+            assert report.competitiveness_grade == grade
+
+    def test_is_valid_true(self) -> None:
+        """Test is_valid returns True with sufficient data."""
+        from services.benchmark_engine import BenchmarkReport, BenchmarkPosition, BenchmarkRadar
+
+        positions = [
+            BenchmarkPosition(domain="kpi", company_value=1.0, industry_median=0.8,
+                             industry_top_quartile=1.4, score_percentile=60.0, narrative="Test"),
+            BenchmarkPosition(domain="tools", company_value=0.5, industry_median=0.5,
+                             industry_top_quartile=0.75, score_percentile=50.0, narrative="Test"),
+            BenchmarkPosition(domain="risk", company_value=0.5, industry_median=0.6,
+                             industry_top_quartile=0.35, score_percentile=55.0, narrative="Test"),
+        ]
+        radar = BenchmarkRadar(
+            categories=["ROI", "Tools", "Risk"],
+            scores=[0.6, 0.5, 0.55],
+        )
+
+        report = BenchmarkReport(positions=positions, radar=radar)
+        assert report.is_valid is True
+
+    def test_is_valid_false_insufficient_positions(self) -> None:
+        """Test is_valid returns False with < 3 positions."""
+        from services.benchmark_engine import BenchmarkReport, BenchmarkPosition, BenchmarkRadar
+
+        positions = [
+            BenchmarkPosition(domain="kpi", company_value=1.0, industry_median=0.8,
+                             industry_top_quartile=1.4, score_percentile=60.0, narrative="Test"),
+        ]
+        radar = BenchmarkRadar(categories=["ROI", "Tools", "Risk"], scores=[0.6, 0.5, 0.55])
+
+        report = BenchmarkReport(positions=positions, radar=radar)
+        assert report.is_valid is False
+
+    def test_above_median_count(self) -> None:
+        """Test above_median_count property."""
+        from services.benchmark_engine import BenchmarkReport, BenchmarkPosition, BenchmarkRadar
+
+        positions = [
+            BenchmarkPosition(domain="kpi", company_value=1.0, industry_median=0.8,
+                             industry_top_quartile=1.4, score_percentile=60.0, narrative="Test"),
+            BenchmarkPosition(domain="tools", company_value=0.4, industry_median=0.5,
+                             industry_top_quartile=0.75, score_percentile=40.0, narrative="Test"),
+            BenchmarkPosition(domain="automation", company_value=0.6, industry_median=0.4,
+                             industry_top_quartile=0.65, score_percentile=70.0, narrative="Test"),
+        ]
+        radar = BenchmarkRadar(categories=["A", "B", "C"], scores=[0.6, 0.4, 0.7])
+
+        report = BenchmarkReport(positions=positions, radar=radar)
+        assert report.above_median_count == 2
+
+    def test_get_position_found(self) -> None:
+        """Test get_position returns correct position."""
+        from services.benchmark_engine import BenchmarkReport, BenchmarkPosition, BenchmarkRadar
+
+        pos_kpi = BenchmarkPosition(domain="kpi", company_value=1.0, industry_median=0.8,
+                                    industry_top_quartile=1.4, score_percentile=60.0, narrative="KPI")
+        pos_tools = BenchmarkPosition(domain="tools", company_value=0.5, industry_median=0.5,
+                                      industry_top_quartile=0.75, score_percentile=50.0, narrative="Tools")
+        radar = BenchmarkRadar(categories=["A", "B", "C"], scores=[0.6, 0.5, 0.5])
+
+        report = BenchmarkReport(positions=[pos_kpi, pos_tools], radar=radar)
+        assert report.get_position("kpi") is not None
+        assert report.get_position("kpi").narrative == "KPI"
+
+    def test_get_position_not_found(self) -> None:
+        """Test get_position returns None for missing domain."""
+        from services.benchmark_engine import BenchmarkReport, BenchmarkPosition, BenchmarkRadar
+
+        pos = BenchmarkPosition(domain="kpi", company_value=1.0, industry_median=0.8,
+                                industry_top_quartile=1.4, score_percentile=60.0, narrative="Test")
+        radar = BenchmarkRadar(categories=["A", "B", "C"], scores=[0.6, 0.5, 0.5])
+
+        report = BenchmarkReport(positions=[pos], radar=radar)
+        assert report.get_position("funding") is None
+
+    def test_to_dict_serialization(self) -> None:
+        """Test to_dict serialization includes all fields."""
+        from services.benchmark_engine import BenchmarkReport, BenchmarkPosition, BenchmarkRadar
+
+        pos = BenchmarkPosition(domain="kpi", company_value=1.0, industry_median=0.8,
+                                industry_top_quartile=1.4, score_percentile=60.0, narrative="Test")
+        radar = BenchmarkRadar(categories=["A", "B", "C"], scores=[0.6, 0.5, 0.5])
+
+        report = BenchmarkReport(
+            positions=[pos],
+            radar=radar,
+            summary="Summary",
+            strengths=["S1"],
+            weaknesses=["W1"],
+            opportunities=["O1"],
+            threats=["T1"],
+        )
+
+        d = report.to_dict()
+        assert "positions" in d
+        assert "radar" in d
+        assert "summary" in d
+        assert "strengths" in d
+        assert "weaknesses" in d
+        assert "opportunities" in d
+        assert "threats" in d
+        assert "maturity_score" in d
+        assert "competitiveness_grade" in d
+
+
+# =============================================================================
+# TEST: Helper Functions
+# =============================================================================
+
+class TestHelperFunctions:
+    """Tests for helper functions."""
+
+    def test_normalize_branch_direct(self) -> None:
+        """Test _normalize_branch with direct matches."""
+        from services.benchmark_engine import _normalize_branch
+
+        assert _normalize_branch("technologie") == "technologie"
+        assert _normalize_branch("IT") == "it"
+        assert _normalize_branch("software") == "software"
+
+    def test_normalize_branch_mapping(self) -> None:
+        """Test _normalize_branch with mapped values."""
+        from services.benchmark_engine import _normalize_branch
+
+        assert _normalize_branch("technology") == "technologie"
+        assert _normalize_branch("finance") == "finanzen"
+        assert _normalize_branch("health") == "healthcare"
+
+    def test_normalize_branch_default(self) -> None:
+        """Test _normalize_branch returns default for unknown."""
+        from services.benchmark_engine import _normalize_branch
+
+        assert _normalize_branch("xyz_random_branch") == "default"
+        assert _normalize_branch("") == "default"
+        assert _normalize_branch(None) == "default"
+
+    def test_normalize_size_solo(self) -> None:
+        """Test _normalize_size recognizes solo keywords."""
+        from services.benchmark_engine import _normalize_size
+
+        assert _normalize_size("solo") == "solo"
+        assert _normalize_size("Einzelunternehmer") == "solo"
+        assert _normalize_size("freelancer") == "solo"
+
+    def test_normalize_size_team(self) -> None:
+        """Test _normalize_size recognizes team keywords."""
+        from services.benchmark_engine import _normalize_size
+
+        assert _normalize_size("team") == "team"
+        assert _normalize_size("klein") == "team"
+        assert _normalize_size("small") == "team"
+
+    def test_normalize_size_kmu(self) -> None:
+        """Test _normalize_size recognizes kmu keywords."""
+        from services.benchmark_engine import _normalize_size
+
+        assert _normalize_size("kmu") == "kmu"
+        assert _normalize_size("sme") == "kmu"
+        assert _normalize_size("mittel") == "kmu"
+
+    def test_normalize_size_default(self) -> None:
+        """Test _normalize_size returns team as default."""
+        from services.benchmark_engine import _normalize_size
+
+        assert _normalize_size("unknown") == "team"
+        assert _normalize_size("") == "team"
+        assert _normalize_size(None) == "team"
+
+    def test_calculate_percentile_above_top_quartile(self) -> None:
+        """Test percentile calculation above top quartile."""
+        from services.benchmark_engine import _calculate_percentile
+
+        # Company value 1.6 > top quartile 1.4
+        percentile = _calculate_percentile(1.6, 0.8, 1.4, 0.3)
+        assert percentile >= 75
+
+    def test_calculate_percentile_above_median(self) -> None:
+        """Test percentile calculation above median."""
+        from services.benchmark_engine import _calculate_percentile
+
+        # Company value 1.0 between median 0.8 and top quartile 1.4
+        percentile = _calculate_percentile(1.0, 0.8, 1.4, 0.3)
+        assert 50 <= percentile < 75
+
+    def test_calculate_percentile_below_median(self) -> None:
+        """Test percentile calculation below median."""
+        from services.benchmark_engine import _calculate_percentile
+
+        # Company value 0.5 below median 0.8
+        percentile = _calculate_percentile(0.5, 0.8, 1.4, 0.3)
+        assert percentile < 50
+
+    def test_calculate_percentile_inverse_risk(self) -> None:
+        """Test percentile calculation for inverse metric (risk)."""
+        from services.benchmark_engine import _calculate_percentile
+
+        # For risk, lower is better
+        # Company value 0.3 < top quartile 0.35, so should be high percentile
+        percentile = _calculate_percentile(0.3, 0.6, 0.35, 0.1, is_inverse=True)
+        assert percentile >= 75
+
+
+# =============================================================================
+# TEST: Report Generation
+# =============================================================================
+
+class TestReportGeneration:
+    """Tests for generate_benchmark_report function."""
+
+    def test_generate_report_basic(self) -> None:
+        """Test basic report generation."""
+        from services.benchmark_engine import generate_benchmark_report
+
+        report = generate_benchmark_report(
+            context=None,
+            sections={},
+            briefing={"branche": "technologie", "unternehmensgroesse": "team"},
+        )
+
+        assert report is not None
+        assert len(report.positions) == 6  # 6 benchmark domains
+        assert report.radar.is_valid
+
+    def test_generate_report_with_kpi_data(self) -> None:
+        """Test report generation with KPI data."""
+        from services.benchmark_engine import generate_benchmark_report
+        from dataclasses import dataclass
+
+        @dataclass
+        class MockKPIData:
+            roi_p50: float = 120.0
+
+        report = generate_benchmark_report(
+            context=None,
+            sections={},
+            kpi_data=MockKPIData(),
+            briefing={"branche": "software"},
+        )
+
+        kpi_pos = report.get_position("kpi")
+        assert kpi_pos is not None
+        assert kpi_pos.company_value == 1.2  # 120% -> 1.2
+
+    def test_generate_report_different_branches(self) -> None:
+        """Test report generation produces different results for different branches."""
+        from services.benchmark_engine import generate_benchmark_report
+
+        report_tech = generate_benchmark_report(
+            context=None,
+            sections={},
+            briefing={"branche": "technologie"},
+        )
+
+        report_health = generate_benchmark_report(
+            context=None,
+            sections={},
+            briefing={"branche": "healthcare"},
+        )
+
+        # Different branches should have different medians
+        kpi_tech = report_tech.get_position("kpi")
+        kpi_health = report_health.get_position("kpi")
+
+        assert kpi_tech is not None
+        assert kpi_health is not None
+        assert kpi_tech.industry_median != kpi_health.industry_median
+
+    def test_generate_report_size_aware(self) -> None:
+        """Test report generation is size-aware."""
+        from services.benchmark_engine import generate_benchmark_report
+
+        report_solo = generate_benchmark_report(
+            context=None,
+            sections={},
+            briefing={"branche": "default", "unternehmensgroesse": "solo"},
+        )
+
+        report_kmu = generate_benchmark_report(
+            context=None,
+            sections={},
+            briefing={"branche": "default", "unternehmensgroesse": "kmu"},
+        )
+
+        # KMU should have higher median expectations for most domains
+        kpi_solo = report_solo.get_position("kpi")
+        kpi_kmu = report_kmu.get_position("kpi")
+
+        assert kpi_solo is not None
+        assert kpi_kmu is not None
+        assert kpi_solo.industry_median < kpi_kmu.industry_median
+
+    def test_generate_report_swot_populated(self) -> None:
+        """Test report generation populates SWOT."""
+        from services.benchmark_engine import generate_benchmark_report
+
+        report = generate_benchmark_report(
+            context=None,
+            sections={},
+            briefing={"branche": "technologie"},
+        )
+
+        assert len(report.strengths) > 0
+        assert len(report.weaknesses) > 0
+        assert len(report.opportunities) > 0
+        assert len(report.threats) > 0
+
+    def test_generate_report_summary_generated(self) -> None:
+        """Test report generation creates summary."""
+        from services.benchmark_engine import generate_benchmark_report
+
+        report = generate_benchmark_report(
+            context=None,
+            sections={},
+            briefing={"branche": "technologie"},
+        )
+
+        assert report.summary != ""
+        assert len(report.summary) > 50
+
+    def test_generate_report_english(self) -> None:
+        """Test report generation in English."""
+        from services.benchmark_engine import generate_benchmark_report
+
+        report = generate_benchmark_report(
+            context=None,
+            sections={},
+            briefing={"industry": "technology"},
+            lang="en",
+        )
+
+        assert report is not None
+        # English radar categories
+        assert "ROI" in report.radar.categories
+
+
+# =============================================================================
+# TEST: HTML Generation
+# =============================================================================
+
+class TestHTMLGeneration:
+    """Tests for HTML generation functions."""
+
+    def test_html_generation_basic(self) -> None:
+        """Test basic HTML generation."""
+        from services.benchmark_engine import generate_benchmark_report, benchmark_report_to_html
+
+        report = generate_benchmark_report(
+            context=None,
+            sections={},
+            briefing={"branche": "technologie"},
+        )
+
+        html = benchmark_report_to_html(report, lang="de")
+
+        assert html is not None
+        assert len(html) > 100
+        assert "benchmark" in html.lower()
+
+    def test_html_contains_maturity_score(self) -> None:
+        """Test HTML contains maturity score display."""
+        from services.benchmark_engine import generate_benchmark_report, benchmark_report_to_html
+
+        report = generate_benchmark_report(
+            context=None,
+            sections={},
+            briefing={"branche": "technologie"},
+        )
+
+        html = benchmark_report_to_html(report, lang="de")
+
+        assert "Reifegrad" in html or "%" in html
+
+    def test_html_contains_positions_table(self) -> None:
+        """Test HTML contains benchmark positions table."""
+        from services.benchmark_engine import generate_benchmark_report, benchmark_report_to_html
+
+        report = generate_benchmark_report(
+            context=None,
+            sections={},
+            briefing={"branche": "technologie"},
+        )
+
+        html = benchmark_report_to_html(report, lang="de")
+
+        assert "<table" in html
+        assert "Branchenmedian" in html or "Industry Median" in html
+
+    def test_html_contains_swot(self) -> None:
+        """Test HTML contains SWOT analysis."""
+        from services.benchmark_engine import generate_benchmark_report, benchmark_report_to_html
+
+        report = generate_benchmark_report(
+            context=None,
+            sections={},
+            briefing={"branche": "technologie"},
+        )
+
+        html = benchmark_report_to_html(report, lang="de")
+
+        assert "SWOT" in html or "Staerken" in html or "Schwaechen" in html
+
+    def test_html_generation_english(self) -> None:
+        """Test HTML generation in English."""
+        from services.benchmark_engine import generate_benchmark_report, benchmark_report_to_html
+
+        report = generate_benchmark_report(
+            context=None,
+            sections={},
+            briefing={"industry": "technology"},
+            lang="en",
+        )
+
+        html = benchmark_report_to_html(report, lang="en")
+
+        assert "Maturity" in html or "Industry" in html
+        assert "Strengths" in html or "Weaknesses" in html
+
+    def test_html_empty_report(self) -> None:
+        """Test HTML generation with empty/invalid report."""
+        from services.benchmark_engine import BenchmarkReport, benchmark_report_to_html
+
+        report = BenchmarkReport()
+        html = benchmark_report_to_html(report, lang="de")
+
+        assert html is not None
+        assert "benchmark" in html.lower() or "berechnet" in html.lower()
+
+
+# =============================================================================
+# TEST: Industry Benchmarks
+# =============================================================================
+
+class TestIndustryBenchmarks:
+    """Tests for industry benchmark data."""
+
+    def test_industry_benchmarks_exist(self) -> None:
+        """Test industry benchmarks are defined."""
+        from services.benchmark_engine import INDUSTRY_BENCHMARKS
+
+        assert "default" in INDUSTRY_BENCHMARKS
+        assert "technologie" in INDUSTRY_BENCHMARKS
+        assert "healthcare" in INDUSTRY_BENCHMARKS
+
+    def test_industry_benchmarks_structure(self) -> None:
+        """Test industry benchmarks have correct structure."""
+        from services.benchmark_engine import INDUSTRY_BENCHMARKS, BENCHMARK_DOMAINS
+
+        for branch, benchmarks in INDUSTRY_BENCHMARKS.items():
+            for domain in BENCHMARK_DOMAINS:
+                assert domain in benchmarks, f"Missing {domain} in {branch}"
+                assert "median" in benchmarks[domain]
+                assert "top_quartile" in benchmarks[domain]
+                assert "floor" in benchmarks[domain]
+
+    def test_size_multipliers_exist(self) -> None:
+        """Test size multipliers are defined."""
+        from services.benchmark_engine import SIZE_BENCHMARK_MULTIPLIERS
+
+        assert "solo" in SIZE_BENCHMARK_MULTIPLIERS
+        assert "team" in SIZE_BENCHMARK_MULTIPLIERS
+        assert "kmu" in SIZE_BENCHMARK_MULTIPLIERS
+
+
+# =============================================================================
+# TEST: Consistency Rules
+# =============================================================================
+
+class TestConsistencyRules:
+    """Tests for consistency rules BENCH_001-BENCH_008."""
+
+    def test_bench_001_percentile_valid(self) -> None:
+        """Test BENCH_001: Valid percentile passes."""
+        from services.benchmark_engine import BenchmarkPosition
+
+        pos = BenchmarkPosition(
+            domain="kpi",
+            company_value=1.0,
+            industry_median=0.8,
+            industry_top_quartile=1.4,
+            score_percentile=75.0,
+            narrative="Test",
+        )
+
+        assert 0 <= pos.score_percentile <= 100
+
+    def test_bench_002_outlier_check(self) -> None:
+        """Test BENCH_002: Outlier detection concept."""
+        from services.benchmark_engine import BenchmarkPosition
+
+        pos = BenchmarkPosition(
+            domain="kpi",
+            company_value=10.0,  # Extreme value
+            industry_median=0.8,
+            industry_top_quartile=1.4,
+            score_percentile=50.0,
+            narrative="Test",
+        )
+
+        # company_value 10.0 > 10 * median 0.8 = 8.0, so it's an outlier
+        assert pos.company_value > pos.industry_median * 10
+
+    def test_bench_004_radar_score_consistency(self) -> None:
+        """Test BENCH_004: Radar scores match positions."""
+        from services.benchmark_engine import generate_benchmark_report
+
+        report = generate_benchmark_report(
+            context=None,
+            sections={},
+            briefing={"branche": "technologie"},
+        )
+
+        # Radar scores should be normalized percentiles
+        for i, pos in enumerate(report.positions):
+            if i < len(report.radar.scores):
+                expected_radar = pos.score_percentile / 100
+                actual_radar = report.radar.scores[i]
+                assert abs(expected_radar - actual_radar) < 0.01
+
+    def test_bench_006_weaknesses_not_empty(self) -> None:
+        """Test BENCH_006: Weaknesses are always populated."""
+        from services.benchmark_engine import generate_benchmark_report
+
+        report = generate_benchmark_report(
+            context=None,
+            sections={},
+            briefing={"branche": "technologie"},
+        )
+
+        assert len(report.weaknesses) > 0
+        assert not all(w.lower() in ["none", "keine", ""] for w in report.weaknesses)
+
+
+# =============================================================================
+# TEST: Edge Cases
+# =============================================================================
+
+class TestEdgeCases:
+    """Tests for edge cases and error handling."""
+
+    def test_empty_briefing(self) -> None:
+        """Test report generation with empty briefing."""
+        from services.benchmark_engine import generate_benchmark_report
+
+        report = generate_benchmark_report(
+            context=None,
+            sections={},
+            briefing={},
+        )
+
+        assert report is not None
+        assert len(report.positions) > 0
+
+    def test_none_briefing(self) -> None:
+        """Test report generation with None briefing."""
+        from services.benchmark_engine import generate_benchmark_report
+
+        report = generate_benchmark_report(
+            context=None,
+            sections={},
+            briefing=None,
+        )
+
+        assert report is not None
+
+    def test_all_sections_empty(self) -> None:
+        """Test report generation with all sections empty."""
+        from services.benchmark_engine import generate_benchmark_report
+
+        report = generate_benchmark_report(
+            context=None,
+            sections={},
+            kpi_data=None,
+            tools_data=None,
+            funding_data=None,
+            risk_report_v3=None,
+            auto_report=None,
+            strategy_plan=None,
+            briefing={"branche": "technologie"},
+        )
+
+        # Should still produce a valid report with default values
+        assert report is not None
+        assert len(report.positions) == 6
+
+    def test_extreme_values(self) -> None:
+        """Test report with extreme input values."""
+        from services.benchmark_engine import BenchmarkPosition
+
+        # Extreme high value
+        pos_high = BenchmarkPosition(
+            domain="kpi",
+            company_value=999999.0,
+            industry_median=0.8,
+            industry_top_quartile=1.4,
+            score_percentile=100.0,
+            narrative="Test",
+        )
+        assert pos_high.company_value >= 0
+
+        # Zero value
+        pos_zero = BenchmarkPosition(
+            domain="kpi",
+            company_value=0.0,
+            industry_median=0.8,
+            industry_top_quartile=1.4,
+            score_percentile=0.0,
+            narrative="Test",
+        )
+        assert pos_zero.company_value == 0.0
+
+    def test_unicode_handling(self) -> None:
+        """Test handling of unicode in narratives."""
+        from services.benchmark_engine import BenchmarkPosition
+
+        pos = BenchmarkPosition(
+            domain="kpi",
+            company_value=1.0,
+            industry_median=0.8,
+            industry_top_quartile=1.4,
+            score_percentile=50.0,
+            narrative="Test mit Umlauten: aou ss and special chars: @#$%",
+        )
+
+        assert "Umlauten" in pos.narrative
+
+    def test_report_grade_calculation_a(self) -> None:
+        """Test grade A is assigned for high maturity."""
+        from services.benchmark_engine import BenchmarkReport, BenchmarkPosition, BenchmarkRadar
+
+        positions = [
+            BenchmarkPosition(domain="kpi", company_value=1.5, industry_median=0.8,
+                             industry_top_quartile=1.4, score_percentile=90.0, narrative="Test"),
+            BenchmarkPosition(domain="tools", company_value=0.8, industry_median=0.5,
+                             industry_top_quartile=0.75, score_percentile=85.0, narrative="Test"),
+            BenchmarkPosition(domain="risk", company_value=0.3, industry_median=0.6,
+                             industry_top_quartile=0.35, score_percentile=80.0, narrative="Test"),
+        ]
+        radar = BenchmarkRadar(categories=["A", "B", "C"], scores=[0.9, 0.85, 0.8])
+
+        report = BenchmarkReport(positions=positions, radar=radar)
+        assert report.competitiveness_grade == "A"
+
+    def test_report_grade_calculation_f(self) -> None:
+        """Test grade F is assigned for low maturity."""
+        from services.benchmark_engine import BenchmarkReport, BenchmarkPosition, BenchmarkRadar
+
+        positions = [
+            BenchmarkPosition(domain="kpi", company_value=0.3, industry_median=0.8,
+                             industry_top_quartile=1.4, score_percentile=20.0, narrative="Test"),
+            BenchmarkPosition(domain="tools", company_value=0.2, industry_median=0.5,
+                             industry_top_quartile=0.75, score_percentile=15.0, narrative="Test"),
+            BenchmarkPosition(domain="risk", company_value=0.9, industry_median=0.6,
+                             industry_top_quartile=0.35, score_percentile=10.0, narrative="Test"),
+        ]
+        radar = BenchmarkRadar(categories=["A", "B", "C"], scores=[0.2, 0.15, 0.1])
+
+        report = BenchmarkReport(positions=positions, radar=radar)
+        assert report.competitiveness_grade == "F"


### PR DESCRIPTION
…ysis

- Add BenchmarkPosition, BenchmarkRadar, BenchmarkReport data classes
- Implement generate_benchmark_report() with size-aware and branch-specific benchmarks
- Add benchmark_report_to_html() for PDF rendering
- Create DE/EN prompts for LLM-based benchmark analysis
- Add BENCH_001 through BENCH_008 consistency rules
- Integrate into gpt_analyze.py workflow
- Update PDF templates with benchmark section
- Add 70 tests covering all components and edge cases