### PR TITLE
fix(locale): derive prompt language from br.lang (authoritative) + pr…

### DIFF
--- a/gpt_analyze.py
+++ b/gpt_analyze.py
@@ -4382,8 +4382,9 @@ def _generate_content_section(section_name: str, briefing: Dict[str, Any], score
     # Prompt-System verwenden, wenn aktiv und Prompt vorhanden
     if USE_PROMPT_SYSTEM and prompt_key and _prompt_enhancer:
         try:
-            # TEIL 3.1.4.8: Hard locale normalization for prompt routing
-            # Ensure prompt_enhancer sees correct language for EN profiles
+            # TEIL 3.1.4.8/3.1.4.9: Locale normalization for prompt routing
+            # Note: Authoritative lang is set upstream from br.lang (3.1.4.9)
+            # This block is a safety net ensuring consistent lang/LANG/sprache fields
             if isinstance(briefing, dict):
                 lang_raw = (
                     briefing.get("lang")
@@ -5443,6 +5444,15 @@ def analyze_briefing(db: Session, briefing_id: int, run_id: str) -> tuple[int, s
     report_lang = getattr(br, "lang", "de")
     strategic_context = build_strategic_context_block(answers, lang=report_lang)
     answers["strategic_context_block"] = strategic_context
+
+    # === 3.1.4.9: AUTHORITATIVE LANGUAGE from br.lang ===
+    # Set lang/LANG/sprache BEFORE content generation so prompt routing is correct
+    # This is the single source of truth - briefing dict alone must NOT decide
+    answers["lang"] = report_lang
+    answers["LANG"] = report_lang
+    answers["sprache"] = report_lang
+    log.info("[%s] 🌐 Authoritative language set from br.lang: %s", run_id, report_lang)
+
     if strategic_context:
         log.info("[%s] 📋 Strategic context block generated (%d chars)", run_id, len(strategic_context))
     else:

--- a/services/prompt_loader.py
+++ b/services/prompt_loader.py
@@ -168,6 +168,7 @@ def load_prompt(section: str, lang: str = "de", vars_dict: Optional[Dict[str, An
         log.error(error_msg)
         raise FileNotFoundError(error_msg)
 
-    log.debug(f"✅ Loading prompt: {path}")
+    # 3.1.4.9: Debug trace for prompt routing verification
+    log.info("[prompt_loader] section=%s lang=%s path=%s", section, lang, path)
     payload = _read_file(path)
     return _interpolate(payload, vars_dict)


### PR DESCRIPTION
…ompt_loader debug trace

Fix-Pack 3.1.4.9: EN profiles were still loading DE prompts because the briefing dict's lang field wasn't authoritatively set from br.lang.

Changes:
- gpt_analyze.py: Set answers["lang/LANG/sprache"] from br.lang BEFORE calling _generate_content_sections() - this is the authoritative source
- gpt_analyze.py: Update comment in safety-net normalization block
- services/prompt_loader.py: Add INFO-level debug trace showing section/lang/path for prompt routing verification

Now the language flow is:
1. br.lang → answers["lang"] (authoritative, before content gen)
2. Safety normalization in _generate_content_section (defense in depth)
3. Debug log shows exact path loaded (prompts/en/* vs prompts/de/*)