### PR TITLE
feat(gate): multilingual v1 step5 - UI strict locale scan + content s…

### DIFF
--- a/scripts/generate_golden_reports.py
+++ b/scripts/generate_golden_reports.py
@@ -37,6 +37,7 @@ import re
 import sys
 import time
 from pathlib import Path
+from html.parser import HTMLParser
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 try:
@@ -608,17 +609,103 @@ def scan_html_for_forbidden_tokens(html_bytes: bytes, profile_id: str) -> Tuple[
 
 
 # =============================================================================
-# TEIL 3.1.1 + 3.1.4: Locale scan for EN profiles (German UI = Hard-Fail)
+# Multilingual v1 Step 5: UI text extractor using html.parser
+# =============================================================================
+class _UITextExtractor(HTMLParser):
+    """
+    Extract text content from elements with data-ui="1" attribute.
+
+    This enables 2-tier locale scanning:
+    - UI text (strict): Hard fail if German found
+    - Content text (soft): Score/warn only, no fail
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.ui_texts: List[str] = []
+        self.all_texts: List[str] = []
+        self._ui_element_stack: List[str] = []  # Stack of UI element tags
+        self._in_style_script = 0  # Skip style/script content
+
+    def handle_starttag(self, tag: str, attrs: List[Tuple[str, Optional[str]]]) -> None:
+        # Track style/script to skip their content
+        if tag in ("style", "script"):
+            self._in_style_script += 1
+            return
+
+        # Check for data-ui="1" attribute
+        attr_dict = dict(attrs)
+        if attr_dict.get("data-ui") == "1":
+            self._ui_element_stack.append(tag)
+
+    def handle_endtag(self, tag: str) -> None:
+        if tag in ("style", "script"):
+            self._in_style_script = max(0, self._in_style_script - 1)
+            return
+
+        # Pop UI element from stack when matching tag closes
+        if self._ui_element_stack and self._ui_element_stack[-1] == tag:
+            self._ui_element_stack.pop()
+
+    def handle_data(self, data: str) -> None:
+        if self._in_style_script > 0:
+            return  # Skip style/script content
+
+        text = data.strip()
+        if not text:
+            return
+
+        self.all_texts.append(text)
+        if self._ui_element_stack:  # Inside a UI element
+            self.ui_texts.append(text)
+
+
+def _extract_ui_and_content_text(html: str) -> Tuple[str, str, bool]:
+    """
+    Extract UI text (from data-ui="1" elements) and content text separately.
+
+    Args:
+        html: Full HTML content
+
+    Returns:
+        (ui_text: str, content_text: str, has_ui_markers: bool)
+        - ui_text: Combined text from data-ui="1" elements
+        - content_text: All other visible text
+        - has_ui_markers: Whether any data-ui="1" markers were found
+    """
+    try:
+        parser = _UITextExtractor()
+        parser.feed(html)
+
+        ui_text = " ".join(parser.ui_texts)
+        all_text = " ".join(parser.all_texts)
+
+        # Content text = all text minus UI text occurrences
+        # Simple approach: just use all_text for content, but flag UI separately
+        has_ui_markers = len(parser.ui_texts) > 0
+
+        # For content, we use all text but the gate logic will check UI separately
+        content_text = all_text
+
+        return ui_text, content_text, has_ui_markers
+    except Exception as e:
+        print(f"[locale-scan] ⚠️ HTML parsing failed: {e}")
+        return "", "", False
+
+
+# =============================================================================
+# Multilingual v1 Step 5: 2-tier Locale scan (UI strict / Content soft)
 # =============================================================================
 def scan_html_for_locale_leaks(html_text: str, expected_lang: str, profile_id: str) -> Tuple[bool, List[str]]:
     """
     Scan HTML for German UI strings when expected_lang is 'en'.
 
-    This ensures EN profiles don't have mixed-locale content.
-    Only scans when expected_lang == "en".
+    Multilingual v1 Step 5: 2-tier scanning:
+    - UI-Strict: German in data-ui="1" elements → HARD FAIL
+    - Content-Soft: German elsewhere → WARN (score logged), but NO FAIL
 
-    TEIL 3.1.4: Uses _strip_noncontent() to avoid false positives from
-    style/script/base64 content.
+    This enables EN reports to pass the gate even if LLM-generated content
+    contains some German, as long as UI labels are correctly translated.
 
     Args:
         html_text: Decoded HTML content
@@ -627,34 +714,91 @@ def scan_html_for_locale_leaks(html_text: str, expected_lang: str, profile_id: s
 
     Returns:
         (passed: bool, found_leaks: list of found German strings)
+        - passed: True if UI scan passed (content warnings don't cause failure)
+        - found_leaks: German strings found in UI (for backward compat)
     """
     if expected_lang != "en":
         return True, []  # Only check EN profiles
 
-    # TEIL 3.1.4: Strip style/script/base64 before locale scan
-    scan_text = _strip_noncontent(html_text)
+    # Step 1: Extract UI text and content text
+    ui_text, content_text, has_ui_markers = _extract_ui_and_content_text(html_text)
 
-    found_leaks = []
-    for de_string in DE_UI_STRINGS_EN_HARDFAIL:
-        if de_string in scan_text:
-            # Find context (from original for debugging)
-            idx = html_text.find(de_string)
-            if idx >= 0:
-                start = max(0, idx - 20)
-                end = min(len(html_text), idx + len(de_string) + 20)
-                context = html_text[start:end].replace("\n", " ").strip()
-                found_leaks.append(f"{de_string} (context: ...{context}...)")
+    # Step 2: Strip style/script/base64 from content (fallback for non-UI scan)
+    content_text_clean = _strip_noncontent(html_text) if not has_ui_markers else content_text
 
-    if found_leaks:
-        print(f"[locale-scan] ❌ FAILED for {profile_id} - {len(found_leaks)} German UI string(s) in EN report:")
-        for leak in found_leaks[:5]:  # Show first 5
-            print(f"[locale-scan]   - {leak}")
-        if len(found_leaks) > 5:
-            print(f"[locale-scan]   ... and {len(found_leaks) - 5} more")
-        return False, found_leaks
+    # ==========================================================================
+    # UI-STRICT SCAN (Hard Fail)
+    # ==========================================================================
+    ui_leaks = []
+    if has_ui_markers:
+        for de_string in DE_UI_STRINGS_EN_HARDFAIL:
+            if de_string in ui_text:
+                # Find context in original HTML
+                idx = html_text.find(de_string)
+                if idx >= 0:
+                    start = max(0, idx - 20)
+                    end = min(len(html_text), idx + len(de_string) + 20)
+                    context = html_text[start:end].replace("\n", " ").strip()
+                    ui_leaks.append(f"{de_string} (context: ...{context}...)")
+
+        if ui_leaks:
+            print(f"[locale-scan-ui] ❌ FAILED for {profile_id} - {len(ui_leaks)} German UI string(s) in EN report:")
+            for leak in ui_leaks[:5]:
+                print(f"[locale-scan-ui]   - {leak}")
+            if len(ui_leaks) > 5:
+                print(f"[locale-scan-ui]   ... and {len(ui_leaks) - 5} more")
+            return False, ui_leaks
+        else:
+            print(f"[locale-scan-ui] ✅ PASSED for {profile_id} - no German in UI elements")
     else:
-        print(f"[locale-scan] ✅ PASSED for {profile_id} - no German UI leaks in EN report")
-        return True, []
+        # No UI markers found - backward compatibility: warn but don't fail
+        print(f"[locale-scan-ui] ⚠️ SKIPPED for {profile_id} - no data-ui=\"1\" markers found (legacy template)")
+        # Fall back to old behavior: scan all content as UI (soft fail for now)
+        # In v1, we skip hard fail for legacy templates
+
+    # ==========================================================================
+    # CONTENT-SOFT SCAN (Score/Warn, No Fail)
+    # ==========================================================================
+    content_leaks = []
+    scan_source = content_text_clean
+
+    for de_string in DE_UI_STRINGS_EN_HARDFAIL:
+        # Skip if already found in UI (to avoid double-counting)
+        if de_string in scan_source:
+            # Only count if NOT in UI text (to get pure content leaks)
+            if has_ui_markers and de_string in ui_text:
+                continue  # Already counted in UI
+            content_leaks.append(de_string)
+
+    content_score = len(content_leaks)
+
+    if content_score > 0:
+        # Scoring thresholds
+        if content_score <= 10:
+            level = "OK"
+            emoji = "✅"
+        elif content_score <= 50:
+            level = "WARN"
+            emoji = "⚠️"
+        else:
+            level = "WARN_HIGH"
+            emoji = "⚠️"
+
+        print(f"[locale-scan-content] {emoji} {level} for {profile_id} - score={content_score} German strings in content")
+        if content_score <= 10:
+            for leak in content_leaks:
+                print(f"[locale-scan-content]   - {leak}")
+        else:
+            print(f"[locale-scan-content]   First 5: {content_leaks[:5]}")
+    else:
+        print(f"[locale-scan-content] ✅ CLEAN for {profile_id} - no German strings in content")
+
+    # ==========================================================================
+    # FINAL RESULT: UI scan determines pass/fail
+    # ==========================================================================
+    # If we got here, UI scan passed (or was skipped for legacy templates)
+    print(f"[locale-scan] ✅ PASSED for {profile_id} - UI check passed (content score={content_score})")
+    return True, []
 
 
 def scan_html_lang_attribute(html_text: str, expected_lang: str, profile_id: str) -> Tuple[bool, str]:

--- a/templates/pdf_template.html
+++ b/templates/pdf_template.html
@@ -2148,7 +2148,7 @@
                 <!-- HEADER -->
 <header class="header">
   <div class="header-main">
-    <div class="eyebrow">
+    <div class="eyebrow" data-ui="1">
       <div class="eyebrow-left">
         <span class="section-kicker">KI-Status-Report</span>
         <span class="eyebrow-divider"></span>
@@ -2168,7 +2168,7 @@
           Sicherheit, Effizienz und Förderpotenziale.
         </p>
       </div>
-      <div class="score-badge">
+      <div class="score-badge" data-ui="1">
         <span class="score-label">Gesamt-Score</span>
         <div class="score-main">
           <span class="score-value">{{ score_gesamt }}</span>
@@ -2177,7 +2177,7 @@
         <span class="score-sub">{{ score_rating }}</span>
       </div>
     </div>
-    <div class="meta-grid">
+    <div class="meta-grid" data-ui="1">
       <div class="meta-item">
         <span class="meta-label">{{ ui("industry_label_colon") }}</span>
         <span class="meta-value">{{ BRANCHE_LABEL }}</span>
@@ -2187,17 +2187,17 @@
         <span class="meta-value">{{ UNTERNEHMENSGROESSE_LABEL }}</span>
       </div>
       <div class="meta-item">
-        <span class="meta-label">Hauptziel mit KI:</span>
+        <span class="meta-label" data-ui="1">Hauptziel mit KI:</span>
         <span class="meta-value">
           {{ STRATEGISCHE_ZIELE or KI_ZIELE_LABELS or 'nicht spezifiziert' }}
         </span>
       </div>
       <div class="meta-item">
-        <span class="meta-label">Reportdatum:</span>
+        <span class="meta-label" data-ui="1">Reportdatum:</span>
         <span class="meta-value">{{ report_date }}</span>
       </div>
     </div>
-    <div class="badge-row">
+    <div class="badge-row" data-ui="1">
       <span class="badge badge-eu">
         <span class="badge-dot"></span>
         EU AI Act – PLATIN++ Branchenbest Practices
@@ -2231,7 +2231,7 @@
                 <!-- HEADER:END -->
                 <!-- HERO METRICS -->
                 <section class="section">
-                    <div class="section-header">
+                    <div class="section-header" data-ui="1">
                         <div class="section-title">
                             <span class="section-kicker">Überblick</span>
                             {% if size_label != 'Solo-Berater' and size_label != 'Solo-Unternehmer' and size_label != 'Freiberufler' %}
@@ -2510,7 +2510,7 @@
                 <!-- G24: Branch Deep-Dive Addon -->
                 {% if BRANCH_DEEP_DIVE_HTML %}
                 <section class="section chapter" id="branch-deep-dive">
-                    <div class="section-header">
+                    <div class="section-header" data-ui="1">
                         <div class="section-title">
                             <span class="section-kicker">Branch Deep Dive</span>
                             <h2>Branchenanalyse & Trends 2025/26</h2>
@@ -2636,7 +2636,7 @@
                 <!-- G37: Benchmark Engine – Branchenvergleich & Wettbewerbsposition -->
                 {% if BENCHMARK_ENGINE_HTML %}
                 <section class="section chapter" id="benchmark-engine">
-                    <div class="section-header">
+                    <div class="section-header" data-ui="1">
                         <div class="section-title">
                             <span class="section-kicker">Benchmarking</span>
                             <h2>{{ ui("industry_benchmark_title") }}</h2>
@@ -2654,7 +2654,7 @@
                 <!-- G32: Recommendations Engine – Priorisierte Handlungsempfehlungen -->
                 {% if RECOMMENDATIONS_ENGINE_HTML %}
                 <section class="section chapter" id="recommendations-engine">
-                    <div class="section-header">
+                    <div class="section-header" data-ui="1">
                         <div class="section-title">
                             <span class="section-kicker">{{ ui("recommendations") }}</span>
                             <h2>Priorisierte Maßnahmen</h2>
@@ -2717,7 +2717,7 @@
                 <!-- SPRINT G19: Funding × Branch Alignment -->
                 {% if FUNDING_BRANCH_ALIGNMENT_HTML %}
                 <section class="section chapter" id="funding-branch-alignment">
-                    <div class="section-header">
+                    <div class="section-header" data-ui="1">
                         <div class="section-title">
                             <span class="section-kicker">{{ ui("industry_specific") }}</span>
                             <h2>{{ ui("industry_funding_title") }}</h2>
@@ -2771,7 +2771,7 @@
                 <!-- SPRINT G19: Tools × Branch Alignment -->
                 {% if TOOLS_BRANCH_ALIGNMENT_HTML %}
                 <section class="section chapter" id="tools-branch-alignment">
-                    <div class="section-header">
+                    <div class="section-header" data-ui="1">
                         <div class="section-title">
                             <span class="section-kicker">{{ ui("industry_optimized") }}</span>
                             <h2>{{ ui("industry_tools_title") }}</h2>
@@ -2936,8 +2936,8 @@
                         <!-- Data Gaps -->
                         {% if AI_ACT_DATA_GAPS_HTML %}
                         <div class="gaps-section" style="margin-bottom:16px;padding:12px;background:#fffbeb;border-radius:6px;">
-                            <h3 style="font-size:14px;margin-bottom:8px;color:#856404;">Datenlücken</h3>
-                            <p class="section-intro" style="font-size:12px;color:#666;margin-bottom:8px;">{{ ui("missing_info") }}</p>
+                            <h3 style="font-size:14px;margin-bottom:8px;color:#856404;" data-ui="1">Datenlücken</h3>
+                            <p class="section-intro" style="font-size:12px;color:#666;margin-bottom:8px;" data-ui="1">{{ ui("missing_info") }}</p>
                             {{ AI_ACT_DATA_GAPS_HTML|safe }}
                         </div>
                         {% endif %}
@@ -2945,7 +2945,7 @@
                         <!-- Next Steps -->
                         {% if AI_ACT_RECOMMENDED_NEXT_STEPS_HTML %}
                         <div class="next-steps-section" style="margin-bottom:16px;">
-                            <h3 style="font-size:14px;margin-bottom:8px;">Empfohlene Nächste Schritte</h3>
+                            <h3 style="font-size:14px;margin-bottom:8px;" data-ui="1">Empfohlene Nächste Schritte</h3>
                             {{ AI_ACT_RECOMMENDED_NEXT_STEPS_HTML|safe }}
                         </div>
                         {% endif %}
@@ -3046,7 +3046,7 @@
                 </section>
                 {% endif %}
                 <!-- FEEDBACK SECTION -->
-                <div class="feedback-section">
+                <div class="feedback-section" data-ui="1">
                     <h2>Ihr Feedback ist uns wichtig!</h2>
                     <p>{{ ui("feedback_cta") }}</p>
                     <div class="highlight-box">


### PR DESCRIPTION
…oft scoring

Part A - Template UI markers:
- Add data-ui="1" to header/eyebrow, score-badge, meta-grid
- Add data-ui="1" to badge-row (EU AI Act, DSGVO badges)
- Add data-ui="1" to section-headers with ui() calls
- Add data-ui="1" to feedback section and data gaps UI

Part B - 2-tier locale scan in generate_golden_reports.py:
- Add _UITextExtractor class using html.parser (no external deps)
- UI-Strict scan: German in data-ui="1" elements → HARD FAIL
- Content-Soft scan: German in content → score/warn (no fail)
- Output: [locale-scan-ui] ✅/❌ + [locale-scan-content] score=...

Part C - Backward compatibility:
- Templates without data-ui="1" markers: skip UI scan with warning
- Legacy templates don't cause hard fail in v1

Expected: kmu_france gate passes as long as UI labels are EN