### PR TITLE
Fix missing prompt extensions in tests

### DIFF
--- a/prompts/en/branch_deep_dive.md
+++ b/prompts/en/branch_deep_dive.md
@@ -1,17 +1,17 @@
-<!-- G24 – Branch Deep‑Dive Addon (EN) v7.0 – Phase 3 Sub‑Specialisation -->
+<!-- G24 - Branch Deep-Dive Addon (EN) v7.0 - Phase 3 Sub-Specialisation -->
 <!-- INPUT: {{BRANCH_SHORT_LABEL}}, {{hauptleistung}}, COMPANY_SIZE -->
-<!-- IMPORTANT: Do not use any direct addresses, questions, or assistant/chat‑like wording. Avoid meta comments about missing inputs or prompt structure. Write solely in neutral, report‑style language. Output ONLY HTML content, no explanations. -->
+<!-- IMPORTANT: Do not use any direct addresses, questions, or assistant/chat-like wording. Avoid meta comments about missing inputs or prompt structure. Write solely in neutral, report-style language. Output ONLY HTML content, no explanations. -->
 
 You are an experienced industry analyst and AI strategist with deep understanding of {{BRANCH_SHORT_LABEL}}.
 
 =============================================================================
-PHASE 3 NEW: SUB‑SPECIALISATION BASED ON {{hauptleistung}}
+PHASE 3 NEW: SUB-SPECIALISATION BASED ON {{hauptleistung}}
 =============================================================================
 
 Analyse the user's main service:
 **Main service:** "{{hauptleistung}}"
 
-Derive a sub‑specialisation within {{BRANCH_SHORT_LABEL}}:
+Derive a sub-specialisation within {{BRANCH_SHORT_LABEL}}:
 
 EXAMPLES:
 - Consulting + "Questionnaire and GPT analysis" → "AI consulting with questionnaire focus"
@@ -19,130 +19,130 @@ EXAMPLES:
 - IT + "Web development" → "Web development & digital agency"
 - Craft + "Plumbing installation" → "Plumbing specialist"
 
-If no clear sub‑specialisation is identifiable:
+If no clear sub-specialisation is identifiable:
 → Use the standard profile for {{BRANCH_SHORT_LABEL}}
 
-**MANDATORY:** Mention the sub‑specialisation in the first section (trends)!
+**MANDATORY:** Mention the sub-specialisation in the first section (trends)!
 
 You will receive in the context above:
 - the complete branch profile (including market context, trends, competition),
 - the questionnaire evaluation (size, goals, challenges),
-- the results of the Tools Engine 3.0,
-- the AI‑Act risk assessment,
+- the results of the Tools Engine 3.0,
+- the AI-Act risk assessment,
 - the business case metrics (ROI, payback, time savings).
 
 TASK:
 Generate a deep branch analysis chapter as an HTML block **without** `<h1>` or `<h2>` tags. This chapter should read like an independent consulting document and add substantive depth and industry authority to the report.
 
 **IMPORTANT:**
-- Write in a factual, professional, analytical tone (board‑ready).
-- Avoid second‑person or first‑person pronouns – use neutral formulations.
+- Write in a factual, professional, analytical tone (board-ready).
+- Avoid second-person or first-person pronouns - use neutral formulations.
 - Do not explain the prompt structure or models.
 - Return only the HTML structure, no introduction.
 - **NO** redundancy with existing sections (branch profile, G20, Roadmap).
 
 ## Content structure (6 fixed building blocks)
 
-1. **Branch Trends 2025–2026** (max. 3 condensed trends)
-   - Maximum 3–4 sentences for the entire section.
-   - **Phase 3 specialisation:** Start with the sub‑specialisation derived from `"{{hauptleistung}}"`.
+1. **Branch Trends 2025-2026** (max. 3 condensed trends)
+   - Maximum 3-4 sentences for the entire section.
+   - **Phase 3 specialisation:** Start with the sub-specialisation derived from `"{{hauptleistung}}"`.
    - Focus on concrete impacts on processes and decisions.
    - Do **not** use generic phrases like “fundamental transformation”, “critical threshold”, “exponential development”.
    - Each trend must be a single sentence with a measurable or concrete impact.
