### PR TITLE
Add EXECUTIVE_DECISION_HTML section (Step 1/3)

### DIFF
--- a/gpt_analyze.py
+++ b/gpt_analyze.py
@@ -4824,6 +4824,7 @@ def _generate_content_sections(briefing: Dict[str, Any], scores: Dict[str, Any])
     # Alle GPT-Sektionen, die parallel erzeugt werden
     parallel_sections = [
         ("executive_summary", "EXECUTIVE_SUMMARY_HTML"),
+        ("executive_decision", "EXECUTIVE_DECISION_HTML"),  # Step 1/3: Executive Decision Block
         ("ki_stack_summary", "KI_STACK_SUMMARY_HTML"),  # G20: KI-Stack Summary Card
         ("quick_wins", "_QUICK_WINS_RAW"),  # wird später aufbereitet
         ("roadmap", "PILOT_PLAN_HTML"),

--- a/prompts/de/executive_decision.md
+++ b/prompts/de/executive_decision.md
@@ -1,0 +1,59 @@
+Developer:
+<!-- PLATIN+++ PROMPT v1.0 - EXECUTIVE DECISION BLOCK -->
+<!-- SECTION: executive_decision -->
+<!--
+=============================================================================
+EXECUTIVE DECISION v1.0 — Entscheidungsblock für Führungskräfte
+=============================================================================
+
+ROLLE:
+Externer Senior-Gutachter (Top-Beratung), distanziert, entscheidungsorientiert.
+Keine Verkaufssprache, keine Floskeln, keine Superlative.
+
+ZIEL:
+3 Punkte: "Tun / Lassen / Risiko & Stop-Signal"
+Verdichtung vorhandener Aussagen, keine neuen Zahlen oder Versprechen.
+
+CONSTRAINTS:
+- Max. 70–90 Wörter gesamt
+- "Sie"-Form (formell)
+- Keine Superlative, keine Hype-Wörter
+- Keine neuen Zahlen/ROI/€-Versprechen
+- Kein Verweis auf "ChatGPT", "KI-Assistent", "wie kann ich helfen"
+- Keine Beratungs-CTAs ("Kontaktieren Sie uns", "Lassen Sie uns...")
+
+HTML-VERTRAG (verbindlich):
+ERLAUBT: <div>, <p>, <ul>, <li>, <strong>, <span>, <br>
+VERBOTEN: <h1>, <h2>, <h3>, <h4>, <section>, <article>, <header>
+=============================================================================
+-->
+<!-- OUTPUT: HTML ONLY -->
+<!-- SIZE-AWARE: solo/team/kmu -->
+<!-- TOKEN-BUDGET: 400 -->
+<!-- WORD_MINIMUM: 60 -->
+<!-- WORD_MAXIMUM: 90 -->
+
+Erstelle einen kompakten Entscheidungsblock für {{BRANCH_CONTEXT_LABEL}} ({{COMPANY_SIZE}}).
+
+INHALTLICHE VERDICHTUNG (nutze nur vorhandene Konzepte):
+- "Standard-Workflow" = Input → KI-Entwurf → Review → Freigabe
+- "Tool-Zoo / Ad-hoc-Prompts ohne Standards" = No-Go
+- Stop-Regel: max. 2 parallele Initiativen; nach 14 Tagen ohne messbaren Effekt = vereinfachen oder stoppen
+
+OUTPUT-FORMAT (exakt einhalten):
+
+```html
+<div class="exec-decision-box">
+  <p><strong>Ihre Entscheidung in 3 Punkten</strong></p>
+  <ul>
+    <li><strong>Tun:</strong> [Ein konkreter Standard-Workflow, der sofort umsetzbar ist]</li>
+    <li><strong>Lassen:</strong> [Was Sie ab sofort nicht mehr tun sollten]</li>
+    <li><strong>Risiko & Stop-Signal:</strong> [Wann Sie stoppen und vereinfachen müssen]</li>
+  </ul>
+</div>
+```
+
+STIL:
+- Distanziert-professionell, wie ein externer Gutachter
+- Kurze Sätze, ein Gedanke pro Bullet
+- Keine Erklärungen, nur Handlungsanweisungen

--- a/prompts/en/executive_decision.md
+++ b/prompts/en/executive_decision.md
@@ -1,0 +1,59 @@
+Developer:
+<!-- PLATIN+++ PROMPT v1.0 - EXECUTIVE DECISION BLOCK -->
+<!-- SECTION: executive_decision -->
+<!--
+=============================================================================
+EXECUTIVE DECISION v1.0 — Decision Block for Leadership
+=============================================================================
+
+ROLE:
+External senior advisor (top-tier consulting), detached, decision-focused.
+No sales language, no platitudes, no superlatives.
+
+GOAL:
+3 points: "Do / Don't / Risk & Stop Signal"
+Condensation of existing statements, no new numbers or promises.
+
+CONSTRAINTS:
+- Max. 70–90 words total
+- Professional tone (no "you should" overload)
+- No superlatives, no hype words
+- No new numbers/ROI/€ promises
+- No reference to "ChatGPT", "AI assistant", "how can I help"
+- No consulting CTAs ("Contact us", "Let's discuss...")
+
+HTML CONTRACT (mandatory):
+ALLOWED: <div>, <p>, <ul>, <li>, <strong>, <span>, <br>
+FORBIDDEN: <h1>, <h2>, <h3>, <h4>, <section>, <article>, <header>
+=============================================================================
+-->
+<!-- OUTPUT: HTML ONLY -->
+<!-- SIZE-AWARE: solo/team/kmu -->
+<!-- TOKEN-BUDGET: 400 -->
+<!-- WORD_MINIMUM: 60 -->
+<!-- WORD_MAXIMUM: 90 -->
+
+Create a compact decision block for {{BRANCH_CONTEXT_LABEL}} ({{COMPANY_SIZE}}).
+
+CONTENT CONDENSATION (use only existing concepts):
+- "Standard workflow" = Input → AI draft → Review → Release
+- "Tool sprawl / ad-hoc prompts without standards" = No-Go
+- Stop rule: max. 2 parallel initiatives; after 14 days without measurable effect = simplify or stop
+
+OUTPUT FORMAT (follow exactly):
+
+```html
+<div class="exec-decision-box">
+  <p><strong>Your decision in 3 points</strong></p>
+  <ul>
+    <li><strong>Do:</strong> [One concrete standard workflow that can be implemented immediately]</li>
+    <li><strong>Don't:</strong> [What to stop doing immediately]</li>
+    <li><strong>Risk & Stop Signal:</strong> [When to stop and simplify]</li>
+  </ul>
+</div>
+```
+
+STYLE:
+- Detached-professional, like an external advisor
+- Short sentences, one thought per bullet
+- No explanations, only action directives

--- a/prompts/prompt_manifest.json
+++ b/prompts/prompt_manifest.json
@@ -53,6 +53,34 @@
         }
       }
     },
