### PR TITLE
fix(locale): 3.1.4.11 - hard guardrail prevents EN→DE prompt fallback

### DIFF
--- a/gpt_analyze.py
+++ b/gpt_analyze.py
@@ -4382,7 +4382,7 @@ def _generate_content_section(section_name: str, briefing: Dict[str, Any], score
     # Prompt-System verwenden, wenn aktiv und Prompt vorhanden
     if USE_PROMPT_SYSTEM and prompt_key and _prompt_enhancer:
         try:
-            # TEIL 3.1.4.8/3.1.4.9: Locale normalization for prompt routing
+            # TEIL 3.1.4.8/3.1.4.9/3.1.4.11: Locale normalization for prompt routing
             # Note: Authoritative lang is set upstream from br.lang (3.1.4.9)
             # This block is a safety net ensuring consistent lang/LANG/sprache fields
             if isinstance(briefing, dict):
@@ -4398,6 +4398,9 @@ def _generate_content_section(section_name: str, briefing: Dict[str, Any], score
                 briefing["lang"] = prompt_lang
                 briefing["LANG"] = prompt_lang
                 briefing["sprache"] = prompt_lang
+
+                # 3.1.4.11: Debug trace for locale normalization
+                log.debug("[locale] section=%s lang_raw=%s → prompt_lang=%s", section_name, lang_raw, prompt_lang)
 
             # 1. Prompt mit Kontext (Branche/Größe) anreichern
             enhanced_prompt = _prompt_enhancer.enhance_prompt(prompt_key, briefing)

--- a/services/prompt_loader.py
+++ b/services/prompt_loader.py
@@ -148,6 +148,15 @@ def load_prompt(section: str, lang: str = "de", vars_dict: Optional[Dict[str, An
         raise ValueError("section must be a non-empty string")
 
     lang = lang or DEFAULT_LANG
+
+    # 3.1.4.11: Normalize language variants (en-US, EN, en_GB → en)
+    lang_norm = str(lang).lower().strip()
+    if lang_norm.startswith("en"):
+        lang = "en"
+    else:
+        lang = "de"  # Only de/en supported
+
+    requested_lang = lang  # Store original request for guardrail check
     path, used_lang = _resolve_section_path(section, lang)
     
     if not path:
@@ -168,7 +177,18 @@ def load_prompt(section: str, lang: str = "de", vars_dict: Optional[Dict[str, An
         log.error(error_msg)
         raise FileNotFoundError(error_msg)
 
-    # 3.1.4.9: Debug trace for prompt routing verification
-    log.info("[prompt_loader] section=%s lang=%s path=%s", section, lang, path)
+    # 3.1.4.11: HARD GUARDRAIL - EN requests must NEVER resolve to DE prompts
+    # This prevents silent fallback from prompts/en/* to prompts/de/*
+    path_str = str(path).replace("\\", "/")  # Normalize for Windows compatibility
+    if requested_lang == "en" and "/prompts/de/" in path_str:
+        raise RuntimeError(
+            f"EN prompt routing violation: section={section} "
+            f"requested_lang={requested_lang} resolved_path={path} "
+            f"(DE fallback is forbidden for EN profiles)"
+        )
+
+    # 3.1.4.9/3.1.4.11: Debug trace for prompt routing verification
+    log.info("[prompt_loader] section=%s requested_lang=%s used_lang=%s path=%s",
+             section, requested_lang, used_lang, path)
     payload = _read_file(path)
     return _interpolate(payload, vars_dict)


### PR DESCRIPTION
Fix-Pack 3.1.4.11: Enforce strict EN prompt routing with hard failure.

Changes:
- services/prompt_loader.py: Add lang normalization (en-US, EN, en_GB → en)
- services/prompt_loader.py: Add HARD GUARDRAIL - if requested_lang=en but resolved path contains /prompts/de/, raise RuntimeError immediately
- services/prompt_loader.py: Enhanced debug log shows requested_lang vs used_lang
- gpt_analyze.py: Added debug trace for locale normalization

This ensures EN profiles (kmu_france) will NEVER silently load DE prompts. If an EN prompt doesn't exist, the system fails loudly instead of falling back to German content that would cause locale-scan failures.