### PR TITLE
feat(qa-gate): implement QA-Gate v1 for testuser-ready reports

### DIFF
--- a/scripts/generate_golden_reports.py
+++ b/scripts/generate_golden_reports.py
@@ -609,6 +609,83 @@ def scan_html_for_forbidden_tokens(html_bytes: bytes, profile_id: str) -> Tuple[
 
 
 # =============================================================================
+# QA-Gate v1: Prompt-leak detection (LLM assistant phrases in final HTML)
+# =============================================================================
+PROMPT_LEAK_PHRASES: List[str] = [
+    # German assistant waiting phrases
+    "du hast noch keine frage",
+    "du hast noch keine aufgabe",
+    "sie haben noch keine frage",
+    "bitte beschreibe, wobei ich dir helfen",
+    "bitte beschreibe kurz, was du benötigst",
+    "wie kann ich dir helfen",
+    "wie kann ich ihnen helfen",
+    "womit kann ich ihnen dienen",
+    "ich stehe dir zur verfügung",
+    "ich stehe ihnen zur verfügung",
+    "keine eingabe erkannt",
+    "keine anfrage erkannt",
+    # German generic LLM responses
+    "ich sehe keine konkrete frage",
+    "als ki-assistent",
+    "als sprachmodell kann ich",
+    "ich bin ein ki-assistent",
+    "ich bin ein sprachmodell",
+    # English assistant waiting phrases
+    "you haven't asked a question yet",
+    "please describe what you need help with",
+    "how can i help you",
+    "how can i assist you",
+    "i'm waiting for your input",
+    "no input detected",
+    "what can i do for you today",
+    # English generic LLM responses
+    "i don't see a specific question",
+    "as an ai assistant",
+    "as a language model",
+    "i'm an ai language model",
+    "i'm just an ai",
+]
+
+
+def scan_html_for_prompt_leaks(html_text: str, profile_id: str) -> Tuple[bool, List[str]]:
+    """
+    QA-Gate v1: Scan HTML for prompt-leak phrases.
+
+    These are LLM assistant phrases that indicate the model didn't understand
+    the task and output generic waiting/help text instead of report content.
+
+    Args:
+        html_text: Decoded HTML content
+        profile_id: For logging
+
+    Returns:
+        (passed: bool, found_leaks: list of found leak phrases)
+    """
+    if not html_text:
+        return True, []
+
+    # Strip style/script/base64 before scanning
+    scan_text = _strip_noncontent(html_text).lower()
+
+    found_leaks = []
+    for phrase in PROMPT_LEAK_PHRASES:
+        if phrase.lower() in scan_text:
+            found_leaks.append(phrase)
+
+    if found_leaks:
+        print(f"[prompt-leak] ❌ FAILED for {profile_id} - {len(found_leaks)} prompt-leak phrase(s) found:")
+        for leak in found_leaks[:5]:
+            print(f"[prompt-leak]   - \"{leak}\"")
+        if len(found_leaks) > 5:
+            print(f"[prompt-leak]   ... and {len(found_leaks) - 5} more")
+        return False, found_leaks
+    else:
+        print(f"[prompt-leak] ✅ PASSED for {profile_id} - no prompt-leak phrases")
+        return True, []
+
+
+# =============================================================================
 # Multilingual v1 Step 5: UI text extractor using html.parser
 # =============================================================================
 class _UITextExtractor(HTMLParser):
@@ -751,10 +828,11 @@ def scan_html_for_locale_leaks(html_text: str, expected_lang: str, profile_id: s
         else:
             print(f"[locale-scan-ui] ✅ PASSED for {profile_id} - no German in UI elements")
     else:
-        # No UI markers found - backward compatibility: warn but don't fail
-        print(f"[locale-scan-ui] ⚠️ SKIPPED for {profile_id} - no data-ui=\"1\" markers found (legacy template)")
-        # Fall back to old behavior: scan all content as UI (soft fail for now)
-        # In v1, we skip hard fail for legacy templates
+        # =======================================================================
+        # QA-Gate v1: No UI markers = HARD FAIL (must have data-ui="1" markers)
+        # =======================================================================
+        print(f"[locale-scan-ui] ❌ FAILED for {profile_id} - no data-ui=\"1\" markers found (template must have UI markers)")
+        return False, ["NO_UI_MARKERS_FOUND"]
 
     # ==========================================================================
     # CONTENT-SOFT SCAN (Score/Warn, No Fail)
@@ -1249,6 +1327,19 @@ def process_profile(
                 "briefing_id": briefing_id,
                 "status": "gate_failed",
                 "error": f"Forbidden tokens in final HTML: {found_tokens}",
+            }
+
+    # 5.55 QA-Gate v1: Prompt-leak scan on final HTML (Hard-Fail Gate)
+    # Catches LLM assistant phrases that indicate task misunderstanding
+    if run_gate and html_bytes:
+        html_text_for_leak = html_bytes.decode("utf-8", errors="replace")
+        leak_scan_passed, found_leaks = scan_html_for_prompt_leaks(html_text_for_leak, profile_name)
+        if not leak_scan_passed:
+            return {
+                "profile": profile_name,
+                "briefing_id": briefing_id,
+                "status": "gate_failed",
+                "error": f"Prompt-leak phrases in final HTML: {found_leaks[:3]}",
             }
 
     # 5.6 TEIL 3.1.1: Locale scan for EN profiles (German UI = Hard-Fail)

--- a/services/html_sanitizer.py
+++ b/services/html_sanitizer.py
@@ -148,6 +148,55 @@ _EN_LOCALE_REPLACEMENTS: List[Tuple[str, LocaleRepl]] = [
     (r"\bDSGVO\b", "GDPR"),
     (r"\bHinweis\b", "Note"),
 
+    # --- QA-Gate v1: Extended content sanitization ---
+    # Priority/Scheduling terms
+    (r"\bPriorität\b", "Priority"),
+    (r"\bPrioritäten\b", "Priorities"),
+    (r"\bZeithorizont\b", "Time horizon"),
+    (r"\bNächste Schritte\b", "Next steps"),
+    (r"\bNächster Schritt\b", "Next step"),
+    # Cost/Business terms
+    (r"\bKosten\b", "Costs"),
+    (r"\bNutzen\b", "Benefits"),
+    (r"\bInvestition\b", "Investment"),
+    (r"\bInvestitionen\b", "Investments"),
+    (r"\bEinsparungen\b", "Savings"),
+    (r"\bEinsparung\b", "Saving"),
+    (r"\bAmortisation\b", "Payback"),
+    (r"\bFörderpotenzial\b", "Funding potential"),
+    (r"\bFörderprogramme\b", "Funding programmes"),
+    (r"\bFörderprogramm\b", "Funding programme"),
+    # Risk terms
+    (r"\bRisikolage\b", "Risk situation"),
+    (r"\bRisikoprofil\b", "Risk profile"),
+    (r"\bRisiko-Matrix\b", "Risk matrix"),
+    (r"\bRisiko\b", "Risk"),
+    # Process/Strategy terms
+    (r"\bUmsetzung\b", "Implementation"),
+    (r"\bStrategie\b", "Strategy"),
+    (r"\bRoadmap\b", "Roadmap"),
+    (r"\bZielbild\b", "Target state"),
+    # Scoring/Rating terms
+    (r"\bGesamt\b", "Overall"),
+    (r"\bDurchschnitt\b", "Average"),
+    (r"\bSehr gut\b", "Very good"),
+    (r"\bSolide\b", "Solid"),
+    (r"\bAusbaufähig\b", "Needs improvement"),
+    # Time units
+    (r"\bMonat\b", "Month"),
+    (r"\bMonate\b", "Months"),
+    (r"\bWoche\b", "Week"),
+    (r"\bWochen\b", "Weeks"),
+    (r"\bQuartal\b", "Quarter"),
+    # Table/Structure terms
+    (r"\bBeschreibung\b", "Description"),
+    (r"\bAuswirkung\b", "Impact"),
+    (r"\bVerantwortung\b", "Responsibility"),
+    (r"\bVerantwortlich\b", "Responsible"),
+    (r"\bQuelle\b", "Source"),
+    (r"\bWert\b", "Value"),
+    (r"\bVergleich\b", "Comparison"),
+
     # single tokens / common nouns
     (r"\bBranche\b", "Industry"),
     (r"\bBewertung\b", "Assessment"),

--- a/services/report_validator.py
+++ b/services/report_validator.py
@@ -371,6 +371,39 @@ class ReportValidator:
         "according to your input",
         "as per your request",
         "as mentioned in your question",
+        # =================================================================
+        # QA-Gate v1: Additional prompt-leak patterns
+        # =================================================================
+        # German assistant waiting phrases
+        "du hast noch keine frage",
+        "du hast noch keine aufgabe",
+        "sie haben noch keine frage",
+        "sie haben noch keine aufgabe",
+        "bitte beschreibe, wobei ich dir helfen",
+        "bitte beschreibe kurz, was du benötigst",
+        "bitte beschreiben sie, wobei ich ihnen helfen",
+        "ich stehe dir zur verfügung",
+        "ich stehe ihnen zur verfügung",
+        "womit kann ich ihnen dienen",
+        "womit kann ich dir dienen",
+        "was führt sie zu mir",
+        "was führt dich zu mir",
+        "ich warte auf ihre eingabe",
+        "ich warte auf deine eingabe",
+        "keine eingabe erkannt",
+        "keine anfrage erkannt",
+        # English assistant waiting phrases
+        "you haven't asked a question yet",
+        "you haven't provided a task",
+        "please describe what you need help with",
+        "please tell me what you'd like",
+        "i'm waiting for your input",
+        "no input detected",
+        "no request detected",
+        "what can i do for you today",
+        "what brings you here today",
+        "i'm ready when you are",
+        "just let me know what you need",
     ]
 
     # SPRINT N: Extended SIZE_FORBIDDEN for Solo personas

--- a/templates/pdf_template_en.html
+++ b/templates/pdf_template_en.html
@@ -1704,7 +1704,7 @@
                 <!-- HEADER -->
 <header class="header">
   <div class="header-main">
-    <div class="eyebrow">
+    <div class="eyebrow" data-ui="1">
       <div class="eyebrow-left">
         <span class="section-kicker">AI Status Report</span>
         <span class="eyebrow-divider"></span>
@@ -1724,7 +1724,7 @@
           security, efficiency, and funding opportunities.
         </p>
       </div>
-      <div class="score-badge">
+      <div class="score-badge" data-ui="1">
         <span class="score-label">Overall Score</span>
         <div class="score-main">
           <span class="score-value">{{ score_gesamt }}</span>
@@ -1733,7 +1733,7 @@
         <span class="score-sub">{{ score_rating }}</span>
       </div>
     </div>
-    <div class="meta-grid">
+    <div class="meta-grid" data-ui="1">
       <div class="meta-item">
         <span class="meta-label">Industry:</span>
         <span class="meta-value">{{ BRANCHE_LABEL }}</span>
@@ -1753,7 +1753,7 @@
         <span class="meta-value">{{ report_date }}</span>
       </div>
     </div>
-    <div class="badge-row">
+    <div class="badge-row" data-ui="1">
       <span class="badge badge-eu">
         <span class="badge-dot"></span>
         EU AI Act – PLATIN++ Industry Best Practices
@@ -1787,7 +1787,7 @@
                 <!-- HEADER:END -->
 <!-- HERO METRICS -->
                 <section class="section">
-                    <div class="section-header">
+                    <div class="section-header" data-ui="1">
                         <div class="section-title">
                             <span class="section-kicker">Overview</span>
                             <h2>Executive Summary</h2>
@@ -2589,7 +2589,7 @@
                 </section>
                 {% endif %}
 <!-- FEEDBACK SECTION -->
-                <div class="feedback-section">
+                <div class="feedback-section" data-ui="1">
                     <h2>Your Feedback Matters!</h2>
                     <p>Help us make this report even better. Your feedback helps other companies.</p>
                     <div class="highlight-box">


### PR DESCRIPTION
Part A - Hard Fixes:
1. Extend GENERIC_LLM_LEAK_PHRASES with 30+ new patterns including:
   - "du hast noch keine frage", "bitte beschreibe, wobei ich dir helfen"
   - English equivalents for waiting/ready phrases
2. Add data-ui="1" markers to pdf_template_en.html:
   - eyebrow, score-badge, meta-grid, badge-row
   - section-header, feedback-section

Part B - Language Quality:
3. Extend _EN_LOCALE_REPLACEMENTS with 40+ new DE→EN mappings:
   - Priority/Scheduling: Priorität→Priority, Zeithorizont→Time horizon
   - Cost/Business: Kosten→Costs, Einsparungen→Savings
   - Risk: Risikolage→Risk situation, Risikoprofil→Risk profile
   - Time units: Monat→Month, Quartal→Quarter

Part C - QA-Gate v1:
4. Add scan_html_for_prompt_leaks() function with PROMPT_LEAK_PHRASES list
5. Make locale-scan-ui SKIPPED a hard fail (NO_UI_MARKERS_FOUND)
6. Add prompt-leak scan to gate sequence (step 5.55)

Gate output format:
- [prompt-leak] ✅/❌ PASSED/FAILED
- [locale-scan-ui] ✅/❌ PASSED/FAILED (not SKIPPED)
- [locale-scan-content] score=N (soft warning)