+    "executive_decision": {
+      "title": "Executive Decision",
+      "path": "executive_decision.md",
+      "purpose": "Entscheidungsblock Tun/Lassen/Stop-Signal",
+      "size_aware": true,
+      "required": false,
+      "output": "html",
+      "tokens": {
+        "base": 400,
+        "solo": 350,
+        "team": 400,
+        "kmu": 450
+      },
+      "persona_rules": {
+        "solo": {
+          "forbidden_terms": [
+            "Abteilung",
+            "Team",
+            "Mitarbeiter",
+            "Vorstand"
+          ],
+          "replacement_map": {
+            "Governance": "Eigenverantwortung",
+            "Stakeholder": "Partner"
+          }
+        }
+      }
+    },
     "quick_wins": {
       "title": "Quick Wins",
       "path": "quick_wins.md",
@@ -821,6 +849,34 @@
             "Governance": "Eigenverantwortung",
             "Stakeholder": "Partner",
             "Compliance": "Sorgfaltspflicht"
+          }
+        }
+      }
+    },
+    "executive_decision": {
+      "title": "Executive Decision",
+      "path": "executive_decision.md",
+      "purpose": "Decision block Do/Don't/Stop-Signal",
+      "size_aware": true,
+      "required": false,
+      "output": "html",
+      "tokens": {
+        "base": 400,
+        "solo": 350,
+        "team": 400,
+        "kmu": 450
+      },
+      "persona_rules": {
+        "solo": {
+          "forbidden_terms": [
+            "Department",
+            "Team",
+            "Employees",
+            "Board"
+          ],
+          "replacement_map": {
+            "Governance": "Self-management",
+            "Stakeholder": "Partner"
           }
         }
       }

--- a/templates/pdf_template.html
+++ b/templates/pdf_template.html
@@ -2287,6 +2287,27 @@
         }
 
         /* ================================================
+           EXECUTIVE DECISION BOX (Step 1/3)
+           ================================================ */
+        .exec-decision-box {
+            border: 1px solid rgba(0,0,0,0.08);
+            border-radius: 10pt;
+            padding: 12pt 14pt;
+            margin: 10pt 0 12pt 0;
+            background: rgba(0,0,0,0.02);
+        }
+        .exec-decision-box p {
+            margin: 0 0 8pt 0;
+        }
+        .exec-decision-box ul {
+            margin: 8pt 0 0 18pt;
+            padding: 0;
+        }
+        .exec-decision-box li {
+            margin: 4pt 0;
+        }
+
+        /* ================================================
            ROI-INTERPRETATION BOX
            ================================================ */
         .roi-interpretation-box {
@@ -2689,6 +2710,13 @@
                     </div>
                     {% endif %}
                 </section>
+
+                <!-- Step 1/3: EXECUTIVE DECISION BLOCK -->
+                {% if EXECUTIVE_DECISION_HTML %}
+                <div class="section executive-decision">
+                    {{ EXECUTIVE_DECISION_HTML|safe }}
+                </div>
+                {% endif %}
 
                 <!-- G20: KI-STACK SUMMARY CARD -->
                 {% if KI_STACK_SUMMARY_HTML %}

--- a/templates/pdf_template_en.html
+++ b/templates/pdf_template_en.html
@@ -1697,6 +1697,27 @@
             height: 18pt;
             vertical-align: middle;
         }
