### PR TITLE
feat(template): P0.1 canonical-to-template bindings for consistent KPIs

### DIFF
--- a/gpt_analyze.py
+++ b/gpt_analyze.py
@@ -12944,6 +12944,56 @@ def analyze_briefing(db: Session, briefing_id: int, run_id: str) -> tuple[int, s
         canonical_bc = create_canonical_from_sections(sections, company_size=size_raw)
         canon_updates = inject_canonical_to_sections(canonical_bc, sections)
         log.info(f"[{run_id}] ✅ [CANONICAL-BC] Injected {canon_updates} canonical KPI values")
+
+        # =========================================================================
+        # P0.1: CANONICAL-TO-TEMPLATE BINDING - Formatted strings for PDF template
+        # These prevent raw floats (e.g., "3.5000001") and ensure German formatting
+        # =========================================================================
+        # Helper: German decimal format (comma separator)
+        def _fmt_de_decimal(val, ndigits: int = 1) -> str:
+            try:
+                formatted = f"{float(val):.{ndigits}f}"
+                return formatted.replace(".", ",")  # German: "3,5" not "3.5"
+            except (ValueError, TypeError):
+                return str(val) if val else "0"
+
+        # Helper: Integer format (no .0 suffix)
+        def _fmt_int_no_float(val) -> str:
+            try:
+                return str(int(float(val)))
+            except (ValueError, TypeError):
+                return str(val) if val else "0"
+
+        # 1. PAYBACK_MONTHS_FMT_DE - German decimal, 1 digit (e.g., "3,5")
+        payback_raw = sections.get("PAYBACK_MONTHS", 0)
+        sections["PAYBACK_MONTHS_FMT_DE"] = _fmt_de_decimal(payback_raw, 1)
+
+        # 2. TIME_SAVINGS_MONTH_HOURS_FMT - Integer, no ".0" (e.g., "25" not "25.0")
+        time_hours_raw = (
+            sections.get("TIME_SAVINGS_MONTH_HOURS_CAPPED")
+            or sections.get("monatsersparnis_stunden")
+            or sections.get("qw_hours_total")
+            or 36
+        )
+        sections["TIME_SAVINGS_MONTH_HOURS_FMT"] = _fmt_int_no_float(time_hours_raw)
+
+        # 3. ROI_12M_DISPLAY_DE - Option A: "241 % (berechnet) / 200 % (Planwert)" if capped
+        roi_capped = sections.get("ROI_12M", 0)
+        roi_raw = sections.get("ROI_12M_RAW", roi_capped)
+        roi_was_capped = sections.get("ROI_WAS_CAPPED", False)
+
+        roi_capped_str = _fmt_int_no_float(roi_capped)
+        roi_raw_str = _fmt_int_no_float(roi_raw)
+
+        if roi_was_capped and float(roi_raw or 0) != float(roi_capped or 0):
+            # Option A: Show both raw (computed) and capped (planning value)
+            sections["ROI_12M_DISPLAY_DE"] = f"{roi_raw_str} % (berechnet) / {roi_capped_str} % (Planwert)"
+        else:
+            sections["ROI_12M_DISPLAY_DE"] = f"{roi_capped_str} %"
+
+        log.info(f"[{run_id}] ✅ [P0.1] Template bindings: PAYBACK={sections['PAYBACK_MONTHS_FMT_DE']}, "
+                 f"HOURS={sections['TIME_SAVINGS_MONTH_HOURS_FMT']}, ROI_DISPLAY={sections['ROI_12M_DISPLAY_DE']}")
+
     except Exception as e:
         log.warning(f"[{run_id}] ⚠️ [CANONICAL-BC] Failed to inject canonical values: {e}")
 

--- a/templates/pdf_template.html
+++ b/templates/pdf_template.html
@@ -6023,7 +6023,7 @@
                         <div style="display: grid; grid-template-columns: repeat(3, 1fr); gap: var(--space-lg); margin-bottom: var(--space-xl);">
                             <div style="text-align: center;">
                                 <div style="font-size: 36px; font-weight: 600; color: var(--color-text-normal); margin-bottom: var(--space-xs);">
-                                    {{ monatsersparnis_stunden or qw_hours_total }} <span style="font-size: 20px; font-weight: 400;">Std.</span>
+                                    {{ TIME_SAVINGS_MONTH_HOURS_FMT or monatsersparnis_stunden or qw_hours_total }} <span style="font-size: 20px; font-weight: 400;">Std.</span>
                                 </div>
                                 <div style="font-size: 13px; font-weight: 500; color: var(--color-text-normal); margin-bottom: 4px;">
                                     Zeitersparnis/Monat
@@ -6040,7 +6040,7 @@
                                     ROI-Details
                                 </div>
                                 <div style="font-size: 11px; color: var(--color-text-muted);">
-                                    Payback: {{ PAYBACK_MONTHS or 'n/a' }} Monate
+                                    Payback: {{ PAYBACK_MONTHS_FMT_DE or PAYBACK_MONTHS or 'n/a' }} Monate
                                 </div>
                             </div>
                             <div style="text-align: center;">
@@ -7240,6 +7240,8 @@
                 </section>
                 {% endif %}
         <!-- Annex: Kreativ-Tools & Glossar -->
+        <!-- P0.1: Branch gate - only show Kreativ-Tools for creative industry -->
+{% if BRANCHE_LABEL and 'Kreativ' in BRANCHE_LABEL or BRANCHE_LABEL == 'Medien & Kreativwirtschaft' %}
 <section class="annex-section annex-kreativtools chapter">
   <h2>Kreativ-Tools {{report_year}} – modulare Alternativen</h2>
   <p>Viele Kreativaufgaben lassen sich heute mit einem modularen Toolset effizient erledigen – oft günstiger als im
@@ -7253,6 +7255,7 @@ monolithischen Abo-Ökosystem. Im Alltag bewährt haben sich u.&nbsp;a.:</p>
 </ul>
 <p><em>Fazit:</em> Adobe bleibt in Spezialfällen relevant. Für viele KMU decken die obigen Tools den Kreativ-Alltag vollständig ab.</p>
 </section>
+{% endif %}
 <section class="annex-section annex-glossar chapter">
   <h2>Glossar – zentrale KI-Begriffe</h2>
   <p class="section-intro">Die wichtigsten Begriffe aus diesem Report (max. 12 Einträge, kompakt).</p>

--- a/tests/test_business_case_consistency.py
+++ b/tests/test_business_case_consistency.py
@@ -249,5 +249,113 @@ class TestPaybackFormatting:
             assert len(formatted.split(".")[-1]) <= 1, f"Long float detected: {formatted}"
 
 
+class TestP01TemplateBindings:
+    """P0.1: Tests for canonical-to-template binding formatted values."""
+
+    def test_fmt_de_decimal(self):
+        """Test German decimal format (comma separator)."""
+        def _fmt_de_decimal(val, ndigits: int = 1) -> str:
+            try:
+                formatted = f"{float(val):.{ndigits}f}"
+                return formatted.replace(".", ",")
+            except (ValueError, TypeError):
+                return str(val) if val else "0"
+
+        assert _fmt_de_decimal(3.5, 1) == "3,5"
+        assert _fmt_de_decimal(10.123, 1) == "10,1"
+        assert _fmt_de_decimal(0, 1) == "0,0"
+        assert _fmt_de_decimal("invalid") == "invalid"
+
+    def test_fmt_int_no_float(self):
+        """Test integer format (no .0 suffix)."""
+        def _fmt_int_no_float(val) -> str:
+            try:
+                return str(int(float(val)))
+            except (ValueError, TypeError):
+                return str(val) if val else "0"
+
+        assert _fmt_int_no_float(25.0) == "25"
+        assert _fmt_int_no_float(25.7) == "25"
+        assert _fmt_int_no_float(36) == "36"
+        assert _fmt_int_no_float("invalid") == "invalid"
+
+    def test_roi_display_de_capped(self):
+        """Test ROI display format when capped (Option A)."""
+        def _fmt_int_no_float(val) -> str:
+            try:
+                return str(int(float(val)))
+            except (ValueError, TypeError):
+                return str(val) if val else "0"
+
+        roi_raw = 240.8
+        roi_capped = 200.0
+        roi_was_capped = True
+
+        roi_raw_str = _fmt_int_no_float(roi_raw)
+        roi_capped_str = _fmt_int_no_float(roi_capped)
+
+        if roi_was_capped and float(roi_raw) != float(roi_capped):
+            roi_display = f"{roi_raw_str} % (berechnet) / {roi_capped_str} % (Planwert)"
+        else:
+            roi_display = f"{roi_capped_str} %"
+
+        assert roi_display == "240 % (berechnet) / 200 % (Planwert)"
+
+    def test_roi_display_de_uncapped(self):
+        """Test ROI display format when not capped."""
+        def _fmt_int_no_float(val) -> str:
+            try:
+                return str(int(float(val)))
+            except (ValueError, TypeError):
+                return str(val) if val else "0"
+
+        roi_raw = 80.0
+        roi_capped = 80.0
+        roi_was_capped = False
+
+        roi_capped_str = _fmt_int_no_float(roi_capped)
+
+        if roi_was_capped and float(roi_raw) != float(roi_capped):
+            roi_display = f"{_fmt_int_no_float(roi_raw)} % (berechnet) / {roi_capped_str} % (Planwert)"
+        else:
+            roi_display = f"{roi_capped_str} %"
+
+        assert roi_display == "80 %"
+
+    def test_payback_months_fmt_de_no_long_float(self):
+        """Test PAYBACK_MONTHS_FMT_DE doesn't contain long float patterns."""
+        def _fmt_de_decimal(val, ndigits: int = 1) -> str:
+            try:
+                formatted = f"{float(val):.{ndigits}f}"
+                return formatted.replace(".", ",")
+            except (ValueError, TypeError):
+                return str(val) if val else "0"
+
+        # Test various payback values
+        test_values = [3.5, 10/3, 2.999999, 4.500001, 12.0]
+
+        for val in test_values:
+            formatted = _fmt_de_decimal(val, 1)
+            # Should not have more than 1 digit after comma
+            parts = formatted.split(",")
+            if len(parts) == 2:
+                assert len(parts[1]) == 1, f"Long decimal detected in: {formatted}"
+
+    def test_time_savings_hours_fmt_no_decimal(self):
+        """Test TIME_SAVINGS_MONTH_HOURS_FMT has no decimal point."""
+        def _fmt_int_no_float(val) -> str:
+            try:
+                return str(int(float(val)))
+            except (ValueError, TypeError):
+                return str(val) if val else "0"
+
+        test_values = [25.0, 36.7, 18, 42.999]
+
+        for val in test_values:
+            formatted = _fmt_int_no_float(val)
+            assert "." not in formatted, f"Decimal point found in: {formatted}"
+            assert formatted.isdigit(), f"Non-digit found in: {formatted}"
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
Ensures Business Case canonical metrics are properly displayed in PDF:

1. Cover/KPI block fixes:
   - TIME_SAVINGS_MONTH_HOURS_FMT: Integer format (no ".0" suffix)
   - PAYBACK_MONTHS_FMT_DE: German decimal format (comma separator)

2. ROI display (Option A):
   - ROI_12M_DISPLAY_DE: Shows "X % (berechnet) / Y % (Planwert)" when capped
   - Shows just "X %" when not capped

3. Branch gate for Kreativ-Tools:
   - Section only shown when BRANCHE_LABEL contains "Kreativ"
   - Prevents irrelevant content for non-creative industries

Files changed:
- gpt_analyze.py: Add formatted binding helpers after canonical injection
- templates/pdf_template.html: Use formatted values, add branch gate
- tests/test_business_case_consistency.py: Add TestP01TemplateBindings tests