### PR TITLE
Add Gamechanger Decision section (Step 3/3)

### DIFF
--- a/gpt_analyze.py
+++ b/gpt_analyze.py
@@ -4826,6 +4826,7 @@ def _generate_content_sections(briefing: Dict[str, Any], scores: Dict[str, Any])
         ("executive_summary", "EXECUTIVE_SUMMARY_HTML"),
         ("executive_decision", "EXECUTIVE_DECISION_HTML"),  # Step 1/3: Executive Decision Block
         ("roadmap_90d_decision", "ROADMAP_90D_DECISION_HTML"),  # Step 2/3: 90-Day Roadmap Decision Version
+        ("gamechanger_decision", "GAMECHANGER_DECISION_HTML"),  # Step 3/3: Gamechanger Decision Version
         ("ki_stack_summary", "KI_STACK_SUMMARY_HTML"),  # G20: KI-Stack Summary Card
         ("quick_wins", "_QUICK_WINS_RAW"),  # wird später aufbereitet
         ("roadmap", "PILOT_PLAN_HTML"),

--- a/prompts/de/gamechanger_decision.md
+++ b/prompts/de/gamechanger_decision.md
@@ -1,0 +1,83 @@
+Developer:
+<!-- PLATIN+++ PROMPT v1.0 - GAMECHANGER DECISION -->
+<!-- SECTION: gamechanger_decision -->
+<!--
+=============================================================================
+GAMECHANGER DECISION v1.0 — Strategische Entscheidungsfassung
+=============================================================================
+
+ROLLE:
+Externer Senior-Berater (Top-Beratung), ruhig, klar, strategisch.
+Keine Verkaufssprache, keine Buzzwords, keine Visionen.
+
+ZIELGRUPPE:
+Entscheider, Investoren, Beirat. Max. 2 Minuten Lesezeit.
+
+ZIEL:
+Den bestehenden Gamechanger-Content auf eine zitierfähige Kernthese verdichten.
+Keine neuen Konzepte – nur Destillation vorhandener Substanz.
+
+CONSTRAINTS:
+- Max. 350–450 Wörter gesamt
+- "Sie"-Form (formell)
+- Keine Superlative, keine Hype-Wörter
+- Keine neuen Zahlen oder ROI-Versprechen
+- Kein Vision-Text, keine Metaphern
+- Keine Beratungs-CTAs
+
+HTML-VERTRAG (verbindlich):
+ERLAUBT: <div>, <p>, <ul>, <li>, <strong>, <span>, <br>
+VERBOTEN: <h1>, <h2>, <h3>, <h4>, <section>, <article>, <header>
+=============================================================================
+-->
+<!-- OUTPUT: HTML ONLY -->
+<!-- SIZE-AWARE: solo/team/kmu -->
+<!-- TOKEN-BUDGET: 800 -->
+<!-- WORD_MINIMUM: 350 -->
+<!-- WORD_MAXIMUM: 450 -->
+
+Erstelle eine strategische Entscheidungsfassung des Gamechangers für {{BRANCH_CONTEXT_LABEL}} ({{COMPANY_SIZE}}).
+
+INHALTLICHE GRUNDLAGE:
+Verdichte den bestehenden Gamechanger-Content. Erfinde nichts Neues.
+Fokus: Eine zitierfähige These, die in 2 Minuten erfassbar ist.
+
+STRUKTUR (exakt einhalten):
+
+```html
+<div class="gamechanger-decision">
+  <p><strong>Der strategische Gamechanger – Entscheidungsfassung</strong></p>
+
+  <p><strong>Strategischer Bruchpunkt</strong></p>
+  <p>[Warum das bisherige Vorgehen nicht mehr skaliert – 2-3 Sätze]</p>
+
+  <p><strong>Die neue Logik</strong></p>
+  <p>[Was sich fundamental ändert – 1 prägnanter Satz]</p>
+
+  <p><strong>Warum das ein Gamechanger ist</strong></p>
+  <ul>
+    <li><strong>Skalierung:</strong> [1 Satz]</li>
+    <li><strong>Qualität & Governance:</strong> [1 Satz]</li>
+    <li><strong>Marktfähigkeit / IP:</strong> [1 Satz]</li>
+  </ul>
+
+  <p><strong>Konsequenz für Sie</strong></p>
+  <p>[Was sich für den Leser konkret ändert – 2-3 Sätze, kein Vision-Text]</p>
+
+  <p><strong>Erster realistischer Schritt (2–4 Wochen)</strong></p>
+  <p>[Konkreter Einstieg, kein 12-Monats-Horizont – 2-3 Sätze]</p>
+</div>
+```
+
+STIL:
+- Ruhig, klar, strategisch
+- Kurze Sätze, ein Gedanke pro Absatz
+- Argumentativ, nicht erklärend
+- Der Leser soll sagen: „Das ist kein Report – das ist ein skalierbares Entscheidungsprodukt."
+
+STRIKTE AUSGABEREGEL (verbindlich):
+- KEINE Platzhalter wie [1 Satz], [2-3 Sätze], {variable}, {{token}}
+- KEINE eckigen Klammern [ ] oder geschweiften Klammern { } im Output
+- Schreibe vollständig ausformulierte, konkrete Sätze
+- Falls branchenspezifische Details fehlen, verwende realistische Standard-Aussagen
+- Jeder Absatz muss sofort zitierbar sein, nicht als Template

