### PR TITLE
fix(locale): 3.1.4.14 - remove remaining DE content strings from EN r…

### DIFF
--- a/services/recommendations_engine.py
+++ b/services/recommendations_engine.py
@@ -620,28 +620,48 @@ def _generate_summary(
     recommendations: List[Recommendation],
     size_label: str,
     branch: str,
+    lang: str = "de",
 ) -> str:
     """Generate narrative summary for recommendations."""
     count = len(recommendations)
     high_impact = sum(1 for r in recommendations if r.impact_level == "high")
     phase_1 = sum(1 for r in recommendations if r.timeline_phase == "phase_1")
 
-    size_names = {"solo": "Einzelunternehmer", "team": "Teams", "kmu": "KMU"}
-    size_name = size_names.get(size_label, "Unternehmen")
+    # 3.1.4.14: i18n for summary text
+    is_en = str(lang or "de").lower().startswith("en")
+
+    if is_en:
+        size_names = {"solo": "solo business", "team": "team", "kmu": "SME"}
+        size_name = size_names.get(size_label, "company")
+    else:
+        size_names = {"solo": "Einzelunternehmer", "team": "Teams", "kmu": "KMU"}
+        size_name = size_names.get(size_label, "Unternehmen")
 
     parts = []
 
-    parts.append(f"Für Ihr {size_name} in der Branche {branch} wurden {count} konkrete Handlungsempfehlungen identifiziert.")
+    if is_en:
+        parts.append(f"For your {size_name} in the {branch} industry, {count} concrete recommendations were identified.")
+    else:
+        parts.append(f"Für Ihr {size_name} in der Branche {branch} wurden {count} konkrete Handlungsempfehlungen identifiziert.")
 
     if high_impact > 0:
-        parts.append(f"Davon haben {high_impact} eine hohe Auswirkung auf Ihren KI-Erfolg.")
+        if is_en:
+            parts.append(f"Of these, {high_impact} have a high impact on your AI success.")
+        else:
+            parts.append(f"Davon haben {high_impact} eine hohe Auswirkung auf Ihren KI-Erfolg.")
 
     if phase_1 > 0:
-        parts.append(f"Starten Sie mit den {phase_1} Empfehlungen für Phase 1, um schnelle Ergebnisse zu erzielen.")
+        if is_en:
+            parts.append(f"Start with the {phase_1} Phase 1 recommendations for quick results.")
+        else:
+            parts.append(f"Starten Sie mit den {phase_1} Empfehlungen für Phase 1, um schnelle Ergebnisse zu erzielen.")
 
     total_invest = sum(r.required_investment or 0 for r in recommendations)
     if total_invest > 0:
-        parts.append(f"Die geschätzte Gesamtinvestition beträgt ca. {total_invest:,.0f} €.")
+        if is_en:
+            parts.append(f"The estimated total investment is approx. €{total_invest:,.0f}.")
+        else:
+            parts.append(f"Die geschätzte Gesamtinvestition beträgt ca. {total_invest:,.0f} €.")
 
     return " ".join(parts)
 
