### PR TITLE
fix(icons): Add road emoji mapping for Seite 3 Umsetzung section

### DIFF
--- a/services/icon_system.py
+++ b/services/icon_system.py
@@ -250,6 +250,8 @@ EMOJI_MAP = {
     "💡": "lightbulb",
     "🎯": "target",
     "🚀": "rocket",
+    "🛣️": "rocket",  # Road/Implementation → rocket icon
+    "🛣": "rocket",   # Variant without selector
     "⭐": "star",
     "✨": "star",
     "⚡": "lightbulb",


### PR DESCRIPTION
Add 🛣️ and 🛣 emoji variants to EMOJI_MAP, mapping to rocket icon for proper rendering in the "Umsetzung & Tiefe" section.