### PR TITLE
fix(locale): normalize briefing lang/LANG/sprache before prompt enhan…

### DIFF
--- a/gpt_analyze.py
+++ b/gpt_analyze.py
@@ -4382,6 +4382,22 @@ def _generate_content_section(section_name: str, briefing: Dict[str, Any], score
     # Prompt-System verwenden, wenn aktiv und Prompt vorhanden
     if USE_PROMPT_SYSTEM and prompt_key and _prompt_enhancer:
         try:
+            # TEIL 3.1.4.8: Hard locale normalization for prompt routing
+            # Ensure prompt_enhancer sees correct language for EN profiles
+            if isinstance(briefing, dict):
+                lang_raw = (
+                    briefing.get("lang")
+                    or briefing.get("LANG")
+                    or briefing.get("sprache")
+                    or "de"
+                )
+                lang_norm = str(lang_raw).lower().strip()
+                prompt_lang = "en" if lang_norm.startswith("en") else "de"
+
+                briefing["lang"] = prompt_lang
+                briefing["LANG"] = prompt_lang
+                briefing["sprache"] = prompt_lang
+
             # 1. Prompt mit Kontext (Branche/Größe) anreichern
             enhanced_prompt = _prompt_enhancer.enhance_prompt(prompt_key, briefing)
             
@@ -4397,7 +4413,7 @@ def _generate_content_section(section_name: str, briefing: Dict[str, Any], score
             briefing_lang = briefing.get("lang", "de") if isinstance(briefing, dict) else "de"
             if section_name == "foerderpotenzial" and briefing_lang != "en":
                 try:
-                    foerder_prog_text = load_prompt("foerderprogramme", lang="de", vars_dict=vars_dict)
+                    foerder_prog_text = load_prompt("foerderprogramme", lang=briefing_lang, vars_dict=vars_dict)
                 except Exception:
                     foerder_prog_text = None
                 if foerder_prog_text:

--- a/services/prompt_enhancer.py
+++ b/services/prompt_enhancer.py
@@ -1712,8 +1712,9 @@ Nutze den Strategischen Kontext wie folgt:
 
         Sprint G4.1: Now size-aware - uses Team/KMU perspective for non-Solo profiles.
         """
-        # Determine language from briefing
-        lang = "en" if briefing_data.get("sprache", "de").lower() == "en" else "de"
+        # Determine language from briefing (robust: lang > LANG > sprache)
+        lang_raw = briefing_data.get("lang") or briefing_data.get("LANG") or briefing_data.get("sprache") or "de"
+        lang = "en" if str(lang_raw).lower().strip().startswith("en") else "de"
         short_labels = generate_short_labels(briefing_data, lang=lang)
 
         branch_label = short_labels.get("BRANCH_CORE_LABEL", "")


### PR DESCRIPTION
…cement (EN/DE)

Fix-Pack 3.1.4.8: EN profiles were loading DE prompts because the briefing dict passed to PromptEnhancer didn't have consistent lang/LANG/sprache fields.

Changes:
- gpt_analyze.py: Add hard locale normalization block before enhance_prompt() and _build_prompt_vars() to ensure all three fields (lang, LANG, sprache) are consistently set based on the best available source
- gpt_analyze.py: Change foerderprogramme load_prompt from hardcoded lang="de" to use briefing_lang for future-proofing
- services/prompt_enhancer.py: Make _build_short_label_instructions() language detection robust by checking lang > LANG > sprache fallback chain

This ensures kmu_france and other EN profiles correctly load prompts/en/*.md instead of falling back to prompts/de/*.md.