### PR TITLE
fix(openai): Always set max_tokens for /v1/chat/completions

### DIFF
--- a/gpt_analyze.py
+++ b/gpt_analyze.py
@@ -1831,12 +1831,14 @@ def _call_openai(
             ],
             "temperature": float(temperature),
         }
-        
-        # GPT-5.x benötigt max_completion_tokens statt max_tokens
+
+        # v14.35.22: Always set max_tokens for /v1/chat/completions
+        # Fix: Previously GPT-5 branch only set max_completion_tokens, causing truncation
+        payload["max_tokens"] = int(max_tokens)
+
+        # Optional forward-compat for models that support max_completion_tokens
         if model.startswith("gpt-5"):
             payload["max_completion_tokens"] = int(max_tokens)
-        else:
-            payload["max_tokens"] = int(max_tokens)
 
         # NOTE: stop parameter removed for OpenAI models (gpt-4o-mini, gpt-4.1, etc.)
         # as it's no longer supported. Stop sequences are still used for Anthropic models


### PR DESCRIPTION
Root cause: GPT-5 branch only set max_completion_tokens, but /v1/chat/completions endpoint requires max_tokens parameter. This caused One-Liner truncation at ~80 tokens despite OPENAI_MAX_TOKENS_ONE_LINER=1500.

Fix: Always set max_tokens in payload, keep max_completion_tokens as optional forward-compat for GPT-5 models.

Before:
  if model.startswith("gpt-5"):
      payload["max_completion_tokens"] = max_tokens
  else:
      payload["max_tokens"] = max_tokens

After:
  payload["max_tokens"] = max_tokens
  if model.startswith("gpt-5"):
      payload["max_completion_tokens"] = max_tokens