### PR TITLE
feat(pdf): add footer with page numbers and report metadata

### DIFF
--- a/docs/REPORT_FRONTMATTER.md
+++ b/docs/REPORT_FRONTMATTER.md
@@ -1,0 +1,63 @@
+# Report Frontmatter Documentation
+
+This document describes the metadata and presentation elements used in PDF reports.
+
+## PDF Footer
+
+Every page of the generated PDF report includes a footer with the following information:
+
+### Left Side
+- **Page Numbers**: `Seite X / Y` (Page X of Y)
+
+### Right Side
+- **Report ID**: Unique identifier in format `R-YYYYMMDD-CODE` (e.g., `R-20251219-KND`)
+- **Report Date**: Date in German format `DD.MM.YYYY` (e.g., `19.12.2025`)
+
+### Example Footer
+```
+Seite 1 / 15                                    Report-ID: R-20251219-KND • 19.12.2025
+```
+
+## Technical Implementation
+
+### Footer Template (Puppeteer)
+The footer is rendered using Puppeteer's `displayHeaderFooter` option with a custom `footerTemplate`:
+
+```python
+from services.pdf_client import build_footer_template
+
+footer_template = build_footer_template(
+    report_id="R-20251219-KND",
+    report_date="19.12.2025"
+)
+
+pdf_options = {
+    "format": "A4",
+    "printBackground": True,
+    "displayHeaderFooter": True,
+    "headerTemplate": "<div></div>",
+    "footerTemplate": footer_template,
+    "margin": {"top": "12mm", "right": "12mm", "bottom": "20mm", "left": "12mm"}
+}
+```
+
+### Data Sources
+- **report_id**: Generated from `R-{YYYYMMDD}-{customer_code}` during report analysis
+- **report_date**: Current date in `DD.MM.YYYY` format, set during report generation
+
+### Fallback Behavior
+If `report_id` or `report_date` are not available:
+- Missing values are replaced with `–` (en-dash)
+- The footer will still display page numbers correctly
+
+### Margin Configuration
+- **Bottom margin**: 20mm to accommodate the footer without overlapping content
+- **Top margin**: 12mm
+- **Left/Right margins**: 12mm
+
+## Related Files
+
+- `services/pdf_client.py` - Contains `build_footer_template()` and `render_pdf_from_html()`
+- `services/report_renderer.py` - Extracts report metadata for footer
+- `gpt_analyze.py` - Main report generation pipeline
+- `routes/report.py` - On-demand PDF generation endpoint

--- a/gpt_analyze.py
+++ b/gpt_analyze.py
@@ -116,7 +116,7 @@ import core.db as core_db
 from field_registry import fields  # added by Patch03
 from models import Analysis, Briefing, Report, User
 from services.report_renderer import render
-from services.pdf_client import render_pdf_from_html
+from services.pdf_client import render_pdf_from_html, build_footer_template
 from services.email_templates import render_report_ready_email
 from settings import settings
 from services.coverage_guard import analyze_coverage, build_html_report
