### PR TITLE
fix(locale): 3.1.4.x - Dynamic prompt language in prompt_enhancer

### DIFF
--- a/services/prompt_enhancer.py
+++ b/services/prompt_enhancer.py
@@ -1871,7 +1871,12 @@ Nutze den Strategischen Kontext wie folgt:
         try:
             from services.prompt_loader import load_prompt
 
-            base_prompt = load_prompt(prompt_name, lang="de", vars_dict=None)
+            # TEIL 3.1.4.x: Dynamic language from briefing_data
+            lang_raw = briefing_data.get("lang") or briefing_data.get("LANG") or "de"
+            lang = str(lang_raw).lower().strip()
+            prompt_lang = "en" if lang.startswith("en") else "de"
+
+            base_prompt = load_prompt(prompt_name, lang=prompt_lang, vars_dict=None)
 
             if not isinstance(base_prompt, str):
                 log.warning(


### PR DESCRIPTION
services/prompt_enhancer.py:
- Line 1874: load_prompt() now uses dynamic lang from briefing_data
- Gets lang from briefing_data["lang"] or briefing_data["LANG"]
- Normalizes to "en" or "de" based on prefix
- EN reports now load prompts from prompts/en/ instead of prompts/de/

This fixes the root cause where EN profiles were loading German prompts regardless of the report language setting.