### PR TITLE
fix(i18n): fix badge detection + extend DE token sanitizer

### DIFF
--- a/scripts/qa_content_checks.py
+++ b/scripts/qa_content_checks.py
@@ -81,9 +81,10 @@ PROMPT_LEAK_PATTERNS: List[str] = [
 ]
 
 # ---------------------------------------------------------------------------
-# Badge keys expected in report
+# Badge CSS classes expected in rendered HTML
+# These are the actual CSS classes in pdf_template_en.html, not variable names
 # ---------------------------------------------------------------------------
-EXPECTED_BADGES = ["badge_security", "badge_compliance", "badge_efficiency"]
+EXPECTED_BADGE_CLASSES = ["badge-eu", "badge-dsgvo", "badge-risk", "badge-time"]
 
 
 def scan_de_tokens(html: str) -> List[Tuple[str, str, int]]:
@@ -118,15 +119,15 @@ def scan_prompt_leaks(html: str) -> List[Tuple[str, int]]:
 
 
 def check_badges(html: str) -> List[str]:
-    """Check for expected badge keys in HTML.
+    """Check for expected badge CSS classes in rendered HTML.
 
-    Returns list of missing badge keys.
+    Returns list of missing badge class names.
     """
     missing = []
-    for badge in EXPECTED_BADGES:
-        # Check for badge in HTML content or data attributes
-        if badge not in html:
-            missing.append(badge)
+    for badge_class in EXPECTED_BADGE_CLASSES:
+        # Check for badge CSS class in HTML (e.g., class="badge badge-eu")
+        if badge_class not in html:
+            missing.append(badge_class)
     return missing
 
 

--- a/services/html_sanitizer.py
+++ b/services/html_sanitizer.py
@@ -262,6 +262,44 @@ _EN_LOCALE_REPLACEMENTS: List[Tuple[str, LocaleRepl]] = [
     (r"\bUnternehmen\b", "Company"),
 
     # ==========================================================================
+    # ADDITIONAL COMMON GERMAN TOKENS (Final polish)
+    # ==========================================================================
+    # Personnel/HR terms
+    (r"\bMitarbeitern\b", "Employees"),
+    (r"\bMitarbeiter\b", "Employees"),
+    # Financial terms
+    (r"\bUmsatz\b", "Revenue"),
+    (r"\bPotenzial\b", "Potential"),
+    # Process terms
+    (r"\bProzesse\b", "Processes"),
+    (r"\bProzess\b", "Process"),
+    # Data terms
+    (r"\bDaten\b", "Data"),
+    # Goal terms
+    (r"\bZiele\b", "Goals"),
+    (r"\bZiel\b", "Goal"),
+    # Analysis/Results
+    (r"\bAnalyse\b", "Analysis"),
+    (r"\bErgebnisse\b", "Results"),
+    (r"\bErgebnis\b", "Result"),
+    # Time - Year
+    (r"\bJahre\b", "Years"),
+    (r"\bJahr\b", "Year"),
+    # Time - Day
+    (r"\bTage\b", "Days"),
+    (r"\bTag\b", "Day"),
+    # Additional common terms
+    (r"\bAbteilung\b", "Department"),
+    (r"\bProjekt\b", "Project"),
+    (r"\bProjekte\b", "Projects"),
+    (r"\bLösung\b", "Solution"),
+    (r"\bLösungen\b", "Solutions"),
+    (r"\bVorteil\b", "Advantage"),
+    (r"\bVorteile\b", "Advantages"),
+    (r"\bAnwendung\b", "Application"),
+    (r"\bAnwendungen\b", "Applications"),
+
+    # ==========================================================================
     # WORD-BOUNDARY SAFE REPLACEMENTS (tag contexts)
     # ==========================================================================
     (r">\s*Unternehmen\s*<", "> Company <"),
@@ -291,7 +329,9 @@ def sanitize_en_locale_tokens(html: str, lang: str) -> str:
 
     # Optional: Log leftover detection (warning only)
     de_check_words = ["Unternehmen", "Branche", "Bewertung", "Reifegrad",
-                      "Kennzahlen", "Risiken", "Handlungsempfehlungen", "Unternehmensgröße"]
+                      "Kennzahlen", "Risiken", "Handlungsempfehlungen", "Unternehmensgröße",
+                      "Mitarbeiter", "Umsatz", "Potenzial", "Prozess", "Daten",
+                      "Ziel", "Analyse", "Ergebnis", "Jahr", "Tag"]
     leftovers = [w for w in de_check_words if w in out]
     if leftovers:
         log.warning("[locale-sanitize] DE leftovers after sanitize: %s", leftovers)


### PR DESCRIPTION
- qa_content_checks.py: Check for actual CSS badge classes (badge-eu, badge-dsgvo, badge-risk, badge-time) instead of variable names that never appear in rendered HTML
- html_sanitizer.py: Add 20+ new DE→EN mappings:
  - Mitarbeiter→Employees, Umsatz→Revenue, Potenzial→Potential
  - Prozess/Prozesse→Process/Processes, Daten→Data
  - Ziel/Ziele→Goal/Goals, Analyse→Analysis
  - Ergebnis/Ergebnisse→Result/Results, Jahr/Jahre→Year/Years
  - Tag/Tage→Day/Days, Projekt/Projekte→Project/Projects
  - Lösung/Lösungen→Solution/Solutions, Vorteil/Vorteile→Advantage/Advantages
  - Anwendung/Anwendungen→Application/Applications
- Update leftover detection list with new tokens