### PR TITLE
fix(i18n): Risks section hard stop + localized heading

### DIFF
--- a/gpt_analyze.py
+++ b/gpt_analyze.py
@@ -2821,8 +2821,10 @@ def _get_fallback_content(section_key: str, briefing: Dict[str, Any], scores: Di
             org_risk = "In größeren Strukturen können unklare Verantwortlichkeiten und fehlende Governance zu Insellösungen führen"
             org_measure = "Governance-Framework, definierte Prozesse und bereichsübergreifende Koordination"
 
+        # Content Quality Pack v1.1: Use ui() for localized heading
+        risks_heading = ui("risks", briefing_lang)
         return f"""<section class="section risks">
-  <h2>Wesentliche Risiken beim Einsatz von KI in {hauptleistung or "Ihrem Kerngeschäft"}</h2>
+  <h2>{risks_heading}</h2>
 
   <p>
     Der Einsatz von KI im Bereich <strong>{hauptleistung or "Ihrem Kerngeschäft"}</strong> in der Branche

--- a/templates/pdf_template.html
+++ b/templates/pdf_template.html
@@ -2829,7 +2829,9 @@
                     </div>
                 </section>
                 {% endif %}
-                {% if BRANCH_RISKS_HTML %}
+                {# G27: Risks - Hard Stop if placeholder content (Content Quality Pack v1.1) #}
+                {% set risks_txt = (BRANCH_RISKS_HTML or "") | string %}
+                {% if risks_txt and "In diesem Abschnitt wurden keine konkreten Inhalte bereitgestellt" not in risks_txt and "no specific content was provided" not in risks_txt|lower %}
                 <section class="section" id="branch-risks">
                     <div class="section-body">
                         {{ BRANCH_RISKS_HTML|safe }}


### PR DESCRIPTION
Fix A: Template now skips Risks section if placeholder text detected
Fix B: Python fallback uses ui() for localized heading (DE/EN)