### PR TITLE
fix: Whitelist h3/h4 tags for quick_wins v7.0 format

### DIFF
--- a/services/html_sanitizer.py
+++ b/services/html_sanitizer.py
@@ -983,12 +983,14 @@ def is_text_section(section_name: str) -> bool:
 
     name_lower = section_name.lower()
 
-    # Sections that ALLOW tables and complex HTML
+    # Sections that ALLOW tables and complex HTML (including h3/h4)
     complex_html_sections = {
         'ai_act_table', 'ai_act_compliance_table',
         'business_case', 'business_case_visual',
         'financial_summary', 'kpi_table',
         'tool_comparison', 'benchmark_table',
+        # v7.0: Quick Wins needs h3/h4 for structured boxes
+        'quick_wins', 'quick_wins_html', 'quick_wins_html_left', 'quick_wins_html_right',
     }
 
     if any(exc in name_lower for exc in complex_html_sections):


### PR DESCRIPTION
Quick Wins v7.0 requires <h3> and <h4> tags for proper structure:
- h3 for Quick Win titles (🎯)
- h4 for section headers (⚡ Copy-Paste-Prompt)

HTML sanitizer was removing these tags, causing PDF to render as simple bullets instead of structured boxes.

This fix adds quick_wins to complex_html_sections, exempting it from h3/h4 removal while maintaining sanitization for other sections.

Root cause: Railway logs showed "Removed forbidden tags: h4, h3" despite GPT generating correct v7.0 format with 11415 chars.