### PR TITLE
FINAL GO v2: Branch Deep Dive fail-closed + Roadmap leak prevention

### DIFF
--- a/prompts/de/branch_deep_dive.md
+++ b/prompts/de/branch_deep_dive.md
@@ -1,4 +1,5 @@
 <!-- G24 – Branch Deep-Dive Addon (DE) -->
+WICHTIG: Verwenden Sie keine Anrede, keine Fragen, keine Assistenz- oder Chat-Formulierungen. Keine Meta-Kommentare über fehlende Eingaben (z.B. "ich sehe keine Frage", "beschreibe dein Anliegen"). Schreiben Sie ausschließlich in neutraler Berichtssprache. Geben Sie NUR HTML-Inhalt aus, keine Erklärungen.
 
 Du bist ein erfahrener Branchenanalyst und KI-Stratege mit tiefem Verständnis für {{BRANCH_SHORT_LABEL}}.
 Du erhältst im Kontext oberhalb:

--- a/prompts/en/branch_deep_dive.md
+++ b/prompts/en/branch_deep_dive.md
@@ -1,4 +1,5 @@
 <!-- G24 – Branch Deep-Dive Addon (EN) -->
+IMPORTANT: Use no address, no questions, no assistant or chat phrasing. No meta-commentary about missing input (e.g., "I don't see a question", "describe your request"). Write in neutral report language only. Output ONLY HTML content, no explanations.
 
 You are an experienced industry analyst and AI strategist with deep understanding of {{BRANCH_SHORT_LABEL}}.
 You receive in the context above:

--- a/services/report_renderer.py
+++ b/services/report_renderer.py
@@ -400,6 +400,29 @@ def render(briefing_obj: Any,
                     sections[key] = cleaned
                     log.debug("[RENDER-HYGIENE] Cleaned '?' from HTML: %s", key)
 
+    # FINAL GO FIX v2: Fail-closed for BRANCH_DEEP_DIVE_HTML
+    # Suppress section entirely if it contains assistant-like text
+    ASSISTANT_POISON_PHRASES = [
+        "beschreibe dein anliegen",
+        "schreib mir, wobei ich dir helfen",
+        "dann antworte ich",
+        "wobei ich dir helfen soll",
+        "ich sehe keine konkrete frage",
+        "du hast noch keine frage",
+        "wie kann ich dir helfen",
+        "describe your request",
+        "tell me what you need",
+        "I don't see a question",
+    ]
+    if sections.get("BRANCH_DEEP_DIVE_HTML"):
+        content_lower = sections["BRANCH_DEEP_DIVE_HTML"].lower()
+        for phrase in ASSISTANT_POISON_PHRASES:
+            if phrase.lower() in content_lower:
+                log.warning("[RENDER-HYGIENE] BRANCH_DEEP_DIVE_HTML contains assistant text '%s' - suppressing section", phrase)
+                sections["BRANCH_DEEP_DIVE_HTML"] = ""
+                sections["branch_deep_dive"] = ""
+                break
+
     # Mark HTML sections as safe (prevent escaping)
     safe_sections = {}
     for key, value in sections.items():

--- a/services/zero_leak_engine.py
+++ b/services/zero_leak_engine.py
@@ -54,6 +54,19 @@ HARD_BLACKLIST_PHRASES: List[str] = [
     "ich benötige weitere informationen",
     "ohne weitere angaben kann ich",
     "mir fehlen die nötigen informationen",
+    # FINAL GO FIX v2: Additional meta-commentary and help-prompt phrases
+    "du hast noch keine frage",
+    "du hast noch keine aufgabe",
+    "sie haben noch keine frage",
+    "sie haben noch keine aufgabe",
+    "beschreibe dein anliegen",
+    "beschreiben sie ihr anliegen",
+    "schreib mir, wobei ich dir helfen",
+    "schreiben sie mir, wobei ich ihnen helfen",
+    "dann antworte ich",
+    "dann werde ich antworten",
+    "wobei ich dir helfen soll",
+    "wobei ich ihnen helfen soll",
     # English assistant phrases
     "how can I help you",
     "how may I assist you",
@@ -68,6 +81,10 @@ HARD_BLACKLIST_PHRASES: List[str] = [
     "I don't see a question",
     "please describe your request",
     "I need more information",
+    "you haven't asked a question",
+    "you have not asked a question",
+    "describe what you need help with",
+    "tell me what you need",
 ]
 
 # Executive sections that require hard blacklist enforcement
@@ -77,6 +94,7 @@ EXECUTIVE_SECTIONS: List[str] = [
     "ROADMAP_90D_DECISION_HTML",
     "GAMECHANGER_DECISION_HTML",
     "KI_STACK_SUMMARY_HTML",
+    "BRANCH_DEEP_DIVE_HTML",  # FINAL GO: Add to prevent assistant text
 ]
 
 # Dual-key aliases: If we clean EXECUTIVE_SUMMARY_HTML, also clean executive_summary

--- a/templates/pdf_template.html
+++ b/templates/pdf_template.html
@@ -3186,8 +3186,8 @@
                     </div>
                 </section>
                 {% endif %}
-                <!-- G24: Branch Deep-Dive Addon -->
-                {% if BRANCH_DEEP_DIVE_HTML %}
+                <!-- G24: Branch Deep-Dive Addon (FINAL GO: fail-closed) -->
+                {% if BRANCH_DEEP_DIVE_HTML and BRANCH_DEEP_DIVE_HTML|trim and '<' in BRANCH_DEEP_DIVE_HTML %}
                 <section class="section chapter" id="branch-deep-dive">
                     <div class="section-header" data-ui="1">
                         <div class="section-title">


### PR DESCRIPTION
ROOT CAUSE ANALYSIS:

BLOCKER 1 (Branch Deep Dive assistant text):
- Prompt guardrail was at END, not TOP - LLM generates help text before reading policy
- BRANCH_DEEP_DIVE_HTML not in EXECUTIVE_SECTIONS - no blacklist enforcement
- No fail-closed mechanism - invalid output was still rendered

BLOCKER 2 (Roadmap "du hast noch keine frage"):
- Phrase was in report_validator.py for detection but NOT in HARD_BLACKLIST
- Triggered N2-Heal (reactive) instead of being prevented (proactive)

FIXES IMPLEMENTED:

1. zero_leak_engine.py:
   - Added 14 new phrases to HARD_BLACKLIST including: "du hast noch keine frage", "beschreibe dein anliegen", "schreib mir, wobei ich dir helfen", "dann antworte ich"
   - Added BRANCH_DEEP_DIVE_HTML to EXECUTIVE_SECTIONS

2. prompts/de/branch_deep_dive.md + prompts/en/branch_deep_dive.md:
   - Added TOP-level guardrail (same as executive prompts)

3. services/report_renderer.py:
   - Added fail-closed logic: suppresses BRANCH_DEEP_DIVE_HTML if it contains any assistant-like poison phrases

4. templates/pdf_template.html:
   - Added stricter conditional for BRANCH_DEEP_DIVE_HTML: must have content, trim, and contain '<'

Expected outcome:
- Branch Deep Dive: either clean content or section suppressed
- Roadmap Decision: 0 leak phrases, N2-Heal = 0
- [precommit_zero_leak] cleaned=0 for all executive sections