@@ -693,6 +713,9 @@ def generate_recommendations_report(
     size_label = _determine_size_label(briefing)
     branch = briefing.get("branche", "Allgemein")
 
+    # 3.1.4.14: Get language for i18n
+    report_lang = briefing.get("lang") or briefing.get("LANG") or briefing.get("sprache") or "de"
+
     # Extract summaries from all engines
     tools_summary = _extract_tools_summary(tools_data)
     funding_summary = _extract_funding_summary(funding_data)
@@ -719,7 +742,7 @@ def generate_recommendations_report(
             top_3_ids = _select_top_3(recommendations)
 
         if not summary:
-            summary = _generate_summary(recommendations, size_label, branch)
+            summary = _generate_summary(recommendations, size_label, branch, report_lang)
 
     else:
         # Generate default recommendations
@@ -734,7 +757,7 @@ def generate_recommendations_report(
         )
 
         top_3_ids = _select_top_3(recommendations)
-        summary = _generate_summary(recommendations, size_label, branch)
+        summary = _generate_summary(recommendations, size_label, branch, report_lang)
 
     # SPRINT N1 (RECO_002): Heal consistency issues
     # Auto-populate related_risks for recommendations with risk_relation="reduces_risk"

--- a/services/report_validator.py
+++ b/services/report_validator.py
@@ -1936,20 +1936,30 @@ def _build_generic_leak_fallback(section_name: str, company_size: str = "team", 
 
     # N3.3 TASK 3: BCG-style template for Branch Deep Dive
     # Structure: Market Dynamics → Competition → Risks → Opportunities → Actions
-    # 3.1.4.13: i18n headings
+    # 3.1.4.13/3.1.4.14: i18n headings and content
     _deep_dive_title = "Industry Deep Dive" if is_en else "Branchen-Deep-Dive"
     _recommendations_title = "Recommendations" if is_en else "Handlungsempfehlungen"
+    _subtitle = "Strategic market and competitive analysis" if is_en else "Strategische Markt- und Wettbewerbsanalyse"
+    _section1_title = "1. Market & Trend Dynamics" if is_en else "1. Markt- & Trenddynamik"
+    _section1_content = (
+        "The industry is undergoing a fundamental digital transformation. AI adoption "
+        "is accelerating exponentially – early adopters are already realizing substantial "
+        "efficiency gains (15-35% in automated processes). The tipping point for mass "
+        "adoption is expected industry-wide within the next 18-24 months."
+    ) if is_en else (
+        "Die Branche durchläuft eine fundamentale digitale Transformation. KI-Adoption "
+        "beschleunigt sich exponentiell – Früheinsteiger realisieren bereits substanzielle "
+        "Effizienzgewinne (15-35% in automatisierten Prozessen). Der Wendepunkt zur "
+        "Massenadoption wird branchenweit innerhalb der nächsten 18-24 Monate erwartet. "
+        "Die Technologiereife kommerzieller KI-Lösungen hat kritische Schwelle überschritten."
+    )
     branch_deep_dive_bcg = f"""
             <p><strong>{_deep_dive_title}</strong></p>
 
-            <p class="subtitle">Strategische Markt- und Wettbewerbsanalyse</p>
+            <p class="subtitle">{_subtitle}</p>
 
-            <p><strong>1. Markt- & Trenddynamik</strong></p>
-            <p>Die Branche durchläuft eine fundamentale digitale Transformation. KI-Adoption
-            beschleunigt sich exponentiell – Früheinsteiger realisieren bereits substanzielle
-            Effizienzgewinne (15-35% in automatisierten Prozessen). Der Wendepunkt zur
-            Massenadoption wird branchenweit innerhalb der nächsten 18-24 Monate erwartet.
-            Die Technologiereife kommerzieller KI-Lösungen hat kritische Schwelle überschritten.</p>
+            <p><strong>{_section1_title}</strong></p>
+            <p>{_section1_content}</p>
 
             <p><strong>2. Wettbewerbsdruck & Differenzierungsfaktoren</strong></p>
             <p>Marktführer investieren signifikant in KI-Capabilities – der Abstand zu


### PR DESCRIPTION
…eports

Fix 1: services/recommendations_engine.py
- Added lang parameter to _generate_summary() function
- i18n for summary sentence: "Für Ihr {size_name}..." → "For your {size_name}..."
- i18n for all follow-up sentences (high_impact, phase_1, total_invest)
- Added report_lang extraction from briefing in generate_recommendations_report()

Fix 2: services/report_validator.py
- Extended i18n for BCG-style Branch Deep Dive fallback template
- i18n for subtitle: "Strategische Markt-..." → "Strategic market..."
- i18n for section 1 title and content
- "Die Branche durchläuft..." → "The industry is undergoing..."

Fix 3: services/research_pipeline.py:138
- Verified: Only a Python comment, not rendered → Safe to ignore

These were the last 3 German string hits from locale-scan.