### PR TITLE
fix(business-case): Unify hourly rates from canonical source for cons…

### DIFF
--- a/gpt_analyze.py
+++ b/gpt_analyze.py
@@ -7612,8 +7612,16 @@ def _build_prompt_vars(briefing: Dict[str, Any], scores: Dict[str, Any]) -> Dict
     })
     
     # ===== BLOCK 7: Quick Wins & ROI (EXTENDED!) =====
-    # Calculate hourly rate using our smart estimation function
-    stundensatz_eur = _estimate_hourly_rate_from_revenue(briefing)
+    # v14.35.23: Use canonical hourly rate from business_case_engine_v2 for consistency
+    # This ensures Quick Wins monetization matches Business Case and ROI sections
+    try:
+        from services.business_case_engine_v2 import get_hourly_rate
+        stundensatz_eur, stundensatz_source = get_hourly_rate(company_size)
+        log.debug("[PROMPT-VARS] Using canonical hourly rate: %d€/h (%s) for size=%s",
+                  stundensatz_eur, stundensatz_source, company_size)
+    except ImportError:
+        stundensatz_eur = _estimate_hourly_rate_from_revenue(briefing)
+        log.debug("[PROMPT-VARS] Fallback to revenue-based hourly rate: %d€/h", stundensatz_eur)
 
     # Quick Win hours from environment or defaults
     qw1_h = int(os.getenv("DEFAULT_QW1_H", "20"))
