### PR TITLE
fix(roadmap): Fix 'no such group' regex error in phase cards

### DIFF
--- a/gpt_analyze.py
+++ b/gpt_analyze.py
@@ -4175,12 +4175,20 @@ def _format_roadmap_as_phase_cards(html_content: str) -> str:
     )
 
     def replace_phase_h3(match):
+        """
+        Replacement function for phase patterns.
+        Safely handles patterns with different numbers of capture groups.
+        """
         nonlocal cards_created
 
         phase_title = match.group(1).strip()
-        goal_p = match.group(2) or ""
-        bullet_list = match.group(3) or ""
-        milestone_p = match.group(4) or ""
+        # Safely access groups - some patterns have fewer groups
+        goal_p = match.group(2) if match.lastindex >= 2 else ""
+        goal_p = goal_p or ""
+        bullet_list = match.group(3) if match.lastindex >= 3 else ""
+        bullet_list = bullet_list or ""
+        milestone_p = match.group(4) if match.lastindex >= 4 else ""
+        milestone_p = milestone_p or ""
 
         # Extract phase number for badge
         phase_num_match = re.search(r'Phase\s*(\d+)', phase_title)
@@ -4210,11 +4218,17 @@ def _format_roadmap_as_phase_cards(html_content: str) -> str:
         return card_html
 
     def replace_phase_strong(match):
+        """
+        Replacement function for strong-wrapped phase patterns.
+        Safely handles patterns with different numbers of capture groups.
+        """
         nonlocal cards_created
 
         phase_title = match.group(1).strip()
-        description = match.group(2).strip() if match.group(2) else ""
-        bullet_list = match.group(3) or ""
+        # Safely access groups
+        description = match.group(2).strip() if match.lastindex >= 2 and match.group(2) else ""
+        bullet_list = match.group(3) if match.lastindex >= 3 else ""
+        bullet_list = bullet_list or ""
 
         phase_num_match = re.search(r'Phase\s*(\d+)', phase_title)
         phase_num = phase_num_match.group(1) if phase_num_match else str(cards_created)

--- a/tests/test_roadmap_phase_cards_regex.py
+++ b/tests/test_roadmap_phase_cards_regex.py
@@ -1,0 +1,85 @@
+# -*- coding: utf-8 -*-
+"""
+Unit test for Roadmap Phase Cards regex transformation.
+
+Regression test for the "no such group" error that occurred when
+phase_pattern_h4 (3 groups) used replace_phase_h3 (expected 4 groups).
+"""
+import pytest
+
+
+class TestRoadmapPhaseCardsRegex:
+    """Tests for _format_roadmap_as_phase_cards function."""
+
+    def test_h4_pattern_does_not_raise_no_such_group(self):
+        """
+        Regression test: h4 pattern with 3 groups must not raise 'no such group'.
+
+        The h4 pattern has only 3 capture groups, but the replacement function
+        previously accessed group(4), causing: re.error: no such group
+        """
+        from gpt_analyze import _format_roadmap_as_phase_cards
+
+        # Sample HTML using h4 format (the problematic pattern)
+        sample_html = """
+        <div class="roadmap-content">
+            <h4>Phase 1: Grundlagen</h4>
+            <p>Aufbau der KI-Infrastruktur</p>
+            <ul>
+                <li>Datenbankanbindung</li>
+                <li>API-Integration</li>
+            </ul>
+            <h4>Phase 2: Pilotprojekt</h4>
+            <p>Erste Implementierung</p>
+            <ul>
+                <li>Prototyp entwickeln</li>
+                <li>Testing durchführen</li>
+            </ul>
+        </div>
+        """
+
+        # Must not raise any exception
+        result = _format_roadmap_as_phase_cards(sample_html)
+
+        # Basic assertions
+        assert result is not None, "Result should not be None"
+        assert isinstance(result, str), "Result should be a string"
+        assert len(result) > 0, "Result should not be empty"
+
+    def test_h3_pattern_creates_phase_cards(self):
+        """Test that h3 pattern successfully creates phase cards."""
+        from gpt_analyze import _format_roadmap_as_phase_cards
+
+        sample_html = """
+        <div class="roadmap">
+            <h3>Phase 1: Initialisierung</h3>
+            <p><strong>Ziel:</strong> Grundstein legen</p>
+            <ul>
+                <li>Team aufbauen</li>
+                <li>Ressourcen sichern</li>
+            </ul>
+            <p>Meilenstein: Kick-off Meeting</p>
+        </div>
+        """
+
+        result = _format_roadmap_as_phase_cards(sample_html)
+
+        assert result is not None
+        assert "roadmap-phase-card" in result, "Should contain phase-card class"
+        assert "phase-badge" in result, "Should contain phase badge"
+
+    def test_short_content_returns_unchanged(self):
+        """Test that content shorter than 200 chars is returned unchanged."""
+        from gpt_analyze import _format_roadmap_as_phase_cards
+
+        short_html = "<p>Too short</p>"
+        result = _format_roadmap_as_phase_cards(short_html)
+
+        assert result == short_html, "Short content should be returned unchanged"
+
+    def test_empty_content_returns_unchanged(self):
+        """Test that empty/None content is handled gracefully."""
+        from gpt_analyze import _format_roadmap_as_phase_cards
+
+        assert _format_roadmap_as_phase_cards("") == ""
+        assert _format_roadmap_as_phase_cards(None) is None


### PR DESCRIPTION
Root cause: phase_pattern_h4 has 3 capture groups, but replace_phase_h3
accessed match.group(4), causing: re.error: no such group

Fix:
- Use match.lastindex to safely check group existence before access
- Apply safe pattern to both replace_phase_h3 and replace_phase_strong

Test: tests/test_roadmap_phase_cards_regex.py
- test_h4_pattern_does_not_raise_no_such_group (regression test)
- test_h3_pattern_creates_phase_cards
- test_short_content_returns_unchanged
- test_empty_content_returns_unchanged