### PR TITLE
feat(roi): Show both raw (computed) and capped ROI values consistentl…

### DIFF
--- a/gpt_analyze.py
+++ b/gpt_analyze.py
@@ -7783,8 +7783,26 @@ def _get_fallback_content(section_key: str, briefing: Dict[str, Any], scores: Di
     payback_raw: float = float(briefing.get("PAYBACK_MONTHS") or 10)
     payback_en: str = f"{float(payback_raw):.1f}" if isinstance(payback_raw, (int, float)) else str(payback_raw)
     payback: str = payback_en.replace(".", ",") if briefing_lang != "en" else payback_en  # German: "3,5" vs English: "3.5"
-    roi_raw: float = float(briefing.get("ROI_12M") or 60)
-    roi_12m: str = f"{float(roi_raw):.0f}" if isinstance(roi_raw, (int, float)) else str(roi_raw)
+
+    # v14.35.24: Get both raw (computed) and capped (planning) ROI values
+    roi_capped_val: float = float(briefing.get("ROI_12M") or briefing.get("ROI_12M_CAPPED") or 60)
+    roi_raw_val: float = float(briefing.get("ROI_12M_RAW") or roi_capped_val)
+    roi_was_capped: bool = briefing.get("ROI_WAS_CAPPED", False)
+
+    # Format individual ROI strings
+    roi_capped_str: str = f"{float(roi_capped_val):.0f}"
+    roi_raw_str: str = f"{float(roi_raw_val):.0f}"
+
+    # v14.35.24: Show both raw and capped ROI if different (Option A implementation)
+    if roi_was_capped and roi_raw_val != roi_capped_val:
+        # German: "241 (berechnet) / 200 (Planwert)"
+        # English: "241 (calculated) / 200 (capped)"
+        if briefing_lang == "en":
+            roi_12m = f"{roi_raw_str} (calculated) / {roi_capped_str} (capped)"
+        else:
+            roi_12m = f"{roi_raw_str} (berechnet) / {roi_capped_str} (Planwert)"
+    else:
+        roi_12m = roi_capped_str
 
     # ════════════════════════════════════════════════════════════════════════════
     # 🎯 PLATIN+ FALLBACK: FOERDERPOTENZIAL (900+ Wörter)
@@ -8909,9 +8927,25 @@ def _get_fallback_content(section_key: str, briefing: Dict[str, Any], scores: Di
         opex = briefing.get("OPEX_REALISTISCH_EUR", "—")
         einsparung = briefing.get("EINSPARUNG_MONAT_EUR", "—")
         payback = briefing.get("PAYBACK_MONTHS", "—")
-        # SPRINT G2.5: Format ROI with 1 decimal place to avoid floating point issues
-        roi_raw = briefing.get("ROI_12M", "—")
-        roi_12m = f"{float(roi_raw):.1f}" if isinstance(roi_raw, (int, float)) else roi_raw
+        # v14.35.23: Get both raw and capped ROI values
+        roi_capped_val = briefing.get("ROI_12M", "—")
+        roi_raw_val = briefing.get("ROI_12M_RAW")
+        roi_was_capped = briefing.get("ROI_WAS_CAPPED", False)
+
+        # Format ROI values (German decimals)
+        def _fmt_roi_pct(val) -> str:
+            if val is None or val == "—":
+                return "—"
+            try:
+                return f"{float(val):.0f}".replace(".", ",")
+            except (ValueError, TypeError):
+                return str(val)
+
+        # v14.35.23: Show both raw and capped ROI if different
+        if roi_was_capped and roi_raw_val is not None:
+            roi_display = f"{_fmt_roi_pct(roi_raw_val)} % (berechnet) / {_fmt_roi_pct(roi_capped_val)} % (Planwert)"
+        else:
+            roi_display = f"{_fmt_roi_pct(roi_capped_val)} %"
 
         return f"""<div class="business-case-summary">
   <h3>Business Case Übersicht</h3>
@@ -8934,7 +8968,7 @@ def _get_fallback_content(section_key: str, briefing: Dict[str, Any], scores: Di
     </tr>
     <tr>
       <td><strong>ROI nach 12 Monaten</strong></td>
-      <td class="text-right">{roi_12m} %</td>
+      <td class="text-right">{roi_display}</td>
     </tr>
   </table>
   <p class="small muted">Detaillierte Berechnungen finden Sie im Business-Case-Abschnitt.</p>

--- a/services/business_case_engine_v2.py
+++ b/services/business_case_engine_v2.py
@@ -344,22 +344,30 @@ class BusinessCaseCanonical:
         return max(MIN_PAYBACK_MONTHS, min(MAX_PAYBACK_MONTHS, raw))
 
     @property
-    def roi_12m_net(self) -> float:
-        """ROI nach 12 Monaten (netto, nach CAPEX und OPEX)"""
+    def roi_12m_net_raw(self) -> float:
+        """ROI nach 12 Monaten (netto, UNCAPPED - mathematisch berechnet)"""
         if self.capex_eur <= 0:
             return 0.0
         net_benefit = self.annual_net - self.capex_eur
-        raw = (net_benefit / self.capex_eur) * 100
-        return max(MIN_ROI, min(MAX_ROI, raw))
+        return (net_benefit / self.capex_eur) * 100
 
     @property
-    def roi_12m_gross(self) -> float:
-        """ROI nach 12 Monaten (brutto, nur CAPEX abgezogen)"""
+    def roi_12m_net(self) -> float:
+        """ROI nach 12 Monaten (netto, CAPPED - konservativer Planwert)"""
+        return max(MIN_ROI, min(MAX_ROI, self.roi_12m_net_raw))
+
+    @property
+    def roi_12m_gross_raw(self) -> float:
+        """ROI nach 12 Monaten (brutto, UNCAPPED)"""
         if self.capex_eur <= 0:
             return 0.0
         gross_benefit = self.annual_gross - self.capex_eur
-        raw = (gross_benefit / self.capex_eur) * 100
-        return max(MIN_ROI, min(MAX_ROI, raw))
+        return (gross_benefit / self.capex_eur) * 100
+
+    @property
+    def roi_12m_gross(self) -> float:
+        """ROI nach 12 Monaten (brutto, CAPPED)"""
+        return max(MIN_ROI, min(MAX_ROI, self.roi_12m_gross_raw))
 
     @property
     def weekly_hours(self) -> float:
@@ -386,8 +394,12 @@ class BusinessCaseCanonical:
             "annual_net": round(self.annual_net, 2),
             "annual_opex": round(self.annual_opex, 2),
             "payback_months": round(self.payback_months, 1),
-            "roi_12m_net": round(self.roi_12m_net, 1),
-            "roi_12m_gross": round(self.roi_12m_gross, 1),
+            # ROI values: both raw (computed) and capped (planning value)
+            "roi_12m_net_raw": round(self.roi_12m_net_raw, 1),
+            "roi_12m_net": round(self.roi_12m_net, 1),  # capped
+            "roi_12m_gross_raw": round(self.roi_12m_gross_raw, 1),
+            "roi_12m_gross": round(self.roi_12m_gross, 1),  # capped
+            "roi_was_capped": self.roi_12m_net_raw > MAX_ROI,
             "weekly_hours": round(self.weekly_hours, 1),
             "annual_hours": round(self.annual_hours, 1),
             # Metadata
@@ -549,10 +561,15 @@ def inject_canonical_to_sections(
         "stundensatz_eur": canonical.hourly_rate_eur,
 
         # ROI / Payback (all from canonical)
-        "ROI_12M": canonical.roi_12m_net,
+        # v14.35.23: Both raw (computed) and capped (planning value) ROI
+        "ROI_12M": canonical.roi_12m_net,  # capped value (for backwards compatibility)
+        "ROI_12M_RAW": canonical.roi_12m_net_raw,  # uncapped computed value
+        "ROI_12M_CAPPED": canonical.roi_12m_net,  # explicit capped alias
         "ROI_12M_RATE": canonical.roi_12m_net,
+        "ROI_WAS_CAPPED": canonical.roi_12m_net_raw > MAX_ROI,
         "PAYBACK_MONTHS": canonical.payback_months,
         "BC_ROI_REALISTIC": canonical.roi_12m_net,
+        "BC_ROI_REALISTIC_RAW": canonical.roi_12m_net_raw,
         "BC_PAYBACK_REALISTIC": canonical.payback_months,
         "BC_MONTHLY_SAVINGS_REALISTIC": canonical.monthly_net,
 

--- a/services/extra_sections.py
+++ b/services/extra_sections.py
@@ -383,24 +383,40 @@ def calc_business_case(answers: Dict[str, Any], env: Dict[str, Any]) -> Dict[str
     savings_12_months = einsparung_monat_eur * 12
     total_investment = capex
 
+    # v14.35.23: Calculate both raw and capped ROI for consistency
+    # Import MAX_ROI from canonical source
+    try:
+        from services.business_case_engine_v2 import MAX_ROI
+    except ImportError:
+        MAX_ROI = 200.0
+
     roi_12m_eur = savings_12_months - total_investment
     denom = float(total_investment)
     if denom > 0:
         roi_12m_rate = roi_12m_eur / denom
-        roi_12m_percent = roi_12m_rate * 100.0
+        roi_12m_percent_raw = roi_12m_rate * 100.0
+        roi_12m_percent_capped = min(MAX_ROI, max(-100.0, roi_12m_percent_raw))
+        roi_was_capped = roi_12m_percent_raw > MAX_ROI
     else:
         roi_12m_rate = None
-        roi_12m_percent = None
+        roi_12m_percent_raw = None
+        roi_12m_percent_capped = None
+        roi_was_capped = False
 
-    if roi_12m_percent is None:
-        roi_percent_str = "—"
+    # v14.35.23: Format both ROI values (German decimals)
+    def _fmt_roi(val: float | None) -> str:
+        if val is None:
+            return "—"
+        return f"{val:,.0f}".replace(",", "X").replace(".", ",").replace("X", ".")
+
+    roi_raw_str = _fmt_roi(roi_12m_percent_raw)
+    roi_capped_str = _fmt_roi(roi_12m_percent_capped)
+
+    # v14.35.23: Show both raw and capped ROI if different
+    if roi_was_capped:
+        roi_display = f"{roi_raw_str} % (berechnet) / {roi_capped_str} % (Planwert, gedeckelt)"
     else:
-        roi_percent_str = (
-            f"{roi_12m_percent:,.1f}"
-            .replace(",", "X")
-            .replace(".", ",")
-            .replace("X", ".")
-        )
+        roi_display = f"{roi_capped_str} %"
 
     table = f"""
 <section class="card">
@@ -415,8 +431,8 @@ def calc_business_case(answers: Dict[str, Any], env: Dict[str, Any]) -> Dict[str
       <tr><td>Laufende Kosten (OPEX)</td><td>{_fmt_eur(opex)} €/Monat</td><td>Lizenzen &amp; Betrieb (größenbereinigt)</td></tr>
       <tr><td>Amortisation</td><td>{'—' if payback is None else _fmt_months(payback) + ' Monate'}</td><td>CAPEX ÷ (Nutzen − OPEX)</td></tr>
       <tr><td>ROI nach 12&nbsp;Monaten</td>
-          <td>{_fmt_eur(roi_12m_eur)} € ({roi_percent_str} %)</td>
-          <td>(Einsparung&nbsp;12M − CAPEX) ÷ CAPEX</td></tr>
+          <td>{_fmt_eur(roi_12m_eur)} € ({roi_display})</td>
+          <td>(Einsparung&nbsp;12M − CAPEX) ÷ CAPEX{' · Cap: ' + str(int(MAX_ROI)) + '%' if roi_was_capped else ''}</td></tr>
     </tbody>
   </table>
 </section>""".strip()
@@ -427,8 +443,10 @@ def calc_business_case(answers: Dict[str, Any], env: Dict[str, Any]) -> Dict[str
         "EINSPARUNG_MONAT_EUR": einsparung_monat_eur,
         "PAYBACK_MONTHS": payback,
         "ROI_12M_RATE": roi_12m_rate,
-        "ROI_12M": roi_12m_percent,
+        "ROI_12M": roi_12m_percent_capped,  # capped for backwards compatibility
+        "ROI_12M_RAW": roi_12m_percent_raw,  # v14.35.23: raw computed value
         "ROI_12M_EUR": roi_12m_eur,
+        "ROI_WAS_CAPPED": roi_was_capped,
         "BUSINESS_CASE_TABLE_HTML": table,
         # Add capped hours for consistent display across report
         "CAPPED_HOURS": capped_hours,
@@ -545,10 +563,21 @@ def _generate_ai_act_adjusted_table(
     einsparung = bc.get("EINSPARUNG_MONAT_EUR", 0)
     payback = bc.get("PAYBACK_MONTHS")
     roi_12m_eur = bc.get("ROI_12M_EUR", 0)
-    roi_12m_pct = bc.get("ROI_12M")
+    roi_12m_pct = bc.get("ROI_12M")  # capped
+    roi_12m_pct_raw = bc.get("ROI_12M_RAW")  # v14.35.23: raw computed value
+    roi_was_capped = bc.get("ROI_WAS_CAPPED", False)
 
-    # Format values
-    roi_percent_str = "—" if roi_12m_pct is None else f"{roi_12m_pct:,.1f}".replace(",", "X").replace(".", ",").replace("X", ".")
+    # v14.35.23: Format both ROI values (German decimals)
+    def _fmt_roi_val(val) -> str:
+        if val is None:
+            return "—"
+        return f"{val:,.0f}".replace(",", "X").replace(".", ",").replace("X", ".")
+
+    # v14.35.23: Show both raw and capped ROI if different
+    if roi_was_capped and roi_12m_pct_raw is not None:
+        roi_percent_str = f"{_fmt_roi_val(roi_12m_pct_raw)} % (berechnet) / {_fmt_roi_val(roi_12m_pct)} % (Planwert)"
+    else:
+        roi_percent_str = "—" if roi_12m_pct is None else f"{_fmt_roi_val(roi_12m_pct)} %"
     payback_str = "—" if payback is None else f"{payback:.1f}".replace(".", ",") + " Monate"
 
     # Compliance note based on risk level

--- a/tests/test_business_case_consistency.py
+++ b/tests/test_business_case_consistency.py
@@ -3,14 +3,16 @@
 Business Case Consistency Test - Single Source of Truth
 =========================================================
 
-v14.35.23: Tests for Business Case metric consistency across all sections.
+v14.35.24: Tests for Business Case metric consistency across all sections.
 
 Ensures:
 1. Hourly rate is consistent across all sources (canonical from business_case_engine_v2)
 2. Payback formatting doesn't contain long floats
 3. ROI values are derived consistently
+4. Both raw (computed) and capped (planning) ROI values are available (Option A)
 
 Ref: TASK - Business Case Consistency – Single Source of Truth (3 Fixes)
+     TASK - Option A: ROI „berechnet" + ROI „gedeckelt" überall konsistent
 """
 import os
 import re
@@ -127,6 +129,79 @@ class TestBusinessCaseConsistency:
         assert bc.annual_net == 17040
         # ROI is capped at MAX_ROI (200%) for conservative estimates
         assert round(bc.roi_12m_net, 1) == MAX_ROI, f"ROI should be capped at {MAX_ROI}%"
+
+    def test_roi_raw_vs_capped_values(self):
+        """Verify ROI raw (uncapped) and capped values are both available (Option A)."""
+        from services.business_case_engine_v2 import BusinessCaseCanonical, MAX_ROI
+
+        # Create a case with high ROI that will be capped
+        bc = BusinessCaseCanonical(
+            hours_saved_per_month=20,
+            hourly_rate_eur=80,
+            capex_eur=5000,
+            opex_month_eur=180,
+        )
+
+        # Raw ROI should be uncapped (~240.8%)
+        assert bc.roi_12m_net_raw > MAX_ROI, "Raw ROI should exceed MAX_ROI cap"
+        assert round(bc.roi_12m_net_raw, 1) == 240.8, f"Raw ROI should be 240.8%, got {bc.roi_12m_net_raw}"
+
+        # Capped ROI should be exactly MAX_ROI
+        assert bc.roi_12m_net == MAX_ROI, f"Capped ROI should be {MAX_ROI}%, got {bc.roi_12m_net}"
+
+        # Both values should be in to_dict()
+        bc_dict = bc.to_dict()
+        assert "roi_12m_net" in bc_dict, "to_dict should include roi_12m_net"
+        assert "roi_12m_net_raw" in bc_dict, "to_dict should include roi_12m_net_raw"
+        assert "roi_was_capped" in bc_dict, "to_dict should include roi_was_capped"
+        assert bc_dict["roi_was_capped"] is True, "roi_was_capped should be True when ROI exceeds MAX_ROI"
+
+    def test_roi_uncapped_when_below_max(self):
+        """Verify ROI is not capped when below MAX_ROI."""
+        from services.business_case_engine_v2 import BusinessCaseCanonical, MAX_ROI
+
+        # Create a case with low ROI that won't be capped
+        bc = BusinessCaseCanonical(
+            hours_saved_per_month=5,
+            hourly_rate_eur=80,
+            capex_eur=10000,
+            opex_month_eur=200,
+        )
+
+        # Both raw and capped should be the same when below MAX_ROI
+        assert bc.roi_12m_net_raw < MAX_ROI, "This test requires ROI below MAX_ROI"
+        assert bc.roi_12m_net == bc.roi_12m_net_raw, "ROI should not be capped when below MAX_ROI"
+
+        # roi_was_capped should be False
+        bc_dict = bc.to_dict()
+        assert bc_dict["roi_was_capped"] is False, "roi_was_capped should be False when ROI is below MAX_ROI"
+
+    def test_inject_canonical_includes_both_roi_values(self):
+        """Verify inject_canonical_to_sections includes both raw and capped ROI."""
+        from services.business_case_engine_v2 import BusinessCaseCanonical, inject_canonical_to_sections, MAX_ROI
+
+        # Create a case with capped ROI
+        bc = BusinessCaseCanonical(
+            hours_saved_per_month=20,
+            hourly_rate_eur=80,
+            capex_eur=5000,
+            opex_month_eur=180,
+        )
+
+        sections = {}
+        inject_canonical_to_sections(bc, sections)
+
+        # Check all ROI keys are injected
+        assert "ROI_12M" in sections, "ROI_12M should be injected"
+        assert "ROI_12M_RAW" in sections, "ROI_12M_RAW should be injected"
+        assert "ROI_12M_CAPPED" in sections, "ROI_12M_CAPPED should be injected"
+        assert "ROI_WAS_CAPPED" in sections, "ROI_WAS_CAPPED should be injected"
+
+        # Verify values
+        assert sections["ROI_12M"] == MAX_ROI, f"ROI_12M should be capped at {MAX_ROI}"
+        assert round(sections["ROI_12M_RAW"], 1) == 240.8, "ROI_12M_RAW should be 240.8"
+        assert sections["ROI_12M_CAPPED"] == MAX_ROI, f"ROI_12M_CAPPED should be {MAX_ROI}"
+        assert sections["ROI_WAS_CAPPED"] is True, "ROI_WAS_CAPPED should be True"
 
     def test_no_hardcoded_81_hourly_rate(self):
         """Ensure there are no hardcoded 81€/h rates in the codebase."""


### PR DESCRIPTION
…y (Option A)

Implements Option A to eliminate ROI contradictions across reports by showing both the mathematically computed ROI and the conservative planning value when the ROI is capped at MAX_ROI (200%).

Changes:
- Add roi_12m_net_raw property to BusinessCaseCanonical (uncapped computation)
- Add roi_was_capped flag to to_dict() output
- Inject ROI_12M_RAW, ROI_WAS_CAPPED into canonical sections
- Update Förderpotenzial fallback to show "241% (berechnet) / 200% (Planwert)"
- Add comprehensive tests for both raw and capped ROI values

Display format when ROI exceeds MAX_ROI:
- German: "241 (berechnet) / 200 (Planwert)"
- English: "241 (calculated) / 200 (capped)"