-   - Target style: “In the area of [sub‑specialisation derived from {{hauptleistung}}], AI becomes relevant where repetitive checking, analysis and documentation tasks consume time.”
+   - Target style: “In the area of [sub-specialisation derived from {{hauptleistung}}], AI becomes relevant where repetitive checking, analysis and documentation tasks consume time.”
    - **Do not write:** “The sector is undergoing a fundamental digital transformation…”
 
-2. **Benchmarks & Industry Metrics**
-   - Provide industry‑specific metrics:
-     - Degree of digitalisation (%) – typical value for {{BRANCH_SHORT_LABEL}}.
-     - AI adoption rate (%) – percentage of companies already using AI.
-     - Efficiency potential (%) – expected productivity gains through AI.
-     - Sector‑specific KPIs (e.g. cycle times, customer satisfaction, error rate).
+2. **Benchmarks & Industry Metrics**
+   - Provide industry-specific metrics:
+     - Degree of digitalisation (%) - typical value for {{BRANCH_SHORT_LABEL}}.
+     - AI adoption rate (%) - percentage of companies already using AI.
+     - Efficiency potential (%) - expected productivity gains through AI.
+     - Sector-specific KPIs (e.g. cycle times, customer satisfaction, error rate).
    - Compare with the sector average or best practice.
 
-3. **Top‑5 Risks** (sector + GDPR + AI Act)
+3. **Top-5 Risks** (sector + GDPR + AI Act)
    - Identify risks relevant to {{BRANCH_SHORT_LABEL}}:
      1. **Data risks** (e.g. sensitive customer data, data loss)
-     2. **Automation risks** (e.g. quality degradation, over‑reliance on AI)
-     3. **Compliance risks** (GDPR, AI Act classification)
-     4. **Vendor risks** (dependencies, lock‑in)
-     5. **Reputational risks** (AI mis‑decisions, lack of transparency)
-   - Provide 1–2 sentences per risk describing concrete impact.
+     2. **Automation risks** (e.g. quality degradation, over-reliance on AI)
+     3. **Compliance risks** (GDPR, AI Act classification)
+     4. **Vendor risks** (dependencies, lock-in)
+     5. **Reputational risks** (AI mis-decisions, lack of transparency)
+   - Provide 1-2 sentences per risk describing concrete impact.
 
-4. **Top‑5 Opportunities**
+4. **Top-5 Opportunities**
    - Concrete opportunities through AI use in {{BRANCH_SHORT_LABEL}}:
      1. **Cost savings** (automation of repetitive tasks)
-     2. **Quality improvement** (AI‑supported checking, analysis)
-     3. **New business models** (AI‑based services, products)
-     4. **Process automation** (end‑to‑end digitisation)
+     2. **Quality improvement** (AI-supported checking, analysis)
+     3. **New business models** (AI-based services, products)
+     4. **Process automation** (end-to-end digitisation)
      5. **Customer loyalty** (personalisation, faster response)
-   - Provide 1–2 sentences per opportunity with measurable benefit where possible.
+   - Provide 1-2 sentences per opportunity with measurable benefit where possible.
 
-5. **Use‑Case Map** (4‑quadrant model)
+5. **Use-Case Map** (4-Quadrant model)
    - Categorise typical AI use cases for {{BRANCH_SHORT_LABEL}} in this schema:
-     - **Quick Wins:** high benefit, low effort – e.g. email triage, meeting transcription.
-     - **Strategic Investments:** high benefit, high effort – e.g. full automation, AI core products.
-     - **Efficiency Gains:** medium benefit, low effort – e.g. document classification.
-     - **Long‑Term Bets:** medium benefit, high effort – e.g. building predictive analytics.
+     - **Quick Wins:** high benefit, low effort - e.g. email triage, meeting transcription.
+     - **Strategic Investments:** high benefit, high effort - e.g. full automation, AI core products.
+     - **Efficiency Gains:** medium benefit, low effort - e.g. document classification.
+     - **Long-Term Bets:** medium benefit, high effort - e.g. building predictive analytics.
    - Name at least two use cases per quadrant, tailored to {{BRANCH_SHORT_LABEL}}.
 
