### PR TITLE
feat(i18n): multilingual v1 step1 - normalize_lang + unify report_lang

### DIFF
--- a/gpt_analyze.py
+++ b/gpt_analyze.py
@@ -123,6 +123,7 @@ from services.coverage_guard import analyze_coverage, build_html_report
 from services.prompt_loader import load_prompt
 from services.prompt_enhancer import PromptEnhancer, get_platin_config
 from services.html_sanitizer import sanitize_sections_dict
+from services.lang_utils import normalize_lang
 from utils.hotfix_gold_standard import apply_hotfix, UTF8Handler
 from utils.encoding_fixer import clean_briefing_data
 from services.anthropic_client import call_anthropic, should_use_anthropic
@@ -5294,10 +5295,8 @@ def _generate_content_sections(briefing: Dict[str, Any], scores: Dict[str, Any])
     # Sprint G7/G8: AI Act Compliance Sections with Cross-Integration
     # ==========================================================================
     try:
-        # Determine report language from briefing
-        report_lang = briefing.get("lang", "de")
-        if report_lang not in ["de", "en"]:
-            report_lang = "de"
+        # Determine report language from briefing (Multilingual v1: normalize)
+        report_lang = normalize_lang(briefing.get("lang"), default="de")
 
         # G8.6: Use optimized version with caching
         ai_act_data = build_ai_act_sections_optimized(briefing, lang=report_lang)
