### PR TITLE
feat(i18n): multilingual v1 step4 - inject ui() into renderer + migra…

### DIFF
--- a/services/report_renderer.py
+++ b/services/report_renderer.py
@@ -21,6 +21,7 @@ from services.html_minifier import optimize_html_for_pdf, strip_unused_sections
 from services.report_validator import GENERIC_LLM_LEAK_PHRASES, remove_leak_phrases_from_html
 from services.html_sanitizer import sanitize_en_locale_tokens
 from services.lang_utils import normalize_lang
+from services.i18n import ui as ui_factory
 
 log = logging.getLogger(__name__)
 
@@ -402,8 +403,14 @@ def render(briefing_obj: Any,
         **sections,
     }
 
+    # =========================================================================
+    # Multilingual v1 Step 4: Inject ui() into template context
+    # =========================================================================
+    ctx["ui"] = ui_factory(lang)
+    ctx["report_lang"] = lang
+
     # Log what we're rendering (for debugging)
-    log.info(f"🎨 Rendering report {run_id} with {len(sections)} sections")
+    log.info(f"🎨 Rendering report {run_id} with {len(sections)} sections (lang={lang})")
     log.debug(f"Sections available: {list(sections.keys())}")
 
     html = env.get_template(tpl_name).render(**ctx)

