### PR TITLE
fix(template): Correct operator precedence in Kreativ-Tools branch gate

### DIFF
--- a/templates/pdf_template.html
+++ b/templates/pdf_template.html
@@ -7241,7 +7241,7 @@
                 {% endif %}
         <!-- Annex: Kreativ-Tools & Glossar -->
         <!-- P0.1: Branch gate - only show Kreativ-Tools for creative industry -->
-{% if BRANCHE_LABEL and 'Kreativ' in BRANCHE_LABEL or BRANCHE_LABEL == 'Medien & Kreativwirtschaft' %}
+{% if BRANCHE_LABEL and ('Kreativ' in BRANCHE_LABEL or BRANCHE_LABEL == 'Medien & Kreativwirtschaft') %}
 <section class="annex-section annex-kreativtools chapter">
   <h2>Kreativ-Tools {{report_year}} – modulare Alternativen</h2>
   <p>Viele Kreativaufgaben lassen sich heute mit einem modularen Toolset effizient erledigen – oft günstiger als im


### PR DESCRIPTION
Add parentheses to ensure the condition is evaluated correctly:
- Before: BRANCHE_LABEL and 'Kreativ' in BRANCHE_LABEL or BRANCHE_LABEL == '...'
- After: BRANCHE_LABEL and ('Kreativ' in BRANCHE_LABEL or BRANCHE_LABEL == '...')

Without parentheses, the 'and' operator binds tighter than 'or', which could cause the section to render for non-creative branches incorrectly.