@@ -7771,9 +7779,10 @@ def _get_fallback_content(section_key: str, briefing: Dict[str, Any], scores: Di
     capex: int = int(briefing.get("CAPEX_REALISTISCH_EUR") or 5000)
     opex: int = int(briefing.get("OPEX_REALISTISCH_EUR") or 150)
     einsparung: int = int(briefing.get("EINSPARUNG_MONAT_EUR") or 500)
-    # SPRINT G2.5: Format payback and ROI with 1 decimal place to avoid floating point issues
+    # SPRINT G2.5 + v14.35.23: Format payback/ROI with 1 decimal, German decimals for DE
     payback_raw: float = float(briefing.get("PAYBACK_MONTHS") or 10)
-    payback: str = f"{float(payback_raw):.1f}" if isinstance(payback_raw, (int, float)) else str(payback_raw)
+    payback_en: str = f"{float(payback_raw):.1f}" if isinstance(payback_raw, (int, float)) else str(payback_raw)
+    payback: str = payback_en.replace(".", ",") if briefing_lang != "en" else payback_en  # German: "3,5" vs English: "3.5"
     roi_raw: float = float(briefing.get("ROI_12M") or 60)
     roi_12m: str = f"{float(roi_raw):.0f}" if isinstance(roi_raw, (int, float)) else str(roi_raw)
 

--- a/services/extra_sections.py
+++ b/services/extra_sections.py
@@ -242,33 +242,44 @@ def get_size_constraints(
     }
     max_investment = investment_mapping.get(investitionsbudget, 10000)
 
+    # v14.35.23: Use canonical hourly rates from business_case_engine_v2 for consistency
+    # This ensures Business Case table matches ROI derivation and Quick Wins
+    try:
+        from services.business_case_engine_v2 import HOURLY_RATES_BY_SIZE
+        solo_rate = HOURLY_RATES_BY_SIZE.get("solo", 80)
+        team_rate = HOURLY_RATES_BY_SIZE.get("team", 95)
+        kmu_rate = HOURLY_RATES_BY_SIZE.get("kmu", 110)
+        enterprise_rate = HOURLY_RATES_BY_SIZE.get("enterprise", 130)
+    except ImportError:
+        solo_rate, team_rate, kmu_rate, enterprise_rate = 80, 95, 110, 130
+
     constraints: Dict[str, Dict[str, float]] = {
         "solo": {
             "max_monthly_savings": min(monthly_revenue * 0.3, 2000),
             "max_capex": min(max_investment, 10000),
             "max_opex_monthly": 200,
-            "hourly_rate": 80,
+            "hourly_rate": solo_rate,
             "max_time_savings_hours": 20,
         },
         "klein": {
             "max_monthly_savings": min(monthly_revenue * 0.4, 10000),
             "max_capex": min(max_investment, 50000),
             "max_opex_monthly": 1000,
-            "hourly_rate": 100,
+            "hourly_rate": team_rate,  # Maps to "team" in canonical system
             "max_time_savings_hours": 80,
         },
         "mittel": {
             "max_monthly_savings": min(monthly_revenue * 0.5, 50000),
             "max_capex": min(max_investment, 250000),
             "max_opex_monthly": 5000,
-            "hourly_rate": 120,
+            "hourly_rate": kmu_rate,  # Maps to "kmu" in canonical system
             "max_time_savings_hours": 200,
         },
         "gross": {
             "max_monthly_savings": monthly_revenue * 0.6,
             "max_capex": max_investment,
             "max_opex_monthly": 20000,
-            "hourly_rate": 150,
+            "hourly_rate": enterprise_rate,  # Maps to "enterprise" in canonical system
             "max_time_savings_hours": 500,
         },
     }

--- a/services/roi_calculator.py
+++ b/services/roi_calculator.py
@@ -5,7 +5,21 @@ from ._normalize import _briefing_to_dict
 
 
 def _estimate_hourly_rate(b: Dict[str, Any]) -> float:
-    # konservative Heuristik aus Umsatzklasse
+    """
+    v14.35.23: Use canonical hourly rate from business_case_engine_v2.
+    This ensures ROI calculator output matches Business Case and Quick Wins.
+    """
+    # v14.35.23: Prefer canonical rate based on company size
+    try:
+        from services.business_case_engine_v2 import get_hourly_rate, normalize_company_size
+        size_raw = b.get("unternehmensgroesse", "")
+        size = normalize_company_size(size_raw)
+        rate, _ = get_hourly_rate(size)
+        return float(rate)
+    except ImportError:
+        pass
+
+    # Fallback: konservative Heuristik aus Umsatzklasse
     rev = b.get("jahresumsatz")
     try:
         if isinstance(rev, (int, float)) and rev > 0:

--- a/tests/test_business_case_consistency.py
+++ b/tests/test_business_case_consistency.py
@@ -1,0 +1,176 @@
+# -*- coding: utf-8 -*-
+"""
+Business Case Consistency Test - Single Source of Truth
+=========================================================
+
+v14.35.23: Tests for Business Case metric consistency across all sections.
+
+Ensures:
+1. Hourly rate is consistent across all sources (canonical from business_case_engine_v2)
+2. Payback formatting doesn't contain long floats
+3. ROI values are derived consistently
+
+Ref: TASK - Business Case Consistency – Single Source of Truth (3 Fixes)
+"""
+import os
+import re
+import pytest
+
+# Set test environment before imports
+os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
+os.environ.setdefault("JWT_SECRET", "test-secret-key-for-testing-only")
+os.environ.setdefault("OPENAI_API_KEY", "test-api-key")
+
+
+class TestBusinessCaseConsistency:
+    """Tests for business case metric consistency."""
+
+    def test_canonical_hourly_rates_defined(self):
+        """Verify canonical hourly rates are defined in business_case_engine_v2."""
+        from services.business_case_engine_v2 import HOURLY_RATES_BY_SIZE, get_hourly_rate
+
+        # Check that all sizes have rates
+        assert "solo" in HOURLY_RATES_BY_SIZE
+        assert "team" in HOURLY_RATES_BY_SIZE
+        assert "kmu" in HOURLY_RATES_BY_SIZE
+        assert "enterprise" in HOURLY_RATES_BY_SIZE
+
+        # Check specific values
+        assert HOURLY_RATES_BY_SIZE["solo"] == 80, "Solo rate should be 80"
+        assert HOURLY_RATES_BY_SIZE["team"] == 95, "Team rate should be 95"
+        assert HOURLY_RATES_BY_SIZE["kmu"] == 110, "KMU rate should be 110"
+
+    def test_get_hourly_rate_returns_canonical_values(self):
+        """Verify get_hourly_rate returns the canonical values."""
+        from services.business_case_engine_v2 import get_hourly_rate
+
+        rate_solo, _ = get_hourly_rate("solo")
+        rate_team, _ = get_hourly_rate("team")
+        rate_kmu, _ = get_hourly_rate("kmu")
+
+        assert rate_solo == 80
+        assert rate_team == 95
+        assert rate_kmu == 110
+
+    def test_extra_sections_uses_canonical_rates(self):
+        """Verify extra_sections.py uses canonical rates via import."""
+        from services.extra_sections import get_size_constraints
+
+        # Test solo constraints
+        solo_constraints = get_size_constraints("solo", "100k_500k", "2000_10000")
+        assert solo_constraints["hourly_rate"] == 80, "Solo should use canonical rate 80"
+
+        # Test klein (maps to team)
+        klein_constraints = get_size_constraints("klein", "100k_500k", "2000_10000")
+        assert klein_constraints["hourly_rate"] == 95, "Klein should use canonical team rate 95"
+
+    def test_roi_calculator_uses_canonical_rates(self):
+        """Verify roi_calculator uses canonical rates."""
+        from services.roi_calculator import _estimate_hourly_rate
+
+        # Solo company
+        solo_briefing = {"unternehmensgroesse": "solo"}
+        rate = _estimate_hourly_rate(solo_briefing)
+        assert rate == 80.0, f"Solo should get canonical rate 80, got {rate}"
+
+        # Team company
+        team_briefing = {"unternehmensgroesse": "team"}
+        rate = _estimate_hourly_rate(team_briefing)
+        assert rate == 95.0, f"Team should get canonical rate 95, got {rate}"
+
+    def test_business_case_canonical_payback_format(self):
+        """Verify payback values are formatted correctly (no long floats)."""
+        from services.business_case_engine_v2 import BusinessCaseCanonical
+
+        # Create a canonical business case
+        bc = BusinessCaseCanonical(
+            hours_saved_per_month=20,
+            hourly_rate_eur=80,
+            capex_eur=5000,
+            opex_month_eur=180,
+        )
+
+        # Get the dict representation
+        bc_dict = bc.to_dict()
+
+        # Check payback is rounded
+        payback = bc_dict["payback_months"]
+        assert isinstance(payback, float)
+        assert payback == round(payback, 1), f"Payback should be rounded to 1 decimal: {payback}"
+
+        # Verify it doesn't have long floating point representation
+        payback_str = str(payback)
+        decimal_places = len(payback_str.split(".")[-1]) if "." in payback_str else 0
+        assert decimal_places <= 1, f"Payback should have at most 1 decimal place: {payback_str}"
+
+    def test_business_case_canonical_roi_consistency(self):
+        """Verify ROI values are computed consistently."""
+        from services.business_case_engine_v2 import BusinessCaseCanonical
+
+        # Create a canonical business case
+        bc = BusinessCaseCanonical(
+            hours_saved_per_month=20,
+            hourly_rate_eur=80,
+            capex_eur=5000,
+            opex_month_eur=180,
+        )
+
+        # Expected values:
+        # monthly_gross = 20 * 80 = 1600
+        # monthly_net = 1600 - 180 = 1420
+        # annual_net = 1420 * 12 = 17040
+        # roi_12m_net = ((17040 - 5000) / 5000) * 100 = 240.8%
+
+        assert bc.monthly_gross == 1600
+        assert bc.monthly_net == 1420
+        assert bc.annual_net == 17040
+        assert round(bc.roi_12m_net, 1) == 240.8
+
+    def test_no_hardcoded_81_hourly_rate(self):
+        """Ensure there are no hardcoded 81€/h rates in the codebase."""
+        import glob
+
+        # Files to check
+        files_to_check = [
+            "gpt_analyze.py",
+            "services/extra_sections.py",
+            "services/roi_calculator.py",
+            "services/business_case_engine_v2.py",
+        ]
+
+        for filepath in files_to_check:
+            full_path = os.path.join(os.path.dirname(__file__), "..", filepath)
+            if os.path.exists(full_path):
+                with open(full_path, "r", encoding="utf-8") as f:
+                    content = f.read()
+                    # Check for 81€/h pattern
+                    matches = re.findall(r'\b81\s*€', content)
+                    assert len(matches) == 0, f"Found hardcoded 81€ in {filepath}: {matches}"
+
+
+class TestPaybackFormatting:
+    """Tests for payback value formatting."""
+
+    def test_payback_german_decimal_format(self):
+        """Test that German payback uses comma as decimal separator."""
+        # Simulate the formatting logic from gpt_analyze.py
+        payback_raw = 3.5
+        payback_en = f"{float(payback_raw):.1f}"
+        payback_de = payback_en.replace(".", ",")
+
+        assert payback_en == "3.5"
+        assert payback_de == "3,5"
+
+    def test_payback_no_long_float(self):
+        """Test that payback formatting prevents long floats."""
+        # Test values that could produce long floats
+        test_values = [3.333333, 10/3, 2.999999, 4.500001]
+
+        for val in test_values:
+            formatted = f"{float(val):.1f}"
+            # Should have at most 1 decimal place
+            assert len(formatted.split(".")[-1]) <= 1, f"Long float detected: {formatted}"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/test_business_case_consistency.py
+++ b/tests/test_business_case_consistency.py
@@ -105,7 +105,7 @@ class TestBusinessCaseConsistency:
 
     def test_business_case_canonical_roi_consistency(self):
         """Verify ROI values are computed consistently."""
-        from services.business_case_engine_v2 import BusinessCaseCanonical
+        from services.business_case_engine_v2 import BusinessCaseCanonical, MAX_ROI
 
         # Create a canonical business case
         bc = BusinessCaseCanonical(
@@ -119,12 +119,14 @@ class TestBusinessCaseConsistency:
         # monthly_gross = 20 * 80 = 1600
         # monthly_net = 1600 - 180 = 1420
         # annual_net = 1420 * 12 = 17040
-        # roi_12m_net = ((17040 - 5000) / 5000) * 100 = 240.8%
+        # roi_12m_net_raw = ((17040 - 5000) / 5000) * 100 = 240.8%
+        # roi_12m_net = min(MAX_ROI, 240.8) = 200.0% (capped)
 
         assert bc.monthly_gross == 1600
         assert bc.monthly_net == 1420
         assert bc.annual_net == 17040
-        assert round(bc.roi_12m_net, 1) == 240.8
+        # ROI is capped at MAX_ROI (200%) for conservative estimates
+        assert round(bc.roi_12m_net, 1) == MAX_ROI, f"ROI should be capped at {MAX_ROI}%"
 
     def test_no_hardcoded_81_hourly_rate(self):
         """Ensure there are no hardcoded 81€/h rates in the codebase."""


### PR DESCRIPTION
…istency

Business Case Consistency – Single Source of Truth (3 Fixes)

Problem: KI-Status-Report showed conflicting numbers:
- Quick Wins used different hourly rate (81€/h)
- ROI derivation used different values
- Business Case table used different rates
- Payback showed raw floats instead of formatted values

Solution: Use canonical hourly rates from business_case_engine_v2.py everywhere

Changes:
1. gpt_analyze.py:7617 - Use get_hourly_rate() for STUNDENSATZ_EUR in prompts
2. gpt_analyze.py:7785 - Add German decimal formatting for payback ("3,5" vs "3.5")
3. services/extra_sections.py:245-254 - Use HOURLY_RATES_BY_SIZE from canonical
4. services/roi_calculator.py:7-19 - Use canonical rate based on company size

Canonical hourly rates (single source of truth):
- Solo: 80€/h
- Team: 95€/h
- KMU: 110€/h
- Enterprise: 130€/h

Test: tests/test_business_case_consistency.py