--- a/prompts/en/gamechanger_decision.md
+++ b/prompts/en/gamechanger_decision.md
@@ -1,0 +1,83 @@
+Developer:
+<!-- PLATIN+++ PROMPT v1.0 - GAMECHANGER DECISION -->
+<!-- SECTION: gamechanger_decision -->
+<!--
+=============================================================================
+GAMECHANGER DECISION v1.0 — Strategic Decision Version
+=============================================================================
+
+ROLE:
+External senior advisor (top-tier consulting), calm, clear, strategic.
+No sales language, no buzzwords, no visionary statements.
+
+AUDIENCE:
+Decision-makers, investors, board members. Max. 2 minutes reading time.
+
+GOAL:
+Distill existing Gamechanger content into a quotable core thesis.
+No new concepts – only distillation of existing substance.
+
+CONSTRAINTS:
+- Max. 350–450 words total
+- Professional tone
+- No superlatives, no hype words
+- No new numbers or ROI promises
+- No visionary text, no metaphors
+- No consulting CTAs
+
+HTML CONTRACT (mandatory):
+ALLOWED: <div>, <p>, <ul>, <li>, <strong>, <span>, <br>
+FORBIDDEN: <h1>, <h2>, <h3>, <h4>, <section>, <article>, <header>
+=============================================================================
+-->
+<!-- OUTPUT: HTML ONLY -->
+<!-- SIZE-AWARE: solo/team/kmu -->
+<!-- TOKEN-BUDGET: 800 -->
+<!-- WORD_MINIMUM: 350 -->
+<!-- WORD_MAXIMUM: 450 -->
+
+Create a strategic decision version of the Gamechanger for {{BRANCH_CONTEXT_LABEL}} ({{COMPANY_SIZE}}).
+
+CONTENT BASIS:
+Distill existing Gamechanger content. Do not invent anything new.
+Focus: A quotable thesis that can be grasped in 2 minutes.
+
+STRUCTURE (follow exactly):
+
+```html
+<div class="gamechanger-decision">
+  <p><strong>The Strategic Gamechanger – Decision Version</strong></p>
+
+  <p><strong>Strategic Inflection Point</strong></p>
+  <p>[Why the current approach no longer scales – 2-3 sentences]</p>
+
+  <p><strong>The New Logic</strong></p>
+  <p>[What fundamentally changes – 1 concise sentence]</p>
+
+  <p><strong>Why This Is a Gamechanger</strong></p>
+  <ul>
+    <li><strong>Scalability:</strong> [1 sentence]</li>
+    <li><strong>Quality & Governance:</strong> [1 sentence]</li>
+    <li><strong>Market Readiness / IP:</strong> [1 sentence]</li>
+  </ul>
+
+  <p><strong>Consequence for You</strong></p>
+  <p>[What concretely changes for the reader – 2-3 sentences, no visionary text]</p>
+
+  <p><strong>First Realistic Step (2–4 Weeks)</strong></p>
+  <p>[Concrete entry point, no 12-month horizon – 2-3 sentences]</p>
+</div>
+```
+
+STYLE:
+- Calm, clear, strategic
+- Short sentences, one thought per paragraph
+- Argumentative, not explanatory
+- The reader should say: "This is not a report – this is a scalable decision product."
+
+STRICT OUTPUT RULE (mandatory):
+- NO placeholders like [1 sentence], [2-3 sentences], {variable}, {{token}}
+- NO square brackets [ ] or curly braces { } in output
+- Write fully formulated, concrete sentences
+- If industry-specific details are missing, use realistic standard statements
+- Every paragraph must be immediately quotable, not a template

--- a/prompts/prompt_manifest.json
+++ b/prompts/prompt_manifest.json
@@ -109,6 +109,34 @@
         }
       }
     },
