### PR TITLE
fix(analysis): store sections in meta for Golden Gate summary validation

### DIFF
--- a/gpt_analyze.py
+++ b/gpt_analyze.py
@@ -6165,7 +6165,7 @@ def analyze_briefing(db: Session, briefing_id: int, run_id: str) -> tuple[int, s
     # === SPRINT FIX: Store sections in meta for Golden Gate summary ===
     # Filter sections to only include JSON-serializable string values (HTML sections)
     # This enables /api/report/summary to validate sections_present
-    serializable_sections = {}
+    serializable_sections: Dict[str, Any] = {}
     for k, v in sections.items():
         # Skip internal/debug keys and non-string values
         if k.startswith("_"):

--- a/gpt_analyze.py
+++ b/gpt_analyze.py
@@ -6162,6 +6162,22 @@ def analyze_briefing(db: Session, briefing_id: int, run_id: str) -> tuple[int, s
     # Execute hard stop validation
     hard_stop_if_invalid(sections, error_gate, persona=persona, run_id=run_id)
 
+    # === SPRINT FIX: Store sections in meta for Golden Gate summary ===
+    # Filter sections to only include JSON-serializable string values (HTML sections)
+    # This enables /api/report/summary to validate sections_present
+    serializable_sections = {}
+    for k, v in sections.items():
+        # Skip internal/debug keys and non-string values
+        if k.startswith("_"):
+            continue
+        if isinstance(v, str) and len(v) < 500000:  # Limit size per section
+            serializable_sections[k] = v
+        elif isinstance(v, (int, float, bool)):
+            serializable_sections[k] = v
+        # Skip complex objects (GuardrailHit, dicts, etc.) to keep meta clean
+
+    log.info(f"[{run_id}] 📦 Storing {len(serializable_sections)} sections in meta for Golden Gate")
+
     result = render(
         br,
         run_id=run_id,
@@ -6171,7 +6187,8 @@ def analyze_briefing(db: Session, briefing_id: int, run_id: str) -> tuple[int, s
         meta={
             "scores": scores,
             "score_details": score_wrap.get("details", {}),
-            "research_last_updated": sections["research_last_updated"]
+            "research_last_updated": sections["research_last_updated"],
+            "sections": serializable_sections,  # Store sections for summary gate
         }
     )
 

--- a/models.py
+++ b/models.py
@@ -100,7 +100,8 @@ class Analysis(Base):
         if isinstance(sections_data, str):
             import json
             try:
-                return json.loads(sections_data)
+                parsed = json.loads(sections_data)
+                return parsed if isinstance(parsed, dict) else {}
             except (json.JSONDecodeError, ValueError):
                 return {}
         return {}

--- a/models.py
+++ b/models.py
@@ -89,6 +89,22 @@ class Analysis(Base):
     user = relationship("User", lazy="joined")
     briefing = relationship("Briefing", lazy="joined")
 
+    @property
+    def sections(self) -> dict:
+        """Return sections from meta JSON. Supports dict or JSON string."""
+        sections_data = (self.meta or {}).get("sections")
+        if sections_data is None:
+            return {}
+        if isinstance(sections_data, dict):
+            return sections_data
+        if isinstance(sections_data, str):
+            import json
+            try:
+                return json.loads(sections_data)
+            except (json.JSONDecodeError, ValueError):
+                return {}
+        return {}
+
     def __repr__(self) -> str:  # pragma: no cover
         return f"<Analysis id={self.id} briefing_id={self.briefing_id}>"
 


### PR DESCRIPTION
Root Cause:
- Analysis model had NO sections column/attribute
- sections dict was never persisted to DB after rendering
- routes/report.py's getattr(analysis, "sections") always returned None
- Result: json_valid=false, sections_present=[] for all reports

Fix:
- models.py: Add @property sections to Analysis that reads from meta["sections"]
  - Supports dict or JSON string formats
  - Returns {} on parse errors (defensive)
- gpt_analyze.py: Store serializable sections in meta before Analysis creation
  - Filters out internal keys (_*) and non-serializable objects
  - Limits section size to 500KB each
  - Logs count of stored sections for debugging

No DB migration required - uses existing meta JSON column.