### PR TITLE
PLATIN+++ v5.4.3: Disable Appendix section for compact reports

### DIFF
--- a/templates/pdf_template.html
+++ b/templates/pdf_template.html
@@ -4069,9 +4069,11 @@ monolithischen Abo-Ökosystem. Im Alltag bewährt haben sich u.&nbsp;a.:</p>
                     </div>
                 </div>
                 <!-- ============================================== -->
-                <!-- PLATIN+++ v5.4.1: APPENDIX FOR SOLO USERS     -->
+                <!-- PLATIN+++ v5.4.3: APPENDIX DISABLED           -->
+                <!-- Solo/Klein: No engines, no appendix (≤25 pages) -->
+                <!-- KMU: Engines in main body (no appendix needed)  -->
                 <!-- ============================================== -->
-                {% if COMPACT_REPORT_MODE %}
+                {% if false %}{# APPENDIX DISABLED v5.4.3 #}
                 <section class="section chapter appendix-section" id="appendix" style="page-break-before: always;">
                     <div class="section-header">
                         <div class="section-title">


### PR DESCRIPTION
The Appendix was previously shown for COMPACT_REPORT_MODE=True users (Solo/Klein), which resulted in ~39 pages instead of target ≤25 pages.

Fix: Completely disable the Appendix section since:
- Solo/Klein: No engines in main body, no appendix → ≤25 pages
- KMU: Engines in main body, no appendix needed → ~43 pages

Changed {% if COMPACT_REPORT_MODE %} to {% if false %} on line 4076.