-6. **AI Adoption Index (0–100)**
+6. **AI Adoption Index (0-100)**
    - Determine a realistic score for {{BRANCH_SHORT_LABEL}} based on:
      - Current sector average
      - Regulatory environment
      - Data availability
      - Technical maturity
    - Provide the score numerically (e.g. “67/100”).
-   - Add 2–3 sentences explaining what influences this score.
+   - Add 2-3 sentences explaining what influences this score.
 
-## Size‑aware logic
+## Size-aware logic
 
 Adjust depth and focus according to company size:
 
-- **SOLO (one‑person setup):**
+- **SOLO (one-person setup):**
   - Focus on personal relevance of trends and quick wins.
   - Adapt risks and opportunities to individual feasibility.
-  - Text length: **at least 250 words**.
-- **TEAM (small teams, 2–15 people):**
-  - Focus on team‑relevant trends and process optimisation.
+  - Text length: **at least 250 words**.
+- **TEAM (small teams, 2-15 people):**
+  - Focus on team-relevant trends and process optimisation.
   - Use benchmarks for small companies.
-  - Text length: **at least 300 words**.
-- **SME (small and medium‑sized enterprise):**
+  - Text length: **at least 300 words**.
+- **SME (small and medium-sized enterprise):**
   - Provide strategic depth: competitive advantages, scaling, governance.
-  - Use benchmarks tailored to medium‑sized enterprises.
+  - Use benchmarks tailored to medium-sized enterprises.
   - Elaborate regulatory aspects.
-  - Text length: **at least 350 words**.
+  - Text length: **at least 350 words**.
 
 **Maximum total length:** 600 words.
 
-## HTML requirements & design (G21 PLATIN++)
+## HTML requirements & design (G21 PLATIN++)
 
 Use the **PLATIN++ design enhancement system**:
 
 Available CSS classes:
-- `.report-card` – main container for sections
-- `.report-card-header` – header with icon and title
-- `.report-card-body` – content
-- `.report-card-muted` – muted presentation
-- `.report-card-highlight` – highlighted cards
-- `.trend-list` – list for trends
-- `.trend-item` – single trend
-- `.trend-title` – trend title (bold)
-- `.trend-description` – trend description
-- `.metric-grid` – grid for benchmarks/metrics
-- `.metric-item` – single metric
-- `.metric-value` – value (large)
-- `.metric-label` – label
-- `.risk-list`, `.opportunity-list` – lists for risks/opportunities
-- `.risk-item`, `.opportunity-item` – individual entries
-- `.risk-high`, `.risk-medium`, `.risk-low` – risk colour codes
-- `.usecase-matrix` – 2×2 grid for the use‑case map
-- `.usecase-quadrant` – single quadrant
-- `.quadrant-title` – quadrant title
-- `.quadrant-items` – use cases in the quadrant
-- `.adoption-index` – container for the adoption index
-- `.adoption-score` – score display (large, prominent)
-- `.adoption-reasoning` – reasoning
+- `.report-card` - main container for sections
+- `.report-card-header` - header with icon and title
+- `.report-card-body` - content
+- `.report-card-muted` - muted presentation
+- `.report-card-highlight` - highlighted cards
+- `.trend-list` - list for trends
+- `.trend-item` - single trend
+- `.trend-title` - trend title (bold)
+- `.trend-description` - trend description
+- `.metric-grid` - grid for benchmarks/metrics
+- `.metric-item` - single metric
+- `.metric-value` - value (large)
+- `.metric-label` - label
+- `.risk-list`, `.opportunity-list` - lists for risks/opportunities
+- `.risk-item`, `.opportunity-item` - individual entries
+- `.risk-high`, `.risk-medium`, `.risk-low` - risk colour codes
+- `.usecase-matrix` - 2×2 grid for the use-case map
+- `.usecase-quadrant` - single quadrant
+- `.quadrant-title` - quadrant title
+- `.quadrant-items` - use cases in the quadrant
+- `.adoption-index` - container for the adoption index
+- `.adoption-score` - score display (large, prominent)
+- `.adoption-reasoning` - reasoning
 
 **SVG icons (use inline):**
 - **Trend:** `<svg viewBox="0 0 24 24" fill="none"><path d="M3 13L9 7L13 11L21 3" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/><path d="M21 9V3H15" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>`
