### PR TITLE
NO-GO Fix Pack: Zero-leak, time-savings, UTF-8 fixes

### DIFF
--- a/gpt_analyze.py
+++ b/gpt_analyze.py
@@ -4966,17 +4966,43 @@ def _generate_content_sections(briefing: Dict[str, Any], scores: Dict[str, Any])
     rate = int(
         briefing.get("stundensatz_eur") or os.getenv("DEFAULT_STUNDENSATZ_EUR", "60") or 60
     )
-    if total_h > 0:
+
+    # === CANONICAL TIME SAVINGS: Apply size-based cap for consistency ===
+    # Cap must match _build_prompt_vars() Block 7 and services/extra_sections.py
+    size_raw = (briefing.get("unternehmensgroesse", "") or "").lower()
+    if "solo" in size_raw or "freiberuf" in size_raw:
+        size_key = "solo"
+    elif "kmu" in size_raw or "11" in size_raw:
+        size_key = "kmu"
+    else:
+        size_key = "team"
+
+    max_hours_by_size = {"solo": 20, "team": 80, "kmu": 200}
+    max_hours = max_hours_by_size.get(size_key, 80)
+    capped_h = min(total_h, max_hours) if total_h > 0 else 0
+
+    if capped_h < total_h:
+        log.info(
+            "[_generate_content_sections] Capped time savings from %d to %d for size '%s'",
+            total_h, capped_h, size_key
+        )
+
+    if capped_h > 0:
         sections.update(
             {
-                "monatsersparnis_stunden": total_h,
-                "monatsersparnis_eur": total_h * rate,
-                "jahresersparnis_stunden": total_h * 12,
-                "jahresersparnis_eur": total_h * rate * 12,
+                # CANONICAL time savings variables (capped)
+                "monatsersparnis_stunden": capped_h,
+                "monatsersparnis_eur": capped_h * rate,
+                "jahresersparnis_stunden": capped_h * 12,
+                "jahresersparnis_eur": capped_h * rate * 12,
+                # Additional aliases for template consistency
+                "TIME_SAVINGS_MONTH_HOURS_CAPPED": capped_h,
+                "EINSPARUNG_STUNDEN_MONAT": capped_h,
+                "qw_hours_total": capped_h,  # Ensure qw_hours_total also uses capped value
                 "stundensatz_eur": rate,
                 "REALITY_NOTE_QW": (
                     "Praxis-Hinweis: Diese Quick-Wins sparen ~"
-                    f"{max(1, int(round(total_h * 0.7)))}–{int(round(total_h * 1.2))} h/Monat "
+                    f"{max(1, int(round(capped_h * 0.7)))}–{int(round(capped_h * 1.2))} h/Monat "
                     "(konservativ geschätzt)."
                 ),
             }
@@ -5476,7 +5502,19 @@ def analyze_briefing(db: Session, briefing_id: int, run_id: str) -> tuple[int, s
 
     log.info("[%s] 🎨 Generating content sections with %s...", run_id, "PROMPT SYSTEM" if USE_PROMPT_SYSTEM else "legacy prompts")
     sections = _generate_content_sections(briefing=answers, scores=scores)
-    
+
+    # === PRECOMMIT ZERO-LEAK GUARD - Run BEFORE ReportValidator/N2-Healing ===
+    # Applies hard blacklist to ALL sections (not just executive), with dual-key hygiene
+    try:
+        from services.zero_leak_engine import precommit_zero_leak_all_sections
+        log.info("[%s] 🛡️ Running precommit zero-leak guard on ALL sections...", run_id)
+        sections = precommit_zero_leak_all_sections(sections)
+    except ImportError:
+        log.debug("[%s] zero_leak_engine.precommit_zero_leak_all_sections not available", run_id)
+    except Exception as exc:
+        log.warning("[%s] ⚠️ Precommit zero-leak guard failed: %s", run_id, exc)
+    # === END PRECOMMIT ZERO-LEAK GUARD ===
+
     now = datetime.now()
     # Core metadata + Language
     sections["LANG"] = getattr(br, "lang", "de")

--- a/services/admin_export.py
+++ b/services/admin_export.py
@@ -9,7 +9,7 @@ from sqlalchemy.orm import Session
 from zipfile import ZipFile, ZIP_DEFLATED
 
 from models import Briefing, Analysis, Report
-from utils.encoding_fixer import clean_briefing_data
+from utils.encoding_fixer import clean_briefing_data, fix_utf8_encoding
 
 log = logging.getLogger(__name__)
 
@@ -36,8 +36,15 @@ def build_briefing_export_zip(db: Session, briefing_id: int, include_pdf: bool =
         }, ensure_ascii=False, indent=2))
 
         if a:
