### PR TITLE
FINAL GO: Empty section hygiene + Executive leak prevention

### DIFF
--- a/prompts/de/executive_decision.md
+++ b/prompts/de/executive_decision.md
@@ -1,4 +1,6 @@
 Developer:
+WICHTIG: Verwenden Sie keine Anrede, keine Fragen, keine Assistenz- oder Chat-Formulierungen. Schreiben Sie ausschließlich in neutraler Berichtssprache.
+
 <!-- PLATIN+++ PROMPT v1.0 - EXECUTIVE DECISION BLOCK -->
 <!-- SECTION: executive_decision -->
 <!--

--- a/prompts/de/gamechanger_decision.md
+++ b/prompts/de/gamechanger_decision.md
@@ -1,4 +1,6 @@
 Developer:
+WICHTIG: Verwenden Sie keine Anrede, keine Fragen, keine Assistenz- oder Chat-Formulierungen. Schreiben Sie ausschließlich in neutraler Berichtssprache.
+
 <!-- PLATIN+++ PROMPT v1.0 - GAMECHANGER DECISION -->
 <!-- SECTION: gamechanger_decision -->
 <!--

--- a/prompts/de/ki_stack_summary.md
+++ b/prompts/de/ki_stack_summary.md
@@ -1,4 +1,5 @@
 <!-- G20 – KI-Stack Summary Card (DE) -->
+WICHTIG: Verwenden Sie keine Anrede, keine Fragen, keine Assistenz- oder Chat-Formulierungen. Schreiben Sie ausschließlich in neutraler Berichtssprache.
 
 Du bist ein erfahrener KI-Consultant mit Fokus auf KMU, Teams und Solo-Selbstständige.
 Du erhältst im Kontext oberhalb:

--- a/prompts/de/roadmap_90d_decision.md
+++ b/prompts/de/roadmap_90d_decision.md
@@ -1,4 +1,6 @@
 Developer:
+WICHTIG: Verwenden Sie keine Anrede, keine Fragen, keine Assistenz- oder Chat-Formulierungen. Schreiben Sie ausschließlich in neutraler Berichtssprache.
+
 <!-- PLATIN+++ PROMPT v1.0 - ROADMAP 90D DECISION -->
 <!-- SECTION: roadmap_90d_decision -->
 <!--

--- a/prompts/en/executive_decision.md
+++ b/prompts/en/executive_decision.md
@@ -1,4 +1,6 @@
 Developer:
+IMPORTANT: Use no address, no questions, no assistant or chat phrasing. Write in neutral report language only.
+
 <!-- PLATIN+++ PROMPT v1.0 - EXECUTIVE DECISION BLOCK -->
 <!-- SECTION: executive_decision -->
 <!--

--- a/prompts/en/gamechanger_decision.md
+++ b/prompts/en/gamechanger_decision.md
@@ -1,4 +1,6 @@
 Developer:
+IMPORTANT: Use no address, no questions, no assistant or chat phrasing. Write in neutral report language only.
+
 <!-- PLATIN+++ PROMPT v1.0 - GAMECHANGER DECISION -->
 <!-- SECTION: gamechanger_decision -->
 <!--

--- a/prompts/en/ki_stack_summary.md
+++ b/prompts/en/ki_stack_summary.md
@@ -1,4 +1,5 @@
 <!-- G20 – KI-Stack Summary Card (EN) -->
+IMPORTANT: Use no address, no questions, no assistant or chat phrasing. Write in neutral report language only.
 
 You are an experienced AI consultant for SMEs, small teams and solo professionals.
 The context above contains:

--- a/prompts/en/roadmap_90d_decision.md
+++ b/prompts/en/roadmap_90d_decision.md
@@ -1,4 +1,6 @@
 Developer:
+IMPORTANT: Use no address, no questions, no assistant or chat phrasing. Write in neutral report language only.
+
 <!-- PLATIN+++ PROMPT v1.0 - ROADMAP 90D DECISION -->
 <!-- SECTION: roadmap_90d_decision -->
 <!--

