### PR TITLE
fix(i18n): add missing 'Förderung' -> 'Funding' mapping

### DIFF
--- a/services/html_sanitizer.py
+++ b/services/html_sanitizer.py
@@ -177,6 +177,7 @@ _EN_LOCALE_REPLACEMENTS: List[Tuple[str, LocaleRepl]] = [
     (r"\bFörderprogramme\b", "Funding programmes"),
     (r"\bFörderprogramm\b", "Funding programme"),
     (r"\bFörderchance\b", "Funding opportunity"),
+    (r"\bFörderung\b", "Funding"),
     # Scenario labels
     (r"\bKonservativ\b", "Conservative"),
     (r"\bRealistisch\b", "Realistic"),


### PR DESCRIPTION
The sanitizer had compound forms (Förderpotenzial, Förderprogramm, etc.) but was missing the base word 'Förderung' which appeared once in the kmu_france report.

Other terms (Nutzen, Kosten, Nächste Schritte, Realistisch) were already mapped - the remaining hit was from the missing base word.

This should reduce locale-v2 score from 6 to <=5.