--- a/services/report_renderer.py
+++ b/services/report_renderer.py
@@ -389,7 +389,7 @@ def render(briefing_obj: Any,
 
     # Safe defaults with FIXED UTF-8
     # TEIL 3.1.4.x: Force LANG to detected value (no fallback to sections)
-    ctx = {
+    ctx: Dict[str, Any] = {
         "LANG": "en" if is_en else "de",  # FORCED, not from sections
         "OWNER_NAME": sections.get("OWNER_NAME", os.getenv("OWNER_NAME", "KI-Sicherheit.jetzt")),  # ✅ FIXED
         "report_date": sections.get("report_date", ""),

--- a/templates/pdf_template.html
+++ b/templates/pdf_template.html
@@ -2138,50 +2138,10 @@
     </style>
 </head>
 <body>
-{# --- 3.1.4.12/3.1.4.13: minimal i18n for template UI strings --- #}
-{% set LANG = (lang or briefing_lang or report_lang or 'de')|lower %}
-{% set IS_EN = LANG.startswith('en') %}
-{% set T = {
-  'de': {
-    'deep_dive_for': 'Tiefenanalyse für',
-    'industry_benchmark_title': 'Branchenvergleich & Wettbewerbsposition',
-    'industry_benchmark_kicker': 'KI-Reife • Branchenmedian • SWOT',
-    'recommendations': 'Handlungsempfehlungen',
-    'industry_specific': 'Branchenspezifisch',
-    'industry_funding_title': 'Branchen-Förderpotenzial',
-    'industry_funding_sub': 'Förderprogramme optimiert für Ihre Branche',
-    'industry_optimized': 'Branchenoptimiert',
-    'industry_tools_title': 'Branchen-Tool-Alignment',
-    'industry_tools_sub': 'KI-Tools mit höchster Branchenrelevanz',
-    'missing_info': 'Diese Informationen fehlen für eine vollständige Compliance-Bewertung:',
-    'feedback_cta': 'Helfen Sie uns, diesen Report noch besser zu machen. Ihre Rückmeldung hilft anderen Unternehmen.',
-    'your_industry': 'Ihre Branche',
-    'company_label_colon': 'Unternehmen:',
-    'industry_label_colon': 'Branche:',
-    'company_size_label_colon': 'Unternehmensgröße:',
-    'your_company': 'Ihr Unternehmen'
-  },
-  'en': {
-    'deep_dive_for': 'Deep dive for',
-    'industry_benchmark_title': 'Industry comparison & competitive position',
-    'industry_benchmark_kicker': 'AI maturity • Industry median • SWOT',
-    'recommendations': 'Recommendations',
-    'industry_specific': 'Industry-specific',
-    'industry_funding_title': 'Industry funding potential',
-    'industry_funding_sub': 'Funding programs optimized for your industry',
-    'industry_optimized': 'Industry-optimized',
-    'industry_tools_title': 'Industry tool alignment',
-    'industry_tools_sub': 'AI tools with the highest industry relevance',
-    'missing_info': 'This information is missing for a complete compliance assessment:',
-    'feedback_cta': 'Help us improve this report. Your feedback helps other companies.',
-    'your_industry': 'Your industry',
-    'company_label_colon': 'Company:',
-    'industry_label_colon': 'Industry:',
-    'company_size_label_colon': 'Company size:',
-    'your_company': 'Your Company'
-  }
-} %}
-{% set TR = T['en'] if IS_EN else T['de'] %}
+{# --- Multilingual v1 Step 4: ui() replaces inline T/TR dict --- #}
+{# Note: ui() function is injected via report_renderer.py context #}
+{# Usage: {{ ui("key") }} or {{ ui("key", "Default") }} #}
+{% set IS_EN = ((report_lang or lang or 'de')|lower)[:2] == 'en' %}
     <div class="page">
         <div class="content">
             <div class="content-inner">
@@ -2193,8 +2153,8 @@
         <span class="section-kicker">KI-Status-Report</span>
         <span class="eyebrow-divider"></span>
         <span class="small">
-          {{ TR.company_label_colon }}
-          <strong>{{ company_name or kundencode or TR.your_company }}</strong>
+          {{ ui("company_label_colon") }}
+          <strong>{{ company_name or kundencode or ui("your_company") }}</strong>
         </span>
       </div>
       <span class="small">Report-ID: {{ report_id }}</span>
@@ -2204,7 +2164,7 @@
         <h1>KI-Readiness {{ score_rating }}</h1>
         <p class="subtitle">
           Individuelle Standortbestimmung für
-          {{ company_name or BRANCHE_LABEL or TR.your_company }} – mit Fokus auf
+          {{ company_name or BRANCHE_LABEL or ui("your_company") }} – mit Fokus auf
           Sicherheit, Effizienz und Förderpotenziale.
         </p>
       </div>
@@ -2219,11 +2179,11 @@
     </div>
     <div class="meta-grid">
       <div class="meta-item">
-        <span class="meta-label">{{ TR.industry_label_colon }}</span>
+        <span class="meta-label">{{ ui("industry_label_colon") }}</span>
         <span class="meta-value">{{ BRANCHE_LABEL }}</span>
       </div>
       <div class="meta-item">
-        <span class="meta-label">{{ TR.company_size_label_colon }}</span>
+        <span class="meta-label">{{ ui("company_size_label_colon") }}</span>
         <span class="meta-value">{{ UNTERNEHMENSGROESSE_LABEL }}</span>
       </div>
       <div class="meta-item">
@@ -2557,7 +2517,7 @@
                         </div>
                         <span class="section-pill">
                             <span class="pill-dot"></span>
-                            {{ TR.deep_dive_for }} {{BRANCH_SHORT_LABEL|default(TR.your_industry)}}
+                            {{ ui("deep_dive_for") }} {{BRANCH_SHORT_LABEL|default(ui("your_industry"))}}
                         </span>
                     </div>
                     <div class="section-body">
@@ -2679,11 +2639,11 @@
                     <div class="section-header">
                         <div class="section-title">
                             <span class="section-kicker">Benchmarking</span>
-                            <h2>{{ TR.industry_benchmark_title }}</h2>
+                            <h2>{{ ui("industry_benchmark_title") }}</h2>
                         </div>
                         <span class="section-pill">
                             <span class="pill-dot"></span>
-                            {{ TR.industry_benchmark_kicker }}
+                            {{ ui("industry_benchmark_kicker") }}
                         </span>
                     </div>
                     <div class="section-body">
@@ -2696,7 +2656,7 @@
                 <section class="section chapter" id="recommendations-engine">
                     <div class="section-header">
                         <div class="section-title">
-                            <span class="section-kicker">{{ TR.recommendations }}</span>
+                            <span class="section-kicker">{{ ui("recommendations") }}</span>
                             <h2>Priorisierte Maßnahmen</h2>
                         </div>
                         <span class="section-pill">
@@ -2759,12 +2719,12 @@
                 <section class="section chapter" id="funding-branch-alignment">
                     <div class="section-header">
                         <div class="section-title">
-                            <span class="section-kicker">{{ TR.industry_specific }}</span>
-                            <h2>{{ TR.industry_funding_title }}</h2>
+                            <span class="section-kicker">{{ ui("industry_specific") }}</span>
+                            <h2>{{ ui("industry_funding_title") }}</h2>
                         </div>
                         <span class="section-pill">
                             <span class="pill-dot"></span>
-                            {{ TR.industry_funding_sub }}
+                            {{ ui("industry_funding_sub") }}
                         </span>
                     </div>
                     <div class="section-body">
@@ -2813,12 +2773,12 @@
                 <section class="section chapter" id="tools-branch-alignment">
                     <div class="section-header">
                         <div class="section-title">
-                            <span class="section-kicker">{{ TR.industry_optimized }}</span>
-                            <h2>{{ TR.industry_tools_title }}</h2>
+                            <span class="section-kicker">{{ ui("industry_optimized") }}</span>
+                            <h2>{{ ui("industry_tools_title") }}</h2>
                         </div>
                         <span class="section-pill">
                             <span class="pill-dot"></span>
-                            {{ TR.industry_tools_sub }}
+                            {{ ui("industry_tools_sub") }}
                         </span>
                     </div>
                     <div class="section-body">
@@ -2977,7 +2937,7 @@
                         {% if AI_ACT_DATA_GAPS_HTML %}
                         <div class="gaps-section" style="margin-bottom:16px;padding:12px;background:#fffbeb;border-radius:6px;">
                             <h3 style="font-size:14px;margin-bottom:8px;color:#856404;">Datenlücken</h3>
-                            <p class="section-intro" style="font-size:12px;color:#666;margin-bottom:8px;">{{ TR.missing_info }}</p>
+                            <p class="section-intro" style="font-size:12px;color:#666;margin-bottom:8px;">{{ ui("missing_info") }}</p>
                             {{ AI_ACT_DATA_GAPS_HTML|safe }}
                         </div>
                         {% endif %}
@@ -3088,7 +3048,7 @@
                 <!-- FEEDBACK SECTION -->
                 <div class="feedback-section">
                     <h2>Ihr Feedback ist uns wichtig!</h2>
-                    <p>{{ TR.feedback_cta }}</p>
+                    <p>{{ ui("feedback_cta") }}</p>
                     <div class="highlight-box">
                         <p><strong>Was hat Ihnen gefallen?</strong> Was können wir verbessern?</p>
                         <p>Nehmen Sie sich 2 Minuten Zeit für unser Feedback-Formular:</p>


### PR DESCRIPTION
…te template

- Add ui_factory import from services.i18n to report_renderer.py
- Inject ui() function into Jinja2 template context with report_lang
- Replace inline T/TR dict with centralized ui() calls in pdf_template.html
- All 17 TR.* usages now use ui("key") from i18n/ui_labels.json
- Template reduced by ~50 lines (removed inline translation dict)