### PR TITLE
feat: Add Anti-Textwüsten rules to GPT prompts (v1.0)

### DIFF
--- a/prompts/de/foerderpotenzial.md
+++ b/prompts/de/foerderpotenzial.md
@@ -34,6 +34,53 @@ REGELN:
 - Sachlich, neutral, keine Werbung
 - Keine Platzhalter, keine Developer-Sprache
 
+=============================================================================
+ANTI-TEXTWÜSTEN REGELN v1.0 (STRIKT - PFLICHT!)
+=============================================================================
+PROBLEM: Lange Textblöcke sind im PDF unlesbar, auch mit farbiger Box.
+LÖSUNG: Jede Sektion MUSS strukturiert sein mit Bullets.
+
+ABSATZ-REGELN (PFLICHT):
+- Maximal 3 Sätze pro Absatz
+- Nach jedem Absatz: Leerzeile ODER Bullet-Liste
+- KEINE Absätze über 80 Wörter
+- KEINE Sektion ohne Bullet-Liste
+
+STRUKTUR PRO SEKTION (PFLICHT):
+1. Einleitungssatz (1-2 Sätze max)
+2. Bullet-Liste mit 3-5 Punkten (PFLICHT in JEDER Sektion!)
+3. Optional: Kurzer Abschlusssatz
+
+FORMAT-TEMPLATE:
+<p><strong>[Kernaussage]</strong></p>
+<ul>
+  <li><strong>[Stichwort]:</strong> [Erklärung in 1 Satz]</li>
+  <li><strong>[Stichwort]:</strong> [Erklärung in 1 Satz]</li>
+  <li><strong>[Stichwort]:</strong> [Erklärung in 1 Satz]</li>
+</ul>
+
+VERBOTEN - TEXTWÜSTEN-MUSTER:
+❌ Absätze mit mehr als 4 Sätzen
+❌ Mehrere Absätze hintereinander ohne Bullet-Liste
+❌ Sektionen die NUR aus Fließtext bestehen
+❌ Fließtext über 100 Wörter am Stück
+
+BEISPIEL Sektion 1 - SO NICHT:
+❌ "Das Geschäftsmodell basiert auf einem skalierbaren Angebot, das verschiedene
+    Komponenten kombiniert und dabei die Wirtschaftlichkeit im Blick behält,
+    wobei die Investitionen sich über einen planbaren Zeitraum amortisieren
+    und gleichzeitig Spielraum für weitere Entwicklung lassen..." [= TEXTWÜSTE!]
+
+BEISPIEL Sektion 1 - SO JA:
+✅ <p><strong>Der Business Case ist auch ohne Förderung tragfähig:</strong></p>
+   <ul>
+     <li><strong>Investition:</strong> Überschaubare Anfangsinvestition mit klarem Scope</li>
+     <li><strong>Amortisation:</strong> Rückfluss innerhalb von X Monaten realistisch</li>
+     <li><strong>Risiko:</strong> Geringes Ausfallrisiko durch modularen Ansatz</li>
+   </ul>
+   <p>Fördermittel verbessern diese Ausgangslage zusätzlich.</p>
+=============================================================================
+
 SPRINT N - SOLO PERSONA REGELN (STRIKT!):
 {% if COMPANY_SIZE == "solo" %}
 NICHT VERWENDEN für Solo:
@@ -56,14 +103,14 @@ Formulierungen ohne Team-/Abteilungsbegriff verwenden!
   </p>
 
   <h3>1. Einordnung des Business Case ohne Förderung</h3>
-  <p>
-    Das KI-Projekt weist eine solide wirtschaftliche Grundlage auf. Die Investition amortisiert sich
-    in überschaubarem Zeitraum bei positivem ROI im ersten Jahr.
-  </p>
-  <p>
-    Das Projekt ist betriebswirtschaftlich plausibel und der Eigenbeitrag tragfähig.
-    Fördermittel können die Investitionsbelastung reduzieren und die Rentabilität verbessern.
-  </p>
+  <p><strong>Der Business Case trägt sich auch ohne Fördermittel:</strong></p>
+  <ul>
+    <li><strong>Investitionshöhe:</strong> [Einordnung der Kosten für {{COMPANY_SIZE}}]</li>
+    <li><strong>Amortisation:</strong> Rückfluss in überschaubarem Zeitraum realistisch</li>
+    <li><strong>Risikoprofil:</strong> [Einordnung des Risikos für {{BRANCHE_LABEL}}]</li>
+    <li><strong>Eigenbeitrag:</strong> Aus laufendem Betrieb finanzierbar</li>
+  </ul>
+  <p>Fördermittel sind kein Muss, verbessern aber die Ausgangslage deutlich.</p>
 
   <h3>2. Wie Fördermittel den Business Case verbessern können</h3>
   <p>

--- a/prompts/de/gamechanger.md
+++ b/prompts/de/gamechanger.md
@@ -22,6 +22,53 @@ HTML-VERTRAG (verbindlich):
 ERLAUBT: <p>, <ul>, <ol>, <li>, <strong>, <em>
 VERBOTEN: <h1>, <h2>, <h3>, <h4>, <section>, <article>
 → Überschriften werden vom Template gesetzt, nicht vom GPT-Output