--- a/services/report_renderer.py
+++ b/services/report_renderer.py
@@ -378,6 +378,17 @@ def render(briefing_obj: Any,
         # Fallback: 10 + 8 + 18 = 36 hours (DEFAULT_QW1_H + DEFAULT_QW2_H + FALLBACK_QW_MONTHLY_H)
         sections['qw_hours_total'] = 36
 
+    # FIX #1: Server-side hygiene for placeholder strings
+    # Clean up placeholder artifacts before template rendering
+    PLACEHOLDER_ARTIFACTS = {'?', '??', '???', '—', '-', '–', '...', '…', 'n/a', 'N/A', 'TBD'}
+    for key, value in list(sections.items()):
+        if isinstance(value, str) and key.endswith('_HTML'):
+            stripped = value.strip()
+            # If the entire section is just a placeholder, set to empty string
+            if stripped in PLACEHOLDER_ARTIFACTS or not stripped:
+                sections[key] = ''
+                log.debug("[RENDER-HYGIENE] Cleared placeholder section: %s", key)
+
     # Mark HTML sections as safe (prevent escaping)
     safe_sections = {}
     for key, value in sections.items():

--- a/templates/pdf_template.html
+++ b/templates/pdf_template.html
@@ -2980,28 +2980,28 @@
                 </section>
 
                 <!-- Step 1/3: EXECUTIVE DECISION BLOCK -->
-                {% if EXECUTIVE_DECISION_HTML %}
+                {% if EXECUTIVE_DECISION_HTML and EXECUTIVE_DECISION_HTML|trim and '<' in EXECUTIVE_DECISION_HTML %}
                 <div class="section executive-decision">
                     {{ EXECUTIVE_DECISION_HTML|safe }}
                 </div>
                 {% endif %}
 
                 <!-- Step 2/3: 90-DAY ROADMAP DECISION VERSION -->
-                {% if ROADMAP_90D_DECISION_HTML %}
+                {% if ROADMAP_90D_DECISION_HTML and ROADMAP_90D_DECISION_HTML|trim and '<' in ROADMAP_90D_DECISION_HTML %}
                 <div class="section roadmap-decision-section">
                     {{ ROADMAP_90D_DECISION_HTML|safe }}
                 </div>
                 {% endif %}
 
                 <!-- Step 3/3: GAMECHANGER DECISION VERSION -->
-                {% if GAMECHANGER_DECISION_HTML %}
+                {% if GAMECHANGER_DECISION_HTML and GAMECHANGER_DECISION_HTML|trim and '<' in GAMECHANGER_DECISION_HTML %}
                 <div class="section gamechanger-decision-section">
                     {{ GAMECHANGER_DECISION_HTML|safe }}
                 </div>
                 {% endif %}
 
                 <!-- G20: KI-STACK SUMMARY CARD -->
-                {% if KI_STACK_SUMMARY_HTML %}
+                {% if KI_STACK_SUMMARY_HTML and KI_STACK_SUMMARY_HTML|trim and '<' in KI_STACK_SUMMARY_HTML %}
                 <section class="section chapter">
                     <div class="section-header">
                         <div class="section-title">


### PR DESCRIPTION
Fix #1 - Eliminate visible "?" placeholders:
- Added server-side hygiene in report_renderer.py to clear _HTML sections containing only placeholder artifacts (?, ??, —, -, n/a, TBD, etc.)
- Updated pdf_template.html with stricter conditionals for executive sections: now require content, trim, and '<' in HTML

Fix #2 - Executive-Frontlayer without Leak-Blacklist:
- Added guardrail line at TOP of all executive prompts (DE/EN): "WICHTIG: Verwenden Sie keine Anrede, keine Fragen, keine Assistenz- oder Chat-Formulierungen. Schreiben Sie ausschließlich in neutraler Berichtssprache."

Files changed:
- services/report_renderer.py: Placeholder hygiene before template render
- templates/pdf_template.html: Stricter _HTML conditional checks
- prompts/de/executive_decision.md: Top guardrail line
- prompts/en/executive_decision.md: Top guardrail line
- prompts/de/roadmap_90d_decision.md: Top guardrail line
- prompts/en/roadmap_90d_decision.md: Top guardrail line
- prompts/de/gamechanger_decision.md: Top guardrail line
- prompts/en/gamechanger_decision.md: Top guardrail line
- prompts/de/ki_stack_summary.md: Top guardrail line
- prompts/en/ki_stack_summary.md: Top guardrail line

Expected outcome:
- [precommit_zero_leak] cleaned=0 sections for executive sections
- 0 visible "?" in PDF pages 1-5
- 0 empty pages or placeholder blocks