### PR TITLE
FINAL GO v3: KI_STACK_SUMMARY fail-closed + fragment prevention

### DIFF
--- a/prompts/de/ki_stack_summary.md
+++ b/prompts/de/ki_stack_summary.md
@@ -1,4 +1,6 @@
 <!-- G20 – KI-Stack Summary Card (DE) -->
+KRITISCH: Produziere NUR den HTML-Report-Inhalt. NIEMALS Assistenz-Text, Chat-Phrasen oder Meta-Kommentare wie "ich sehe keine Frage", "oder Aufgabe in deiner Nachricht", "beschreibe dein Anliegen". Keine Anrede, keine Fragen. Nur neutraler Bericht-HTML.
+
 WICHTIG: Verwenden Sie keine Anrede, keine Fragen, keine Assistenz- oder Chat-Formulierungen. Keine Meta-Kommentare über fehlende Eingaben (z.B. "ich sehe keine Frage"). Schreiben Sie ausschließlich in neutraler Berichtssprache.
 
 Du bist ein erfahrener KI-Consultant mit Fokus auf KMU, Teams und Solo-Selbstständige.

--- a/prompts/en/ki_stack_summary.md
+++ b/prompts/en/ki_stack_summary.md
@@ -1,4 +1,6 @@
 <!-- G20 – KI-Stack Summary Card (EN) -->
+CRITICAL: Output ONLY the HTML report content. NEVER produce assistant text, chat phrases or meta-commentary like "I don't see a question", "or task in your message", "describe your request". No address, no questions. Only neutral report HTML.
+
 IMPORTANT: Use no address, no questions, no assistant or chat phrasing. No meta-commentary about missing input (e.g., "I don't see a question"). Write in neutral report language only.
 
 You are an experienced AI consultant for SMEs, small teams and solo professionals.

--- a/services/report_renderer.py
+++ b/services/report_renderer.py
@@ -400,7 +400,7 @@ def render(briefing_obj: Any,
                     sections[key] = cleaned
                     log.debug("[RENDER-HYGIENE] Cleaned '?' from HTML: %s", key)
 
-    # FINAL GO FIX v2: Fail-closed for BRANCH_DEEP_DIVE_HTML
+    # FINAL GO FIX v3: Fail-closed for executive sections with assistant text
     # Suppress section entirely if it contains assistant-like text
     ASSISTANT_POISON_PHRASES = [
         "beschreibe dein anliegen",
@@ -413,7 +413,13 @@ def render(briefing_obj: Any,
         "describe your request",
         "tell me what you need",
         "I don't see a question",
+        # FINAL GO v3: Additional fragment patterns
+        "oder aufgabe in deiner nachricht",
+        "in deiner nachricht",
+        "aufgabe in deiner",
+        "frage in deiner",
     ]
+    # Check BRANCH_DEEP_DIVE_HTML
     if sections.get("BRANCH_DEEP_DIVE_HTML"):
         content_lower = sections["BRANCH_DEEP_DIVE_HTML"].lower()
         for phrase in ASSISTANT_POISON_PHRASES:
@@ -421,6 +427,15 @@ def render(briefing_obj: Any,
                 log.warning("[RENDER-HYGIENE] BRANCH_DEEP_DIVE_HTML contains assistant text '%s' - suppressing section", phrase)
                 sections["BRANCH_DEEP_DIVE_HTML"] = ""
                 sections["branch_deep_dive"] = ""
+                break
+    # Check KI_STACK_SUMMARY_HTML (FINAL GO v3)
+    if sections.get("KI_STACK_SUMMARY_HTML"):
+        content_lower = sections["KI_STACK_SUMMARY_HTML"].lower()
+        for phrase in ASSISTANT_POISON_PHRASES:
+            if phrase.lower() in content_lower:
+                log.warning("[RENDER-HYGIENE] KI_STACK_SUMMARY_HTML contains assistant text '%s' - suppressing section", phrase)
+                sections["KI_STACK_SUMMARY_HTML"] = ""
+                sections["ki_stack_summary"] = ""
                 break
 
     # Mark HTML sections as safe (prevent escaping)

--- a/services/zero_leak_engine.py
+++ b/services/zero_leak_engine.py
@@ -85,6 +85,16 @@ HARD_BLACKLIST_PHRASES: List[str] = [
     "you have not asked a question",
     "describe what you need help with",
     "tell me what you need",
+    # FINAL GO FIX v3: Fragment patterns (remnants after partial cleanup)
+    "oder aufgabe in deiner nachricht",
+    "oder frage in deiner nachricht",
+    "aufgabe in deiner nachricht",
+    "frage in deiner nachricht",
+    "in deiner nachricht",
+    "in ihrer nachricht",
+    "or task in your message",
+    "or question in your message",
+    "in your message",
 ]
 
 # Executive sections that require hard blacklist enforcement
@@ -796,6 +806,7 @@ def precommit_zero_leak_all_sections(
     Features:
     - Runs on ALL section keys, not just EXECUTIVE_SECTIONS
     - Dual-key hygiene: cleans both *_HTML and lowercase aliases
+    - FAIL-CLOSED for EXECUTIVE_SECTIONS: if any phrase removed, suppress entirely
     - Logs: [leak_blacklist] and [precommit_zero_leak]
 
     Args:
@@ -822,6 +833,23 @@ def precommit_zero_leak_all_sections(
         cleaned_content, removed_phrases = apply_hard_blacklist(content, section_key)
 
         if removed_phrases:
+            # FINAL GO FIX v3: FAIL-CLOSED for executive sections
+            # If ANY phrase was removed from an executive section, suppress it entirely
+            # Better no section than fragmentary assistant text
+            if section_key in EXECUTIVE_SECTIONS:
+                log.warning(
+                    "[precommit_zero_leak] FAIL-CLOSED: %s had %d phrases removed - suppressing section entirely",
+                    section_key, len(removed_phrases)
+                )
+                cleaned[section_key] = ""
+                # Also suppress the alias
+                alias_key = DUAL_KEY_ALIASES.get(section_key)
+                if alias_key and alias_key in cleaned:
+                    cleaned[alias_key] = ""
+                cleaned_count += 1
+                total_phrases_removed += len(removed_phrases)
+                continue
+
             cleaned[section_key] = cleaned_content
             cleaned_count += 1
             total_phrases_removed += len(removed_phrases)


### PR DESCRIPTION
Root cause: Blacklist removed "ich sehe keine Frage" but left fragment "oder Aufgabe in deiner Nachricht. ?" visible in PDF.

Fixes:
- zero_leak_engine: FAIL-CLOSED for EXECUTIVE_SECTIONS - if any phrase removed, suppress entire section instead of passing fragments
- zero_leak_engine: Add fragment patterns to HARD_BLACKLIST
- report_renderer: Add KI_STACK_SUMMARY_HTML to poison phrase check
- prompts: Strengthen guardrails in DE/EN ki_stack_summary.md

Expected result: KI_STACK_SUMMARY either renders clean or not at all.