### PR TITLE
docs: add profile folder hygiene (READMEs + manifest)

### DIFF
--- a/data/golden_profiles_manifest.json
+++ b/data/golden_profiles_manifest.json
@@ -1,0 +1,16 @@
+{
+  "version": "1.0.0",
+  "profiles_dir": "data/test_profiles_gold_optimized",
+  "purpose": "Golden artifact generation (HTML, PDF, hashes)",
+  "description": "This manifest defines the authoritative list of profiles used for Golden Artifact runs. Only profiles listed here should be used by generate_golden_reports.py.",
+  "profiles": [
+    "solo_beratung_ki_assessments_optimized.json",
+    "team_finance_insurance_advisory_optimized.json",
+    "kmu_france_eu_core_en_gold_optimized.json"
+  ],
+  "rules": {
+    "changes_require_review": true,
+    "no_adhoc_profiles": true,
+    "source_of_truth": "test_profiles_gold_optimized/"
+  }
+}

--- a/data/test_profiles_en/README.md
+++ b/data/test_profiles_en/README.md
@@ -1,0 +1,19 @@
+# English Test Profiles
+
+## Purpose
+Additional English test cases for exploratory testing and legacy support.
+
+## Usage
+- Exploratory and manual testing
+- Legacy profile archive
+- Candidate pool for future gold profiles
+
+## Rules
+- **NOT for Golden Artifact runs** (use `test_profiles_gold_optimized/` instead)
+- **NOT part of CI baseline**
+- May contain experimental or incomplete profiles
+- Profiles here can be promoted to gold status after review
+
+## Related
+- `test_profiles_gold_optimized/` - Authoritative profiles for Golden Runs
+- `golden_profiles_manifest.json` - Manifest defining official Golden profiles

--- a/data/test_profiles_gold/README.md
+++ b/data/test_profiles_gold/README.md
@@ -1,0 +1,19 @@
+# Gold Baseline Profiles
+
+## Purpose
+Canonical gold baseline profiles for the KI-Briefing system.
+
+## Usage
+- Reference for regression testing
+- Baseline for comparison with optimized variants
+- Source of truth for profile structure and content
+
+## Rules
+- Changes require explicit review and approval
+- Modifications should be rare and intentional
+- All changes must be versioned and documented
+- Do NOT use directly for Golden Artifact runs (use `test_profiles_gold_optimized/` instead)
+
+## Related
+- `test_profiles_gold_optimized/` - Optimized variants used for Golden Artifact generation
+- `golden_profiles_manifest.json` - Manifest defining which profiles are used for Golden Runs

--- a/data/test_profiles_gold_optimized/README.md
+++ b/data/test_profiles_gold_optimized/README.md
@@ -1,0 +1,27 @@
+# Optimized Gold Profiles
+
+## Purpose
+Optimized and hardened variants of the gold baseline profiles.
+These are the **source of truth for Golden Artifact generation**.
+
+## Usage
+- Golden Artifact runs (HTML, PDF, SHA-256 hashes)
+- CI/CD pipeline validation
+- Reproducible report generation
+
+## Rules
+- Source profiles originate from `test_profiles_gold/`
+- No ad-hoc or experimental profiles allowed
+- All profiles must be listed in `golden_profiles_manifest.json`
+- Changes require review to ensure artifact reproducibility
+
+## Current Profiles
+| Profile | Description |
+|---------|-------------|
+| `solo_beratung_ki_assessments_optimized.json` | Solo consultant, KI assessments |
+| `team_finance_insurance_advisory_optimized.json` | Team, finance/insurance sector |
+| `kmu_france_eu_core_en_gold_optimized.json` | SME France, EU core, English |
+
+## Related
+- `golden_profiles_manifest.json` - Authoritative list of profiles for Golden Runs
+- `scripts/generate_golden_reports.py` - Script that consumes these profiles

--- a/scripts/generate_golden_reports.py
+++ b/scripts/generate_golden_reports.py
@@ -49,7 +49,16 @@ REPO_ROOT = SCRIPT_DIR.parent
 PROFILES_DIR = REPO_ROOT / "data" / "test_profiles_gold_optimized"
 ARTIFACTS_DIR = REPO_ROOT / "artifacts" / "golden_reports"
 
+# ---------------------------------------------------------------------------
+# GOLDEN PROFILES MANIFEST
+# ---------------------------------------------------------------------------
+# Golden Runs use profiles defined in: data/golden_profiles_manifest.json
+# Changes to Golden profiles are review-required to ensure reproducibility.
+# Do NOT add ad-hoc profiles here - update the manifest instead.
+# ---------------------------------------------------------------------------
+
 # Verfügbare Profile (aus test_profiles_gold_optimized)
+# Must match profiles listed in golden_profiles_manifest.json
 AVAILABLE_PROFILES = {
     "solo": "solo_beratung_ki_assessments_optimized.json",
     "team_finance": "team_finance_insurance_advisory_optimized.json",


### PR DESCRIPTION
Add documentation and structure for test profile directories:

- data/test_profiles_gold/README.md - canonical baseline profiles
- data/test_profiles_gold_optimized/README.md - Golden Artifact profiles
- data/test_profiles_en/README.md - exploratory/legacy EN profiles
- data/golden_profiles_manifest.json - authoritative profile list

The manifest defines which profiles are used for Golden Artifact runs. Changes to Golden profiles are now explicitly review-required.

No JSON profile content was modified.