@@ -6873,10 +6873,29 @@ def run_briefing_pipeline(db: Session, briefing_id: int, email: Optional[str] = 
         db.commit()
         db.refresh(rep)
 
-        # PDF generation
+        # PDF generation with footer
         if DBG_PDF:
             log.debug("[%s] 📄 pdf_render start", run_id)
-        pdf_info = render_pdf_from_html(html, meta={"analysis_id": an_id, "briefing_id": briefing_id, "run_id": run_id})
+
+        # Build PDF options with footer template (page numbers + report metadata)
+        footer_template = build_footer_template(
+            report_id=meta.get("report_id", ""),
+            report_date=meta.get("report_date", "")
+        )
+        pdf_options = {
+            "format": "A4",
+            "printBackground": True,
+            "displayHeaderFooter": True,
+            "headerTemplate": "<div></div>",
+            "footerTemplate": footer_template,
+            "margin": {"top": "12mm", "right": "12mm", "bottom": "20mm", "left": "12mm"}
+        }
+
+        pdf_info = render_pdf_from_html(
+            html,
+            meta={"analysis_id": an_id, "briefing_id": briefing_id, "run_id": run_id},
+            pdf_options=pdf_options
+        )
         pdf_url = pdf_info.get("pdf_url")
         pdf_bytes = pdf_info.get("pdf_bytes")
         pdf_error = pdf_info.get("error")
@@ -6952,13 +6971,33 @@ def run_async(briefing_id: int, email: Optional[str] = None) -> None:
         db.commit()
         db.refresh(rep)
         
-        if DBG_PDF: 
+        # PDF generation with footer
+        if DBG_PDF:
             log.debug("[%s] 📄 pdf_render start", run_id)
-        pdf_info = render_pdf_from_html(html, meta={"analysis_id": an_id, "briefing_id": briefing_id, "run_id": run_id})
+
+        # Build PDF options with footer template (page numbers + report metadata)
+        footer_template = build_footer_template(
+            report_id=meta.get("report_id", ""),
+            report_date=meta.get("report_date", "")
+        )
+        pdf_options = {
+            "format": "A4",
+            "printBackground": True,
+            "displayHeaderFooter": True,
+            "headerTemplate": "<div></div>",
+            "footerTemplate": footer_template,
+            "margin": {"top": "12mm", "right": "12mm", "bottom": "20mm", "left": "12mm"}
+        }
+
+        pdf_info = render_pdf_from_html(
+            html,
+            meta={"analysis_id": an_id, "briefing_id": briefing_id, "run_id": run_id},
+            pdf_options=pdf_options
+        )
         pdf_url = pdf_info.get("pdf_url")
         pdf_bytes = pdf_info.get("pdf_bytes")
         pdf_error = pdf_info.get("error")
-        if DBG_PDF: 
+        if DBG_PDF:
             log.debug("[%s] 📄 pdf_render done url=%s bytes=%s error=%s", run_id, bool(pdf_url), len(pdf_bytes or b""), pdf_error)
         
         if not pdf_url and not pdf_bytes:

--- a/routes/report.py
+++ b/routes/report.py
@@ -252,7 +252,7 @@ def get_report_pdf_v2(
 
     # Render PDF from HTML via PDF service
     try:
-        from services.pdf_client import render_pdf_from_html
+        from services.pdf_client import render_pdf_from_html, build_footer_template
     except ImportError as exc:
         log.error(f"[PDF] pdf_client import failed: {exc}")
         return JSONResponse(
@@ -262,9 +262,26 @@ def get_report_pdf_v2(
 
     log.info(f"[PDF] Rendering on-demand PDF for briefing {briefing_id} (html_size={len(html_content)})")
 
+    # Extract report metadata from analysis for footer
+    analysis_meta = getattr(analysis, "meta", {}) or {}
+    report_id = analysis_meta.get("report_id", "")
+    report_date = analysis_meta.get("report_date", "")
+
+    # Build PDF options with footer template (page numbers + report metadata)
+    footer_template = build_footer_template(report_id=report_id, report_date=report_date)
+    pdf_options = {
+        "format": "A4",
+        "printBackground": True,
+        "displayHeaderFooter": True,
+        "headerTemplate": "<div></div>",
+        "footerTemplate": footer_template,
+        "margin": {"top": "12mm", "right": "12mm", "bottom": "20mm", "left": "12mm"}
+    }
+
     result = render_pdf_from_html(
         html=html_content,
-        meta={"briefing_id": briefing_id, "analysis_id": getattr(analysis, "id", None)}
+        meta={"briefing_id": briefing_id, "analysis_id": getattr(analysis, "id", None)},
+        pdf_options=pdf_options
     )
 
     if result.get("error"):

--- a/services/pdf_client.py
+++ b/services/pdf_client.py
@@ -176,15 +176,48 @@ def slim_html_sections(sections: Dict[str, Any]) -> Dict[str, Any]:
     return sections
 
 
-def render_pdf_from_html(html: str, meta: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+def build_footer_template(report_id: str, report_date: str) -> str:
+    """
+    Build Puppeteer footerTemplate with page numbers and report metadata.
+
+    Args:
+        report_id: Report ID (e.g., "R-20251219-KND")
+        report_date: Report date in DD.MM.YYYY format
+
+    Returns:
+        HTML string for footerTemplate
+    """
+    # Fallback for missing values
+    report_id_display = report_id if report_id else "–"
+    report_date_display = report_date if report_date else "–"
+
+    return f'''<div style="width:100%; font-size:9px; padding:0 14mm; box-sizing:border-box; color:#666;
+            display:flex; align-items:center; justify-content:space-between;">
+  <div>
+    Seite <span class="pageNumber"></span> / <span class="totalPages"></span>
+  </div>
+  <div>
+    Report-ID: {report_id_display} • {report_date_display}
+  </div>
+</div>'''
+
+
+def render_pdf_from_html(
+    html: str,
+    meta: Optional[Dict[str, Any]] = None,
+    pdf_options: Optional[Dict[str, Any]] = None
+) -> Dict[str, Any]:
     """
     Render HTML to PDF via PDF service.
 
     SPRINT G14-D: Enhanced with error categorization and retry metrics.
+    Footer Support: Added pdf_options parameter for Puppeteer page.pdf() settings.
 
     Args:
         html: HTML content to render
         meta: Optional metadata dict
+        pdf_options: Optional PDF rendering options (footerTemplate, headerTemplate,
+                     displayHeaderFooter, margin, etc.)
 
     Returns:
         Dict with pdf_bytes/pdf_url or error
@@ -202,7 +235,13 @@ def render_pdf_from_html(html: str, meta: Optional[Dict[str, Any]] = None) -> Di
     rid = _as_str(rid)
     url = f"{PDF_SERVICE_URL}/generate-pdf"
 
-    payload = {"html": html, "meta": meta}
+    # Build payload with optional PDF options
+    payload: Dict[str, Any] = {"html": html, "meta": meta}
+
+    # Add PDF options if provided (for Puppeteer page.pdf() settings)
+    if pdf_options:
+        payload["pdf_options"] = pdf_options
+        log.debug("[PDF] Using custom PDF options: %s", list(pdf_options.keys()))
     headers = {
         "Content-Type": "application/json",
         "Accept": "application/pdf, application/json",

--- a/services/report_renderer.py
+++ b/services/report_renderer.py
@@ -549,4 +549,8 @@ def render(briefing_obj: Any,
         meta = {}
     meta.update(locale_v2_meta)
 
+    # Add report metadata for PDF footer
+    meta["report_id"] = ctx.get("report_id", "")
+    meta["report_date"] = ctx.get("report_date", "")
+
     return {"html": html, "meta": meta or {}}


### PR DESCRIPTION
- Add build_footer_template() helper in pdf_client.py for Puppeteer footer
- Extend render_pdf_from_html() to accept pdf_options parameter
- Update all PDF generation calls to include footer with:
  - Left: "Seite X / Y" (page numbers)
  - Right: "Report-ID: {id} • {date}"
- Add report_id and report_date to render() output meta in report_renderer.py
- Create docs/REPORT_FRONTMATTER.md with footer documentation

Footer displays Report-ID (R-YYYYMMDD-CODE) and date (DD.MM.YYYY format). Missing values fallback to en-dash (–). Margin bottom set to 20mm.