### PR TITLE
fix: increase PDF HTML payload limit to 1MB with ENV configuration

### DIFF
--- a/services/pdf_client.py
+++ b/services/pdf_client.py
@@ -24,9 +24,11 @@ PDF_TIMEOUT = int(os.getenv("PDF_TIMEOUT_MS", "90000")) / 1000.0  # Sekunden
 MAX_RETRIES = int(os.getenv("PDF_MAX_RETRIES", "3"))
 
 # PDF-SLIMDOWN v2.0: Size Validation Limits
-MAX_HTML_PAYLOAD_KB = int(os.getenv("MAX_HTML_PAYLOAD_KB", "350"))  # 350KB default
+# ENV-gesteuert: PDF_MAX_HTML_KB (Default: 1024 KB = 1 MB)
+MAX_HTML_PAYLOAD_KB = int(os.getenv("PDF_MAX_HTML_KB", "1024"))  # Default: 1024 KB = 1 MB
 MAX_PDF_SIZE_MB = int(os.getenv("MAX_PDF_SIZE_MB", "20"))  # 20MB default
 WARN_PDF_SIZE_MB = 10  # Warning threshold at 10MB
+WARN_HTML_SIZE_KB = 500  # Warning threshold at 500KB
 
 # SPRINT G14-D: Error categorization for better diagnostics
 TRANSIENT_ERRORS = {408, 429, 500, 502, 503, 504}  # Errors worth retrying
@@ -70,15 +72,31 @@ def validate_html_size(html: str) -> Optional[str]:
         return "HTML content is empty"
 
     html_size_kb = len(html.encode('utf-8')) / 1024
+
+    # Log payload size for monitoring
+    log.info(
+        "[PDF] HTML payload size before render: %.1fKB (limit=%dKB)",
+        html_size_kb,
+        MAX_HTML_PAYLOAD_KB
+    )
+
     if html_size_kb > MAX_HTML_PAYLOAD_KB:
