### PR TITLE
fix: Increase quick_wins max_tokens from 1800 to 3500 for v7.0 format

### DIFF
--- a/services/prompt_enhancer.py
+++ b/services/prompt_enhancer.py
@@ -1093,9 +1093,9 @@ PLATIN_CRITICAL_SECTIONS: Dict[str, PlatinSectionConfig] = {
         "frequency_penalty": 0.1,
         "min_words": 320,  # G17.R: Base 320 → Solo 256 (0.8x), Team 320 (1.0x), KMU 368 (1.15x)
     },
-    # Quick Wins: kompakt (4 Quick Wins)
+    # Quick Wins: v7.0 format needs more tokens for structured boxes, blockquotes, prompts
     "quick_wins": {
-        "max_tokens": 1800,  # Kompakt: ~100 Wörter je nach Größe
+        "max_tokens": 3500,  # v7.0: strukturierte Boxen, Blockquotes, Copy-Paste-Prompts
         "temperature": 0.3,
         "presence_penalty": 0.1,
         "frequency_penalty": 0.1,

--- a/tests/test_platin_llm_params.py
+++ b/tests/test_platin_llm_params.py
@@ -63,7 +63,7 @@ class TestPlatinCriticalSections:
             "recommendations": 2500,
             "roadmap_12m": 2800,
             "roadmap_90d": 2800,  # G17.R: Increased from 2200 for Booster sections
-            "quick_wins": 1800,
+            "quick_wins": 3500,  # v7.0: increased for structured boxes, blockquotes, prompts
             "gamechanger": 3000,
             "unternehmensprofil_markt": 3000,
             "transparency_box": 1500,


### PR DESCRIPTION
Root cause identified from Railway logs:
- v7.0 prompt was correctly loaded and sent to GPT
- GPT response was truncated at 1800 tokens (reason=length)
- Code fell back to PLATIN fallback producing v6.0 format

The v7.0 format requires more tokens because it includes:
- Structured <div class="quick-win"> boxes
- Full <blockquote> with complete quotes (no truncation)
- <pre class="prompt-template"> code blocks
- 3-5 Quick Wins at ~600-800 tokens each
- v7.0 footer

Expected log after fix:
  finished with reason=stop (not reason=length) Contains div.quick-win: True Contains blockquote: True