-            z.writestr("analysis/meta.json", json.dumps(getattr(a, "meta", {}) or {}, ensure_ascii=False, indent=2))
-            z.writestr("analysis/report.html", getattr(a, "html", "") or "")
+            # Also clean analysis.meta for UTF-8 consistency
+            raw_meta = getattr(a, "meta", {}) or {}
+            cleaned_meta = clean_briefing_data(raw_meta)
+            z.writestr("analysis/meta.json", json.dumps(cleaned_meta, ensure_ascii=False, indent=2))
+
+            # Clean report HTML for UTF-8 consistency
+            raw_html = getattr(a, "html", "") or ""
+            cleaned_html = fix_utf8_encoding(raw_html) if raw_html else ""
+            z.writestr("analysis/report.html", cleaned_html)
 
         if r:
             z.writestr("report/info.json", json.dumps({

--- a/services/zero_leak_engine.py
+++ b/services/zero_leak_engine.py
@@ -62,6 +62,25 @@ EXECUTIVE_SECTIONS: List[str] = [
     "KI_STACK_SUMMARY_HTML",
 ]
 
+# Dual-key aliases: If we clean EXECUTIVE_SUMMARY_HTML, also clean executive_summary
+DUAL_KEY_ALIASES: Dict[str, str] = {
+    "EXECUTIVE_SUMMARY_HTML": "executive_summary",
+    "EXECUTIVE_DECISION_HTML": "executive_decision",
+    "ROADMAP_90D_DECISION_HTML": "roadmap_90d_decision",
+    "GAMECHANGER_DECISION_HTML": "gamechanger_decision",
+    "KI_STACK_SUMMARY_HTML": "ki_stack_summary",
+    "BRANCH_DEEP_DIVE_HTML": "branch_deep_dive",
+    "ROADMAP_SPRINT_HTML": "roadmap_sprint",
+    "QUICK_WINS_HTML": "quick_wins",
+    "BUSINESSCASE_HTML": "businesscase",
+    "GAMECHANGER_HTML": "gamechanger",
+    "RISIKEN_CHANCEN_HTML": "risiken_chancen",
+    "PROZESSCHECK_HTML": "prozesscheck",
+    "DATENSTRATEGIE_HTML": "datenstrategie",
+    "MITARBEITER_ENABLEMENT_HTML": "mitarbeiter_enablement",
+    "RESPONSIBLE_AI_HTML": "responsible_ai",
+}
+
 
 def apply_hard_blacklist(text: str, section_name: str = "") -> Tuple[str, List[str]]:
     """
@@ -722,3 +741,91 @@ def process_sections_zero_leak(
         )
 
     return cleaned, total_report
+
+
+def precommit_zero_leak_all_sections(
+    sections: Dict[str, Any],
+) -> Dict[str, Any]:
+    """
+    Pre-commit zero-leak guard for ALL sections.
+
+    This function runs IMMEDIATELY after section generation, BEFORE
+    ReportValidator and N2-Healing. It applies the hard blacklist to
+    ALL sections (not just executive), with dual-key hygiene.
+
+    Features:
+    - Runs on ALL section keys, not just EXECUTIVE_SECTIONS
+    - Dual-key hygiene: cleans both *_HTML and lowercase aliases
+    - Logs: [leak_blacklist] and [precommit_zero_leak]
+
+    Args:
+        sections: Section dictionary from _generate_content_sections()
+
+    Returns:
+        Cleaned sections dictionary
+    """
+    cleaned = dict(sections)
+    cleaned_count = 0
+    total_phrases_removed = 0
+
+    # Process all string sections
+    for section_key, content in list(sections.items()):
+        # Skip metadata and non-string content
+        if section_key.startswith("_"):
+            continue
+        if not isinstance(content, str):
+            continue
+        if not content:
+            continue
+
+        # Apply hard blacklist
+        cleaned_content, removed_phrases = apply_hard_blacklist(content, section_key)
+
+        if removed_phrases:
+            cleaned[section_key] = cleaned_content
+            cleaned_count += 1
+            total_phrases_removed += len(removed_phrases)
+
+            # Dual-key hygiene: also clean the alias if exists
+            alias_key = DUAL_KEY_ALIASES.get(section_key)
+            if alias_key and alias_key in cleaned:
+                alias_content = cleaned.get(alias_key)
+                if isinstance(alias_content, str) and alias_content:
+                    cleaned_alias, alias_removed = apply_hard_blacklist(alias_content, alias_key)
+                    if alias_removed:
+                        cleaned[alias_key] = cleaned_alias
+                        log.debug(
+                            "[leak_blacklist] Also cleaned alias %s (%d phrases)",
+                            alias_key, len(alias_removed)
+                        )
+
+    # Also check reverse: lowercase keys that have uppercase aliases
+    reverse_aliases = {v: k for k, v in DUAL_KEY_ALIASES.items()}
+    for section_key, content in list(sections.items()):
+        if section_key.startswith("_"):
+            continue
+        if not isinstance(content, str) or not content:
+            continue
+        if section_key in DUAL_KEY_ALIASES:
+            continue  # Already processed above
+
+        # Check if this lowercase key has an uppercase alias
+        uppercase_key = reverse_aliases.get(section_key)
+        if uppercase_key:
+            # Already handled via dual-key hygiene above
+            continue
+
+        # Apply blacklist to remaining sections
+        cleaned_content, removed_phrases = apply_hard_blacklist(content, section_key)
+        if removed_phrases:
+            cleaned[section_key] = cleaned_content
+            cleaned_count += 1
+            total_phrases_removed += len(removed_phrases)
+
+    if cleaned_count > 0:
+        log.info(
+            "[precommit_zero_leak] cleaned=%d sections, phrases_removed=%d",
+            cleaned_count, total_phrases_removed
+        )
+
+    return cleaned


### PR DESCRIPTION
Fix #0: Pre-commit zero-leak guard for ALL sections
- Added precommit_zero_leak_all_sections() in zero_leak_engine.py
- Runs immediately after section generation, BEFORE ReportValidator/N2
- Applies hard blacklist to ALL sections (not just EXECUTIVE_SECTIONS)
- Dual-key hygiene: cleans both *_HTML and lowercase aliases
- Logging: [leak_blacklist] and [precommit_zero_leak]

Fix #1.1: Time-savings consistency (one canonical variable)
- Added size-based cap to _generate_content_sections() in gpt_analyze.py
- Now matches _build_prompt_vars() and extra_sections.py caps
- Added TIME_SAVINGS_MONTH_HOURS_CAPPED alias for templates
- Ensures KPI box, bar chart, and business case all use same value

Fix #3: UTF-8 recursive encoding in admin export
- Extended clean_briefing_data() application to analysis.meta
- Added fix_utf8_encoding() to analysis.html
- Ensures all exported data has consistent UTF-8 encoding