### PR TITLE
Add ROADMAP_90D_DECISION_HTML section (Step 2/3)

### DIFF
--- a/gpt_analyze.py
+++ b/gpt_analyze.py
@@ -4825,6 +4825,7 @@ def _generate_content_sections(briefing: Dict[str, Any], scores: Dict[str, Any])
     parallel_sections = [
         ("executive_summary", "EXECUTIVE_SUMMARY_HTML"),
         ("executive_decision", "EXECUTIVE_DECISION_HTML"),  # Step 1/3: Executive Decision Block
+        ("roadmap_90d_decision", "ROADMAP_90D_DECISION_HTML"),  # Step 2/3: 90-Day Roadmap Decision Version
         ("ki_stack_summary", "KI_STACK_SUMMARY_HTML"),  # G20: KI-Stack Summary Card
         ("quick_wins", "_QUICK_WINS_RAW"),  # wird später aufbereitet
         ("roadmap", "PILOT_PLAN_HTML"),

--- a/prompts/de/roadmap_90d_decision.md
+++ b/prompts/de/roadmap_90d_decision.md
@@ -84,3 +84,10 @@ STIL:
 - Kurze Sätze, ein Gedanke pro Bullet
 - Keine Erklärungen, nur Handlungsanweisungen
 - Jede Phase muss eigenständig lesbar sein
+
+STRIKTE AUSGABEREGEL (verbindlich):
+- KEINE Platzhalter wie [1 Satz], [Max. 2-3 Schritte], {variable}, {{token}}
+- KEINE eckigen Klammern [ ] oder geschweiften Klammern { } im Output
+- Schreibe vollständig ausformulierte, konkrete Sätze
+- Falls branchenspezifische Details fehlen, verwende realistische Standard-Maßnahmen
+- Jeder Bullet muss sofort umsetzbar formuliert sein, nicht als Template

--- a/prompts/de/roadmap_90d_decision.md
+++ b/prompts/de/roadmap_90d_decision.md
@@ -1,0 +1,86 @@
+Developer:
+<!-- PLATIN+++ PROMPT v1.0 - ROADMAP 90D DECISION -->
+<!-- SECTION: roadmap_90d_decision -->
+<!--
+=============================================================================
+90-TAGE-ROADMAP ENTSCHEIDUNGSFASSUNG v1.0
+=============================================================================
+
+ROLLE:
+Externer Senior-Berater, distanziert, entscheidungsorientiert.
+Keine Erklärungen, keine Absicherungen, nur klare Ansagen.
+
+ZIELGRUPPE:
+Solo-/KMU-Entscheider mit wenig Zeit. Max. 2–3 Minuten Lesezeit.
+
+ZIEL:
+Verdichtung der bestehenden 90-Tage-Roadmap auf Entscheidungslogik.
+Keine neuen Maßnahmen erfinden – nur aus bestehendem Content priorisieren.
+
+CONSTRAINTS:
+- Max. 250–300 Wörter gesamt
+- Keine Tabellen
+- Keine Marketing-Sprache
+- Keine Beratungs-CTAs
+- Keine Tool-Namen (nur Funktions-Kategorien)
+- Jede Phase in <30 Sekunden erfassbar
+
+HTML-VERTRAG (verbindlich):
+ERLAUBT: <div>, <p>, <ul>, <li>, <strong>, <span>, <br>
+VERBOTEN: <h1>, <h2>, <h3>, <h4>, <section>, <article>, <header>
+=============================================================================
+-->
+<!-- OUTPUT: HTML ONLY -->
+<!-- SIZE-AWARE: solo/team/kmu -->
+<!-- TOKEN-BUDGET: 600 -->
+<!-- WORD_MINIMUM: 200 -->
+<!-- WORD_MAXIMUM: 300 -->
+
+Erstelle eine Entscheidungsfassung der 90-Tage-Roadmap für {{BRANCH_CONTEXT_LABEL}} ({{COMPANY_SIZE}}).
+
+INHALTLICHE GRUNDLAGE:
+Verdichte die bestehenden Roadmap-Inhalte. Erfinde nichts Neues.
+Fokus: Was muss entschieden werden, nicht was gemacht werden könnte.
+
+STRUKTUR (exakt einhalten):
+
+```html
+<div class="roadmap-decision">
+  <p><strong>90-Tage-Umsetzungs-Roadmap – Entscheidungsfassung</strong></p>
+
+  <p><strong>Phase 1 (0–30 Tage): Fundament</strong></p>
+  <ul>
+    <li><strong>Ziel:</strong> [1 Satz, messbar]</li>
+    <li><strong>Umsetzung:</strong> [Max. 2-3 konkrete Schritte]</li>
+    <li><strong>Erfolgskriterium:</strong> [1 klares, prüfbares Kriterium]</li>
+    <li><strong>Stop-Regel:</strong> [Wann wird Phase abgebrochen/pausiert]</li>
+  </ul>
+
+  <p><strong>Phase 2 (31–60 Tage): Pilotierung</strong></p>
+  <ul>
+    <li><strong>Ziel:</strong> [1 Satz, messbar]</li>
+    <li><strong>Umsetzung:</strong> [Max. 2-3 konkrete Schritte]</li>
+    <li><strong>Erfolgskriterium:</strong> [1 klares, prüfbares Kriterium]</li>
+    <li><strong>Stop-Regel:</strong> [Wann wird Phase abgebrochen/pausiert]</li>
+  </ul>
+
+  <p><strong>Phase 3 (61–90 Tage): Entscheidung</strong></p>
+  <ul>
+    <li><strong>Ziel:</strong> [1 Satz, messbar]</li>
+    <li><strong>Umsetzung:</strong> [Max. 2-3 konkrete Schritte]</li>
+    <li><strong>Erfolgskriterium:</strong> [1 klares, prüfbares Kriterium]</li>
+    <li><strong>Stop-Regel:</strong> [Wann wird Skalierung nicht empfohlen]</li>
+  </ul>
+</div>
+```
+
+STOP-REGELN (Beispiele zur Orientierung):
+- "Kein messbarer Zeitgewinn nach 14 Tagen → vereinfachen oder stoppen"
+- "Qualitätsprobleme >20% → zurück zu manueller Prüfung"
+- "Keine Akzeptanz im Alltag → Pilotierung abbrechen"
+
+STIL:
+- Distanziert-professionell
+- Kurze Sätze, ein Gedanke pro Bullet
+- Keine Erklärungen, nur Handlungsanweisungen
+- Jede Phase muss eigenständig lesbar sein

--- a/prompts/en/roadmap_90d_decision.md
+++ b/prompts/en/roadmap_90d_decision.md
@@ -1,0 +1,86 @@
+Developer:
+<!-- PLATIN+++ PROMPT v1.0 - ROADMAP 90D DECISION -->
+<!-- SECTION: roadmap_90d_decision -->
+<!--
+=============================================================================
+90-DAY ROADMAP DECISION VERSION v1.0
+=============================================================================
+
+ROLE:
+External senior advisor, detached, decision-focused.
+No explanations, no hedging, only clear directives.
+
+AUDIENCE:
+Solo/SME decision-makers with limited time. Max. 2–3 minutes reading time.
+
+GOAL:
+Condense existing 90-day roadmap into decision logic.
+Do not invent new measures – only prioritize from existing content.
+
+CONSTRAINTS:
+- Max. 250–300 words total
+- No tables
+- No marketing language
+- No consulting CTAs
+- No tool names (only function categories)
+- Each phase readable in <30 seconds
+
+HTML CONTRACT (mandatory):
+ALLOWED: <div>, <p>, <ul>, <li>, <strong>, <span>, <br>
+FORBIDDEN: <h1>, <h2>, <h3>, <h4>, <section>, <article>, <header>
+=============================================================================
+-->
+<!-- OUTPUT: HTML ONLY -->
+<!-- SIZE-AWARE: solo/team/kmu -->
+<!-- TOKEN-BUDGET: 600 -->
+<!-- WORD_MINIMUM: 200 -->
+<!-- WORD_MAXIMUM: 300 -->
+
+Create a decision version of the 90-day roadmap for {{BRANCH_CONTEXT_LABEL}} ({{COMPANY_SIZE}}).
+
+CONTENT BASIS:
+Condense existing roadmap content. Do not invent anything new.
+Focus: What must be decided, not what could be done.
+
+STRUCTURE (follow exactly):
+
+```html
+<div class="roadmap-decision">
+  <p><strong>90-Day Implementation Roadmap – Decision Version</strong></p>
+
+  <p><strong>Phase 1 (0–30 Days): Foundation</strong></p>
+  <ul>
+    <li><strong>Goal:</strong> [1 sentence, measurable]</li>
+    <li><strong>Implementation:</strong> [Max. 2-3 concrete steps]</li>
+    <li><strong>Success Criterion:</strong> [1 clear, verifiable criterion]</li>
+    <li><strong>Stop Rule:</strong> [When to abort/pause phase]</li>
+  </ul>
+
+  <p><strong>Phase 2 (31–60 Days): Piloting</strong></p>
+  <ul>
+    <li><strong>Goal:</strong> [1 sentence, measurable]</li>
+    <li><strong>Implementation:</strong> [Max. 2-3 concrete steps]</li>
+    <li><strong>Success Criterion:</strong> [1 clear, verifiable criterion]</li>
+    <li><strong>Stop Rule:</strong> [When to abort/pause phase]</li>
+  </ul>
+
+  <p><strong>Phase 3 (61–90 Days): Decision</strong></p>
+  <ul>
+    <li><strong>Goal:</strong> [1 sentence, measurable]</li>
+    <li><strong>Implementation:</strong> [Max. 2-3 concrete steps]</li>
+    <li><strong>Success Criterion:</strong> [1 clear, verifiable criterion]</li>
+    <li><strong>Stop Rule:</strong> [When scaling is not recommended]</li>
+  </ul>
+</div>
+```
+
+STOP RULES (examples for guidance):
+- "No measurable time savings after 14 days → simplify or stop"
+- "Quality issues >20% → revert to manual review"
+- "No adoption in daily work → abort pilot"
+
+STYLE:
+- Detached-professional
+- Short sentences, one thought per bullet
+- No explanations, only action directives
+- Each phase must be independently readable

--- a/prompts/en/roadmap_90d_decision.md
+++ b/prompts/en/roadmap_90d_decision.md
@@ -84,3 +84,10 @@ STYLE:
 - Short sentences, one thought per bullet
 - No explanations, only action directives
 - Each phase must be independently readable
+
+STRICT OUTPUT RULE (mandatory):
+- NO placeholders like [1 sentence], [Max. 2-3 steps], {variable}, {{token}}
+- NO square brackets [ ] or curly braces { } in output
+- Write fully formulated, concrete sentences
+- If industry-specific details are missing, use realistic standard measures
+- Every bullet must be actionable as written, not as a template

--- a/prompts/prompt_manifest.json
+++ b/prompts/prompt_manifest.json
@@ -81,6 +81,34 @@
         }
       }
     },
