### PR TITLE
fix(ci): scope mypy explicitly to core directories

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -106,4 +106,5 @@ jobs:
           pip install -r requirements-test.txt
           pip install mypy
       - name: Run mypy
-        run: mypy --config-file mypy.ini .
+        # Explicitly scope to core directories to avoid phantom file issues
+        run: mypy --config-file mypy.ini core/ routes/ services/ main.py settings.py


### PR DESCRIPTION
The exclude pattern in mypy.ini was not reliably filtering out scripts/ directory in CI, causing phantom file errors. Changed mypy command to explicitly target core/, routes/, services/, main.py, and settings.py instead of relying on exclude patterns.