### PR TITLE
feat(locale): TEIL 3.1.1 - Strict EN for kmu_france profile

### DIFF
--- a/gpt_analyze.py
+++ b/gpt_analyze.py
@@ -2502,14 +2502,18 @@ def _get_fallback_content(section_key: str, briefing: Dict[str, Any], scores: Di
     - NEU: recommendations Fallback mit 800+ Wörtern
     - roadmap_12m: Erweitert auf 900+ Wörter
     """
-    branche = briefing.get("BRANCHE_LABEL") or briefing.get("branche", "Ihr Unternehmen")
+    # TEIL 3.1.1: Get lang first for language-aware fallbacks
+    briefing_lang = briefing.get("lang", "de") if isinstance(briefing, dict) else "de"
+
+    # Language-aware fallbacks
+    default_company = "Your Company" if briefing_lang == "en" else "Ihr Unternehmen"
+    branche = briefing.get("BRANCHE_LABEL") or briefing.get("branche", default_company)
     size_label = briefing.get("UNTERNEHMENSGROESSE_LABEL") or briefing.get("unternehmensgroesse", "")
     hauptleistung = briefing.get("hauptleistung", briefing.get("HAUPTLEISTUNG", ""))
 
     # SPRINT G2.4: Generate short labels for redundancy reduction
     # PLATIN+++ v5.4: Use briefing's actual lang, not hardcoded "de"
     from services.prompt_enhancer import generate_short_labels
-    briefing_lang = briefing.get("lang", "de") if isinstance(briefing, dict) else "de"
     short_labels = generate_short_labels(briefing, lang=briefing_lang)
     branch_core_label = short_labels.get("BRANCH_CORE_LABEL", branche)
     offering_label = short_labels.get("OFFERING_LABEL", "")
@@ -2524,8 +2528,9 @@ def _get_fallback_content(section_key: str, briefing: Dict[str, Any], scores: Di
     else:
         size_group = "kmu"
 
-    # Business Case Variablen
-    bundesland = briefing.get("BUNDESLAND_LABEL") or briefing.get("bundesland", "Ihrem Bundesland")
+    # Business Case Variablen - TEIL 3.1.1: Language-aware
+    default_bundesland = "your region" if briefing_lang == "en" else "Ihrem Bundesland"
+    bundesland = briefing.get("BUNDESLAND_LABEL") or briefing.get("bundesland", default_bundesland)
     # BC-Werte mit sinnvollen Defaults (werden von calc_business_case vorher gesetzt)
     capex = briefing.get("CAPEX_REALISTISCH_EUR") or 5000
     opex = briefing.get("OPEX_REALISTISCH_EUR") or 150

--- a/scripts/generate_golden_reports.py
+++ b/scripts/generate_golden_reports.py
@@ -62,6 +62,41 @@ FORBIDDEN_TOKENS: List[str] = [
     "FIXME:",
     "__DEBUG__",
 ]
+
+# =============================================================================
+# TEIL 3.1.1: German UI strings that must NOT appear in EN reports
+# =============================================================================
+DE_UI_STRINGS_EN_HARDFAIL: List[str] = [
+    # Report Header / Meta
+    "KI-Status-Report",
+    "Überblick",
+    "Unternehmensgröße",
+    "Reportdatum",
+    # Core Sections
+    "Handlungsempfehlungen",
+    "Nächste Schritte",
+    "Bewertung",
+    "Reifegrad",
+    "Kennzahlen",
+    "Risiken",
+    "Maßnahmen",
+    "Hauptziel",
+    "Zusammenfassung",
+    # Compliance/Notes
+    "DSGVO-konforme",
+    "DSGVO",
+    "Hinweis",
+    "Näherungen",
+    # Business Case
+    "Einsparungen",
+    "Konservativ",
+    "Realistisch",
+    "Optimistisch",
+    "Zeithorizont",
+    "Priorität",
+    "Verantwortung",
+]
+
 PROFILES_DIR = REPO_ROOT / "data" / "test_profiles_gold_optimized"
 ARTIFACTS_DIR = REPO_ROOT / "artifacts" / "golden_reports"
 MANIFEST_PATH = REPO_ROOT / "data" / "golden_profiles_manifest.json"
@@ -484,6 +519,85 @@ def scan_html_for_forbidden_tokens(html_bytes: bytes, profile_id: str) -> Tuple[
         return True, []
 
 
+# =============================================================================
+# TEIL 3.1.1: Locale scan for EN profiles (German UI = Hard-Fail)
+# =============================================================================
+def scan_html_for_locale_leaks(html_text: str, expected_lang: str, profile_id: str) -> Tuple[bool, List[str]]:
+    """
+    Scan HTML for German UI strings when expected_lang is 'en'.
+
+    This ensures EN profiles don't have mixed-locale content.
+    Only scans when expected_lang == "en".
+
+    Args:
+        html_text: Decoded HTML content
+        expected_lang: Expected language from profile ("en" or "de")
+        profile_id: For logging
+
+    Returns:
+        (passed: bool, found_leaks: list of found German strings)
+    """
+    if expected_lang != "en":
+        return True, []  # Only check EN profiles
+
+    found_leaks = []
+    for de_string in DE_UI_STRINGS_EN_HARDFAIL:
+        if de_string in html_text:
+            # Find context
+            idx = html_text.find(de_string)
+            start = max(0, idx - 20)
+            end = min(len(html_text), idx + len(de_string) + 20)
+            context = html_text[start:end].replace("\n", " ").strip()
+            found_leaks.append(f"{de_string} (context: ...{context}...)")
+
+    if found_leaks:
+        print(f"[locale-scan] ❌ FAILED for {profile_id} - {len(found_leaks)} German UI string(s) in EN report:")
+        for leak in found_leaks[:5]:  # Show first 5
+            print(f"[locale-scan]   - {leak}")
+        if len(found_leaks) > 5:
+            print(f"[locale-scan]   ... and {len(found_leaks) - 5} more")
+        return False, found_leaks
+    else:
+        print(f"[locale-scan] ✅ PASSED for {profile_id} - no German UI leaks in EN report")
+        return True, []
+
+
+def scan_html_lang_attribute(html_text: str, expected_lang: str, profile_id: str) -> Tuple[bool, str]:
+    """
+    Verify <html lang="..."> attribute matches expected language.
+
+    For EN profiles: <html lang="en"> must exist.
+    <html lang="de"> or missing lang = FAIL.
+
+    Args:
+        html_text: Decoded HTML content
+        expected_lang: Expected language ("en" or "de")
+        profile_id: For logging
+
+    Returns:
+        (passed: bool, error_message: str if failed)
+    """
+    if expected_lang != "en":
+        return True, ""  # Only strict check for EN profiles
+
+    import re
+    # Look for <html ... lang="..." ...> in first 500 chars
+    html_head = html_text[:500]
+    match = re.search(r'<html[^>]*\slang=["\']([^"\']+)["\']', html_head, re.IGNORECASE)
+
+    if not match:
+        print(f"[lang-attr] ❌ FAILED for {profile_id} - no lang attribute in <html> tag")
+        return False, "Missing lang attribute in <html> tag"
+
+    found_lang = match.group(1).lower()
+    if found_lang != "en":
+        print(f"[lang-attr] ❌ FAILED for {profile_id} - <html lang=\"{found_lang}\"> (expected: en)")
+        return False, f"Wrong lang attribute: found '{found_lang}', expected 'en'"
+
+    print(f"[lang-attr] ✅ PASSED for {profile_id} - <html lang=\"en\">")
+    return True, ""
+
+
 def save_summary_artifact(profile_id: str, summary_data: Union[str, Dict[str, Any]]) -> Path:
     """Save summary as artifact for debugging/CI."""
     output_dir = ARTIFACTS_DIR / profile_id
@@ -885,6 +999,30 @@ def process_profile(
                 "briefing_id": briefing_id,
                 "status": "gate_failed",
                 "error": f"Forbidden tokens in final HTML: {found_tokens}",
+            }
+
+    # 5.6 TEIL 3.1.1: Locale scan for EN profiles (German UI = Hard-Fail)
+    if run_gate and html_bytes and profile_lang == "en":
+        html_text = html_bytes.decode("utf-8", errors="replace")
+
+        # A1: Check for German UI strings in EN report
+        locale_passed, found_de_strings = scan_html_for_locale_leaks(html_text, profile_lang, profile_name)
+        if not locale_passed:
+            return {
+                "profile": profile_name,
+                "briefing_id": briefing_id,
+                "status": "gate_failed",
+                "error": f"German UI strings in EN report: {found_de_strings[:3]}",
+            }
+
+        # A2: Check <html lang="en"> attribute
+        lang_attr_passed, lang_attr_error = scan_html_lang_attribute(html_text, profile_lang, profile_name)
+        if not lang_attr_passed:
+            return {
+                "profile": profile_name,
+                "briefing_id": briefing_id,
+                "status": "gate_failed",
+                "error": f"HTML lang attribute error: {lang_attr_error}",
             }
 
     # 6. Download PDF (with retry)

--- a/services/prompt_enhancer.py
+++ b/services/prompt_enhancer.py
@@ -373,15 +373,24 @@ def generate_short_labels(briefing_data: Dict[str, Any], lang: str = "de") -> Di
         context_labels = BRANCH_CONTEXT_LABELS_DE
         short_labels = BRANCH_SHORT_LABELS_DE
 
-    # Get labels with fallbacks
-    branch_core = branch_labels.get(branche, branch_labels.get("beratung", "KI-Beratung"))
-    offering = offering_labels.get(branche, offering_labels.get("beratung", "KI-Lösungen"))
+    # Get labels with fallbacks - TEIL 3.1.1: Language-aware fallbacks
+    if lang == "en":
+        default_branch = "AI Consulting"
+        default_offering = "AI Solutions"
+        default_short = "Your Company"
+    else:
+        default_branch = "KI-Beratung"
+        default_offering = "KI-Lösungen"
+        default_short = "Ihr Unternehmen"
+
+    branch_core = branch_labels.get(branche, branch_labels.get("beratung", default_branch))
+    offering = offering_labels.get(branche, offering_labels.get("beratung", default_offering))
     # SPRINT G4.2: Short context label (4-6 words)
     branch_context = context_labels.get(branche, context_labels.get("beratung", "Consulting"))
 
     # SPRINT G17.S: Size-aware short label (3-5 words)
     short_key = f"{company_size}_{branche}"
-    branch_short = short_labels.get(short_key, short_labels.get(f"{company_size}_beratung", "Ihr Unternehmen"))
+    branch_short = short_labels.get(short_key, short_labels.get(f"{company_size}_beratung", default_short))
 
     # Regulatory label only for regulated industries
     regulatory = ""


### PR DESCRIPTION
Implements locale hardening for EN profiles:

A) Gate Hard-Fails for EN profiles:
- Added DE_UI_STRINGS_EN_HARDFAIL list (24 German UI strings)
- scan_html_for_locale_leaks() detects German UI in EN reports
- scan_html_lang_attribute() verifies <html lang="en">
- Gate fails if German UI strings found in EN report

B) Locale as Single Source of Truth:
- Language-aware fallbacks in prompt_enhancer.py (AI Consulting vs KI-Beratung, Your Company vs Ihr Unternehmen)
- Language-aware fallbacks in gpt_analyze.py (_get_fallback_content with EN/DE defaults)

Files changed:
- scripts/generate_golden_reports.py: Gate scans for EN profiles
- services/prompt_enhancer.py: EN fallback labels
- gpt_analyze.py: EN fallback content defaults