### PR TITLE
fix(locale): 3.1.4.18 - global EN locale sanitizer on final HTML + co…

### DIFF
--- a/services/html_sanitizer.py
+++ b/services/html_sanitizer.py
@@ -136,9 +136,17 @@ _EN_LOCALE_REPLACEMENTS: List[Tuple[str, LocaleRepl]] = [
     (r"\bBewertungen\b", "Assessments"),
     (r"\bMaßnahmenplan\b", "Action plan"),
     (r"\bMaßnahmen\b", "Actions"),
+    (r"\bZusammenfassungen\b", "Summaries"),  # 3.1.4.18: plural before singular
     (r"\bZusammenfassung\b", "Summary"),
     (r"\bEmpfehlungen\b", "Recommendations"),
     (r"\bEmpfehlung\b", "Recommendation"),
+
+    # --- 3.1.4.18: compound/plural + GDPR ---
+    (r"\bBranchen-", "Industry-"),  # Prefix for Branchen-Templates, Branchen-Module, etc.
+    (r"\bBranchen\b", "Industries"),  # plural before singular
+    (r"\bDatenschutz\b", "Data protection"),
+    (r"\bDSGVO\b", "GDPR"),
+    (r"\bHinweis\b", "Note"),
 
     # single tokens / common nouns
     (r"\bBranche\b", "Industry"),

--- a/services/report_renderer.py
+++ b/services/report_renderer.py
@@ -19,6 +19,7 @@ from markupsafe import Markup
 from utils.logo_embedder import embed_logos_in_html
 from services.html_minifier import optimize_html_for_pdf, strip_unused_sections
 from services.report_validator import GENERIC_LLM_LEAK_PHRASES, remove_leak_phrases_from_html
+from services.html_sanitizer import sanitize_en_locale_tokens
 
 log = logging.getLogger(__name__)
 
@@ -518,5 +519,11 @@ def render(briefing_obj: Any,
     # PLATIN+++ v5.4: Final development placeholder scrub
     # =========================================================================
     html = scrub_development_placeholders(html, run_id=run_id)
+
+    # =========================================================================
+    # 3.1.4.18: FINAL EN locale sanitize on full HTML (global hook)
+    # =========================================================================
+    html = sanitize_en_locale_tokens(html, lang=lang)
+    log.info(f"[RENDER] Applied EN locale sanitizer (lang={lang}) for run={run_id}")
 
     return {"html": html, "meta": meta or {}}


### PR DESCRIPTION
…mpound/plural + GDPR

Extended _EN_LOCALE_REPLACEMENTS with:
- Zusammenfassungen → Summaries (plural)
- Branchen- → Industry- (prefix for Branchen-Templates, etc.)
- Branchen → Industries (plural)
- Datenschutz → Data protection
- DSGVO → GDPR
- Hinweis → Note

Added global hook in report_renderer.py:
- sanitize_en_locale_tokens() now runs on final rendered HTML
- Placed after all template rendering and post-processing
- Uses authoritative lang from render() function