### PR TITLE
feat(quality): PLATIN+++ v5.4 - Post-Golden-Run quality hardening

### DIFF
--- a/gpt_analyze.py
+++ b/gpt_analyze.py
@@ -2507,8 +2507,10 @@ def _get_fallback_content(section_key: str, briefing: Dict[str, Any], scores: Di
     hauptleistung = briefing.get("hauptleistung", briefing.get("HAUPTLEISTUNG", ""))
 
     # SPRINT G2.4: Generate short labels for redundancy reduction
+    # PLATIN+++ v5.4: Use briefing's actual lang, not hardcoded "de"
     from services.prompt_enhancer import generate_short_labels
-    short_labels = generate_short_labels(briefing, lang="de")
+    briefing_lang = briefing.get("lang", "de") if isinstance(briefing, dict) else "de"
+    short_labels = generate_short_labels(briefing, lang=briefing_lang)
     branch_core_label = short_labels.get("BRANCH_CORE_LABEL", branche)
     offering_label = short_labels.get("OFFERING_LABEL", "")
 
@@ -4183,19 +4185,26 @@ def _generate_content_section(section_name: str, briefing: Dict[str, Any], score
                     log.info("[N4.6] ✅ Regeneration successful – no leaks in %s", section_name)
                     result = regenerated
                 else:
-                    # If still leaky, strip the leak phrases as last resort
+                    # PLATIN+++ v5.4: If still leaky, use PLATIN fallback instead of stripping
+                    # Rationale: Stripped content is often broken/incoherent - full fallback is better
                     log.warning(
-                        "[N4.6] ⚠️ Regeneration still has leaks in %s – stripping phrases",
+                        "[N4.6] ⚠️ Regeneration still has leaks in %s – using PLATIN fallback (not stripping)",
                         section_name
                     )
-                    for leak in detected_leaks:
-                        # Remove sentences containing leak phrases
-                        import re as _re_leak
-                        pattern = _re_leak.compile(
-                            r'[^.!?]*' + _re_leak.escape(leak) + r'[^.!?]*[.!?]',
-                            _re_leak.IGNORECASE
-                        )
-                        result = pattern.sub('', result)
+                    fallback_content = _get_fallback_content(section_name, briefing, scores)
+                    if fallback_content:
+                        log.info("[N4.6] ✅ PLATIN fallback used for %s", section_name)
+                        result = fallback_content
+                    else:
+                        # Last resort: strip only if no fallback available
+                        log.warning("[N4.6] No fallback for %s, stripping leaks as last resort", section_name)
+                        for leak in detected_leaks:
+                            import re as _re_leak
+                            pattern = _re_leak.compile(
+                                r'[^.!?]*' + _re_leak.escape(leak) + r'[^.!?]*[.!?]',
+                                _re_leak.IGNORECASE
+                            )
+                            result = pattern.sub('', result)
 
             # PLATIN+ Minimalumfang prüfen (dynamisch nach Section-Typ)
             # WICHTIG: Werte sind jetzt in WÖRTERN, nicht Zeichen!
@@ -4706,15 +4715,19 @@ def _generate_content_sections(briefing: Dict[str, Any], scores: Dict[str, Any])
     )
 
     # NEXT ACTIONS – Prompt-System oder Legacy
+    # PLATIN+++ v5.4: Use briefing's actual lang
+    briefing_lang_for_actions = briefing.get("lang", "de") if isinstance(briefing, dict) else "de"
     if USE_PROMPT_SYSTEM:
         try:
             vars_dict = _build_prompt_vars(briefing, scores)
-            prompt_text = load_prompt("next_actions", lang="de", vars_dict=vars_dict)
+            prompt_text = load_prompt("next_actions", lang=briefing_lang_for_actions, vars_dict=vars_dict)
             params = _llm_params_for("next_actions")
+            # PLATIN+++ v5.4: Language-aware system prompt
+            sys_prompt = "Du bist PMO-Lead. Antworte nur mit HTML." if briefing_lang_for_actions == "de" else "You are a PMO lead. Reply only with HTML."
             nxt = _call_llm_for_section(
                 section_key="next_actions",
                 prompt=prompt_text,
-                system_prompt="Du bist PMO-Lead. Antworte nur mit HTML.",
+                system_prompt=sys_prompt,
                 temperature=params["temperature"],
                 max_tokens=min(params["max_tokens"], 600),
                 model=params["model"],

--- a/scripts/generate_golden_reports.py
+++ b/scripts/generate_golden_reports.py
@@ -48,6 +48,20 @@ except ImportError:
 # Repo-Root
 SCRIPT_DIR = Path(__file__).resolve().parent
 REPO_ROOT = SCRIPT_DIR.parent
+
+# =============================================================================
+# FIX 1: PLATIN+++ v5.4 - Forbidden tokens that must not appear in final HTML/PDF
+# =============================================================================
+FORBIDDEN_TOKENS: List[str] = [
+    "DEFAULT_STUNDENSATZ_EUR",
+    "DEFAULT_",  # Any DEFAULT_ pattern
+    "{{",        # Unresolved template placeholders
+    "}}",
+    "PLACEHOLDER_",
+    "TODO:",
+    "FIXME:",
+    "__DEBUG__",
+]
 PROFILES_DIR = REPO_ROOT / "data" / "test_profiles_gold_optimized"
 ARTIFACTS_DIR = REPO_ROOT / "artifacts" / "golden_reports"
 MANIFEST_PATH = REPO_ROOT / "data" / "golden_profiles_manifest.json"
@@ -422,6 +436,52 @@ def validate_summary_gate(parsed_summary: Dict[str, Any]) -> Tuple[bool, List[st
 
     passed = len(failures) == 0
     return passed, failures
+
+
+# =============================================================================
+# FIX 1: PLATIN+++ v5.4 - Final HTML Token Scan (Hard-Fail Gate)
+# =============================================================================
+def scan_html_for_forbidden_tokens(html_bytes: bytes, profile_id: str) -> Tuple[bool, List[str]]:
+    """
+    Scan final HTML for forbidden development tokens.
+
+    This is the LAST line of defense - if tokens appear here, Gate MUST fail.
+    No report with visible tokens should reach test users.
+
+    Args:
+        html_bytes: Raw HTML content as bytes
+        profile_id: For logging
+
+    Returns:
+        (passed: bool, found_tokens: list of found token strings)
+    """
+    if not html_bytes:
+        return True, []  # No HTML = nothing to scan
+
+    try:
+        html_text = html_bytes.decode("utf-8", errors="replace")
+    except Exception as e:
+        print(f"[token-scan] ⚠️ Failed to decode HTML for {profile_id}: {e}")
+        return True, []  # Decode error = can't scan, let it pass
+
+    found_tokens = []
+    for token in FORBIDDEN_TOKENS:
+        if token in html_text:
+            # Find context (first occurrence, up to 100 chars around it)
+            idx = html_text.find(token)
+            start = max(0, idx - 30)
+            end = min(len(html_text), idx + len(token) + 30)
+            context = html_text[start:end].replace("\n", " ").strip()
+            found_tokens.append(f"{token} (context: ...{context}...)")
+
+    if found_tokens:
+        print(f"[token-scan] ❌ FAILED for {profile_id} - {len(found_tokens)} forbidden token(s) found:")
+        for t in found_tokens:
+            print(f"[token-scan]   - {t}")
+        return False, found_tokens
+    else:
+        print(f"[token-scan] ✅ PASSED for {profile_id} - no forbidden tokens")
+        return True, []
 
 
 def save_summary_artifact(profile_id: str, summary_data: Union[str, Dict[str, Any]]) -> Path:
@@ -814,6 +874,18 @@ def process_profile(
         download_timeout=download_timeout,
         max_retries=max_retries,
     )
+
+    # 5.5 PLATIN+++ v5.4: Token scan on final HTML (Hard-Fail Gate)
+    # This catches ANY forbidden tokens that escaped earlier scrubbing
+    if run_gate and html_bytes:
+        token_scan_passed, found_tokens = scan_html_for_forbidden_tokens(html_bytes, profile_name)
+        if not token_scan_passed:
+            return {
+                "profile": profile_name,
+                "briefing_id": briefing_id,
+                "status": "gate_failed",
+                "error": f"Forbidden tokens in final HTML: {found_tokens}",
+            }
 
     # 6. Download PDF (with retry)
     pdf_bytes = download_pdf(

--- a/services/business_case_engine_v2.py
+++ b/services/business_case_engine_v2.py
@@ -366,6 +366,13 @@ def validate_scenario_consistency(scenarios: List[ScenarioKPIs]) -> Tuple[bool, 
     if not all([opt, real, cons]):
         return False, ["Missing one or more scenario types"]
 
+    # PLATIN+++ v5.4: Block 0.0% scenarios - these are NOT healable
+    # 0.0% ROI in realistic/optimistic indicates fundamentally broken data
+    if real and real.roi_12m <= 0.0:
+        errors.append(f"CRITICAL: Realistic ROI is {real.roi_12m:.1f}% (must be > 0%)")
+    if opt and opt.roi_12m <= 0.0:
+        errors.append(f"CRITICAL: Optimistic ROI is {opt.roi_12m:.1f}% (must be > 0%)")
+
     # Validate ordering
     if opt and real and opt.roi_12m < real.roi_12m:
         errors.append(f"Optimistic ROI ({opt.roi_12m:.1f}%) < Realistic ROI ({real.roi_12m:.1f}%)")
@@ -414,6 +421,12 @@ def heal_scenario_consistency(scenarios: List[ScenarioKPIs]) -> List[ScenarioKPI
     is_valid, errors = validate_scenario_consistency(scenarios)
     if is_valid:
         return scenarios
+
+    # PLATIN+++ v5.4: CRITICAL errors cannot be healed - need full fallback
+    critical_errors = [e for e in errors if "CRITICAL" in e]
+    if critical_errors:
+        log.error("[BC_001] CRITICAL errors detected - cannot heal: %s", critical_errors)
+        raise ValueError(f"Business case has unhealable CRITICAL errors: {critical_errors}")
 
     log.info("[BC_001] Healing scenario consistency issues: %s", errors)
 


### PR DESCRIPTION
Fix-Pack TEIL 3.1 - Five targeted fixes for testuser-ready reports:

FIX 1: Gate um Final-HTML Token-Scan erweitern
- Added FORBIDDEN_TOKENS list for dev placeholders
- New scan_html_for_forbidden_tokens() function
- Gate hard-fails if DEFAULT_STUNDENSATZ_EUR or similar tokens found

FIX 2: Final-Scrub already covered (verified in pre-flight)
- Single return path through scrub_development_placeholders()

FIX 3: Locale Single-Source-of-Truth
- Fixed hardcoded lang="de" in short_labels generation
- Fixed hardcoded lang="de" in next_actions prompt loading
- Language-aware system prompts for LLM calls

FIX 4: Business-Case 0.0% blockieren
- CRITICAL errors (ROI <= 0%) now block healing
- ValueError raised to trigger PLATIN fallback
- No testuser sees 0.0% ROI/Savings

FIX 5: Leak-Phrases früher blockieren
- PLATIN fallback used instead of stripping leaks
- Stripped content often broken - full fallback is better
- Last resort stripping only if no fallback available