### PR TITLE
test: Update max_tokens validation to match v14.30 changes

### DIFF
--- a/.github/workflows/platin-report-check.yml
+++ b/.github/workflows/platin-report-check.yml
@@ -256,10 +256,10 @@ jobs:
                   if field not in config:
                       errors.append(f'{section}: Missing field {field}')
 
-              # Validate max_tokens (FIX 178969e: extended range to prevent truncation)
+              # Validate max_tokens (v14.30: extended range for Risk/Recommendation cards)
               max_tokens = config.get('max_tokens', 0)
-              if not 1500 <= max_tokens <= 5000:
-                  errors.append(f"{section}: max_tokens {max_tokens} not in range [1500, 5000]")
+              if not 1500 <= max_tokens <= 7000:
+                  errors.append(f"{section}: max_tokens {max_tokens} not in range [1500, 7000]")
 
               # Validate temperature range
               temp = config.get('temperature', 0)

--- a/services/content_quality_enforcer.py
+++ b/services/content_quality_enforcer.py
@@ -601,7 +601,7 @@ EXTENDED_SIEZEN_PATTERNS = [
     # Diese Enterprise-Begriffe werden für Solo ersetzt
     (r'\bModule\b', 'Bausteine'),  # Modul → Baustein
     (r'\bModul\b', 'Baustein'),
-    (r'\bSkalierung\b', 'Erweiterung')  # feminin bleibt feminin
+    (r'\bSkalierung\b', 'Erweiterung'),  # feminin bleibt feminin
     (r'\bSkalieren\b', 'Erweitern'),
     (r'\bEngine\b', 'System'),
     (r'\bFramework\b', 'Konzept'),

--- a/tests/test_platin_llm_params.py
+++ b/tests/test_platin_llm_params.py
@@ -60,8 +60,8 @@ class TestPlatinCriticalSections:
         # FIX 178969e: Increased limits to prevent text truncation
         expected_tokens = {
             "foerderpotenzial": 3200,
-            "risks": 3000,
-            "recommendations": 4000,  # FIX: Increased from 2500 to prevent truncation
+            "risks": 6000,            # v14.30: Increased for complete Risk-Cards
+            "recommendations": 6000,  # v14.30: Increased for complete Recommendation-Cards
             "roadmap_12m": 4000,      # FIX: Increased from 2800 to prevent truncation
             "roadmap_90d": 4000,      # FIX: Increased from 2800 to prevent truncation
             "quick_wins": 4500,       # FIX: Increased from 3500 to prevent truncation
@@ -79,9 +79,9 @@ class TestPlatinCriticalSections:
                 )
             else:
                 # Any section not in expected_tokens should still be in valid range
-                # FIX 178969e: Extended range to [1500, 5000] for truncation prevention
-                assert 1500 <= config["max_tokens"] <= 5000, (
-                    f"Section {section} max_tokens={config['max_tokens']} not in valid range [1500, 5000]"
+                # v14.30: Extended range to [1500, 7000] for Risk/Recommendation cards
+                assert 1500 <= config["max_tokens"] <= 7000, (
+                    f"Section {section} max_tokens={config['max_tokens']} not in valid range [1500, 7000]"
                 )
 
     def test_platin_temperature_is_reasonable(self):

--- a/tests/test_platin_sections_valid.py
+++ b/tests/test_platin_sections_valid.py
@@ -359,15 +359,15 @@ class TestPromptEnhancerConfig:
     def test_all_platin_sections_have_max_tokens_in_range(self):
         """Verify all PLATIN sections have max_tokens in valid range.
 
-        FIX 178969e: Extended range to [1500, 5000] to prevent text truncation.
-        Some sections (recommendations, roadmap_*, quick_wins) need higher limits.
+        v14.30: Extended range to [1500, 7000] for Risk/Recommendation cards.
+        Some sections (risks, recommendations, roadmap_*, quick_wins) need higher limits.
         """
         from services.prompt_enhancer import PLATIN_CRITICAL_SECTIONS
 
         for section, config in PLATIN_CRITICAL_SECTIONS.items():
             max_tokens = config.get("max_tokens", 0)
-            assert 1500 <= max_tokens <= 5000, (
-                f"Section {section} max_tokens={max_tokens} not in range [1500, 5000]"
+            assert 1500 <= max_tokens <= 7000, (
+                f"Section {section} max_tokens={max_tokens} not in range [1500, 7000]"
             )
 
     def test_all_platin_sections_have_min_words(self):


### PR DESCRIPTION
- risks: 3000 → 6000 (for complete Risk-Cards)
- recommendations: 4000 → 6000 (for complete Recommendation-Cards)
- Validation range extended to [1500, 7000]