+    "gamechanger_decision": {
+      "title": "Gamechanger Entscheidungsfassung",
+      "path": "gamechanger_decision.md",
+      "purpose": "Strategische Verdichtung des Gamechangers",
+      "size_aware": true,
+      "required": false,
+      "output": "html",
+      "tokens": {
+        "base": 800,
+        "solo": 700,
+        "team": 800,
+        "kmu": 900
+      },
+      "persona_rules": {
+        "solo": {
+          "forbidden_terms": [
+            "Abteilung",
+            "Team",
+            "Mitarbeiter",
+            "Vorstand"
+          ],
+          "replacement_map": {
+            "Governance": "Eigenverantwortung",
+            "Stakeholder": "Partner"
+          }
+        }
+      }
+    },
     "quick_wins": {
       "title": "Quick Wins",
       "path": "quick_wins.md",
@@ -921,6 +949,34 @@
         "solo": 500,
         "team": 600,
         "kmu": 700
+      },
+      "persona_rules": {
+        "solo": {
+          "forbidden_terms": [
+            "Department",
+            "Team",
+            "Employees",
+            "Board"
+          ],
+          "replacement_map": {
+            "Governance": "Self-management",
+            "Stakeholder": "Partner"
+          }
+        }
+      }
+    },
+    "gamechanger_decision": {
+      "title": "Gamechanger Decision Version",
+      "path": "gamechanger_decision.md",
+      "purpose": "Strategic distillation of Gamechanger",
+      "size_aware": true,
+      "required": false,
+      "output": "html",
+      "tokens": {
+        "base": 800,
+        "solo": 700,
+        "team": 800,
+        "kmu": 900
       },
       "persona_rules": {
         "solo": {

--- a/templates/pdf_template.html
+++ b/templates/pdf_template.html
@@ -2329,6 +2329,33 @@
         }
 
         /* ================================================
+           GAMECHANGER DECISION (Step 3/3)
+           ================================================ */
+        .gamechanger-decision {
+            border: 1px solid rgba(0,0,0,0.08);
+            border-radius: 10pt;
+            padding: 14pt 16pt;
+            margin: 14pt 0 18pt 0;
+            background: rgba(0,0,0,0.02);
+        }
+        .gamechanger-decision p {
+            margin: 0 0 10pt 0;
+        }
+        .gamechanger-decision ul {
+            margin: 8pt 0 12pt 18pt;
+            padding: 0;
+        }
+        .gamechanger-decision li {
+            margin: 5pt 0;
+        }
+        .decision-bridge {
+            font-size: 9pt;
+            color: #666;
+            font-style: italic;
+            margin: 8pt 0 16pt 0;
+        }
+
+        /* ================================================
            ROI-INTERPRETATION BOX
            ================================================ */
         .roi-interpretation-box {
@@ -2744,6 +2771,14 @@
                 <div class="section roadmap-decision-section">
                     {{ ROADMAP_90D_DECISION_HTML|safe }}
                 </div>
+                {% endif %}
+
+                <!-- Step 3/3: GAMECHANGER DECISION VERSION -->
+                {% if GAMECHANGER_DECISION_HTML %}
+                <div class="section gamechanger-decision-section">
+                    {{ GAMECHANGER_DECISION_HTML|safe }}
+                </div>
+                <p class="decision-bridge">Die folgende Ausführung vertieft diese Logik.</p>
                 {% endif %}
 
                 <!-- G20: KI-STACK SUMMARY CARD -->

--- a/templates/pdf_template_en.html
+++ b/templates/pdf_template_en.html
@@ -1739,6 +1739,33 @@
         .roadmap-decision li {
             margin: 4pt 0;
         }
+
+        /* ================================================
+           GAMECHANGER DECISION (Step 3/3)
+           ================================================ */
+        .gamechanger-decision {
+            border: 1px solid rgba(0,0,0,0.08);
+            border-radius: 10pt;
+            padding: 14pt 16pt;
+            margin: 14pt 0 18pt 0;
+            background: rgba(0,0,0,0.02);
+        }
+        .gamechanger-decision p {
+            margin: 0 0 10pt 0;
+        }
+        .gamechanger-decision ul {
+            margin: 8pt 0 12pt 18pt;
+            padding: 0;
+        }
+        .gamechanger-decision li {
+            margin: 5pt 0;
+        }
+        .decision-bridge {
+            font-size: 9pt;
+            color: #666;
+            font-style: italic;
+            margin: 8pt 0 16pt 0;
+        }
     </style>
 </head>
 <body>
@@ -1914,6 +1941,14 @@
                 <div class="section roadmap-decision-section">
                     {{ ROADMAP_90D_DECISION_HTML|safe }}
                 </div>
+                {% endif %}
+
+                <!-- Step 3/3: GAMECHANGER DECISION VERSION -->
+                {% if GAMECHANGER_DECISION_HTML %}
+                <div class="section gamechanger-decision-section">
+                    {{ GAMECHANGER_DECISION_HTML|safe }}
+                </div>
+                <p class="decision-bridge">The following section elaborates on this logic.</p>
                 {% endif %}
 
                 <!-- G20: AI STACK SUMMARY CARD -->


### PR DESCRIPTION
Implements condensed, decision-focused Gamechanger section:
- New prompts DE/EN with strict anti-placeholder guardrails
- Section registered in gpt_analyze.py parallel_sections
- Template slots after 90-day roadmap, before KI-Stack
- CSS for .gamechanger-decision and .decision-bridge
- Updated prompt_manifest.json with token budgets

Max 450 words, strategically focused, immediately quotable. Existing Gamechanger section remains untouched.