+
+        /* ================================================
+           EXECUTIVE DECISION BOX (Step 1/3)
+           ================================================ */
+        .exec-decision-box {
+            border: 1px solid rgba(0,0,0,0.08);
+            border-radius: 10pt;
+            padding: 12pt 14pt;
+            margin: 10pt 0 12pt 0;
+            background: rgba(0,0,0,0.02);
+        }
+        .exec-decision-box p {
+            margin: 0 0 8pt 0;
+        }
+        .exec-decision-box ul {
+            margin: 8pt 0 0 18pt;
+            padding: 0;
+        }
+        .exec-decision-box li {
+            margin: 4pt 0;
+        }
     </style>
 </head>
 <body>
@@ -1859,6 +1880,13 @@
                     </div>
                     <div class="exec-divider"></div>
                 </section>
+
+                <!-- Step 1/3: EXECUTIVE DECISION BLOCK -->
+                {% if EXECUTIVE_DECISION_HTML %}
+                <div class="section executive-decision">
+                    {{ EXECUTIVE_DECISION_HTML|safe }}
+                </div>
+                {% endif %}
 
                 <!-- G20: AI STACK SUMMARY CARD -->
                 {% if KI_STACK_SUMMARY_HTML %}


### PR DESCRIPTION
- Create prompts/de/executive_decision.md (DE: Tun/Lassen/Stop-Signal)
- Create prompts/en/executive_decision.md (EN: Do/Don't/Stop Signal)
- Register executive_decision in parallel_sections (gpt_analyze.py)
- Add manifest entries for DE and EN (prompt_manifest.json)
- Insert template slot after #exec-brutal-summary (both templates)
- Add .exec-decision-box CSS styling (both templates)

Block position: After brutal-summary, before KI_STACK_SUMMARY_HTML
Sanitizer-safe: Uses only div/p/ul/li/strong (no forbidden tags)