### PR TITLE
fix: Resolve critical report generation bugs

### DIFF
--- a/.github/workflows/platin-report-check.yml
+++ b/.github/workflows/platin-report-check.yml
@@ -256,10 +256,10 @@ jobs:
                   if field not in config:
                       errors.append(f'{section}: Missing field {field}')
 
-              # Validate max_tokens (PDF-SLIMDOWN v2.0: varied limits 1500-3200)
+              # Validate max_tokens (FIX 178969e: extended range to prevent truncation)
               max_tokens = config.get('max_tokens', 0)
-              if not 1500 <= max_tokens <= 3500:
-                  errors.append(f"{section}: max_tokens {max_tokens} not in range [1500, 3500]")
+              if not 1500 <= max_tokens <= 5000:
+                  errors.append(f"{section}: max_tokens {max_tokens} not in range [1500, 5000]")
 
               # Validate temperature range
               temp = config.get('temperature', 0)

--- a/gpt_analyze.py
+++ b/gpt_analyze.py
@@ -3050,7 +3050,7 @@ def _get_fallback_content(section_key: str, briefing: Dict[str, Any], scores: Di
     # ════════════════════════════════════════════════════════════════════════════
     if section_key == "risks":
         score_gov = scores.get("governance", 50)
-        score_sec = scores.get("sicherheit", 50)
+        score_sec = scores.get("security", 50)  # FIX: "sicherheit" → "security" (korrekter Key)
 
         # NOTE: English fallback removed (Content Quality Pack v1)
         # English reports now use prompts/en/risks.md exclusively

--- a/services/prompt_enhancer.py
+++ b/services/prompt_enhancer.py
@@ -1067,18 +1067,18 @@ PLATIN_CRITICAL_SECTIONS: Dict[str, PlatinSectionConfig] = {
         "frequency_penalty": 0.0,
         "min_words": 600,  # Reduziert von 800
     },
-    # Recommendations: deutlich reduziert (5 Empfehlungen, je 80-100 Wörter)
+    # Recommendations: erhöht um Truncation zu vermeiden
     "recommendations": {
-        "max_tokens": 2500,  # Reduziert von 4096 (-39%)
+        "max_tokens": 4000,  # FIX: Erhöht von 2500 um Truncation zu vermeiden
         "temperature": 0.4,
         "presence_penalty": 0.1,  # Leichte Penalty gegen Wiederholungen
         "frequency_penalty": 0.1,
         "min_words": 400,  # Reduziert von 800
     },
-    # Roadmap 12m: PDF-SLIMDOWN v2.0 token budget
+    # Roadmap 12m: Erhöht um Truncation zu vermeiden
     # Sprint N min_words enforced via report_validator.py (size-aware: 500/600/700)
     "roadmap_12m": {
-        "max_tokens": 2800,  # PDF-SLIMDOWN v2.0 value
+        "max_tokens": 4000,  # FIX: Erhöht von 2800 um Truncation zu vermeiden
         "temperature": 0.4,
         "presence_penalty": 0.1,
         "frequency_penalty": 0.1,
@@ -1087,7 +1087,7 @@ PLATIN_CRITICAL_SECTIONS: Dict[str, PlatinSectionConfig] = {
     # Roadmap 90d: Sprint G17.R - Roadmap-Booster (extended with KPI + Change sections)
     # Size-aware min_words: Solo 250, Team 320, KMU 350 (after multipliers)
     "roadmap_90d": {
-        "max_tokens": 2800,  # G17.R: Increased for booster sections
+        "max_tokens": 4000,  # FIX: Erhöht von 2800 um Truncation zu vermeiden
         "temperature": 0.4,
         "presence_penalty": 0.1,
         "frequency_penalty": 0.1,
@@ -1095,7 +1095,7 @@ PLATIN_CRITICAL_SECTIONS: Dict[str, PlatinSectionConfig] = {
     },
     # Quick Wins: v7.0 format needs more tokens for structured boxes, blockquotes, prompts
     "quick_wins": {
-        "max_tokens": 3500,  # v7.0: strukturierte Boxen, Blockquotes, Copy-Paste-Prompts
+        "max_tokens": 4500,  # FIX: Erhöht von 3500 um Truncation zu vermeiden
         "temperature": 0.3,
         "presence_penalty": 0.1,
         "frequency_penalty": 0.1,
@@ -1777,13 +1777,19 @@ Nutze den Strategischen Kontext wie folgt:
             size_perspective_en = "as an SME/company"
 
         if lang == "en":
+            # FIX: Ensure labels are not empty
+            branch_label_safe = branch_label or "Your Industry"
+            offering_label_safe = offering_label or "Your Core Services"
+            context_label_safe = context_label or "Your Business"
+
             instructions = f"""
 ## Anti-Redundancy: Use Short Labels (Sprint G4)
 
-**Use ONLY these short labels for context references:**
-- **Branch Focus:** {branch_label}
-- **Core Offering:** {offering_label}
-- **Context Tag:** {context_label}
+**IMPORTANT: The following labels are for reference only - do NOT output them literally!**
+**Use natural language with these concepts instead:**
+- Industry: {branch_label_safe}
+- Service Area: {offering_label_safe}
+- Context: {context_label_safe}
 """
             if regulatory_label:
                 instructions += f"- **Compliance:** {regulatory_label}\n"
@@ -1812,13 +1818,19 @@ Nutze den Strategischen Kontext wie folgt:
 
 """
         else:
+            # FIX: Sicherstellen dass Labels nicht leer sind
+            branch_label_safe = branch_label or "Ihr Fachbereich"
+            offering_label_safe = offering_label or "Ihre Kernleistung"
+            context_label_safe = context_label or "Ihr Geschäftsbereich"
+
             instructions = f"""
 ## Anti-Redundanz: Kurzlabels verwenden (Sprint G4)
 
-**Verwende ausschließlich diese Kurzlabels für Kontextbezüge:**
-- **Branchen-Fokus:** {branch_label}
-- **Hauptleistung:** {offering_label}
-- **Kontext-Tag:** {context_label}
+**WICHTIG: Die folgenden Labels dienen nur als Referenz - gib sie NICHT wortwörtlich im Output aus!**
+**Nutze stattdessen natürliche Formulierungen mit diesen Begriffen:**
+- Branche: {branch_label_safe}
+- Leistungsbereich: {offering_label_safe}
+- Kontext: {context_label_safe}
 """
             if regulatory_label:
                 instructions += f"- **Compliance:** {regulatory_label}\n"

--- a/tests/test_platin_llm_params.py
+++ b/tests/test_platin_llm_params.py
@@ -57,13 +57,14 @@ class TestPlatinCriticalSections:
 
         # PDF-SLIMDOWN v2.0: Expected token limits per section
         # G17.R: roadmap_90d increased for Roadmap-Booster sections
+        # FIX 178969e: Increased limits to prevent text truncation
         expected_tokens = {
             "foerderpotenzial": 3200,
             "risks": 3000,
-            "recommendations": 2500,
-            "roadmap_12m": 2800,
-            "roadmap_90d": 2800,  # G17.R: Increased from 2200 for Booster sections
-            "quick_wins": 3500,  # v7.0: increased for structured boxes, blockquotes, prompts
+            "recommendations": 4000,  # FIX: Increased from 2500 to prevent truncation
+            "roadmap_12m": 4000,      # FIX: Increased from 2800 to prevent truncation
+            "roadmap_90d": 4000,      # FIX: Increased from 2800 to prevent truncation
+            "quick_wins": 4500,       # FIX: Increased from 3500 to prevent truncation
             "gamechanger": 3000,
             "unternehmensprofil_markt": 3000,
             "transparency_box": 1500,
@@ -78,8 +79,9 @@ class TestPlatinCriticalSections:
                 )
             else:
                 # Any section not in expected_tokens should still be in valid range
-                assert 1500 <= config["max_tokens"] <= 3500, (
-                    f"Section {section} max_tokens={config['max_tokens']} not in valid range [1500, 3500]"
+                # FIX 178969e: Extended range to [1500, 5000] for truncation prevention
+                assert 1500 <= config["max_tokens"] <= 5000, (
+                    f"Section {section} max_tokens={config['max_tokens']} not in valid range [1500, 5000]"
                 )
 
     def test_platin_temperature_is_reasonable(self):

--- a/tests/test_platin_sections_valid.py
+++ b/tests/test_platin_sections_valid.py
@@ -357,17 +357,17 @@ class TestPromptEnhancerConfig:
     """Tests for PLATIN_CRITICAL_SECTIONS configuration (PDF-SLIMDOWN v2.0)."""
 
     def test_all_platin_sections_have_max_tokens_in_range(self):
-        """Verify all PLATIN sections have max_tokens in valid range (PDF-SLIMDOWN v2.0).
+        """Verify all PLATIN sections have max_tokens in valid range.
 
-        PDF-SLIMDOWN v2.0: Token limits reduced by 20-30% for shorter outputs.
-        Valid range: 1500-3500 depending on section complexity.
+        FIX 178969e: Extended range to [1500, 5000] to prevent text truncation.
+        Some sections (recommendations, roadmap_*, quick_wins) need higher limits.
         """
         from services.prompt_enhancer import PLATIN_CRITICAL_SECTIONS
 
         for section, config in PLATIN_CRITICAL_SECTIONS.items():
             max_tokens = config.get("max_tokens", 0)
-            assert 1500 <= max_tokens <= 3500, (
-                f"Section {section} max_tokens={max_tokens} not in range [1500, 3500]"
+            assert 1500 <= max_tokens <= 5000, (
+                f"Section {section} max_tokens={max_tokens} not in range [1500, 5000]"
             )
 
     def test_all_platin_sections_have_min_words(self):


### PR DESCRIPTION
FIX 1: Score Inconsistency (gpt_analyze.py:3053)
- Changed scores.get("sicherheit", 50) → scores.get("security", 50)
- Root cause: Wrong key "sicherheit" used, but scores dict uses "security"
- This caused fallback to 50 instead of actual calculated score

FIX 2: Token Limits for Truncation (services/prompt_enhancer.py)
- Increased max_tokens for critical sections to prevent text cutoff:
  - recommendations: 2500 → 4000
  - roadmap_12m: 2800 → 4000
  - roadmap_90d: 2800 → 4000
  - quick_wins: 3500 → 4500

FIX 3: Placeholder Labels in Output (services/prompt_enhancer.py)
- Added fallback values for empty labels (branch_label, offering_label, etc.)
- Clarified instructions to GPT: labels are reference only, not to be output literally
- Prevents "Branchen-Fokus:", "Kontext-Tag:" appearing in final report