### PR TITLE
fix: Enable quality gate and update validation thresholds

### DIFF
--- a/gpt_analyze.py
+++ b/gpt_analyze.py
@@ -12201,9 +12201,9 @@ def analyze_briefing(db: Session, briefing_id: int, run_id: str) -> tuple[int, s
             log.warning(f"[{run_id}]   [{err.category}] {err.section}: {err.message}")
 
     if not is_valid:
-        # Phase 1.5: Quality Gate now LOGS but doesn't block (soft enforcement)
-        # Set to True to enable hard blocking of bad reports
-        HARD_QUALITY_GATE_ENABLED = False  # Set to True in production for strict mode
+        # Phase 2: Quality Gate NOW ENABLED - blocks reports with critical errors
+        # Set to False only for debugging/testing
+        HARD_QUALITY_GATE_ENABLED = True  # ENABLED: Strict mode active
 
         if HARD_QUALITY_GATE_ENABLED and critical_errors:
             log.error(f"[{run_id}] 🚫 QUALITY GATE BLOCKED: {len(critical_errors)} critical errors")

--- a/services/report_validator.py
+++ b/services/report_validator.py
@@ -1780,40 +1780,66 @@ class ReportValidator:
 
     def _check_hauptleistung_limits(self) -> None:
         """
-        Sprint P1.5-1: Validate hauptleistung occurrence counts.
-        - Executive Summary: MIN 4 occurrences
-        - Roadmap: MAX 3 occurrences per size variant
+        Phase 2: Validate hauptleistung occurrence counts.
+        - Executive Summary: MIN 4 occurrences (per prompt requirement)
+        - Recommendations: MIN 3 occurrences (per prompt requirement)
+        - Roadmap: MAX 5 occurrences
         """
         hauptleistung = self.meta.get("hauptleistung", "")
         if not hauptleistung or len(hauptleistung) < 3:
             return  # No hauptleistung to check
 
-        # Check Executive Summary (minimum 3, recommended 4)
+        # Check Executive Summary (minimum 4 per prompt requirement)
         exec_summary = self.sections.get("EXEC_SUMMARY_HTML", "")
         if exec_summary and isinstance(exec_summary, str):
             count = exec_summary.lower().count(hauptleistung.lower())
-            if count < 2:  # CRITICAL: less than 2 is unacceptable
+            if count < 4:  # CRITICAL: less than 4 violates prompt requirement
                 self.errors.append(
                     ValidationError(
                         severity="CRITICAL",
                         category="HAUPTLEISTUNG_UNDERUSE",
                         section="EXEC_SUMMARY_HTML",
-                        message=f"Executive Summary enthält nur {count}x hauptleistung (Minimum: 3)",
-                        details=f"Hauptleistung '{hauptleistung}' muss mindestens 3x vorkommen",
+                        message=f"Executive Summary enthält nur {count}x hauptleistung (Minimum: 4)",
+                        details=f"Hauptleistung '{hauptleistung}' muss mindestens 4x vorkommen (Prompt-Requirement)",
                     )
                 )
-            elif count < 3:  # WARNING: 2 is low but acceptable
+            elif count < 5:  # WARNING: 4 is minimum, 5 is ideal
                 self.errors.append(
                     ValidationError(
                         severity="WARNING",
                         category="HAUPTLEISTUNG_UNDERUSE",
                         section="EXEC_SUMMARY_HTML",
-                        message=f"Executive Summary enthält nur {count}x hauptleistung (Empfohlen: 3-4)",
-                        details=f"Hauptleistung '{hauptleistung}' sollte 3-4x vorkommen",
+                        message=f"Executive Summary enthält nur {count}x hauptleistung (Empfohlen: 4-5)",
+                        details=f"Hauptleistung '{hauptleistung}' sollte 4-5x vorkommen für optimale Integration",
                     )
                 )
 
-        # Check Roadmap (maximum 5, hard limit 8)
+        # Check Recommendations (minimum 3 per prompt requirement)
+        recommendations = self.sections.get("RECOMMENDATIONS_HTML", "")
+        if recommendations and isinstance(recommendations, str):
+            count = recommendations.lower().count(hauptleistung.lower())
+            if count < 3:  # CRITICAL: less than 3 violates prompt requirement
+                self.errors.append(
+                    ValidationError(
+                        severity="CRITICAL",
+                        category="HAUPTLEISTUNG_UNDERUSE",
+                        section="RECOMMENDATIONS_HTML",
+                        message=f"Recommendations enthält nur {count}x hauptleistung (Minimum: 3)",
+                        details=f"Hauptleistung '{hauptleistung}' muss mindestens 3x vorkommen (Prompt-Requirement)",
+                    )
+                )
+            elif count > 6:  # WARNING: too many occurrences
+                self.errors.append(
+                    ValidationError(
+                        severity="WARNING",
+                        category="HAUPTLEISTUNG_OVERUSE",
+                        section="RECOMMENDATIONS_HTML",
+                        message=f"Recommendations enthält {count}x hauptleistung (Maximum: 6)",
+                        details=f"Zu viele Wiederholungen - nutze Synonyme",
+                    )
+                )
+
+        # Check Roadmap (maximum 5, hard limit 10)
         roadmap = self.sections.get("ROADMAP_90D_HTML", "")
         if roadmap and isinstance(roadmap, str):
             count = roadmap.lower().count(hauptleistung.lower())
@@ -1840,64 +1866,45 @@ class ReportValidator:
 
     def _check_roi_consistency(self) -> None:
         """
-        Sprint P1.5-3: Validate ROI values are consistent across sections.
-        Only one ROI percentage should appear (from business_case).
+        Phase 2: ROI PROHIBITION - No ROI percentages allowed outside Business Case.
+        Per prompt requirement: ROI-Werte sind in diesen Sektionen VERBOTEN.
         """
-        roi_12m = self.meta.get("ROI_12M", "")
-        if not roi_12m:
-            return
-
-        # Pattern to find ROI percentages (e.g., "284%", "337%", "200%")
+        # Pattern to find ROI percentages (e.g., "284%", "337%", "200%", "150%")
+        # Matches 2-3 digit numbers followed by %
         roi_pattern = r"(\d{2,3})\s*%"
 
-        # Sections that should NOT have their own ROI calculations
-        non_roi_sections = [
+        # Sections where ROI is PROHIBITED (per prompt requirement)
+        prohibited_roi_sections = [
             "EXEC_SUMMARY_HTML",
             "GAMECHANGER_HTML",
             "RECOMMENDATIONS_HTML",
             "ROADMAP_90D_HTML",
         ]
 
-        for section_name in non_roi_sections:
+        for section_name in prohibited_roi_sections:
             content = self.sections.get(section_name, "")
             if not content or not isinstance(content, str):
                 continue
 
-            # Find all ROI-like percentages
+            # Find all percentage values
             matches = re.findall(roi_pattern, content)
-            # Filter for typical ROI ranges (100-400%)
+            # Filter for ROI-like ranges (100-500%) - typical ROI values
             roi_values = [int(m) for m in matches if 100 <= int(m) <= 500]
 
             if roi_values:
-                # Check if any differ from the official ROI
-                try:
-                    official_roi = int(str(roi_12m).replace("%", "").strip())
-                    for found_roi in roi_values:
-                        diff = abs(found_roi - official_roi)
-                        if diff > 50:  # CRITICAL: Major inconsistency (>50%)
-                            self.errors.append(
-                                ValidationError(
-                                    severity="CRITICAL",
-                                    category="ROI_INCONSISTENCY",
-                                    section=section_name,
-                                    message=f"Stark abweichender ROI-Wert {found_roi}% (offiziell: {official_roi}%)",
-                                    details="ROI-Werte müssen konsistent sein - Single Source of Truth!",
-                                )
-                            )
-                            break
-                        elif diff > 20:  # WARNING: Minor inconsistency (20-50%)
-                            self.errors.append(
-                                ValidationError(
-                                    severity="WARNING",
-                                    category="ROI_INCONSISTENCY",
-                                    section=section_name,
-                                    message=f"Abweichender ROI-Wert {found_roi}% (offiziell: {official_roi}%)",
-                                    details="ROI sollte nur im Business Case definiert sein",
-                                )
-                            )
-                            break
-                except (ValueError, TypeError):
-                    pass
+                # ANY ROI percentage in these sections is CRITICAL
+                # Per prompt: "ROI PROHIBITION - ZERO TOLERANCE"
+                self.errors.append(
+                    ValidationError(
+                        severity="CRITICAL",
+                        category="ROI_PROHIBITED",
+                        section=section_name,
+                        message=f"ROI-Prozentsatz {roi_values[0]}% in verbotenem Abschnitt gefunden",
+                        details="ROI-Werte sind nur im Business Case erlaubt. Entfernen oder durch '→ siehe Business Case' ersetzen.",
+                    )
+                )
+                # Only report first occurrence per section
+                continue
 
     def _check_incomplete_sentences(self) -> None:
         """


### PR DESCRIPTION
Phase 2 Fixes für Report-Qualität:

1. **Quality Gate AKTIVIERT** (gpt_analyze.py:12206)
   - HARD_QUALITY_GATE_ENABLED = True
   - Reports mit CRITICAL Errors werden jetzt BLOCKIERT

2. **hauptleistung Schwellenwerte angepasst** (report_validator.py)
   - Executive Summary: MIN 4x (CRITICAL wenn < 4)
   - Recommendations: MIN 3x (CRITICAL wenn < 3) - NEU!
   - Roadmap: MAX 5x (WARNING), MAX 10x (CRITICAL)

3. **RECOMMENDATIONS_HTML Validierung hinzugefügt**
   - Neue Prüfung für hauptleistung MIN 3x
   - MAX 6x Warnung bei zu vielen Wiederholungen

4. **ROI PROHIBITION statt nur Inconsistency**
   - Jeder ROI-Prozentsatz (100-500%) in verbotenen Sektionen = CRITICAL
   - Kategorie: ROI_PROHIBITED (nicht mehr nur ROI_INCONSISTENCY)
   - Betroffene Sektionen: EXEC_SUMMARY, GAMECHANGER, RECOMMENDATIONS, ROADMAP

Diese Änderungen setzen die Prompt-Requirements um:
- executive_summary.md: "MINIMUM 4x {{hauptleistung}}"
- recommendations.md: "MINIMUM 3x {{hauptleistung}}"
- Alle: "ROI PROHIBITION - ZERO TOLERANCE"