### PR TITLE
fix(solo-persona): Add language normalizer to replace enterprise term…

### DIFF
--- a/gpt_analyze.py
+++ b/gpt_analyze.py
@@ -11347,13 +11347,21 @@ def _generate_content_sections(briefing: Dict[str, Any], scores: Dict[str, Any])
                 log.warning(f"[SIEZEN-GUARD] {key} failed: {e}")
 
     # ========== v14.0: CONTENT QUALITY ENFORCER (Post-Processing Safety Net) ==========
-    # Fixes: ROI-Leak, Fragments, hauptleistung MIN, Extended Siezen
+    # Fixes: ROI-Leak, Fragments, hauptleistung MIN, Extended Siezen, Solo Language
     try:
         from services.content_quality_enforcer import apply_all_quality_enforcers
         hauptleistung_value = briefing.get("hauptleistung", "")
         bundesland_value = briefing.get("BUNDESLAND_LABEL") or briefing.get("bundesland", "")
-        sections = apply_all_quality_enforcers(sections, hauptleistung_value, bundesland_value)
-        log.info(f"[QUALITY-ENFORCER] Applied all quality fixes for hauptleistung={hauptleistung_value[:30] if hauptleistung_value else 'N/A'}...")
+        # Derive company_size for solo-language normalizer
+        size_raw_qe = (briefing.get("UNTERNEHMENSGROESSE_LABEL") or briefing.get("unternehmensgroesse") or "").lower()
+        if "solo" in size_raw_qe or "freiberuf" in size_raw_qe or size_raw_qe in ("1", "einzelunternehmer"):
+            company_size_qe = "solo"
+        elif any(x in size_raw_qe for x in ("2-10", "2 bis 10", "team", "klein")):
+            company_size_qe = "team"
+        else:
+            company_size_qe = "kmu"
+        sections = apply_all_quality_enforcers(sections, hauptleistung_value, bundesland_value, company_size_qe)
+        log.info(f"[QUALITY-ENFORCER] Applied all quality fixes for hauptleistung={hauptleistung_value[:30] if hauptleistung_value else 'N/A'}, company_size={company_size_qe}")
     except Exception as e:
         log.warning(f"[QUALITY-ENFORCER] Failed: {e}")
 
@@ -11490,8 +11498,16 @@ def _generate_content_sections(briefing: Dict[str, Any], scores: Dict[str, Any])
         from services.content_quality_enforcer import apply_all_quality_enforcers
         hauptleistung_final = briefing.get("hauptleistung", "")
         bundesland_final = briefing.get("BUNDESLAND_LABEL") or briefing.get("bundesland", "")
-        sections = apply_all_quality_enforcers(sections, hauptleistung_final, bundesland_final)
-        log.info(f"[QUALITY-ENFORCER-FINAL] Applied FINAL quality fixes")
+        # Derive company_size for solo-language normalizer (repeat for robustness)
+        size_raw_final = (briefing.get("UNTERNEHMENSGROESSE_LABEL") or briefing.get("unternehmensgroesse") or "").lower()
+        if "solo" in size_raw_final or "freiberuf" in size_raw_final or size_raw_final in ("1", "einzelunternehmer"):
+            company_size_final = "solo"
+        elif any(x in size_raw_final for x in ("2-10", "2 bis 10", "team", "klein")):
+            company_size_final = "team"
+        else:
+            company_size_final = "kmu"
+        sections = apply_all_quality_enforcers(sections, hauptleistung_final, bundesland_final, company_size_final)
+        log.info(f"[QUALITY-ENFORCER-FINAL] Applied FINAL quality fixes, company_size={company_size_final}")
     except Exception as e:
         log.warning(f"[QUALITY-ENFORCER-FINAL] Failed: {e}")
     return sections