+
+=============================================================================
+ANTI-TEXTWÜSTEN REGELN v1.0 (STRIKT - PFLICHT!)
+=============================================================================
+PROBLEM: Lange Textblöcke sind im PDF unlesbar, auch mit farbiger Box.
+LÖSUNG: Strukturierter Output mit visuellen Ankerpunkten.
+
+ABSATZ-REGELN (PFLICHT):
+- Maximal 3 Sätze pro Absatz
+- Nach jedem Absatz: Leerzeile ODER Bullet-Liste
+- KEINE Absätze über 80 Wörter
+
+STRUKTUR PRO SEKTION (PFLICHT):
+Jede der 4 Sektionen MUSS enthalten:
+1. Einen kurzen Einleitungssatz (1-2 Sätze max)
+2. Eine Bullet-Liste mit 3-5 Punkten
+3. Optional: Einen Abschlusssatz
+
+FORMAT-TEMPLATE PRO SEKTION:
+<p><strong>[Kernaussage in 1 Satz]</strong></p>
+<ul>
+  <li><strong>[Stichwort]:</strong> [Erklärung in 1 Satz]</li>
+  <li><strong>[Stichwort]:</strong> [Erklärung in 1 Satz]</li>
+  <li><strong>[Stichwort]:</strong> [Erklärung in 1 Satz]</li>
+</ul>
+<p>[Optionaler Abschlusssatz]</p>
+
+VERBOTEN - TEXTWÜSTEN-MUSTER:
+❌ Absätze mit mehr als 4 Sätzen
+❌ Mehrere Absätze ohne Bullet-Liste dazwischen
+❌ Sektionen ohne jegliche <ul> oder <ol>
+❌ Fließtext über 100 Wörter am Stück
+
+BEISPIEL - SO NICHT:
+❌ "Die Transformation basiert auf einem modularen Ansatz, der verschiedene
+    Komponenten integriert und dabei sowohl technische als auch organisatorische
+    Aspekte berücksichtigt, wobei die Skalierbarkeit im Vordergrund steht und
+    gleichzeitig die bestehenden Prozesse nicht vollständig ersetzt werden..."
+    [= Textwüste, unlesbar!]
+
+BEISPIEL - SO JA:
+✅ <p><strong>Die Transformation basiert auf drei Säulen:</strong></p>
+   <ul>
+     <li><strong>Modularität:</strong> Wiederverwendbare Bausteine statt Einzellösungen</li>
+     <li><strong>Skalierbarkeit:</strong> Wachstum ohne proportionalen Mehraufwand</li>
+     <li><strong>Integration:</strong> Aufbau auf bestehenden Prozessen</li>
+   </ul>
 =============================================================================
 -->
 

--- a/prompts/de/risks.md
+++ b/prompts/de/risks.md
@@ -50,6 +50,36 @@ REGELN:
 - Scores aktiv interpretieren
 - Branchenspezifische Compliance bei regulierten Branchen
 - Sachlich, konkret, keine Floskeln
+
+=============================================================================
+ANTI-TEXTWÜSTEN REGELN v1.0 (STRIKT - PFLICHT!)
+=============================================================================
+PROBLEM: Risiko-Sektionen werden oft zu Fließtext-Wänden.
+LÖSUNG: Strikte Bullet-Struktur einhalten!
+
+FORMAT PRO RISIKO-SEKTION (PFLICHT):
+Jede der 4 Risiko-Sektionen MUSS als Bullet-Liste formatiert sein:
+<ul>
+  <li><strong>[Risiko-Name]:</strong> [1 Satz Beschreibung]. Maßnahme: [1 Satz].</li>
+  <li><strong>[Risiko-Name]:</strong> [1 Satz Beschreibung]. Maßnahme: [1 Satz].</li>
+  ...
+</ul>
+
+VERBOTEN:
+❌ Fließtext-Absätze statt Bullet-Listen
+❌ Mehr als 2 Sätze pro Bullet-Punkt
+❌ Risiko-Beschreibungen über 40 Wörter
+❌ Maßnahmen über 20 Wörter
+
+BEISPIEL - SO NICHT:
+❌ "Ein wesentliches Risiko besteht in der mangelnden Transparenz bezüglich der
+    KI-gestützten Entscheidungsprozesse, was zu Misstrauen bei Kunden führen kann
+    und langfristig die Akzeptanz der Lösungen gefährdet..." [= TEXTWÜSTE!]
+
+BEISPIEL - SO JA:
+✅ <li><strong>Mangelnde Transparenz:</strong> Kunden verstehen KI-Entscheidungen nicht.
+   Maßnahme: Einfache Erklärungen zu KI-Methoden bereitstellen.</li>
+=============================================================================
 -->
 
 <section class="section risks">


### PR DESCRIPTION
Added strict formatting rules to prevent text walls in PDF output:

- gamechanger.md: Max 3 sentences/paragraph, require bullets in each section
- foerderpotenzial.md: Same rules + updated Section 1 template with bullets
- risks.md: Enforce bullet structure, max 2 sentences per bullet

Key rules:
- No paragraphs over 80 words
- Every section MUST have a bullet list
- Format: <strong>[Keyword]:</strong> [1-2 sentences]
- Explicit examples of what NOT to do (Textwüsten)