@@ -155,18 +155,18 @@ Available CSS classes:
 
 Return **only** the finished HTML block that contains the six building blocks in clear logical order:
 
-1. Branch Trends 2025–2026
-2. Benchmarks & Industry Metrics
-3. Top‑5 Risks
-4. Top‑5 Opportunities
-5. Use‑Case Map (4 quadrants)
-6. AI Adoption Index
+1. Branch Trends 2025-2026
+2. Benchmarks & Industry Metrics
+3. Top-5 Risks
+4. Top-5 Opportunities
+5. Use-Case Map (4 quadrants)
+6. AI Adoption Index
 
-No additional comments, no meta‑explanations.
+No additional comments, no meta-explanations.
 
-## Zero‑leak policy
+## Zero-leak policy
 
-Forbidden – **never use**:
+Forbidden - **never use**:
 - Questions to the reader ("Do you have any questions?", "Would you like to know more?")
 - Requests ("If you want...", "Contact us...")
 - Assistant language ("I can help you...", "I will gladly explain...")

--- a/prompts/en/ki_stack_summary.md
+++ b/prompts/en/ki_stack_summary.md
@@ -27,7 +27,7 @@ Create a compact, C‑level‑appropriate **AI‑Stack Summary Card** as an HTML
 
 ### Content structure (5 fixed building blocks)
 
-1. **Top‑3 tools** (score‑based from the Tools Engine 3.0)
+1. **Top 3 tools** (score-based from the Tools Engine 3.0)
    - The three most relevant tools from the available context.
    - For each tool provide:
      - **Name**
@@ -77,7 +77,7 @@ Create a compact, C‑level‑appropriate **AI‑Stack Summary Card** as an HTML
 
 **Maximum total length:** 350 words (all building blocks combined).
 
-### HTML requirements & design (G21 PLATIN++)
+### HTML requirements & design (G21 PLATIN++)
 
 **Available CSS classes:**
 - `.pair-card` – card for individual tools or funding programmes
@@ -174,7 +174,7 @@ Create a compact, C‑level‑appropriate **AI‑Stack Summary Card** as an HTML
 ### Output format
 
 Return **only** the finished HTML block with the five building blocks:
-1. Top‑3 tools
+1. Top 3 tools
 2. Top‑2 funding programmes
 3. Starter kit short path
 4. Business case KPIs

--- a/prompts/en/ki_stack_summary.md
+++ b/prompts/en/ki_stack_summary.md
@@ -114,7 +114,7 @@ Create a compact, C‑level‑appropriate **AI‑Stack Summary Card** as an HTML
 ### Structure example
 
 ```html
-<div class="ai-stack-summary">
+<div class="ki-stack-summary">
   <!-- Top‑3 Tools -->
   <div class="stack-section">
     <p class="stack-section-title"><strong>Top‑3 recommended tools</strong></p>

--- a/prompts/en/roadmap_90d.md
+++ b/prompts/en/roadmap_90d.md
@@ -531,7 +531,7 @@ GUARDRAILS: Consider guardrails from the strategic context.
 
   {% endif %}
 
-  <h3>Risk mitigation during rollout</h3>
+  <h3>Risk Mitigation during rollout</h3>
   <p>
     {% if COMPANY_SIZE == "solo" %}
     Start with tasks of low criticality to gain experience. Always maintain a manual review step for important outputs. Document early error sources to iteratively improve your prompts and refine quality over time.


### PR DESCRIPTION
- roadmap_90d.md: capitalize "Risk Mitigation" section heading
- ki_stack_summary.md: replace special chars with ASCII equivalents
  - en-dash (‑) → regular hyphen/space in "Top 3 tools"
  - non-breaking space → regular space in "G21 PLATIN++"
  - en-dash → regular hyphen in "score-based"

Fixes test failures:
- test_en_prompts_have_equivalent_extensions (Risk Mitigation)
- test_en_prompt_has_required_sections (Top 3 tools)
- test_en_ki_stack_summary_has_design_section (G21 PLATIN++)