-        log.error(
-            "PDF-1 VIOLATION: HTML payload too large: %.1fKB > %dKB limit",
+        error_msg = (
+            f"PDF failed: HTML payload {html_size_kb:.1f}KB exceeds limit {MAX_HTML_PAYLOAD_KB}KB. "
+            "Consider enabling SLIM mode or reducing content."
+        )
+        log.error("[PDF] %s", error_msg)
+        return error_msg
+
+    if html_size_kb > WARN_HTML_SIZE_KB:
+        log.warning(
+            "[PDF] HTML payload approaching limit: %.1fKB (warning threshold: %dKB, limit: %dKB)",
             html_size_kb,
+            WARN_HTML_SIZE_KB,
             MAX_HTML_PAYLOAD_KB
         )
-        return f"HTML payload too large: {html_size_kb:.1f}KB exceeds {MAX_HTML_PAYLOAD_KB}KB limit"
 
-    log.debug("HTML size validation passed: %.1fKB", html_size_kb)
+    log.debug("[PDF] HTML size validation passed: %.1fKB", html_size_kb)
     return None
 
 
@@ -114,6 +132,48 @@ def validate_pdf_size(pdf_bytes: bytes) -> Optional[str]:
 
     log.debug("PDF size validation passed: %.2fMB", pdf_size_mb)
     return None
+
+
+def slim_html_sections(sections: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    Optional Slim Mode – removes large comfort sections to reduce HTML payload size.
+
+    This function is prepared for future use (G38+) but NOT activated by default.
+    It removes sections that are nice-to-have but not essential for the core report.
+
+    Args:
+        sections: Dictionary containing HTML sections
+
+    Returns:
+        Modified sections dict with large non-essential sections removed
+
+    Note:
+        To activate, call this function before rendering HTML template.
+        Example: sections = slim_html_sections(sections)
+    """
+    # Keys of large comfort sections that can be removed in slim mode
+    SLIM_REMOVE_KEYS = [
+        "NEWS_BOX_HTML",           # Market news (can be large)
+        "MARKET_INSIGHTS_HTML",    # Market insights
+        "KREATIV_SPECIAL_HTML",    # Creative special sections
+        "RESEARCH_DETAILS_HTML",   # Detailed research output
+        "RAW_RESEARCH_HTML",       # Raw research data
+    ]
+
+    removed_keys = []
+    for key in SLIM_REMOVE_KEYS:
+        if key in sections:
+            sections.pop(key, None)
+            removed_keys.append(key)
+
+    if removed_keys:
+        log.info(
+            "[PDF-SLIM] Removed %d sections to reduce payload: %s",
+            len(removed_keys),
+            ", ".join(removed_keys)
+        )
+
+    return sections
 
 
 def render_pdf_from_html(html: str, meta: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:

--- a/tests/test_pdf_payload_limit.py
+++ b/tests/test_pdf_payload_limit.py
@@ -1,0 +1,284 @@
+# -*- coding: utf-8 -*-
+"""
+Tests for PDF payload limit validation.
+
+Tests the ENV-configurable HTML payload limit and slim mode preparation.
+"""
+import os
+import sys
+import pytest
+from unittest.mock import MagicMock, patch
+
+# Mock requests before importing pdf_client
+sys.modules['requests'] = MagicMock()
+
+
+class TestPDFPayloadLimit:
+    """Tests for HTML payload size validation."""
+
+    def test_pdf_payload_under_limit(self):
+        """Test that HTML under the limit passes validation."""
+        with patch.dict(os.environ, {"PDF_MAX_HTML_KB": "1024"}):
+            # Force reimport with new ENV
+            if 'services.pdf_client' in sys.modules:
+                del sys.modules['services.pdf_client']
+            from services import pdf_client
+
+            html = "A" * (900 * 1024)  # 900 KB - under 1024 KB limit
+            result = pdf_client.validate_html_size(html)
+            assert result is None, f"Expected None for valid payload, got: {result}"
+
+    def test_pdf_payload_over_limit(self):
+        """Test that HTML over the limit fails validation."""
+        with patch.dict(os.environ, {"PDF_MAX_HTML_KB": "1024"}):
+            if 'services.pdf_client' in sys.modules:
+                del sys.modules['services.pdf_client']
+            from services import pdf_client
+
+            html = "A" * (1500 * 1024)  # 1.5 MB - over 1024 KB limit
+            result = pdf_client.validate_html_size(html)
+            assert result is not None, "Expected error message for oversized payload"
+            assert "exceeds limit" in result
+            assert "1024KB" in result
+
+    def test_pdf_payload_exactly_at_limit(self):
+        """Test that HTML exactly at the limit passes validation."""
+        with patch.dict(os.environ, {"PDF_MAX_HTML_KB": "100"}):
+            if 'services.pdf_client' in sys.modules:
+                del sys.modules['services.pdf_client']
+            from services import pdf_client
+
+            # Slightly under limit (accounting for encoding)
+            html = "A" * (99 * 1024)  # 99 KB
+            result = pdf_client.validate_html_size(html)
+            assert result is None
+
+    def test_pdf_payload_empty_html(self):
+        """Test that empty HTML returns error."""
+        if 'services.pdf_client' in sys.modules:
+            del sys.modules['services.pdf_client']
+        from services import pdf_client
+
+        result = pdf_client.validate_html_size("")
+        assert result is not None
+        assert "empty" in result.lower()
+
+    def test_pdf_payload_env_variable_default(self):
+        """Test that default limit is 1024 KB when ENV not set."""
+        # Remove PDF_MAX_HTML_KB if present
+        env_copy = os.environ.copy()
+        env_copy.pop("PDF_MAX_HTML_KB", None)
+
+        with patch.dict(os.environ, env_copy, clear=True):
+            if 'services.pdf_client' in sys.modules:
+                del sys.modules['services.pdf_client']
+            from services import pdf_client
+
+            assert pdf_client.MAX_HTML_PAYLOAD_KB == 1024
+
+    def test_pdf_payload_env_variable_custom(self):
+        """Test that custom ENV value is respected when module reloaded."""
+        # This test verifies the ENV variable is read - we test indirectly via validate_html_size
+        if 'services.pdf_client' in sys.modules:
+            del sys.modules['services.pdf_client']
+        from services import pdf_client
+
+        # Test that we can read the constant (already verified default is 1024)
+        assert pdf_client.MAX_HTML_PAYLOAD_KB >= 1024
+        # The actual value may vary based on ENV at test time
+
+    def test_pdf_payload_error_message_format(self):
+        """Test that error message includes helpful information."""
+        if 'services.pdf_client' in sys.modules:
+            del sys.modules['services.pdf_client']
+        from services import pdf_client
+
+        # Use a size that's definitely over any reasonable limit
+        html = "A" * (2000 * 1024)  # 2 MB - over 1024 KB default limit
+        result = pdf_client.validate_html_size(html)
+        assert result is not None
+        assert "PDF failed" in result
+        assert "SLIM mode" in result
+
+
+class TestSlimHtmlSections:
+    """Tests for slim_html_sections function (prepared but not activated)."""
+
+    def test_slim_removes_news_box(self):
+        """Test that slim mode removes NEWS_BOX_HTML."""
+        if 'services.pdf_client' in sys.modules:
+            del sys.modules['services.pdf_client']
+        from services.pdf_client import slim_html_sections
+
+        sections = {
+            "TITLE": "Test Report",
+            "NEWS_BOX_HTML": "<div>Large news content...</div>",
+            "SUMMARY_HTML": "<div>Summary</div>",
+        }
+
+        result = slim_html_sections(sections.copy())
+
+        assert "NEWS_BOX_HTML" not in result
+        assert "TITLE" in result
+        assert "SUMMARY_HTML" in result
+
+    def test_slim_removes_market_insights(self):
+        """Test that slim mode removes MARKET_INSIGHTS_HTML."""
+        if 'services.pdf_client' in sys.modules:
+            del sys.modules['services.pdf_client']
+        from services.pdf_client import slim_html_sections
+
+        sections = {
+            "MARKET_INSIGHTS_HTML": "<div>Market data...</div>",
+            "CORE_CONTENT": "Important stuff",
+        }
+
+        result = slim_html_sections(sections.copy())
+
+        assert "MARKET_INSIGHTS_HTML" not in result
+        assert "CORE_CONTENT" in result
+
+    def test_slim_removes_kreativ_special(self):
+        """Test that slim mode removes KREATIV_SPECIAL_HTML."""
+        if 'services.pdf_client' in sys.modules:
+            del sys.modules['services.pdf_client']
+        from services.pdf_client import slim_html_sections
+
+        sections = {
+            "KREATIV_SPECIAL_HTML": "<div>Creative content...</div>",
+            "MAIN_REPORT": "Main report content",
+        }
+
+        result = slim_html_sections(sections.copy())
+
+        assert "KREATIV_SPECIAL_HTML" not in result
+        assert "MAIN_REPORT" in result
+
+    def test_slim_preserves_essential_sections(self):
+        """Test that slim mode preserves essential sections."""
+        if 'services.pdf_client' in sys.modules:
+            del sys.modules['services.pdf_client']
+        from services.pdf_client import slim_html_sections
+
+        sections = {
+            "TITLE": "Report Title",
+            "SUMMARY_HTML": "<div>Executive Summary</div>",
+            "RISK_HTML": "<div>Risk Assessment</div>",
+            "ROI_HTML": "<div>ROI Analysis</div>",
+            "NEWS_BOX_HTML": "<div>News to remove</div>",
+        }
+
+        result = slim_html_sections(sections.copy())
+
+        # Essential sections preserved
+        assert "TITLE" in result
+        assert "SUMMARY_HTML" in result
+        assert "RISK_HTML" in result
+        assert "ROI_HTML" in result
+        # Non-essential removed
+        assert "NEWS_BOX_HTML" not in result
+
+    def test_slim_handles_empty_sections(self):
+        """Test that slim mode handles empty sections dict."""
+        if 'services.pdf_client' in sys.modules:
+            del sys.modules['services.pdf_client']
+        from services.pdf_client import slim_html_sections
+
+        result = slim_html_sections({})
+        assert result == {}
+
+    def test_slim_handles_no_removable_sections(self):
+        """Test slim mode when no removable sections present."""
+        if 'services.pdf_client' in sys.modules:
+            del sys.modules['services.pdf_client']
+        from services.pdf_client import slim_html_sections
+
+        sections = {
+            "TITLE": "Test",
+            "CONTENT": "Content",
+        }
+
+        result = slim_html_sections(sections.copy())
+
+        assert result == sections
+
+    def test_slim_removes_multiple_sections(self):
+        """Test that slim removes all configured sections at once."""
+        if 'services.pdf_client' in sys.modules:
+            del sys.modules['services.pdf_client']
+        from services.pdf_client import slim_html_sections
+
+        sections = {
+            "TITLE": "Test",
+            "NEWS_BOX_HTML": "News",
+            "MARKET_INSIGHTS_HTML": "Market",
+            "KREATIV_SPECIAL_HTML": "Creative",
+            "RESEARCH_DETAILS_HTML": "Research",
+            "RAW_RESEARCH_HTML": "Raw",
+        }
+
+        result = slim_html_sections(sections.copy())
+
+        assert "TITLE" in result
+        assert "NEWS_BOX_HTML" not in result
+        assert "MARKET_INSIGHTS_HTML" not in result
+        assert "KREATIV_SPECIAL_HTML" not in result
+        assert "RESEARCH_DETAILS_HTML" not in result
+        assert "RAW_RESEARCH_HTML" not in result
+
+
+class TestPDFSizeValidation:
+    """Tests for PDF output size validation."""
+
+    def test_pdf_size_under_limit(self):
+        """Test that PDF under limit passes validation."""
+        if 'services.pdf_client' in sys.modules:
+            del sys.modules['services.pdf_client']
+        from services.pdf_client import validate_pdf_size
+
+        pdf_bytes = b"A" * (5 * 1024 * 1024)  # 5 MB
+        result = validate_pdf_size(pdf_bytes)
+        assert result is None
+
+    def test_pdf_size_over_limit(self):
+        """Test that PDF over limit fails validation."""
+        if 'services.pdf_client' in sys.modules:
+            del sys.modules['services.pdf_client']
+        from services import pdf_client
+
+        # Default limit is 20 MB, so use 25 MB to exceed it
+        pdf_bytes = b"A" * (25 * 1024 * 1024)  # 25 MB - over 20 MB default limit
+        result = pdf_client.validate_pdf_size(pdf_bytes)
+        assert result is not None
+        assert "exceeds" in result
+
+    def test_pdf_size_empty_bytes(self):
+        """Test that empty PDF bytes returns None (no error)."""
+        if 'services.pdf_client' in sys.modules:
+            del sys.modules['services.pdf_client']
+        from services.pdf_client import validate_pdf_size
+
+        result = validate_pdf_size(b"")
+        assert result is None
+
+
+class TestWarningThresholds:
+    """Tests for warning thresholds."""
+
+    def test_html_warning_threshold_exists(self):
+        """Test that HTML warning threshold is defined."""
+        if 'services.pdf_client' in sys.modules:
+            del sys.modules['services.pdf_client']
+        from services import pdf_client
+
+        assert hasattr(pdf_client, "WARN_HTML_SIZE_KB")
+        assert pdf_client.WARN_HTML_SIZE_KB == 500
+
+    def test_pdf_warning_threshold_exists(self):
+        """Test that PDF warning threshold is defined."""
+        if 'services.pdf_client' in sys.modules:
+            del sys.modules['services.pdf_client']
+        from services import pdf_client
+
+        assert hasattr(pdf_client, "WARN_PDF_SIZE_MB")
+        assert pdf_client.WARN_PDF_SIZE_MB == 10


### PR DESCRIPTION
- Change ENV variable from MAX_HTML_PAYLOAD_KB to PDF_MAX_HTML_KB
- Increase default limit from 350KB to 1024KB (1MB)
- Add WARN_HTML_SIZE_KB (500KB) for early warning logging
- Improve error messages with actionable guidance (SLIM mode hint)
- Add slim_html_sections() function prepared for G38+ (not activated)
- Add comprehensive logging before PDF render
- Add 19 tests for payload validation and slim mode