@@ -12917,10 +12933,18 @@ def analyze_briefing(db: Session, briefing_id: int, run_id: str) -> tuple[int, s
         from services.content_quality_enforcer import apply_all_quality_enforcers
         hauptleistung_render = answers.get("hauptleistung", "")
         bundesland_render = answers.get("BUNDESLAND_LABEL") or answers.get("bundesland", "")
-        sections = apply_all_quality_enforcers(sections, hauptleistung_render, bundesland_render)
-        log.info(f"[{run_id}] ✅ [QUALITY-ENFORCER-RENDER] Applied FINAL quality fixes before render")
+        # Derive company_size for solo-language normalizer
+        size_raw_render = (answers.get("UNTERNEHMENSGROESSE_LABEL") or answers.get("unternehmensgroesse") or "").lower()
+        if "solo" in size_raw_render or "freiberuf" in size_raw_render or size_raw_render in ("1", "einzelunternehmer"):
+            company_size_render = "solo"
+        elif any(x in size_raw_render for x in ("2-10", "2 bis 10", "team", "klein")):
+            company_size_render = "team"
+        else:
+            company_size_render = "kmu"
+        sections = apply_all_quality_enforcers(sections, hauptleistung_render, bundesland_render, company_size_render)
+        log.info(f"[{run_id}] [QUALITY-ENFORCER-RENDER] Applied FINAL quality fixes before render, company_size={company_size_render}")
     except Exception as e:
-        log.warning(f"[{run_id}] ⚠️ [QUALITY-ENFORCER-RENDER] Failed: {e}")
+        log.warning(f"[{run_id}] [QUALITY-ENFORCER-RENDER] Failed: {e}")
     log.info("=" * 80)
 
     result = render(

--- a/services/content_quality_enforcer.py
+++ b/services/content_quality_enforcer.py
@@ -8,6 +8,7 @@ Fixes:
 2. Fragment-Repair: Repariert unvollständige Sätze
 3. hauptleistung-Enforcer: Injiziert hauptleistung wenn unter Minimum
 4. Product Name Safety Net: Korrigiert "Microsoft Kapazitäten" → "Microsoft Teams" (v14.35.21)
+5. Solo Language Normalizer: Enterprise-Begriffe → Solo-freundlich (v14.35.22)
 
 Wird nach SIEZEN-GUARD aufgerufen, vor Validation.
 """
@@ -16,6 +17,96 @@ import re
 import logging
 
 log = logging.getLogger(__name__)
+
+# =============================================================================
+# v14.35.22: SOLO LANGUAGE NORMALIZER
+# =============================================================================
+# Replaces enterprise-ish terms with solo-appropriate alternatives ONLY for solo persona.
+# This reduces SIZE_MISMATCH warnings without changing meaning.
+
+SOLO_TERM_REPLACEMENTS = [
+    # (pattern, replacement, description)
+    # Technical enterprise terms → Solo-friendly alternatives
+    (r'\bModulen\b', 'Bausteinen', 'Modul→Baustein (Dativ Plural)'),
+    (r'\bModule\b', 'Bausteine', 'Modul→Baustein (Plural)'),
+    (r'\bModul\b', 'Baustein', 'Modul→Baustein'),
+    (r'\bPlattformen\b', 'Tool-Setups', 'Plattform→Tool-Setup (Plural)'),
+    (r'\bPlattform\b', 'Tool-Setup', 'Plattform→Tool-Setup'),
+    (r'\bArchitekturen\b', 'Strukturen', 'Architektur→Struktur (Plural)'),
+    (r'\bArchitektur\b', 'Struktur', 'Architektur→Struktur'),
+    (r'\bTech-Stack\b', 'Tool-Set', 'Tech-Stack→Tool-Set'),
+    (r'\bKI-Stack\b', 'KI-Werkzeuge', 'KI-Stack→KI-Werkzeuge'),
+    (r'\bStack\b', 'Tool-Set', 'Stack→Tool-Set'),
+    (r'\bLayer\b', 'Ebene', 'Layer→Ebene'),
+    (r'\bDeployment\b', 'Einrichtung', 'Deployment→Einrichtung'),
+    (r'\bRollout\b', 'Einführung', 'Rollout→Einführung'),
+    (r'\bStakeholder\b', 'Beteiligte', 'Stakeholder→Beteiligte'),
+    (r'\bGovernance-Struktur\b', 'Ordnungsrahmen', 'Governance-Struktur→Ordnungsrahmen'),
+    (r'\bCompliance-Framework\b', 'Regelwerk', 'Compliance-Framework→Regelwerk'),
+    (r'\bKPI-Dashboard\b', 'Kennzahlen-Übersicht', 'KPI-Dashboard→Kennzahlen-Übersicht'),
+    (r'\bProzesslandschaft\b', 'Arbeitsabläufe', 'Prozesslandschaft→Arbeitsabläufe'),
+    (r'\bMeilenstein-Planung\b', 'Etappenplanung', 'Meilenstein-Planung→Etappenplanung'),
+]
+
+
+def apply_solo_language_normalizer(sections: dict, company_size: str) -> dict:
+    """
+    Ersetzt Enterprise-Begriffe durch Solo-freundliche Alternativen.
+
+    v14.35.22: Nur angewendet wenn company_size == "solo".
+    Reduziert SIZE_MISMATCH Warnings ohne Bedeutungsänderung.
+
+    Args:
+        sections: Dict mit allen Report-Sections
+        company_size: Unternehmensgröße ("solo", "team", "kmu")
+
+    Returns:
+        sections: Bereinigtes Dict
+    """
+    # Only apply for solo
+    if not company_size or company_size.lower() != "solo":
+        return sections
+
+    total_replacements = 0
+    sections_touched = 0
+
+    # Sections to process
+    check_sections = [
+        "EXECUTIVE_SUMMARY_HTML", "RECOMMENDATIONS_HTML", "QUICK_WINS_HTML",
+        "ROADMAP_90D_HTML", "ROADMAP_12M_HTML", "GAMECHANGER_HTML",
+        "FOERDERPOTENZIAL_HTML", "RISKS_HTML", "ORG_CHANGE_HTML",
+        "KI_SKILLPLAN_HTML", "BUSINESS_CASE_HTML", "AI_ACT_HTML",
+        "TOOLS_HTML", "DATA_STRATEGY_HTML", "GOVERNANCE_HTML",
+    ]
+
+    for section_key in check_sections:
+        content = sections.get(section_key)
+        if not content or not isinstance(content, str):
+            continue
+
+        section_replacements = 0
+        modified_content = content
+
+        for pattern, replacement, desc in SOLO_TERM_REPLACEMENTS:
+            matches = len(re.findall(pattern, modified_content, re.IGNORECASE))
+            if matches > 0:
+                modified_content = re.sub(pattern, replacement, modified_content, flags=re.IGNORECASE)
+                section_replacements += matches
+
+        if section_replacements > 0:
+            sections[section_key] = modified_content
+            sections_touched += 1
+            total_replacements += section_replacements
+
+    if total_replacements > 0:
+        log.info(
+            "[SOLO-LANGUAGE] replaced_terms=%d in %d sections (company_size=solo)",
+            total_replacements,
+            sections_touched
+        )
+
+    return sections
+
 
 # =============================================================================
 # v14.35.21: PRODUCT NAME SAFETY NET (Seatbelt)
@@ -1382,11 +1473,11 @@ def apply_location_validator(sections: dict, bundesland: str) -> dict:
     
     log.info(f"[LOCATION-VALIDATOR] Complete: {total_removals} total removals")
     return sections
-def apply_all_quality_enforcers(sections: dict, hauptleistung: str = "", bundesland: str = "") -> dict:
+def apply_all_quality_enforcers(sections: dict, hauptleistung: str = "", bundesland: str = "", company_size: str = "") -> dict:
 
     """
     Wendet alle Quality Enforcer in der richtigen Reihenfolge an.
-    
+
     Order:
     1. ROI-Filter (entfernt verbotene ROI-Werte)
     2. Fragment-Repair (repariert unvollständige Sätze)
@@ -1394,11 +1485,14 @@ def apply_all_quality_enforcers(sections: dict, hauptleistung: str = "", bundesl
     4. hauptleistung-Enforcer (injiziert fehlende hauptleistung)
     5. Location-Validator (entfernt falsche Bundesländer)
     6. Grammar-Fixer (korrigiert Grammatikfehler)
-    
+    7. Solo-Language-Normalizer (ersetzt Enterprise-Begriffe für Solo-Persona)
+
     Args:
         sections: Dict mit allen Report-Sections
         hauptleistung: Das Kerngeschäft des Users
-        
+        bundesland: Das Bundesland des Users
+        company_size: Die Unternehmensgröße ("solo", "team", "kmu")
+
     Returns:
         sections: Bereinigtes Dict
     """
@@ -1439,6 +1533,10 @@ def apply_all_quality_enforcers(sections: dict, hauptleistung: str = "", bundesl
 
     # 10. Open Example Paren Fixer (v14.35.22) - Fix "(z.B." incomplete patterns
     sections = apply_open_example_paren_fixer(sections)
+
+    # 11. Solo Language Normalizer (v14.35.22) - Replace enterprise terms for solo persona
+    if company_size:
+        sections = apply_solo_language_normalizer(sections, company_size)
 
     log.info("[QUALITY-ENFORCER] Pipeline complete")
     return sections


### PR DESCRIPTION
…s for solo users

- Add SOLO_TERM_REPLACEMENTS list with enterprise→solo-friendly mappings
- Implement apply_solo_language_normalizer() for solo persona only
- Replace: Modul→Baustein, Plattform→Tool-Setup, Architektur→Struktur, Stack→Tool-Set, Deployment→Einrichtung, Rollout→Einführung, etc.
- Update apply_all_quality_enforcers() to accept company_size parameter
- Pass company_size to quality enforcer in all 3 call sites
- Add INFO logging for replaced terms count