+    "roadmap_90d_decision": {
+      "title": "90-Tage-Roadmap Entscheidungsfassung",
+      "path": "roadmap_90d_decision.md",
+      "purpose": "Verdichtete Roadmap mit Stop-Regeln",
+      "size_aware": true,
+      "required": false,
+      "output": "html",
+      "tokens": {
+        "base": 600,
+        "solo": 500,
+        "team": 600,
+        "kmu": 700
+      },
+      "persona_rules": {
+        "solo": {
+          "forbidden_terms": [
+            "Abteilung",
+            "Team",
+            "Mitarbeiter",
+            "Vorstand"
+          ],
+          "replacement_map": {
+            "Governance": "Eigenverantwortung",
+            "Stakeholder": "Partner"
+          }
+        }
+      }
+    },
     "quick_wins": {
       "title": "Quick Wins",
       "path": "quick_wins.md",
@@ -865,6 +893,34 @@
         "solo": 350,
         "team": 400,
         "kmu": 450
+      },
+      "persona_rules": {
+        "solo": {
+          "forbidden_terms": [
+            "Department",
+            "Team",
+            "Employees",
+            "Board"
+          ],
+          "replacement_map": {
+            "Governance": "Self-management",
+            "Stakeholder": "Partner"
+          }
+        }
+      }
+    },
+    "roadmap_90d_decision": {
+      "title": "90-Day Roadmap Decision Version",
+      "path": "roadmap_90d_decision.md",
+      "purpose": "Condensed roadmap with stop rules",
+      "size_aware": true,
+      "required": false,
+      "output": "html",
+      "tokens": {
+        "base": 600,
+        "solo": 500,
+        "team": 600,
+        "kmu": 700
       },
       "persona_rules": {
         "solo": {

--- a/templates/pdf_template.html
+++ b/templates/pdf_template.html
@@ -2308,6 +2308,27 @@
         }
 
         /* ================================================
+           ROADMAP DECISION (Step 2/3)
+           ================================================ */
+        .roadmap-decision {
+            border: 1px solid rgba(0,0,0,0.08);
+            border-radius: 10pt;
+            padding: 12pt 14pt;
+            margin: 12pt 0 16pt 0;
+            background: rgba(0,0,0,0.02);
+        }
+        .roadmap-decision p {
+            margin: 0 0 8pt 0;
+        }
+        .roadmap-decision ul {
+            margin: 6pt 0 12pt 18pt;
+            padding: 0;
+        }
+        .roadmap-decision li {
+            margin: 4pt 0;
+        }
+
+        /* ================================================
            ROI-INTERPRETATION BOX
            ================================================ */
         .roi-interpretation-box {
@@ -2715,6 +2736,13 @@
                 {% if EXECUTIVE_DECISION_HTML %}
                 <div class="section executive-decision">
                     {{ EXECUTIVE_DECISION_HTML|safe }}
+                </div>
+                {% endif %}
+
+                <!-- Step 2/3: 90-DAY ROADMAP DECISION VERSION -->
+                {% if ROADMAP_90D_DECISION_HTML %}
+                <div class="section roadmap-decision-section">
+                    {{ ROADMAP_90D_DECISION_HTML|safe }}
                 </div>
                 {% endif %}
 

--- a/templates/pdf_template_en.html
+++ b/templates/pdf_template_en.html
@@ -1718,6 +1718,27 @@
         .exec-decision-box li {
             margin: 4pt 0;
         }
+
+        /* ================================================
+           ROADMAP DECISION (Step 2/3)
+           ================================================ */
+        .roadmap-decision {
+            border: 1px solid rgba(0,0,0,0.08);
+            border-radius: 10pt;
+            padding: 12pt 14pt;
+            margin: 12pt 0 16pt 0;
+            background: rgba(0,0,0,0.02);
+        }
+        .roadmap-decision p {
+            margin: 0 0 8pt 0;
+        }
+        .roadmap-decision ul {
+            margin: 6pt 0 12pt 18pt;
+            padding: 0;
+        }
+        .roadmap-decision li {
+            margin: 4pt 0;
+        }
     </style>
 </head>
 <body>
@@ -1885,6 +1906,13 @@
                 {% if EXECUTIVE_DECISION_HTML %}
                 <div class="section executive-decision">
                     {{ EXECUTIVE_DECISION_HTML|safe }}
+                </div>
+                {% endif %}
+
+                <!-- Step 2/3: 90-DAY ROADMAP DECISION VERSION -->
+                {% if ROADMAP_90D_DECISION_HTML %}
+                <div class="section roadmap-decision-section">
+                    {{ ROADMAP_90D_DECISION_HTML|safe }}
                 </div>
                 {% endif %}
 


### PR DESCRIPTION
- Create prompts/de/roadmap_90d_decision.md (DE: Entscheidungsfassung)
- Create prompts/en/roadmap_90d_decision.md (EN: Decision Version)
- Register roadmap_90d_decision in parallel_sections (gpt_analyze.py)
- Add manifest entries for DE and EN (prompt_manifest.json)
- Insert template slot after Executive Decision Block (both templates)
- Add .roadmap-decision CSS styling (both templates)

Structure per phase: Goal, Implementation, Success Criterion, Stop Rule Block position: After Executive Decision, before KI_STACK_SUMMARY_HTML Original detailed roadmap remains unchanged (no breaking changes)