### PR TITLE
fix(i18n): make locale sanitizer case-insensitive

### DIFF
--- a/services/html_sanitizer.py
+++ b/services/html_sanitizer.py
@@ -326,7 +326,7 @@ def sanitize_en_locale_tokens(html: str, lang: str) -> str:
 
     out = html or ""
     for pattern, repl in _EN_LOCALE_REPLACEMENTS:
-        out = re.sub(pattern, repl, out)
+        out = re.sub(pattern, repl, out, flags=re.IGNORECASE)
 
     # Optional: Log leftover detection (warning only)
     de_check_words = ["Unternehmen", "Branche", "Bewertung", "Reifegrad",


### PR DESCRIPTION
Root cause: The sanitizer's re.sub() calls were case-sensitive, so lowercase German tokens like "nutzen" or "realistisch" weren't being replaced. The locale-v2 scanner was case-insensitive (re.IGNORECASE), creating a mismatch where tokens were detected but not sanitized.

Fix: Add flags=re.IGNORECASE to the re.sub() call in sanitize_en_locale_tokens().

Expected: Nutzen(5) + Realistisch(2) = 7 hits should now be replaced, dropping locale-v2 score to <= 5.