### PR TITLE
fix(teil3): three blockers for golden run re-validation

### DIFF
--- a/scripts/generate_golden_reports.py
+++ b/scripts/generate_golden_reports.py
@@ -771,9 +771,14 @@ def process_profile(
     profile_data = load_profile(profile_name)
     answers = profile_data.get("answers", profile_data)
 
+    # PLATIN+++ v5.4: Use lang from profile if available (overrides CLI default)
+    profile_lang = profile_data.get("lang", lang)
+    if profile_lang != lang:
+        print(f"[profile] Using profile lang '{profile_lang}' (override CLI default '{lang}')")
+
     # 2. Submit briefing (with retry)
     briefing_id = submit_briefing(
-        base_url, service_token, answers, lang,
+        base_url, service_token, answers, profile_lang,
         submit_timeout=submit_timeout,
         max_retries=max_retries,
     )

--- a/services/extra_sections.py
+++ b/services/extra_sections.py
@@ -362,7 +362,7 @@ def calc_business_case(answers: Dict[str, Any], env: Dict[str, Any]) -> Dict[str
     <thead><tr><th>Parameter</th><th>Wert</th><th>Erläuterung</th></tr></thead>
     <tbody>
       <tr><td>Gesamteinsparung</td><td>{_fmt_eur(total_hours)} h/Monat</td><td>Summe Quick‑Wins</td></tr>
-      <tr><td>Stundensatz</td><td>{_fmt_eur(stundensatz)} €</td><td>DEFAULT_STUNDENSATZ_EUR (size-aware)</td></tr>
+      <tr><td>Stundensatz</td><td>{_fmt_eur(stundensatz)} €</td><td>Standardsatz (größenabhängig)</td></tr>
       <tr><td>Monetärer Nutzen</td><td>{_fmt_eur(einsparung_monat_eur)} €/Monat</td><td>Einsparung × Stundensatz (gedeckelt)</td></tr>
       <tr><td>Einführungskosten (CAPEX)</td><td>{_fmt_eur(capex)} €</td><td>Mittel des Budgetbandes, größenbereinigt</td></tr>
       <tr><td>Laufende Kosten (OPEX)</td><td>{_fmt_eur(opex)} €/Monat</td><td>Lizenzen &amp; Betrieb (größenbereinigt)</td></tr>

--- a/services/report_renderer.py
+++ b/services/report_renderer.py
@@ -185,6 +185,65 @@ def final_leak_cleanup(html: str, run_id: str | None = None) -> str:
         # Return original HTML - better to have leaks than no PDF
         return html
 
+
+# =============================================================================
+# PLATIN+++ v5.4: Final Development Placeholder Scrub
+# =============================================================================
+# Root Cause Fix: Development placeholders like DEFAULT_STUNDENSATZ_EUR
+# can leak into final HTML if not caught by source fixes.
+
+# Patterns to scrub from final HTML (development/debug tokens)
+_DEV_PLACEHOLDER_PATTERNS = [
+    r"DEFAULT_STUNDENSATZ_EUR",
+    r"DEFAULT_[A-Z_]+_EUR",  # Any DEFAULT_*_EUR pattern
+    r"\{\{[A-Z_]+\}\}",  # Unreplaced {{PLACEHOLDER}} patterns
+]
+
+
+def scrub_development_placeholders(html: str, run_id: str | None = None) -> str:
+    """
+    PLATIN+++ v5.4: Final scrub for development placeholders before PDF rendering.
+
+    This is a last-line-of-defense that removes any development tokens
+    that leaked into the final HTML.
+
+    Args:
+        html: HTML content to scrub
+        run_id: Optional run ID for logging
+
+    Returns:
+        Scrubbed HTML string
+    """
+    if not html or not isinstance(html, str):
+        return html or ""
+
+    result = html
+    scrubbed_count = 0
+
+    try:
+        for pattern in _DEV_PLACEHOLDER_PATTERNS:
+            matches = re.findall(pattern, result)
+            if matches:
+                scrubbed_count += len(matches)
+                result = re.sub(pattern, "", result)
+
+        # Normalize whitespace (double spaces -> single)
+        result = re.sub(r"  +", " ", result)
+
+        if scrubbed_count > 0:
+            log.warning(
+                "[PLATIN-SCRUB] Removed %d development placeholders from final HTML (run=%s)",
+                scrubbed_count, run_id
+            )
+
+    except Exception as e:
+        log.error(f"[PLATIN-SCRUB] Scrub failed for run={run_id}: {e}")
+        # Return original on error - don't block PDF
+        return html
+
+    return result
+
+
 def _env() -> Environment:
     tpl_dir = Path(os.getenv("REPORT_TEMPLATE_DIR", "templates"))
     env = Environment(
@@ -395,5 +454,10 @@ def render(briefing_obj: Any,
     log.info(f"[RENDER] Before final leak cleanup: len(html)={len(html)} for run={run_id}")
     html = final_leak_cleanup(html, run_id=run_id)
     log.info(f"[RENDER] After final leak cleanup: len(html)={len(html)} for run={run_id}")
+
+    # =========================================================================
+    # PLATIN+++ v5.4: Final development placeholder scrub
+    # =========================================================================
+    html = scrub_development_placeholders(html, run_id=run_id)
 
     return {"html": html, "meta": meta or {}}

--- a/workers/briefings_worker.py
+++ b/workers/briefings_worker.py
@@ -71,6 +71,8 @@ def claim_next_briefing(db: Session) -> Optional[Briefing]:
     This ensures that multiple workers can safely compete for jobs without
     double-processing. PostgreSQL's SKIP LOCKED allows non-blocking claims.
 
+    PLATIN+++ v5.4: Now accepts both 'accepted' AND 'queued' status for robustness.
+
     Args:
         db: SQLAlchemy session
 
@@ -79,10 +81,11 @@ def claim_next_briefing(db: Session) -> Optional[Briefing]:
     """
     if is_sqlite:
         # SQLite fallback: simple SELECT (not race-safe, but works for dev/test)
+        # PLATIN+++ v5.4: Accept both 'accepted' and 'queued'
         briefing = db.query(Briefing).filter(
-            Briefing.status == "accepted"
+            Briefing.status.in_(["accepted", "queued"])
         ).order_by(
-            Briefing.accepted_at.asc()
+            Briefing.created_at.asc()  # FIFO by creation time
         ).first()
 
         if briefing:
@@ -96,11 +99,12 @@ def claim_next_briefing(db: Session) -> Optional[Briefing]:
     # PostgreSQL: Use FOR UPDATE SKIP LOCKED for race-safe claiming
     try:
         # Raw SQL for FOR UPDATE SKIP LOCKED (SQLAlchemy 2.x compatible)
+        # PLATIN+++ v5.4: Accept both 'accepted' and 'queued'
         result = db.execute(
             text("""
                 SELECT id FROM briefings
-                WHERE status = 'accepted'
-                ORDER BY accepted_at ASC
+                WHERE status IN ('accepted', 'queued')
+                ORDER BY created_at ASC
                 LIMIT 1
                 FOR UPDATE SKIP LOCKED
             """)


### PR DESCRIPTION
FIX A: Worker claims both 'accepted' AND 'queued' status
- workers/briefings_worker.py: Modified claim_next_briefing() to use status IN ('accepted', 'queued') instead of status = 'accepted'
- Ensures worker picks up jobs regardless of which status was set
- Changed ORDER BY from accepted_at to created_at for FIFO

rg Treffer:
  routes/briefings.py:152: status="accepted" if payload.queue_analysis workers/briefings_worker.py:102: WHERE status = 'accepted'

FIX B: Final placeholder scrub for DEFAULT_STUNDENSATZ_EUR
- services/extra_sections.py:365: Fixed source - replaced debug text "DEFAULT_STUNDENSATZ_EUR (size-aware)" with "Standardsatz (größenabhängig)"
- services/report_renderer.py: Added scrub_development_placeholders() function as last-line-of-defense before PDF rendering
- Scrubs: DEFAULT_STUNDENSATZ_EUR, DEFAULT_*_EUR, {{PLACEHOLDER}} patterns

rg Treffer:
  services/extra_sections.py:365: DEFAULT_STUNDENSATZ_EUR (size-aware) gpt_analyze.py:816,1177,2255,4682: DEFAULT_STUNDENSATZ_EUR usage

FIX C: kmu_france uses profile lang instead of CLI default
- scripts/generate_golden_reports.py: process_profile() now reads profile_data.get("lang") and uses it instead of args.lang
- kmu_france profile has lang="en", script was using default "de"

rg Treffer:
  data/test_profiles_gold_optimized/kmu_france_*.json:4: "lang": "en" scripts/generate_golden_reports.py:932: args.lang (was CLI default)