@@ -5444,7 +5443,8 @@ def analyze_briefing(db: Session, briefing_id: int, run_id: str) -> tuple[int, s
         pass
 
     # === STRATEGIC CONTEXT BLOCK erzeugen (für spätere Prompt-Anreicherung) ===
-    report_lang = getattr(br, "lang", "de")
+    # Multilingual v1: normalize language from br.lang
+    report_lang = normalize_lang(getattr(br, "lang", "de"), default="de")
     strategic_context = build_strategic_context_block(answers, lang=report_lang)
     answers["strategic_context_block"] = strategic_context
 
@@ -5667,7 +5667,8 @@ def analyze_briefing(db: Session, briefing_id: int, run_id: str) -> tuple[int, s
     # 🎯 KERN-FÖRDERMATRIX 2025/2026: Statischer, size-aware Kern immer einfügen
     # v4.16.0: Enable funding for EN reports when country is DE/Germany
     # v4.17.0: Phase 2 - Enable EU core funding for EN reports with non-German countries
-    report_lang = sections.get("LANG", "de")
+    # Multilingual v1: normalize language from sections
+    report_lang = normalize_lang(sections.get("LANG"), default="de")
     report_country = (answers.get("country") or "").upper()
 
     # Check if this is an EN report for Germany (enable DE funding)

--- a/services/lang_utils.py
+++ b/services/lang_utils.py
@@ -1,0 +1,110 @@
+# -*- coding: utf-8 -*-
+"""
+services.lang_utils
+-------------------
+Multilingual v1 Step 1: Unified language normalization utilities.
+
+Provides consistent language code normalization across the backend:
+- Supports: de, en, fr, es, it
+- Normalizes variants like EN, en-US, en_GB, DE-de, fr-FR, etc.
+- Single source of truth for language handling
+
+Version: 1.0.0 (Multilingual v1)
+"""
+from __future__ import annotations
+
+from typing import Any
+
+# Supported language codes (ISO 639-1)
+SUPPORTED_LANGS = ("de", "en", "fr", "es", "it")
+
+
+def normalize_lang(raw: Any, default: str = "de") -> str:
+    """
+    Normalize a language code to a supported base language.
+
+    Handles various input formats:
+    - None, empty strings, non-string types
+    - Uppercase: "EN" -> "en"
+    - Locale variants: "en-US", "en_GB", "de-DE", "fr_FR" -> base code
+    - Whitespace: "  en  " -> "en"
+
+    Args:
+        raw: Raw language value (any type, will be converted to str)
+        default: Fallback language if normalization fails (default: "de")
+
+    Returns:
+        Normalized language code from SUPPORTED_LANGS, or default
+
+    Examples:
+        >>> normalize_lang("en-US")
+        'en'
+        >>> normalize_lang("EN")
+        'en'
+        >>> normalize_lang("fr_FR")
+        'fr'
+        >>> normalize_lang("pt")  # unsupported
+        'de'
+        >>> normalize_lang(None)
+        'de'
+        >>> normalize_lang("")
+        'de'
+    """
+    # Handle None, empty, or non-string input
+    if raw is None:
+        return default
+
+    # Convert to string and normalize
+    lang_str = str(raw).strip().lower()
+
+    if not lang_str:
+        return default
+
+    # Extract base language (before any separator)
+    # Handles: en-US, en_GB, de-DE, fr_FR, es-ES, it-IT, etc.
+    if "-" in lang_str:
+        lang_str = lang_str.split("-")[0]
+    elif "_" in lang_str:
+        lang_str = lang_str.split("_")[0]
+
+    # Check if the base language is supported
+    if lang_str in SUPPORTED_LANGS:
+        return lang_str
+
+    # Check prefix match for edge cases (e.g., "english" -> "en")
+    # This is a safety net, not expected in normal usage
+    for supported in SUPPORTED_LANGS:
+        if lang_str.startswith(supported):
+            return supported
+
+    # Fallback to default
+    return default
+
+
+def is_lang_supported(lang: str) -> bool:
+    """
+    Check if a language code is supported.
+
+    Args:
+        lang: Language code to check (should be normalized first)
+
+    Returns:
+        True if the language is in SUPPORTED_LANGS
+
+    Examples:
+        >>> is_lang_supported("en")
+        True
+        >>> is_lang_supported("pt")
+        False
+    """
+    return lang in SUPPORTED_LANGS
+
+
+def get_supported_langs() -> tuple:
+    """
+    Get the tuple of supported language codes.
+
+    Returns:
+        Tuple of supported language codes: ("de", "en", "fr", "es", "it")
+    """
+    return SUPPORTED_LANGS

--- a/services/report_renderer.py
+++ b/services/report_renderer.py
@@ -20,6 +20,7 @@ from utils.logo_embedder import embed_logos_in_html
 from services.html_minifier import optimize_html_for_pdf, strip_unused_sections
 from services.report_validator import GENERIC_LLM_LEAK_PHRASES, remove_leak_phrases_from_html
 from services.html_sanitizer import sanitize_en_locale_tokens
+from services.lang_utils import normalize_lang
 
 log = logging.getLogger(__name__)
 
@@ -323,9 +324,9 @@ def render(briefing_obj: Any,
         lang_raw = "de"
         log.debug("[LANG] No language found, defaulting to: de")
 
-    # Normalize: lowercase, strip, check for "en" prefix
-    lang = str(lang_raw).lower().strip()
-    is_en = lang.startswith("en")
+    # Multilingual v1: Normalize to supported language codes (de/en/fr/es/it)
+    lang = normalize_lang(lang_raw, default="de")
+    is_en = (lang == "en")
 
     log.info(f"[LANG] Detected language: '{lang}' (is_en={is_en}) for report {run_id}")
 


### PR DESCRIPTION
Step 1 of Multilingual v1 implementation:

New file: services/lang_utils.py
- normalize_lang(raw, default="de") - normalizes language codes
- Supports: de, en, fr, es, it
- Handles variants: EN, en-US, en_GB, de-DE, fr-FR, etc.
- is_lang_supported(lang) helper
- SUPPORTED_LANGS constant

Updated: services/report_renderer.py
- Import and use normalize_lang() for language normalization
- Replace manual lower().strip() + startswith() with normalize_lang()
- is_en now uses exact match (lang == "en")

Updated: gpt_analyze.py
- Import normalize_lang from services.lang_utils
- Replace hardcoded whitelist checks with normalize_lang()
- All 3 report_lang assignments now use normalize_lang()