### PR TITLE
fix(bc): Fix-Batch-2.1 FINAL LOCK prevents canonical rebuild

### DIFF
--- a/services/business_case_engine_v2.py
+++ b/services/business_case_engine_v2.py
@@ -490,6 +490,8 @@ def create_canonical_from_sections(
     This is the ENTRY POINT for establishing the single source of truth.
     It reads from various potential sources and creates ONE canonical model.
 
+    Fix-Batch-2.1: FINAL LOCK - If canonical already exists, return None to signal skip.
+
     Priority for hours_saved:
     1. qw_hours_total (aggregated from Quick Wins)
     2. monatsersparnis_stunden (explicit user input)
@@ -497,9 +499,14 @@ def create_canonical_from_sections(
     4. Default based on company size
 
     Priority for hourly_rate:
-    1. stundensatz_eur (explicit)
-    2. Derived from company size
+    ALWAYS from get_hourly_rate(size) - never from sections (Fix-Batch-2.1)
     """
+    # Fix-Batch-2.1: FINAL LOCK - Check if canonical already exists
+    if sections.get("_bc_canonical_locked"):
+        existing_rate = sections.get("CANON_RATE_EUR", sections.get("stundensatz_eur", "?"))
+        log.info("[CANON] FINAL LOCK active - skipping rebuild (existing rate=%s€/h)", existing_rate)
+        return None
+
     # Normalize company size
     size = normalize_company_size(company_size or sections.get("company_size", "team"))
 
@@ -532,15 +539,17 @@ def create_canonical_from_sections(
     # Apply cap for company size
     hours_capped, was_capped = cap_time_savings(hours_raw, size)
 
-    # 2. Determine hourly_rate
-    explicit_rate = sections.get("stundensatz_eur")
-    if explicit_rate:
-        try:
-            hourly_rate = float(explicit_rate)
-        except (ValueError, TypeError):
-            hourly_rate, _ = get_hourly_rate(size)
-    else:
-        hourly_rate, _ = get_hourly_rate(size)
+    # 2. Determine hourly_rate - Fix-Batch-2.1: ALWAYS use canonical, never from sections
+    # This prevents non-canonical rate leaks when sections has stale/derived values
+    hourly_rate, rate_source = get_hourly_rate(size)
+    hourly_rate = int(hourly_rate)  # Ensure integer (80, not 80.0)
+
+    # Fix-Batch-2.1: Guard against non-canonical rates
+    expected_rates = {"solo": 80, "team": 95, "kmu": 110, "enterprise": 130}
+    if hourly_rate != expected_rates.get(size, 95):
+        log.warning("[CANON] Rate mismatch for %s: got %d, expected %d - forcing canonical",
+                    size, hourly_rate, expected_rates.get(size, 95))
+        hourly_rate = expected_rates.get(size, 95)
 
     # 3. Determine CAPEX
     capex_candidates = [
@@ -592,12 +601,13 @@ def create_canonical_from_sections(
         company_size=size,
     )
 
-    log.info("[CANON] Created: %s", canonical)
+    # Fix-Batch-2.1: Log with LOCKED indicator
+    log.info("[CANON] Created (LOCKED): %s", canonical)
     return canonical
 
 
 def inject_canonical_to_sections(
-    canonical: BusinessCaseCanonical,
+    canonical: Optional[BusinessCaseCanonical],
     sections: Dict[str, Any]
 ) -> int:
     """
@@ -605,8 +615,14 @@ def inject_canonical_to_sections(
 
     Returns the number of fields updated/overwritten.
 
+    Fix-Batch-2.1: If canonical is None (FINAL LOCK active), returns 0 without changes.
     v14.35.22: This ensures ALL section keys are derived from the single source.
     """
+    # Fix-Batch-2.1: Handle FINAL LOCK case
+    if canonical is None:
+        log.info("[CANON] Injection skipped - FINAL LOCK active")
+        return 0
+
     updates = 0
 
     # Core canonical values (always set)
@@ -659,7 +675,11 @@ def inject_canonical_to_sections(
     sections["_canonical_bc"] = canonical.to_dict()
     sections["_bc_canonical_applied"] = True
 
-    log.info("[CANON] Injected %d values into sections", updates)
+    # Fix-Batch-2.1: Set FINAL LOCK to prevent rebuild
+    sections["_bc_canonical_locked"] = True
+    sections["_bc_canonical_source"] = "G30"
+
+    log.info("[CANON] Injected %d values into sections (LOCKED)", updates)
     return updates
 
 

--- a/tests/test_business_case_canonical.py
+++ b/tests/test_business_case_canonical.py
@@ -167,17 +167,23 @@ class TestCreateCanonicalFromSections:
         assert canonical.hours_saved_per_month == 25
         assert canonical.was_capped is True
 
-    def test_create_with_explicit_rate(self):
-        """Test explicit hourly rate."""
+    def test_create_uses_canonical_rate(self):
+        """Test that canonical rates are always used (Fix-Batch-2.1).
+
+        Since Fix-Batch-2.1, explicit stundensatz_eur in sections is ignored
+        to prevent non-canonical rate leaks. Canonical rates are always used:
+        solo=80, team=95, kmu=110, enterprise=130
+        """
         sections = {
             "qw_hours_total": 20,
-            "stundensatz_eur": 100,
+            "stundensatz_eur": 100,  # Should be ignored - canonical rate used
             "company_size": "team",
         }
 
         canonical = create_canonical_from_sections(sections, "team")
 
-        assert canonical.hourly_rate_eur == 100
+        # Canonical rate for team is 95, not the explicit 100
+        assert canonical.hourly_rate_eur == 95
 
 
 class TestInjectCanonicalToSections:

--- a/tests/test_business_case_consistency.py
+++ b/tests/test_business_case_consistency.py
@@ -700,5 +700,96 @@ class TestFixBatch2CanonicalRateAndNetPayback:
             assert result == expected, f"Expected {expected}, got {result}"
 
 
+class TestFixBatch21FinalLock:
+    """Fix-Batch-2.1: Tests for FINAL LOCK - no canonical rebuild."""
+
+    def test_final_lock_prevents_rebuild(self):
+        """Verify that _bc_canonical_locked prevents rebuild."""
+        from services.business_case_engine_v2 import (
+            create_canonical_from_sections,
+            inject_canonical_to_sections,
+        )
+
+        # First creation - should succeed
+        sections = {"qw_hours_total": 25}
+        canonical1 = create_canonical_from_sections(sections, company_size="solo")
+        assert canonical1 is not None, "First creation should succeed"
+        assert canonical1.hourly_rate_eur == 80
+
+        # Inject and set lock
+        inject_canonical_to_sections(canonical1, sections)
+        assert sections.get("_bc_canonical_locked") is True
+
+        # Second creation attempt - should return None due to lock
+        canonical2 = create_canonical_from_sections(sections, company_size="solo")
+        assert canonical2 is None, "Second creation should be blocked by FINAL LOCK"
+
+    def test_final_lock_preserves_values(self):
+        """Verify locked sections retain their values."""
+        from services.business_case_engine_v2 import (
+            create_canonical_from_sections,
+            inject_canonical_to_sections,
+        )
+
+        sections = {"qw_hours_total": 25}
+        canonical = create_canonical_from_sections(sections, company_size="solo")
+        inject_canonical_to_sections(canonical, sections)
+
+        # Store original values
+        original_rate = sections["CANON_RATE_EUR"]
+        original_hours = sections["CANON_HOURS_MONTH"]
+        original_roi = sections["ROI_12M"]
+
+        # Try to "pollute" sections with different values
+        sections["stundensatz_eur"] = 81  # Try to inject wrong rate
+
+        # Attempt rebuild
+        canonical2 = create_canonical_from_sections(sections, company_size="solo")
+        assert canonical2 is None  # Blocked by lock
+
+        # Values should be unchanged
+        assert sections["CANON_RATE_EUR"] == original_rate
+        assert sections["CANON_HOURS_MONTH"] == original_hours
+        assert sections["ROI_12M"] == original_roi
+
+    def test_solo_rate_always_80(self):
+        """Verify solo company always gets 80€/h rate."""
+        from services.business_case_engine_v2 import create_canonical_from_sections
+
+        # Even with a pre-existing stundensatz_eur, canonical should use 80
+        sections = {
+            "qw_hours_total": 25,
+            "stundensatz_eur": 81,  # This should be ignored
+        }
+        canonical = create_canonical_from_sections(sections, company_size="solo")
+
+        assert canonical.hourly_rate_eur == 80, \
+            f"Solo rate should be 80, got {canonical.hourly_rate_eur}"
+
+    def test_inject_sets_lock_flag(self):
+        """Verify inject_canonical_to_sections sets _bc_canonical_locked."""
+        from services.business_case_engine_v2 import (
+            create_canonical_from_sections,
+            inject_canonical_to_sections,
+        )
+
+        sections = {}
+        canonical = create_canonical_from_sections(sections, company_size="team")
+        inject_canonical_to_sections(canonical, sections)
+
+        assert sections.get("_bc_canonical_locked") is True
+        assert sections.get("_bc_canonical_source") == "G30"
+
+    def test_inject_skips_when_canonical_none(self):
+        """Verify inject handles None canonical (from FINAL LOCK)."""
+        from services.business_case_engine_v2 import inject_canonical_to_sections
+
+        sections = {"_bc_canonical_locked": True, "ROI_12M": 150}
+        updates = inject_canonical_to_sections(None, sections)
+
+        assert updates == 0
+        assert sections["ROI_12M"] == 150  # Value unchanged
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
A) Located second canonical creation:
   - Issue was sections["stundensatz_eur"] being read with stale value
   - create_canonical_from_sections at line 536 was using explicit_rate

B) Implement FINAL LOCK:
   - Add _bc_canonical_locked flag check at start of create_canonical_from_sections
   - If locked, return None and skip rebuild
   - inject_canonical_to_sections sets _bc_canonical_locked=True, _bc_canonical_source="G30"
   - Handle None canonical in inject function

C) Ensure 80€/h lock:
   - ALWAYS use get_hourly_rate(size), NEVER read stundensatz_eur from sections
   - Add guard with expected_rates dict to force canonical if mismatch detected
   - hourly_rate = int(hourly_rate) to ensure 80, not 80.0

D) Deterministic logging:
   - "[CANON] Created (LOCKED): ..." on first creation
   - "[CANON] FINAL LOCK active - skipping rebuild (existing rate=X€/h)"
   - "[CANON] Injection skipped - FINAL LOCK active"
   - "[CANON] Injected N values into sections (LOCKED)"

E) Tests:
   - TestFixBatch21FinalLock class with 5 tests
   - test_final_lock_prevents_rebuild
   - test_final_lock_preserves_values
   - test_solo_rate_always_80
   - test_inject_sets_lock_flag
   - test_inject_skips_when_canonical_none

Result: 51 tests pass, no 81€/h possible