### PR TITLE
fix(pdf): Prevent text truncation in prompt templates

### DIFF
--- a/gpt_analyze.py
+++ b/gpt_analyze.py
@@ -2023,7 +2023,27 @@ def _apply_pdf_inline_styles(html: str) -> str:
 
     result = th_pattern.sub(add_th_style, result)
 
-    # Fix 3: Replace emojis with custom SVG icons for reliable PDF rendering
+    # Fix 3: Add inline styles to <pre> elements for text wrapping (Quick Wins prompts)
+    # Puppeteer may ignore CSS classes, so inline styles ensure proper word-wrap
+    pre_wrap_style = 'white-space: pre-wrap; word-wrap: break-word; overflow-wrap: break-word; max-width: 100%; overflow-x: hidden;'
+
+    # Fix <pre class="prompt-template"> specifically
+    result = result.replace(
+        '<pre class="prompt-template"',
+        f'<pre class="prompt-template" style="{pre_wrap_style}"'
+    )
+
+    # Fix other <pre> tags that don't have inline styles yet
+    pre_pattern = re.compile(r'<pre(?!\s+style)(\s+class="[^"]*")?(\s*)>', re.IGNORECASE)
+
+    def add_pre_style(match):
+        class_attr = match.group(1) or ''
+        space = match.group(2) or ''
+        return f'<pre{class_attr} style="{pre_wrap_style}"{space}>'
+
+    result = pre_pattern.sub(add_pre_style, result)
+
+    # Fix 4: Replace emojis with custom SVG icons for reliable PDF rendering
     # Uses the icon_system module with branded SVG icons
     result = replace_emojis_with_icons(result, size=18)
 

--- a/templates/pdf_template.html
+++ b/templates/pdf_template.html
@@ -661,6 +661,42 @@
             border-radius: 50%;
             background: var(--color-success);
         }
+
+        /* ══════════════════════════════════════════════════════════════
+           FIX: Prompt-Templates Text-Wrapping (Seite 5 Quick Wins)
+           ══════════════════════════════════════════════════════════════ */
+
+        pre,
+        code,
+        .prompt-template,
+        pre.prompt-template {
+            white-space: pre-wrap !important;
+            word-wrap: break-word !important;
+            overflow-wrap: break-word !important;
+            max-width: 100% !important;
+            overflow-x: hidden !important;
+            box-sizing: border-box;
+        }
+
+        /* Spezifisch für Prompt-Boxen in Quick Wins */
+        .quick-win pre,
+        .quick-win code,
+        .quick-win-card pre,
+        .quick-win-card code,
+        section pre,
+        section code {
+            white-space: pre-wrap !important;
+            word-wrap: break-word !important;
+            overflow-wrap: break-word !important;
+            font-size: 11px;
+            line-height: 1.5;
+            padding: 12px;
+            background: #f8fafc;
+            border: 1px solid #e2e8f0;
+            border-radius: 6px;
+            max-width: 100%;
+        }
+
         /* Roadmap Grid - Light Mode */
         .roadmap-grid {
             display: grid;


### PR DESCRIPTION
- Add word-wrap and overflow-wrap CSS to pre/code elements
- Add inline styles fallback for Puppeteer compatibility
- Ensure prompt templates break correctly in Quick Wins section (page 5)
- Fix applies to all <pre> elements including .prompt-template class