### PR TITLE
fix(locale): 3.1.4.13 - remaining EN locale hardening (template label…

### DIFF
--- a/services/html_sanitizer.py
+++ b/services/html_sanitizer.py
@@ -520,7 +520,8 @@ def generate_auto_summary(
     recovered_text: str,
     branch: str = "",
     size: str = "",
-    guardrails: bool = False
+    guardrails: bool = False,
+    lang: str = ""
 ) -> str:
     """
     Generiert eine Auto-Summary für Recovery-Situationen (Stufe 3 im Fallback).
@@ -536,6 +537,7 @@ def generate_auto_summary(
         branch: Branche (für branchen-aware Summary)
         size: Unternehmensgröße (solo/team/kmu)
         guardrails: Ob Guardrails-Hinweise eingefügt werden sollen
+        lang: Language code (de/en) - if provided, overrides content detection
 
     Returns:
         HTML-formatierte Auto-Summary (80-120 Wörter)
@@ -638,15 +640,21 @@ Implementation should proceed step by step, taking company size into account.</p
     # Wähle Template
     section_templates = templates.get(section_name, default_template)
 
-    # Sprache aus Kontext erkennen
-    de_indicators = ["der", "die", "das", "und", "für", "mit", "eine", "einen"]
-    is_german = any(ind in recovered_text.lower() for ind in de_indicators)
-    lang = "de" if is_german else "en"
+    # 3.1.4.13: Use explicit lang parameter if provided, otherwise detect from content
+    if lang and str(lang).lower().startswith("en"):
+        detected_lang = "en"
+    elif lang and str(lang).lower().startswith("de"):
+        detected_lang = "de"
+    else:
+        # Sprache aus Kontext erkennen (fallback)
+        de_indicators = ["der", "die", "das", "und", "für", "mit", "eine", "einen"]
+        is_german = any(ind in recovered_text.lower() for ind in de_indicators)
+        detected_lang = "de" if is_german else "en"
 
-    result = section_templates.get(lang, section_templates.get("de", default_template["de"]))
+    result = section_templates.get(detected_lang, section_templates.get("de", default_template["de"]))
 
     log.info("[AUTO-SUMMARY] Generated summary for section=%s (lang=%s, size=%s)",
-             section_name, lang, size or "unknown")
+             section_name, detected_lang, size or "unknown")
 
     return result
 

--- a/services/report_validator.py
+++ b/services/report_validator.py
@@ -1869,7 +1869,7 @@ def heal_placeholder_sections(sections: Dict[str, Any]) -> int:
     return healed_count
 
 
-def _build_generic_leak_fallback(section_name: str, company_size: str = "team") -> str:
+def _build_generic_leak_fallback(section_name: str, company_size: str = "team", lang: str = "de") -> str:
     """
     SPRINT N3.2/N3.3: Build a constructive fallback for sections with quality issues.
 
@@ -1880,10 +1880,13 @@ def _build_generic_leak_fallback(section_name: str, company_size: str = "team") 
     Args:
         section_name: Name of the section needing fallback
         company_size: Company size for personalization
+        lang: Language code (de/en)
 
     Returns:
         HTML fallback content
     """
+    # 3.1.4.13: i18n helper for fallback headings
+    is_en = str(lang or "de").lower().startswith("en")
     # Size-aware context
     if "solo" in company_size.lower():
         context = "Ihre Tätigkeit"
@@ -1933,8 +1936,11 @@ def _build_generic_leak_fallback(section_name: str, company_size: str = "team") 
 
     # N3.3 TASK 3: BCG-style template for Branch Deep Dive
     # Structure: Market Dynamics → Competition → Risks → Opportunities → Actions
+    # 3.1.4.13: i18n headings
+    _deep_dive_title = "Industry Deep Dive" if is_en else "Branchen-Deep-Dive"
+    _recommendations_title = "Recommendations" if is_en else "Handlungsempfehlungen"
     branch_deep_dive_bcg = f"""
-            <p><strong>Branchen-Deep-Dive</strong></p>
+            <p><strong>{_deep_dive_title}</strong></p>
 
             <p class="subtitle">Strategische Markt- und Wettbewerbsanalyse</p>
 
@@ -1967,7 +1973,7 @@ def _build_generic_leak_fallback(section_name: str, company_size: str = "team") 
               <li><strong>Kundenzentrierung:</strong> Datengestützte Personalisierung erhöht Kundenbindung messbar</li>
             </ul>
 
-            <p><strong>5. Handlungsempfehlungen</strong></p>
+            <p><strong>5. {_recommendations_title}</strong></p>
             <ol>
               <li><strong>Strategische Positionierung:</strong> KI als Kernbestandteil der Unternehmensstrategie verankern – Investitionsbudget sichern</li>
               <li><strong>Fokussierte Umsetzung:</strong> 2-3 High-Impact Use Cases priorisieren statt breiter Streuung – Ressourcen bündeln</li>
@@ -2031,6 +2037,8 @@ def validate_and_heal(
         Tuple of (is_valid, errors, healed_count)
     """
     company_size = briefing.get("unternehmensgroesse", "team")
+    # 3.1.4.13: Get language for i18n fallbacks
+    report_lang = briefing.get("lang") or briefing.get("LANG") or briefing.get("sprache") or "de"
 
     # First, heal empty placeholder sections
     placeholder_healed = heal_placeholder_sections(sections)
@@ -2051,9 +2059,9 @@ def validate_and_heal(
                     "[N2-Heal] Replacing leaked content in section '%s'",
                     section_name
                 )
-                # Replace with fallback
+                # Replace with fallback (3.1.4.13: pass lang for i18n)
                 sections[section_name] = _build_generic_leak_fallback(
-                    section_name, company_size
+                    section_name, company_size, report_lang
                 )
                 leak_healed += 1
 

--- a/templates/pdf_template.html
+++ b/templates/pdf_template.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>KI-Status-Report {{ report_id }} – {{ company_name or kundencode or 'Ihr Unternehmen' }}</title>
+    <title>KI-Status-Report {{ report_id }} – {{ company_name or kundencode or ('Your Company' if ((lang or briefing_lang or report_lang or 'de')|lower)[:2] == 'en' else 'Ihr Unternehmen') }}</title>
     <style id="platin-v52-template">
         /* ============================================
            PLATIN++ V5.2 PDF TEMPLATE
@@ -2138,7 +2138,7 @@
     </style>
 </head>
 <body>
-{# --- 3.1.4.12: minimal i18n for template UI strings --- #}
+{# --- 3.1.4.12/3.1.4.13: minimal i18n for template UI strings --- #}
 {% set LANG = (lang or briefing_lang or report_lang or 'de')|lower %}
 {% set IS_EN = LANG.startswith('en') %}
 {% set T = {
@@ -2155,7 +2155,11 @@
     'industry_tools_sub': 'KI-Tools mit höchster Branchenrelevanz',
     'missing_info': 'Diese Informationen fehlen für eine vollständige Compliance-Bewertung:',
     'feedback_cta': 'Helfen Sie uns, diesen Report noch besser zu machen. Ihre Rückmeldung hilft anderen Unternehmen.',
-    'your_industry': 'Ihre Branche'
+    'your_industry': 'Ihre Branche',
+    'company_label_colon': 'Unternehmen:',
+    'industry_label_colon': 'Branche:',
+    'company_size_label_colon': 'Unternehmensgröße:',
+    'your_company': 'Ihr Unternehmen'
   },
   'en': {
     'deep_dive_for': 'Deep dive for',
@@ -2170,7 +2174,11 @@
     'industry_tools_sub': 'AI tools with the highest industry relevance',
     'missing_info': 'This information is missing for a complete compliance assessment:',
     'feedback_cta': 'Help us improve this report. Your feedback helps other companies.',
-    'your_industry': 'Your industry'
+    'your_industry': 'Your industry',
+    'company_label_colon': 'Company:',
+    'industry_label_colon': 'Industry:',
+    'company_size_label_colon': 'Company size:',
+    'your_company': 'Your Company'
   }
 } %}
 {% set TR = T['en'] if IS_EN else T['de'] %}
@@ -2185,8 +2193,8 @@
         <span class="section-kicker">KI-Status-Report</span>
         <span class="eyebrow-divider"></span>
         <span class="small">
-          Unternehmen:
-          <strong>{{ company_name or kundencode or 'Ihr Unternehmen' }}</strong>
+          {{ TR.company_label_colon }}
+          <strong>{{ company_name or kundencode or TR.your_company }}</strong>
         </span>
       </div>
       <span class="small">Report-ID: {{ report_id }}</span>
@@ -2196,7 +2204,7 @@
         <h1>KI-Readiness {{ score_rating }}</h1>
         <p class="subtitle">
           Individuelle Standortbestimmung für
-          {{ company_name or BRANCHE_LABEL or 'Ihr Unternehmen' }} – mit Fokus auf
+          {{ company_name or BRANCHE_LABEL or TR.your_company }} – mit Fokus auf
           Sicherheit, Effizienz und Förderpotenziale.
         </p>
       </div>
@@ -2211,11 +2219,11 @@
     </div>
     <div class="meta-grid">
       <div class="meta-item">
-        <span class="meta-label">Branche:</span>
+        <span class="meta-label">{{ TR.industry_label_colon }}</span>
         <span class="meta-value">{{ BRANCHE_LABEL }}</span>
       </div>
       <div class="meta-item">
-        <span class="meta-label">Unternehmensgröße:</span>
+        <span class="meta-label">{{ TR.company_size_label_colon }}</span>
         <span class="meta-value">{{ UNTERNEHMENSGROESSE_LABEL }}</span>
       </div>
       <div class="meta-item">


### PR DESCRIPTION
…s + code fallbacks)

Part A: No German tokens found in prompts/en/* (verified clean)

Part B: Template i18n extended (templates/pdf_template.html)
- Extended TR dict with: company_label_colon, industry_label_colon, company_size_label_colon, your_company
- Replaced "Unternehmen:" → {{ TR.company_label_colon }}
- Replaced "Branche:" → {{ TR.industry_label_colon }}
- Replaced "Unternehmensgröße:" → {{ TR.company_size_label_colon }}
- Replaced 'Ihr Unternehmen' defaults → TR.your_company
- Title uses inline conditional for pre-TR context

Part C: Code-generated HTML fallbacks i18n-enabled
- services/report_validator.py:
  - Added lang parameter to _build_generic_leak_fallback()
  - i18n headings: "Branchen-Deep-Dive" → "Industry Deep Dive"
  - i18n headings: "5. Handlungsempfehlungen" → "5. Recommendations"
  - validate_and_heal() now passes report_lang to fallback builder

- services/html_sanitizer.py:
  - Added optional lang parameter to generate_auto_summary()
  - Language detection now respects explicit lang over content-based detection
  - EN profiles will now use English summary templates

Ensures kmu_france and other EN profiles have 0 German UI strings.