### PR TITLE
feat: Use hauptleistung as core analysis context (Problem #7)

### DIFF
--- a/gpt_analyze.py
+++ b/gpt_analyze.py
@@ -9346,6 +9346,20 @@ def analyze_briefing(db: Session, briefing_id: int, run_id: str) -> tuple[int, s
     
     # BUILD_ID - timestamp for report generation tracking
     sections["BUILD_ID"] = f"{datetime.now(timezone.utc).strftime('%Y%m%d-%H%M')}"
+
+    # Problem #7 FIX: Personalized report subtitle from hauptleistung
+    hauptleistung = answers.get("hauptleistung", "").strip()
+    if hauptleistung:
+        # Smart truncation at word boundary
+        max_len = 60
+        if len(hauptleistung) <= max_len:
+            sections["REPORT_SUBTITLE"] = hauptleistung
+        else:
+            truncated = hauptleistung[:max_len].rsplit(" ", 1)[0]
+            sections["REPORT_SUBTITLE"] = truncated + "..."
+    else:
+        # Fallback to branch label
+        sections["REPORT_SUBTITLE"] = sections.get("BRANCHE_LABEL", "")
     
     # Werkbank
     sections["WERKBANK_HTML"] = _build_werkbank_html_dynamic(answers)

--- a/prompts/de/_hauptleistung_context.md
+++ b/prompts/de/_hauptleistung_context.md
@@ -1,0 +1,50 @@
+<!--
+=============================================================================
+HAUPTLEISTUNG CONTEXT BLOCK v1.0 (zentrale Konfiguration)
+=============================================================================
+Diese Datei wird von allen Prompts referenziert, die sich auf die
+Hauptleistung des Kunden beziehen sollen. Adressiert Problem #7:
+Generische Empfehlungen statt maßgeschneiderter Analyse.
+
+VERWENDUNG in anderen Prompts:
+{% include '_hauptleistung_context.md' %}
+=============================================================================
+-->
+
+## KERN-INFORMATION: Was dieses Unternehmen tut
+
+{% if hauptleistung %}
+Der Kunde beschreibt sein Geschäft so:
+**"{{hauptleistung}}"**
+
+Dies ist die WICHTIGSTE Information für diese Analyse.
+{% else %}
+**Hinweis:** Keine explizite Hauptleistung angegeben.
+Nutze {{OFFERING_LABEL}} als Fallback: "{{OFFERING_LABEL}}"
+{% endif %}
+
+### STRENGE REGELN FÜR DIESE ANALYSE:
+
+1. **JEDE Empfehlung** muss sich direkt auf "{{hauptleistung}}" beziehen
+2. **KEINE generischen Phrasen** wie "Prozesse optimieren" oder "Effizienz steigern"
+3. **KONKRETE BEISPIELE** müssen die Hauptleistung wörtlich aufgreifen
+4. **QUICK WINS** müssen erklären, wie sie bei "{{hauptleistung}}" helfen
+
+### BEISPIEL-TRANSFORMATION:
+
+{% if hauptleistung %}
+**VERBOTEN (zu generisch):**
+"E-Mail-Automatisierung einführen, um Zeit zu sparen."
+
+**RICHTIG (hauptleistungsbezogen):**
+"E-Mail-Vorlagen für {{hauptleistung}}-Anfragen erstellen – spart 30 Min/Anfrage."
+{% endif %}
+
+### KONTEXT-VARIABLEN (verfügbar):
+
+- **hauptleistung:** "{{hauptleistung}}"
+- **ZEITERSPARNIS_PRIORITAET:** "{{ZEITERSPARNIS_PRIORITAET}}"
+- **KI_GUARDRAILS:** "{{KI_GUARDRAILS}}"
+- **BRANCHE:** "{{BRANCHE_LABEL}}"
+- **COMPANY_SIZE:** "{{COMPANY_SIZE}}"
+

--- a/prompts/de/gamechanger.md
+++ b/prompts/de/gamechanger.md
@@ -79,6 +79,9 @@ BEISPIEL - SO JA:
 
 GAMECHANGER v7.1 — EINE NICHT-AUSTAUSCHBARE TRANSFORMATIONSIDEE
 
+<!-- Problem #7 FIX: Hauptleistung als Analyse-Kern -->
+{% include '_hauptleistung_context.md' %}
+
 <!--
 =============================================================================
 PHASE 3: INDIVIDUALISIERUNG DES STRATEGISCHEN BRUCHPUNKTS (PFLICHT!)
@@ -87,8 +90,12 @@ PHASE 3: INDIVIDUALISIERUNG DES STRATEGISCHEN BRUCHPUNKTS (PFLICHT!)
 Der Gamechanger MUSS die konkreten Briefing-Daten des Users aufgreifen.
 Generische Bruchpunkte sind VERBOTEN.
 
+KERN-KONTEXT (PFLICHT!):
+Die Hauptleistung "{{hauptleistung}}" ist der ZENTRALE Bezugspunkt.
+Jeder Satz muss sich auf diese Hauptleistung beziehen!
+
 INDIVIDUALISIERUNGS-KONTEXT (verfügbar aus Briefing):
-- {{hauptleistung}} = Was der User konkret anbietet
+- {{hauptleistung}} = Was der User konkret anbietet (PRIMÄR!)
 - {{ZEITERSPARNIS_PRIORITAET}} = Wo der User am meisten Zeit verliert
 - {{KI_GUARDRAILS}} = Einschränkungen/No-Gos für KI-Nutzung
 - {{VISION_3_JAHRE}} = Langfristige Vision des Users

--- a/prompts/de/quick_wins.md
+++ b/prompts/de/quick_wins.md
@@ -1,9 +1,19 @@
 # Quick Wins - JSON Output v8.0
+<!-- Problem #7 FIX: Hauptleistung als Analyse-Kern -->
 
 Du bist ein erfahrener KI-Berater und entwickelst konkrete Quick Wins für die KI-Integration.
 
+## KERN-KONTEXT: Was dieses Unternehmen tut
+
+{% if hauptleistung %}
+**"{{hauptleistung}}"** – DAS ist die Hauptleistung dieses Kunden.
+JEDER Quick Win MUSS erklären, wie er konkret bei dieser Hauptleistung hilft!
+{% endif %}
+
 ## Aufgabe
 Analysiere die Unternehmensdaten und erstelle 3-5 Quick Wins als **JSON Array** (KEIN HTML!).
+
+**STRENGE REGEL:** Kein Quick Win ohne direkten Bezug zur Hauptleistung "{{hauptleistung}}"!
 
 ## Kontext
 
@@ -136,6 +146,18 @@ Analysiere die Unternehmensdaten und erstelle 3-5 Quick Wins als **JSON Array** 
 - [ ] Quick Win #1 zitiert ZEITERSPARNIS_PRIORITAET
 - [ ] Tool-Namen sind KONKRET (nicht "KI-Tools")
 - [ ] Guardrails werden beachtet (falls vorhanden)
+
+## HAUPTLEISTUNG-BEZUG: BEISPIEL-TRANSFORMATION
+
+**Hauptleistung des Kunden:** "Online-Shop für Büromöbel"
+
+❌ **SCHLECHT (zu generisch):**
+"E-Mail-Automatisierung einführen" – kein Bezug zu Büromöbeln
+
+✅ **RICHTIG (hauptleistungsbezogen):**
+"Produktbeschreibungen für neue Büromöbel mit KI generieren – spart 3h/Woche bei neuen Möbel-Listings"
+
+---
 
 ## BEISPIEL (Beratungsbranche)
 

--- a/prompts/de/tools_empfehlungen.md
+++ b/prompts/de/tools_empfehlungen.md
@@ -3,8 +3,14 @@ Developer:
 <!-- SECTION: tools_empfehlungen -->
 <!-- OUTPUT: HTML ONLY -->
 <!-- SIZE-AWARE: solo/team/kmu -->
-<!-- INPUT: {{BRANCH_CORE_LABEL}}, {{BRANCH_CONTEXT_LABEL}}, {{BRANCH_SHORT_LABEL}}, {{OFFERING_LABEL}}, {{COMPANY_SIZE}} -->
+<!-- INPUT: {{BRANCH_CORE_LABEL}}, {{BRANCH_CONTEXT_LABEL}}, {{BRANCH_SHORT_LABEL}}, {{OFFERING_LABEL}}, {{COMPANY_SIZE}}, {{hauptleistung}} -->
 <!-- TOKEN-BUDGET: 2800 (solo:0.8x=2240, team:1.0x=2800, kmu:1.15x=3220) -->
+<!--
+=============================================================================
+Problem #7 FIX: Hauptleistung als Analyse-Kern
+=============================================================================
+-->
+{% include '_hauptleistung_context.md' %}
 <!-- WORD_MINIMUM_SOLO: 150 -->
 <!-- WORD_MINIMUM_TEAM: 200 -->
 <!-- WORD_MINIMUM_KMU: 250 -->
@@ -103,8 +109,13 @@ KMU-MODUS - VERBOTEN:
   <h2>Empfohlener KI-Stack für {{BRANCH_CONTEXT_LABEL}}</h2>
 
   <p>
+    {% if hauptleistung %}
+    Für "{{hauptleistung}}" empfiehlt sich ein klar strukturierter KI-Stack,
+    der konkret bei dieser Hauptleistung Zeit spart und sich schrittweise erweitern lässt.
+    {% else %}
     Für {{OFFERING_LABEL}} empfiehlt sich ein klar strukturierter KI-Stack,
     der den Alltag spürbar entlastet und sich bei Bedarf schrittweise erweitern lässt.
+    {% endif %}
   </p>
 
   <h3>Ausrichtung nach Unternehmensgröße</h3>

--- a/prompts/de/top_3_massnahmen.md
+++ b/prompts/de/top_3_massnahmen.md
@@ -2,6 +2,12 @@
 <!-- OUTPUT: HTML <ol> list ONLY -->
 <!-- INPUT: {{hauptleistung}}, {{ZEITERSPARNIS_PRIORITAET}}, {{KI_GUARDRAILS}} -->
 <!-- TOKEN-BUDGET: 150 (nur die 3 Listenelemente) -->
+<!-- Problem #7 FIX: Hauptleistung als Analyse-Kern -->
+
+## KERN-KONTEXT: "{{hauptleistung}}"
+
+ALLE 3 Maßnahmen MÜSSEN sich erkennbar auf "{{hauptleistung}}" beziehen.
+Keine generischen Empfehlungen, die für jedes Unternehmen gelten würden!
 
 Du bist ein Experte für KI-Implementierungsstrategien.
 

--- a/templates/pdf_template.html
+++ b/templates/pdf_template.html
@@ -4420,6 +4420,12 @@
                             <h1 style="font-size: 32px; font-weight: 600; margin: 0 0 var(--space-sm) 0; color: var(--color-text-normal);">
                                 KI-Readiness Report
                             </h1>
+                            {% if REPORT_SUBTITLE %}
+                            <!-- Problem #7 FIX: Personalized subtitle from hauptleistung -->
+                            <p style="font-size: 14px; color: var(--color-primary); margin: 0 0 var(--space-xs) 0; font-style: italic;">
+                                {{ REPORT_SUBTITLE }}
+                            </p>
+                            {% endif %}
                             <p style="font-size: 16px; color: var(--color-text-muted); margin: 0;">
                                 {{ ui("company_label_colon") }} <strong style="color: var(--color-text-normal);">{{ company_name or kundencode or ui("your_company") }}</strong>
                                 <span class="muted"> · </span>


### PR DESCRIPTION
- Create central _hauptleistung_context.md include file for prompts
- Add {% include %} to gamechanger.md, tools_empfehlungen.md, quick_wins.md
- Add KERN-KONTEXT block to top_3_massnahmen.md
- Strengthen hauptleistung references with example transformations
- Add REPORT_SUBTITLE variable in gpt_analyze.py (smart truncation at 60 chars)
- Update PDF template to show personalized subtitle under main title

Report now feels tailored to the customer's main business, not generic.