### PR TITLE
feat(email): add global DISABLE_EMAILS kill-switch

### DIFF
--- a/gpt_analyze.py
+++ b/gpt_analyze.py
@@ -6390,6 +6390,11 @@ def _fetch_pdf_if_needed(pdf_url: Optional[str], pdf_bytes: Optional[bytes]) -> 
 
 def _send_emails(db: Session, rep: Report, br: Briefing, pdf_url: Optional[str], pdf_bytes: Optional[bytes], run_id: str) -> None:
     """Send emails via Resend API"""
+    # Global Email Kill-Switch
+    if os.getenv("DISABLE_EMAILS", "").lower() in ("1", "true", "yes", "on"):
+        log.info("[%s] 📧 Emails disabled via DISABLE_EMAILS=1. Skipping user/admin email send.", run_id)
+        return
+
     best_pdf = _fetch_pdf_if_needed(pdf_url, pdf_bytes)
     attachments_admin: List[Dict[str, Any]] = []
     if best_pdf:

--- a/services/email_sender.py
+++ b/services/email_sender.py
@@ -160,6 +160,16 @@ def _send_via_smtp(to_email: str, subject: str, text: str) -> bool:
 
 def send_code(to_email: str, code: str) -> bool:
     """Versendet den Login‑Code gemäß EMAIL_PROVIDER (default: resend)."""
+    # Global Email Kill-Switch - blocks ALL emails including auth codes
+    if _truthy("DISABLE_EMAILS", False):
+        log.info(
+            "Emails disabled via DISABLE_EMAILS=1. Skipping auth code email. "
+            "Code for %s: %s",
+            to_email,
+            code,
+        )
+        return True  # Return True to not break auth flow (code is logged for staging)
+
     subject = _build_subject()
     text = _build_text(code)
     provider = (_env("EMAIL_PROVIDER", "resend") or "resend").strip().lower()

--- a/services/mailer.py
+++ b/services/mailer.py
@@ -1,4 +1,3 @@
-
 """
 services/mailer.py — E-Mail Versand via Resend oder SMTP
 """
@@ -6,6 +5,8 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
+import os
 import smtplib
 from email.mime.text import MIMEText
 from typing import Optional
@@ -15,6 +16,14 @@ import httpx
 from pydantic import EmailStr
 
 from settings import AppSettings, get_settings
+
+logger = logging.getLogger(__name__)
+
+
+def _is_emails_disabled() -> bool:
+    """Check if global email kill-switch is enabled."""
+    val = os.getenv("DISABLE_EMAILS", "").strip().lower()
+    return val in ("1", "true", "yes", "on")
 
 
 class Mailer:
@@ -26,6 +35,11 @@ class Mailer:
         return cls(s or get_settings())
 
     async def send(self, to: str | EmailStr, subject: str, text: str, html: Optional[str] = None) -> None:
+        # Global Email Kill-Switch
+        if _is_emails_disabled():
+            logger.info("📧 Emails disabled via DISABLE_EMAILS=1. Skipping email to %s", to)
+            return
+
         provider = (self.s.mail.provider or "resend").lower()
         if provider == "resend":
             await self._send_resend(to=str(to), subject=subject, text=text, html=html)

--- a/settings.py
+++ b/settings.py
@@ -34,6 +34,9 @@ class MailConfig(BaseModel):
     from_email: Optional[EmailStr] = None
     from_name: str | None = None
 
+    # Global Email Kill-Switch
+    disable_emails: bool = False  # DISABLE_EMAILS=1 blocks ALL email sending
+
     # SMTP
     host: Optional[str] = None
     port: int = 587
@@ -245,6 +248,7 @@ class AppSettings(BaseSettings):
                 provider=os.getenv("EMAIL_PROVIDER", "resend"),
                 from_email=os.getenv("RESEND_FROM") or os.getenv("SMTP_FROM"),
                 from_name=os.getenv("SMTP_FROM_NAME") or "KI‑Sicherheit.jetzt",
+                disable_emails=get_bool("DISABLE_EMAILS", False),
                 host=os.getenv("SMTP_HOST"),
                 port=int(os.getenv("SMTP_PORT", "587")),
                 user=os.getenv("SMTP_USER"),


### PR DESCRIPTION
Implements DISABLE_EMAILS=1 environment variable that blocks all email sending without affecting other functionality:

- settings.py: Added mail.disable_emails config option
- gpt_analyze.py: Kill-switch in _send_emails() (user + admin emails)
- services/email_sender.py: Kill-switch in send_code() (auth emails)
- services/mailer.py: Kill-switch in Mailer.send() (async emails)

Behavior when DISABLE_EMAILS=1:
- All email sends are skipped with info logging
- Auth codes are logged (for staging testing)
- Pipeline continues without errors (status: done)
- No impact on Worker, Gates, PDF, or Report generation

Values recognized: "1", "true", "yes", "on" (case-insensitive)
Default: disabled (emails sent normally)