### PR TITLE
Leak-free executive prompts: declarative output rules + forbidden phr…

### DIFF
--- a/prompts/de/executive_decision.md
+++ b/prompts/de/executive_decision.md
@@ -1,4 +1,10 @@
 Developer:
+AUSGABEREGEL (zwingend): Schreibe ausschließlich deklarative Berichtssätze. Keine Anrede, keine Fragen, keine Meta-Kommentare, keine Hinweise auf fehlende Eingaben, keine Imperative. Beginne niemals mit Verben wie „beschreibe", „schreibe", „antworte", „hilf". Kein Bezug auf den Leser oder auf „Nachrichten/Fragen".
+
+STARTFORMAT: Beginne mit einem neutralen Substantivsatz (z. B. „Der aktuelle Zustand…", „Die empfohlene Vorgehensweise…", „Der strategische Rahmen…").
+
+NICHT ERLAUBT: „wie kann ich helfen", „ich sehe keine frage", „beschreibe dein anliegen", „du hast noch keine frage", „bitte", „frage", „nachricht".
+
 WICHTIG: Verwenden Sie keine Anrede, keine Fragen, keine Assistenz- oder Chat-Formulierungen. Keine Meta-Kommentare über fehlende Eingaben (z.B. "ich sehe keine Frage"). Schreiben Sie ausschließlich in neutraler Berichtssprache.
 
 <!-- PLATIN+++ PROMPT v1.0 - EXECUTIVE DECISION BLOCK -->

--- a/prompts/de/gamechanger_decision.md
+++ b/prompts/de/gamechanger_decision.md
@@ -1,4 +1,10 @@
 Developer:
+AUSGABEREGEL (zwingend): Schreibe ausschließlich deklarative Berichtssätze. Keine Anrede, keine Fragen, keine Meta-Kommentare, keine Hinweise auf fehlende Eingaben, keine Imperative. Beginne niemals mit Verben wie „beschreibe", „schreibe", „antworte", „hilf". Kein Bezug auf den Leser oder auf „Nachrichten/Fragen".
+
+STARTFORMAT: Beginne mit einem neutralen Substantivsatz (z. B. „Der aktuelle Zustand…", „Die empfohlene Vorgehensweise…", „Der strategische Rahmen…").
+
+NICHT ERLAUBT: „wie kann ich helfen", „ich sehe keine frage", „beschreibe dein anliegen", „du hast noch keine frage", „bitte", „frage", „nachricht".
+
 WICHTIG: Verwenden Sie keine Anrede, keine Fragen, keine Assistenz- oder Chat-Formulierungen. Keine Meta-Kommentare über fehlende Eingaben (z.B. "ich sehe keine Frage"). Schreiben Sie ausschließlich in neutraler Berichtssprache.
 
 <!-- PLATIN+++ PROMPT v1.0 - GAMECHANGER DECISION -->

--- a/prompts/de/ki_stack_summary.md
+++ b/prompts/de/ki_stack_summary.md
@@ -1,5 +1,9 @@
 <!-- G20 – KI-Stack Summary Card (DE) -->
-KRITISCH: Produziere NUR den HTML-Report-Inhalt. NIEMALS Assistenz-Text, Chat-Phrasen oder Meta-Kommentare wie "ich sehe keine Frage", "oder Aufgabe in deiner Nachricht", "beschreibe dein Anliegen". Keine Anrede, keine Fragen. Nur neutraler Bericht-HTML.
+AUSGABEREGEL (zwingend): Schreibe ausschließlich deklarative Berichtssätze. Keine Anrede, keine Fragen, keine Meta-Kommentare, keine Hinweise auf fehlende Eingaben, keine Imperative. Beginne niemals mit Verben wie „beschreibe", „schreibe", „antworte", „hilf". Kein Bezug auf den Leser oder auf „Nachrichten/Fragen".
+
+STARTFORMAT: Beginne mit einem neutralen Substantivsatz (z. B. „Der aktuelle Zustand…", „Die empfohlene Vorgehensweise…", „Der strategische Rahmen…").
+
+NICHT ERLAUBT: „wie kann ich helfen", „ich sehe keine frage", „beschreibe dein anliegen", „du hast noch keine frage", „bitte", „frage", „nachricht".
 
 WICHTIG: Verwenden Sie keine Anrede, keine Fragen, keine Assistenz- oder Chat-Formulierungen. Keine Meta-Kommentare über fehlende Eingaben (z.B. "ich sehe keine Frage"). Schreiben Sie ausschließlich in neutraler Berichtssprache.
 

--- a/prompts/de/roadmap_90d_decision.md
+++ b/prompts/de/roadmap_90d_decision.md
@@ -1,4 +1,10 @@
 Developer:
+AUSGABEREGEL (zwingend): Schreibe ausschließlich deklarative Berichtssätze. Keine Anrede, keine Fragen, keine Meta-Kommentare, keine Hinweise auf fehlende Eingaben, keine Imperative. Beginne niemals mit Verben wie „beschreibe", „schreibe", „antworte", „hilf". Kein Bezug auf den Leser oder auf „Nachrichten/Fragen".
+
+STARTFORMAT: Beginne mit einem neutralen Substantivsatz (z. B. „Der aktuelle Zustand…", „Die empfohlene Vorgehensweise…", „Der strategische Rahmen…").
+
+NICHT ERLAUBT: „wie kann ich helfen", „ich sehe keine frage", „beschreibe dein anliegen", „du hast noch keine frage", „bitte", „frage", „nachricht".
+
 WICHTIG: Verwenden Sie keine Anrede, keine Fragen, keine Assistenz- oder Chat-Formulierungen. Keine Meta-Kommentare über fehlende Eingaben (z.B. "ich sehe keine Frage"). Schreiben Sie ausschließlich in neutraler Berichtssprache.
 
 <!-- PLATIN+++ PROMPT v1.0 - ROADMAP 90D DECISION -->

--- a/prompts/en/executive_decision.md
+++ b/prompts/en/executive_decision.md
@@ -1,4 +1,10 @@
 Developer:
+OUTPUT RULE (mandatory): Write declarative report statements only. No address, no questions, no meta commentary, no references to missing input, no imperatives. Never start with verbs like "describe", "write", "answer", "help". No reference to the reader or messages/questions.
+
+START FORMAT: Begin with a neutral noun-led sentence (e.g., "The current state…", "The recommended approach…", "The strategic framework…").
+
+NOT ALLOWED: "how can I help", "I don't see a question", "describe your request", "you haven't asked", "please", "question", "message".
+
 IMPORTANT: Use no address, no questions, no assistant or chat phrasing. No meta-commentary about missing input (e.g., "I don't see a question"). Write in neutral report language only.
 
 <!-- PLATIN+++ PROMPT v1.0 - EXECUTIVE DECISION BLOCK -->

--- a/prompts/en/gamechanger_decision.md
+++ b/prompts/en/gamechanger_decision.md
@@ -1,4 +1,10 @@
 Developer:
+OUTPUT RULE (mandatory): Write declarative report statements only. No address, no questions, no meta commentary, no references to missing input, no imperatives. Never start with verbs like "describe", "write", "answer", "help". No reference to the reader or messages/questions.
+
+START FORMAT: Begin with a neutral noun-led sentence (e.g., "The current state…", "The recommended approach…", "The strategic framework…").
+
+NOT ALLOWED: "how can I help", "I don't see a question", "describe your request", "you haven't asked", "please", "question", "message".
+
 IMPORTANT: Use no address, no questions, no assistant or chat phrasing. No meta-commentary about missing input (e.g., "I don't see a question"). Write in neutral report language only.
 
 <!-- PLATIN+++ PROMPT v1.0 - GAMECHANGER DECISION -->

--- a/prompts/en/ki_stack_summary.md
+++ b/prompts/en/ki_stack_summary.md
@@ -1,5 +1,9 @@
 <!-- G20 – KI-Stack Summary Card (EN) -->
-CRITICAL: Output ONLY the HTML report content. NEVER produce assistant text, chat phrases or meta-commentary like "I don't see a question", "or task in your message", "describe your request". No address, no questions. Only neutral report HTML.
+OUTPUT RULE (mandatory): Write declarative report statements only. No address, no questions, no meta commentary, no references to missing input, no imperatives. Never start with verbs like "describe", "write", "answer", "help". No reference to the reader or messages/questions.
+
+START FORMAT: Begin with a neutral noun-led sentence (e.g., "The current state…", "The recommended approach…", "The strategic framework…").
+
+NOT ALLOWED: "how can I help", "I don't see a question", "describe your request", "you haven't asked", "please", "question", "message".
 
 IMPORTANT: Use no address, no questions, no assistant or chat phrasing. No meta-commentary about missing input (e.g., "I don't see a question"). Write in neutral report language only.
 

--- a/prompts/en/roadmap_90d_decision.md
+++ b/prompts/en/roadmap_90d_decision.md
@@ -1,4 +1,10 @@
 Developer:
+OUTPUT RULE (mandatory): Write declarative report statements only. No address, no questions, no meta commentary, no references to missing input, no imperatives. Never start with verbs like "describe", "write", "answer", "help". No reference to the reader or messages/questions.
+
+START FORMAT: Begin with a neutral noun-led sentence (e.g., "The current state…", "The recommended approach…", "The strategic framework…").
+
+NOT ALLOWED: "how can I help", "I don't see a question", "describe your request", "you haven't asked", "please", "question", "message".
+
 IMPORTANT: Use no address, no questions, no assistant or chat phrasing. No meta-commentary about missing input (e.g., "I don't see a question"). Write in neutral report language only.
 
 <!-- PLATIN+++ PROMPT v1.0 - ROADMAP 90D DECISION -->


### PR DESCRIPTION
…ases

Added to all 8 executive decision prompts (DE/EN):
- AUSGABEREGEL/OUTPUT RULE: Declarative statements only, no imperatives
- STARTFORMAT/START FORMAT: Begin with neutral noun-led sentences
- NICHT ERLAUBT/NOT ALLOWED: Short forbidden phrase list

Goal: precommit_zero_leak cleaned=0 for all executive sections, eliminating need for fail-closed suppression.

Files: executive_decision, roadmap_90d_decision, gamechanger_decision, ki_stack_summary (DE/EN versions)