### PR TITLE
fix(p0): implement P0.4-P0.6 release blocker fixes

### DIFF
--- a/services/business_case_engine_v2.py
+++ b/services/business_case_engine_v2.py
@@ -1698,8 +1698,8 @@ def generate_business_case_report(
         # Generate scenarios (Fix-Batch-2: pass opex for net payback)
         scenarios = generate_scenarios(investment_total, base_monthly_savings, funding_effect, opex_monthly)
 
-        # Generate KPI targets
-        kpi_targets_6m, kpi_targets_12m = generate_kpi_targets(scenarios, baseline_effort_hours)
+        # Generate KPI targets (P0.5: Use capped hours for consistency)
+        kpi_targets_6m, kpi_targets_12m = generate_kpi_targets(scenarios, capped_effort_hours)
 
         # Generate narrative
         narrative_summary = _generate_narrative_summary(

--- a/services/recommendations_engine.py
+++ b/services/recommendations_engine.py
@@ -253,6 +253,37 @@ class RecommendationsReport:
         """Count recommendations with high impact."""
         return sum(1 for r in self.recommendations if r.impact_level == "high")
 
+    @property
+    def displayed_count(self) -> int:
+        """P0.6: Count of recommendations that will be displayed (top3 + others)."""
+        return len(self.top_3_recommendations) + len(self.other_recommendations)
+
+    def validate_count_consistency(self) -> Tuple[bool, str]:
+        """
+        P0.6: Validate that the count in summary matches actual recommendations.
+
+        Returns:
+            Tuple of (is_valid, error_message)
+        """
+        actual_count = len(self.recommendations)
+        displayed_count = self.displayed_count
+
+        # Check 1: displayed count matches total
+        if displayed_count != actual_count:
+            return False, f"Displayed count ({displayed_count}) != total ({actual_count})"
+
+        # Check 2: Extract count from summary if present
+        if self.summary:
+            # Pattern: "wurden X konkrete" or "X concrete"
+            count_pattern = re.compile(r'(\d+)\s+(?:konkrete|concrete)', re.IGNORECASE)
+            match = count_pattern.search(self.summary)
+            if match:
+                summary_count = int(match.group(1))
+                if summary_count != actual_count:
+                    return False, f"Summary mentions {summary_count} but actual is {actual_count}"
+
+        return True, ""
+
     def get_recommendation(self, rec_id: str) -> Optional[Recommendation]:
         """Get recommendation by ID."""
         for r in self.recommendations:
@@ -787,6 +818,11 @@ def generate_recommendations_report(
         summary=summary,
         top_3_ids=top_3_ids,
     )
+
+    # P0.6: Validate count consistency
+    is_valid, error = report.validate_count_consistency()
+    if not is_valid:
+        log.warning("[P0.6] Recommendations count mismatch: %s", error)
 
     log.info(
         "[G32] Recommendations Report generated: %d recommendations, top_3=%s",

--- a/services/report_renderer.py
+++ b/services/report_renderer.py
@@ -35,6 +35,130 @@ _LEAK_PATTERN = re.compile(
 
 
 # =============================================================================
+# P0.4: Pagebreak Cleanup - Prevent Empty/Low-Value Pages
+# =============================================================================
+# Patterns for detecting pagebreak elements
+_PAGEBREAK_CLASSES = [
+    r'class="[^"]*page-break[^"]*"',
+    r'class="[^"]*chapter-start[^"]*"',
+    r'style="[^"]*page-break-before:\s*always[^"]*"',
+    r'style="[^"]*break-before:\s*page[^"]*"',
+]
+
+# Compiled pattern for pagebreak detection
+_PAGEBREAK_PATTERN = re.compile(
+    r'<div\s+(?:' + '|'.join(_PAGEBREAK_CLASSES) + r')[^>]*>\s*</div>',
+    re.IGNORECASE | re.DOTALL
+)
+
+# Pattern for consecutive pagebreaks (2+ in a row with only whitespace between)
+_CONSECUTIVE_PAGEBREAKS = re.compile(
+    r'(<div\s+class="[^"]*page-break[^"]*"[^>]*>\s*</div>\s*){2,}',
+    re.IGNORECASE | re.DOTALL
+)
+
+# Pattern for empty sections that could cause blank pages
+_EMPTY_SECTION_PATTERNS = [
+    # Empty section with only whitespace
+    re.compile(r'<section[^>]*>\s*</section>', re.IGNORECASE | re.DOTALL),
+    # Section with only empty divs
+    re.compile(r'<section[^>]*>\s*(?:<div[^>]*>\s*</div>\s*)*</section>', re.IGNORECASE | re.DOTALL),
+    # Pagebreak followed immediately by another pagebreak element
+    re.compile(
+        r'(<div\s+class="page-break"[^>]*>\s*</div>)\s*'
+        r'(<(?:div|section)[^>]*(?:chapter|page-break)[^>]*>)',
+        re.IGNORECASE
+    ),
+]
+
+
+def cleanup_pagebreaks(html: str, run_id: str | None = None) -> Tuple[str, int]:
+    """
+    P0.4: Clean up pagebreak artifacts that cause empty or low-value pages.
+
+    Removes:
+    - Consecutive pagebreak divs (keeps only first)
+    - Empty sections that would create blank pages
+    - Orphaned pagebreaks at document start/end
+
+    Args:
+        html: HTML content to clean
+        run_id: Optional run ID for logging
+
+    Returns:
+        Tuple of (cleaned_html, count_removed)
+    """
+    if not html or not isinstance(html, str):
+        return html or "", 0
+
+    result = html
+    removed_count = 0
+
+    try:
+        # Step 1: Remove consecutive pagebreaks (keep only first)
+        def keep_first_pagebreak(match):
+            nonlocal removed_count
+            # Count how many pagebreaks were in the match
+            pagebreaks = re.findall(r'<div\s+class="[^"]*page-break[^"]*"', match.group(0), re.IGNORECASE)
+            if len(pagebreaks) > 1:
+                removed_count += len(pagebreaks) - 1
+            # Return just one pagebreak
+            return '<div class="page-break"></div>'
+
+        result = _CONSECUTIVE_PAGEBREAKS.sub(keep_first_pagebreak, result)
+
+        # Step 2: Remove empty sections
+        for pattern in _EMPTY_SECTION_PATTERNS[:2]:  # First two patterns
+            matches = pattern.findall(result)
+            if matches:
+                removed_count += len(matches)
+                result = pattern.sub('', result)
+
+        # Step 3: Fix pagebreak immediately before another pagebreak element
+        # (removes the first one to avoid double breaks)
+        third_pattern = _EMPTY_SECTION_PATTERNS[2]
+        while True:
+            match = third_pattern.search(result)
+            if not match:
+                break
+            # Keep only the second element (the chapter/section)
+            result = result[:match.start()] + match.group(2) + result[match.end():]
+            removed_count += 1
+
+        # Step 4: Remove pagebreak at very start of body content
+        result = re.sub(
+            r'(<body[^>]*>)\s*<div\s+class="page-break"[^>]*>\s*</div>',
+            r'\1',
+            result,
+            flags=re.IGNORECASE
+        )
+
+        # Step 5: Remove pagebreak at very end before </body>
+        result = re.sub(
+            r'<div\s+class="page-break"[^>]*>\s*</div>\s*(</body>)',
+            r'\1',
+            result,
+            flags=re.IGNORECASE
+        )
+
+        # Step 6: Normalize whitespace around remaining pagebreaks
+        result = re.sub(
+            r'\s*(<div\s+class="page-break"[^>]*>\s*</div>)\s*',
+            r'\n\1\n',
+            result
+        )
+
+        if removed_count > 0:
+            log.info(f"[P0.4] Pagebreak cleanup removed {removed_count} artifacts for run={run_id}")
+
+    except Exception as e:
+        log.error(f"[P0.4] Pagebreak cleanup failed for run={run_id}: {e}", exc_info=True)
+        return html, 0
+
+    return result, removed_count
+
+
+# =============================================================================
 # SPRINT N2.5: Defensive Final Leak Cleanup
 # =============================================================================
 def detect_leak_phrases(html: str) -> List[str]:
@@ -575,6 +699,13 @@ def render(briefing_obj: Any,
     if original_size > 0:
         savings_pct = (1 - new_size / original_size) * 100
         log.info(f"[RENDER] PDF-SLIMDOWN: {original_size}→{new_size} bytes ({savings_pct:.1f}% saved)")
+
+    # =========================================================================
+    # P0.4: Pagebreak cleanup - prevent empty/low-value pages
+    # =========================================================================
+    html, pagebreak_removed = cleanup_pagebreaks(html, run_id=run_id)
+    if pagebreak_removed > 0:
+        log.info(f"[P0.4] Pagebreak cleanup: removed {pagebreak_removed} artifacts for run={run_id}")
 
     # =========================================================================
     # SPRINT N2.5: Final leak phrase safety check (defensive)

--- a/templates/pdf_template.html
+++ b/templates/pdf_template.html
@@ -244,13 +244,11 @@
             page-break-before: auto !important;
             break-before: auto !important;
         }
+        /* P0.4: Keep small atomic elements together (avoid orphaned partial cards) */
         .no-page-break-inside,
-        .card,
         .kpi-card,
         .quick-win-card-new,
         .hero-metric-card,
-        .roadmap-phase,
-        .phase-card,
         .roi-herleitung,
         .roi-explanation-box,
         .foerder-card,
@@ -260,7 +258,14 @@
         .starter-template,
         .datenlucken-box,
         .recommendation-card,
-        .business-case-card,
+        .business-case-card {
+            page-break-inside: avoid;
+            break-inside: avoid;
+        }
+        /* P0.4: Larger containers allow breaks to prevent empty pages */
+        .card,
+        .roadmap-phase,
+        .phase-card,
         .content-card,
         .section {
             page-break-inside: auto;
@@ -4968,13 +4973,19 @@
             margin-bottom: 0 !important;
             padding-bottom: 0 !important;
         }
-        /* Tables should never create massive empty space */
+        /* P0.4: Tables should never create massive empty space */
         table {
             page-break-inside: auto !important;
         }
+        /* P0.4: Keep table rows together (avoid row splits) */
         tr {
-            page-break-inside: auto;
-            break-inside: auto;
+            page-break-inside: avoid;
+            break-inside: avoid;
+        }
+        /* P0.4: Keep table headers with first rows */
+        thead {
+            display: table-header-group;
+            break-inside: avoid;
         }
         /* Colgroup fixes for column widths */
         colgroup col {

--- a/tests/test_p04_pdf_preflight.py
+++ b/tests/test_p04_pdf_preflight.py
@@ -1,0 +1,213 @@
+# -*- coding: utf-8 -*-
+"""
+Tests for P0.4 - PDF Preflight: Pagebreak Cleanup & Empty Page Prevention
+
+Tests:
+- test_pagebreak_cleanup_removes_consecutive_breaks()
+- test_pagebreak_cleanup_removes_empty_sections()
+- test_css_has_break_inside_avoid()
+"""
+
+import pytest
+import re
+from pathlib import Path
+
+
+class TestPagebreakCleanup:
+    """Test the pagebreak cleanup function from report_renderer."""
+
+    def test_pagebreak_cleanup_removes_consecutive_breaks(self):
+        """Test that consecutive pagebreak divs are reduced to one or removed."""
+        from services.report_renderer import cleanup_pagebreaks
+
+        # Input with 3 consecutive pagebreaks followed by chapter
+        # Note: .chapter has CSS page-break-before:always, so the div pagebreak is redundant
+        html = '''<body>
+<div class="page-break"></div>
+<div class="page-break"></div>
+<div class="page-break"></div>
+<section class="chapter">Content</section>
+</body>'''
+
+        cleaned, count = cleanup_pagebreaks(html, run_id="test")
+
+        # Should have removed at least 2 (consecutive reduction + orphan at body start)
+        # All 3 may be removed since .chapter already has page-break-before
+        assert count >= 2, f"Expected at least 2 removed, got {count}"
+
+        # Content should be preserved
+        assert "Content" in cleaned
+
+    def test_pagebreak_cleanup_removes_empty_sections(self):
+        """Test that empty sections are removed."""
+        from services.report_renderer import cleanup_pagebreaks
+
+        # Input with empty sections
+        html = '''<body>
+<section class="chapter"></section>
+<section class="empty"><div></div></section>
+<section class="content">Real content here</section>
+</body>'''
+
+        cleaned, count = cleanup_pagebreaks(html, run_id="test")
+
+        # Should have removed the empty sections
+        assert count >= 1, f"Expected at least 1 removed, got {count}"
+
+        # Real content should be preserved
+        assert "Real content here" in cleaned
+
+    def test_pagebreak_cleanup_removes_orphaned_at_start(self):
+        """Test that pagebreak at body start is removed."""
+        from services.report_renderer import cleanup_pagebreaks
+
+        html = '''<body>
+<div class="page-break"></div>
+<section>Content</section>
+</body>'''
+
+        cleaned, count = cleanup_pagebreaks(html, run_id="test")
+
+        # Should not have pagebreak immediately after body
+        assert '<body>\n<div class="page-break"' not in cleaned
+        # Content should be preserved
+        assert "Content" in cleaned
+
+    def test_pagebreak_cleanup_removes_orphaned_at_end(self):
+        """Test that pagebreak at body end is removed."""
+        from services.report_renderer import cleanup_pagebreaks
+
+        html = '''<body>
+<section>Content</section>
+<div class="page-break"></div>
+</body>'''
+
+        cleaned, count = cleanup_pagebreaks(html, run_id="test")
+
+        # Should not have pagebreak immediately before </body>
+        assert '<div class="page-break"></div>\n</body>' not in cleaned
+        # Content should be preserved
+        assert "Content" in cleaned
+
+    def test_pagebreak_cleanup_preserves_valid_breaks(self):
+        """Test that pagebreaks between non-chapter content are preserved."""
+        from services.report_renderer import cleanup_pagebreaks
+
+        # Note: pagebreaks before .chapter are removed (redundant with CSS)
+        # but pagebreaks before non-chapter content are preserved
+        html = '''<body>
+<section class="content">Content 1</section>
+<div class="page-break"></div>
+<section class="content">Content 2</section>
+<div class="page-break"></div>
+<section class="content">Content 3</section>
+</body>'''
+
+        cleaned, count = cleanup_pagebreaks(html, run_id="test")
+
+        # Valid pagebreaks between non-chapter sections should be preserved
+        pagebreak_matches = re.findall(r'<div class="page-break"[^>]*>', cleaned)
+        assert len(pagebreak_matches) == 2, f"Expected 2 pagebreaks, found {len(pagebreak_matches)}"
+
+    def test_pagebreak_cleanup_removes_before_chapter(self):
+        """Test that pagebreaks before .chapter elements are removed (redundant)."""
+        from services.report_renderer import cleanup_pagebreaks
+
+        # .chapter has CSS page-break-before:always, so div pagebreak is redundant
+        html = '''<body>
+<section class="chapter">Chapter 1</section>
+<div class="page-break"></div>
+<section class="chapter">Chapter 2</section>
+</body>'''
+
+        cleaned, count = cleanup_pagebreaks(html, run_id="test")
+
+        # Pagebreak before .chapter should be removed (redundant)
+        assert count >= 1, f"Expected at least 1 removed, got {count}"
+
+        # All chapter content should be preserved
+        assert "Chapter 1" in cleaned
+        assert "Chapter 2" in cleaned
+
+
+class TestCSSBreakInsideAvoid:
+    """Test that CSS has proper break-inside rules for cards/tables."""
+
+    @pytest.fixture
+    def template_css(self):
+        """Load the PDF template CSS."""
+        template_path = Path(__file__).parent.parent / "templates" / "pdf_template.html"
+        with open(template_path, "r", encoding="utf-8") as f:
+            return f.read()
+
+    def test_css_has_break_inside_avoid_for_cards(self, template_css):
+        """Test that card elements have break-inside: avoid."""
+        # P0.4: These elements should have break-inside: avoid
+        avoid_elements = [
+            ".kpi-card",
+            ".quick-win-card-new",
+            ".hero-metric-card",
+            ".roi-herleitung",
+            ".recommendation-card",
+            ".business-case-card",
+        ]
+
+        for element in avoid_elements:
+            # Check that the element is in the avoid rule block
+            pattern = rf'{re.escape(element)}[^{{]*\{{[^}}]*break-inside:\s*avoid'
+            match = re.search(pattern, template_css, re.DOTALL)
+            assert match is not None, f"{element} should have break-inside: avoid"
+
+    def test_css_has_break_inside_avoid_for_table_rows(self, template_css):
+        """Test that table rows have break-inside: avoid."""
+        # P0.4: tr should have break-inside: avoid
+        pattern = r'tr\s*\{[^}]*break-inside:\s*avoid'
+        match = re.search(pattern, template_css, re.DOTALL)
+        assert match is not None, "tr should have break-inside: avoid"
+
+    def test_css_tables_allow_breaks(self, template_css):
+        """Test that tables themselves allow breaks (for long tables)."""
+        # Tables should have break-inside: auto or page-break-inside: auto
+        pattern = r'table\s*\{[^}]*(?:page-)?break-inside:\s*auto'
+        match = re.search(pattern, template_css, re.DOTALL)
+        assert match is not None, "table should have break-inside: auto"
+
+    def test_css_section_allows_breaks(self, template_css):
+        """Test that .section allows breaks (to prevent empty pages)."""
+        # .section should have break-inside: auto
+        pattern = r'\.section\s*\{[^}]*break-inside:\s*auto'
+        match = re.search(pattern, template_css, re.DOTALL)
+        assert match is not None, ".section should have break-inside: auto"
+
+
+class TestP04Integration:
+    """Integration tests for P0.4 in the render pipeline."""
+
+    def test_cleanup_integrated_in_render_pipeline(self):
+        """Test that cleanup_pagebreaks is called in render pipeline."""
+        from services import report_renderer
+        import inspect
+
+        # Get the source code of the render function
+        source = inspect.getsource(report_renderer.render)
+
+        # Check that cleanup_pagebreaks is called
+        assert "cleanup_pagebreaks" in source, "cleanup_pagebreaks should be called in render()"
+
+    def test_cleanup_function_exists(self):
+        """Test that cleanup_pagebreaks function is exported."""
+        from services.report_renderer import cleanup_pagebreaks
+
+        assert callable(cleanup_pagebreaks), "cleanup_pagebreaks should be callable"
+
+    def test_cleanup_handles_empty_input(self):
+        """Test that cleanup handles empty/None input gracefully."""
+        from services.report_renderer import cleanup_pagebreaks
+
+        result, count = cleanup_pagebreaks("", run_id="test")
+        assert result == ""
+        assert count == 0
+
+        result, count = cleanup_pagebreaks(None, run_id="test")
+        assert result == ""
+        assert count == 0

--- a/tests/test_p05_bc_single_source_truth.py
+++ b/tests/test_p05_bc_single_source_truth.py
@@ -1,0 +1,257 @@
+# -*- coding: utf-8 -*-
+"""
+Tests for P0.5 - Business Case Single Source of Truth
+
+Tests:
+- KPI values consistent with canonical BC (hours * rate = EUR)
+- Scenarios respect solo cap (no >20h)
+- ROI formula uses OPEX everywhere (NET formula)
+- generate_kpi_targets uses capped hours
+"""
+
+import pytest
+
+
+class TestKPIValueConsistency:
+    """Test that KPI values are consistent with canonical BC calculation."""
+
+    def test_monthly_savings_equals_hours_times_rate(self):
+        """Test that monthly savings = hours * rate."""
+        from services.business_case_engine_v2 import calculate_monthly_savings
+
+        # Test: 20 hours * 80 EUR/hour = 1600 EUR
+        result = calculate_monthly_savings(20, hourly_rate=80)
+        assert result == 1600, f"20h * 80€ should be 1600€, got {result}"
+
+        # Test: 15 hours * 95 EUR/hour = 1425 EUR
+        result = calculate_monthly_savings(15, hourly_rate=95)
+        assert result == 1425, f"15h * 95€ should be 1425€, got {result}"
+
+    def test_annual_savings_equals_12_times_monthly(self):
+        """Test that annual savings = 12 * monthly savings."""
+        from services.business_case_engine_v2 import calculate_annual_savings
+
+        # Test: 1600 EUR/month * 12 = 19200 EUR/year
+        result = calculate_annual_savings(1600)
+        assert result == 19200, f"1600€ * 12 should be 19200€, got {result}"
+
+
+class TestScenariosSoloCapRespect:
+    """Test that scenarios respect the solo cap of 20h."""
+
+    def test_solo_cap_is_20_hours(self):
+        """Test that solo max is 20 hours (P0.3)."""
+        from services.business_case_engine_v2 import MAX_TIME_SAVINGS_BY_SIZE
+
+        assert MAX_TIME_SAVINGS_BY_SIZE.get("solo") == 20, "Solo max should be 20h"
+
+    def test_cap_time_savings_enforces_solo_cap(self):
+        """Test that cap_time_savings enforces 20h for solo."""
+        from services.business_case_engine_v2 import cap_time_savings
+
+        # 30h for solo should be capped to 20h
+        capped, was_capped = cap_time_savings(30, "solo")
+        assert capped == 20, f"30h for solo should cap to 20h, got {capped}"
+        assert was_capped is True
+
+        # 15h for solo should not be capped
+        capped, was_capped = cap_time_savings(15, "solo")
+        assert capped == 15, f"15h for solo should stay 15h, got {capped}"
+        assert was_capped is False
+
+    def test_scenarios_use_capped_hours_for_savings(self):
+        """Test that scenario generation uses capped hours."""
+        from services.business_case_engine_v2 import (
+            generate_scenarios,
+            cap_time_savings,
+            get_hourly_rate,
+        )
+
+        # For solo with 30h input (should be capped to 20h)
+        raw_hours = 30
+        capped_hours, _ = cap_time_savings(raw_hours, "solo")
+        rate, _ = get_hourly_rate("solo")
+
+        # Base monthly savings should use capped hours
+        expected_base_savings = capped_hours * rate  # 20h * 80€ = 1600€
+        assert expected_base_savings == 1600, f"Expected 1600€, got {expected_base_savings}"
+
+        # Generate scenarios with capped savings
+        scenarios = generate_scenarios(
+            investment_total=5000,
+            base_monthly_savings=expected_base_savings,
+            funding_effect=0,
+            opex_monthly=50,
+        )
+
+        # Realistic scenario should have base savings (1600€)
+        realistic = next((s for s in scenarios if s.name == "realistic"), None)
+        assert realistic is not None
+        assert realistic.monthly_savings == expected_base_savings, \
+            f"Realistic savings should be {expected_base_savings}€, got {realistic.monthly_savings}"
+
+
+class TestROIFormulaWithOPEX:
+    """Test that ROI formula uses NET (includes OPEX)."""
+
+    def test_roi_calculation_includes_opex(self):
+        """Test that ROI is calculated with OPEX deduction."""
+        from services.business_case_engine_v2 import calculate_roi
+
+        # ROI formula: (annual_net - investment) / investment * 100
+        # With: annual_net = annual_savings - annual_opex
+        investment = 5000
+        annual_gross_savings = 19200  # 1600 * 12
+        annual_opex = 600  # 50 * 12
+        annual_net = annual_gross_savings - annual_opex  # 18600
+
+        # ROI = (18600 - 5000) / 5000 * 100 = 272%
+        expected_roi = ((annual_net - investment) / investment) * 100
+        assert expected_roi == 272.0
+
+        # calculate_roi should give same result
+        result = calculate_roi(annual_net, investment)
+        # ROI is capped at MAX_ROI (200%)
+        assert result == 200.0, f"ROI should be capped at 200%, got {result}"
+
+    def test_scenarios_use_net_payback(self):
+        """Test that scenario payback uses NET (gross - opex)."""
+        from services.business_case_engine_v2 import generate_scenarios
+
+        # Generate scenarios with known values
+        scenarios = generate_scenarios(
+            investment_total=5000,
+            base_monthly_savings=1600,  # Gross
+            funding_effect=0,
+            opex_monthly=100,  # OPEX
+        )
+
+        # For realistic scenario:
+        # Net = 1600 - 100 = 1500
+        # Payback = 5000 / 1500 = 3.33 months
+        realistic = next((s for s in scenarios if s.name == "realistic"), None)
+        assert realistic is not None
+
+        expected_net = 1600 - 100  # 1500
+        expected_payback = 5000 / expected_net  # 3.33
+
+        assert abs(realistic.payback_months - expected_payback) < 0.1, \
+            f"Payback should be ~{expected_payback:.1f}m, got {realistic.payback_months}"
+
+
+class TestGenerateKPITargetsUsesCappedHours:
+    """Test that generate_kpi_targets uses capped hours."""
+
+    def test_kpi_targets_use_provided_hours(self):
+        """Test that KPI targets use the provided (capped) hours."""
+        from services.business_case_engine_v2 import generate_kpi_targets, ScenarioKPIs
+
+        # Create mock scenarios
+        scenarios = [
+            ScenarioKPIs(
+                name="optimistic",
+                roi_12m=200,
+                payback_months=3,
+                monthly_savings=2000,
+                annual_savings=24000,
+                investment_total=5000,
+            ),
+            ScenarioKPIs(
+                name="realistic",
+                roi_12m=150,
+                payback_months=4,
+                monthly_savings=1600,
+                annual_savings=19200,
+                investment_total=5000,
+            ),
+            ScenarioKPIs(
+                name="conservative",
+                roi_12m=100,
+                payback_months=5,
+                monthly_savings=1200,
+                annual_savings=14400,
+                investment_total=5000,
+            ),
+        ]
+
+        # P0.5: Use capped hours (20h for solo)
+        capped_hours = 20
+
+        kpi_6m, kpi_12m = generate_kpi_targets(scenarios, capped_hours)
+
+        # 12m target should use the provided capped hours
+        assert kpi_12m["time_savings_hours"] == capped_hours, \
+            f"12m KPI should use capped hours ({capped_hours}), got {kpi_12m['time_savings_hours']}"
+
+        # 6m target should use 60% of capped hours
+        expected_6m_hours = capped_hours * 0.6
+        assert kpi_6m["time_savings_hours"] == expected_6m_hours, \
+            f"6m KPI should use 60% of capped hours ({expected_6m_hours}), got {kpi_6m['time_savings_hours']}"
+
+
+class TestP05Integration:
+    """Integration tests for P0.5 Business Case Single Source of Truth."""
+
+    def test_business_case_uses_capped_hours_throughout(self):
+        """Test that capped hours are used throughout the business case pipeline."""
+        from services.business_case_engine_v2 import (
+            cap_time_savings,
+            get_hourly_rate,
+            calculate_monthly_savings,
+            generate_scenarios,
+            generate_kpi_targets,
+        )
+
+        # Solo user with 35h claimed savings (should be capped to 20h)
+        raw_hours = 35
+        company_size = "solo"
+
+        # Step 1: Cap hours
+        capped_hours, was_capped = cap_time_savings(raw_hours, company_size)
+        assert capped_hours == 20
+        assert was_capped is True
+
+        # Step 2: Get canonical hourly rate
+        rate, _ = get_hourly_rate(company_size)
+        assert rate == 80
+
+        # Step 3: Calculate base savings with capped hours
+        base_savings = calculate_monthly_savings(capped_hours, hourly_rate=rate)
+        assert base_savings == 1600  # 20h * 80€
+
+        # Step 4: Generate scenarios with capped savings
+        scenarios = generate_scenarios(
+            investment_total=5000,
+            base_monthly_savings=base_savings,
+            funding_effect=0,
+            opex_monthly=50,
+        )
+
+        realistic = next((s for s in scenarios if s.name == "realistic"), None)
+        assert realistic.monthly_savings == base_savings  # Uses capped hours
+
+        # Step 5: Generate KPI targets with capped hours
+        kpi_6m, kpi_12m = generate_kpi_targets(scenarios, capped_hours)
+        assert kpi_12m["time_savings_hours"] == capped_hours  # Uses capped hours
+
+    def test_canonical_bc_consistency(self):
+        """Test that BusinessCaseCanonical produces consistent values."""
+        from services.business_case_engine_v2 import BusinessCaseCanonical
+
+        # Solo: 20h * 80€ = 1600€/month gross
+        canonical = BusinessCaseCanonical(
+            hours_saved_per_month=20,
+            hourly_rate_eur=80,
+            capex_eur=5000,
+            opex_month_eur=50,
+        )
+
+        # Verify derived values
+        assert canonical.monthly_gross == 1600  # 20 * 80
+        assert canonical.monthly_net == 1550  # 1600 - 50
+        assert canonical.annual_gross == 19200  # 1600 * 12
+        assert canonical.annual_net == 18600  # 1550 * 12
+
+        # Payback uses NET
+        expected_payback = 5000 / 1550  # ~3.23 months
+        assert abs(canonical.payback_months - expected_payback) < 0.01

--- a/tests/test_p06_recommendations_count.py
+++ b/tests/test_p06_recommendations_count.py
@@ -1,0 +1,301 @@
+# -*- coding: utf-8 -*-
+"""
+Tests for P0.6 - Recommendations Count Consistency
+
+Tests:
+- Count in summary matches displayed items
+- top_3 + others = total count
+- validate_count_consistency method works correctly
+"""
+
+import pytest
+
+
+class TestRecommendationsCountConsistency:
+    """Test that recommendations count matches displayed items."""
+
+    def test_displayed_count_equals_total(self):
+        """Test that displayed_count (top3 + others) equals total."""
+        from services.recommendations_engine import (
+            Recommendation,
+            RecommendationsReport,
+        )
+
+        # Create 5 recommendations
+        recommendations = [
+            Recommendation(
+                id=f"rec_{i}",
+                title=f"Recommendation {i}",
+                description=f"Description {i}",
+                reason=f"Reason {i}",
+                impact_level="high" if i < 2 else "medium",
+                urgency_level="high" if i < 2 else "medium",
+                risk_relation="neutral",
+                timeline_phase="phase_1",
+            )
+            for i in range(5)
+        ]
+
+        report = RecommendationsReport(
+            recommendations=recommendations,
+            summary="5 konkrete Empfehlungen wurden identifiziert.",
+            top_3_ids=["rec_0", "rec_1", "rec_2"],
+        )
+
+        # displayed_count = top_3 + others = 5
+        assert report.displayed_count == 5
+        assert len(report.top_3_recommendations) == 3
+        assert len(report.other_recommendations) == 2
+        assert report.displayed_count == len(report.recommendations)
+
+    def test_validate_count_consistency_passes(self):
+        """Test validation passes when counts match."""
+        from services.recommendations_engine import (
+            Recommendation,
+            RecommendationsReport,
+        )
+
+        recommendations = [
+            Recommendation(
+                id=f"rec_{i}",
+                title=f"Recommendation {i}",
+                description=f"Description {i}",
+                reason=f"Reason {i}",
+                impact_level="medium",
+                urgency_level="medium",
+                risk_relation="neutral",
+            )
+            for i in range(4)
+        ]
+
+        report = RecommendationsReport(
+            recommendations=recommendations,
+            summary="Für Ihr Team wurden 4 konkrete Handlungsempfehlungen identifiziert.",
+            top_3_ids=["rec_0", "rec_1", "rec_2"],
+        )
+
+        is_valid, error = report.validate_count_consistency()
+        assert is_valid is True, f"Should be valid, got error: {error}"
+
+    def test_validate_count_consistency_fails_on_summary_mismatch(self):
+        """Test validation fails when summary count doesn't match actual."""
+        from services.recommendations_engine import (
+            Recommendation,
+            RecommendationsReport,
+        )
+
+        recommendations = [
+            Recommendation(
+                id=f"rec_{i}",
+                title=f"Recommendation {i}",
+                description=f"Description {i}",
+                reason=f"Reason {i}",
+                impact_level="medium",
+                urgency_level="medium",
+                risk_relation="neutral",
+            )
+            for i in range(3)  # Only 3 recommendations
+        ]
+
+        # Summary says 5 but we only have 3
+        report = RecommendationsReport(
+            recommendations=recommendations,
+            summary="Für Ihr Team wurden 5 konkrete Handlungsempfehlungen identifiziert.",
+            top_3_ids=["rec_0", "rec_1", "rec_2"],
+        )
+
+        is_valid, error = report.validate_count_consistency()
+        assert is_valid is False, "Should fail due to summary mismatch"
+        assert "5" in error and "3" in error
+
+    def test_top_3_ids_filtered_to_existing(self):
+        """Test that invalid top_3_ids are filtered out."""
+        from services.recommendations_engine import (
+            Recommendation,
+            RecommendationsReport,
+        )
+
+        recommendations = [
+            Recommendation(
+                id="rec_0",
+                title="Recommendation 0",
+                description="Description 0",
+                reason="Reason 0",
+                impact_level="high",
+                urgency_level="high",
+                risk_relation="neutral",
+            ),
+            Recommendation(
+                id="rec_1",
+                title="Recommendation 1",
+                description="Description 1",
+                reason="Reason 1",
+                impact_level="medium",
+                urgency_level="medium",
+                risk_relation="neutral",
+            ),
+        ]
+
+        # top_3_ids includes non-existent IDs
+        report = RecommendationsReport(
+            recommendations=recommendations,
+            summary="2 konkrete Empfehlungen",
+            top_3_ids=["rec_0", "rec_1", "rec_invalid", "rec_missing"],
+        )
+
+        # Should only have 2 valid top_3
+        assert len(report.top_3_recommendations) == 2
+        assert len(report.other_recommendations) == 0
+        assert report.displayed_count == 2
+
+    def test_english_summary_validation(self):
+        """Test validation works with English summary."""
+        from services.recommendations_engine import (
+            Recommendation,
+            RecommendationsReport,
+        )
+
+        recommendations = [
+            Recommendation(
+                id=f"rec_{i}",
+                title=f"Recommendation {i}",
+                description=f"Description {i}",
+                reason=f"Reason {i}",
+                impact_level="medium",
+                urgency_level="medium",
+                risk_relation="neutral",
+            )
+            for i in range(6)
+        ]
+
+        report = RecommendationsReport(
+            recommendations=recommendations,
+            summary="For your company, 6 concrete recommendations were identified.",
+            top_3_ids=["rec_0", "rec_1", "rec_2"],
+        )
+
+        is_valid, error = report.validate_count_consistency()
+        assert is_valid is True, f"Should be valid for EN summary, got error: {error}"
+
+
+class TestRecommendationsReportProperties:
+    """Test RecommendationsReport properties."""
+
+    def test_to_dict_includes_count(self):
+        """Test that to_dict includes count field."""
+        from services.recommendations_engine import (
+            Recommendation,
+            RecommendationsReport,
+        )
+
+        recommendations = [
+            Recommendation(
+                id=f"rec_{i}",
+                title=f"Test {i}",
+                description="Desc",
+                reason="Reason",
+                impact_level="medium",
+                urgency_level="medium",
+                risk_relation="neutral",
+            )
+            for i in range(4)
+        ]
+
+        report = RecommendationsReport(
+            recommendations=recommendations,
+            summary="Summary",
+            top_3_ids=["rec_0", "rec_1", "rec_2"],
+        )
+
+        data = report.to_dict()
+        assert "count" in data
+        assert data["count"] == 4
+
+
+class TestP06Integration:
+    """Integration tests for P0.6."""
+
+    def test_generate_recommendations_validates_consistency(self):
+        """Test that generate_recommendations_report validates count."""
+        from services.recommendations_engine import generate_recommendations_report
+
+        # Generate with minimal context
+        report = generate_recommendations_report(
+            briefing={"UNTERNEHMENSGRÖSSE": "team", "BRANCHE": "IT"},
+        )
+
+        # Validation should pass
+        is_valid, error = report.validate_count_consistency()
+        assert is_valid is True, f"Generated report should be consistent, got: {error}"
+
+        # Count should be positive
+        assert len(report.recommendations) > 0
+        assert report.displayed_count == len(report.recommendations)
+
+    def test_html_renders_all_recommendations(self):
+        """Test that HTML contains all recommendations."""
+        from services.recommendations_engine import (
+            Recommendation,
+            RecommendationsReport,
+            recommendations_report_to_html,
+        )
+
+        recommendations = [
+            Recommendation(
+                id=f"rec_{i}",
+                title=f"Unique Title {i}",
+                description=f"Unique Description {i}",
+                reason=f"Unique Reason {i}",
+                impact_level="medium",
+                urgency_level="medium",
+                risk_relation="neutral",
+            )
+            for i in range(5)
+        ]
+
+        report = RecommendationsReport(
+            recommendations=recommendations,
+            summary="5 konkrete Empfehlungen",
+            top_3_ids=["rec_0", "rec_1", "rec_2"],
+        )
+
+        html = recommendations_report_to_html(report, lang="de")
+
+        # All 5 titles should appear in HTML
+        for i in range(5):
+            assert f"Unique Title {i}" in html, f"Title {i} should be in HTML"
+
+    def test_html_with_exclude_top3(self):
+        """Test that exclude_top_3 option works correctly."""
+        from services.recommendations_engine import (
+            Recommendation,
+            RecommendationsReport,
+            recommendations_report_to_html,
+        )
+
+        recommendations = [
+            Recommendation(
+                id=f"rec_{i}",
+                title=f"Title {i}",
+                description=f"Description {i}",
+                reason=f"Reason {i}",
+                impact_level="medium",
+                urgency_level="medium",
+                risk_relation="neutral",
+            )
+            for i in range(5)
+        ]
+
+        report = RecommendationsReport(
+            recommendations=recommendations,
+            summary="5 Empfehlungen",
+            top_3_ids=["rec_0", "rec_1", "rec_2"],
+        )
+
+        # With exclude_top_3=True, only other 2 should be rendered
+        html = recommendations_report_to_html(report, lang="de", exclude_top_3=True)
+
+        # Top-3 titles should NOT appear (or only in "other" section)
+        # Others (rec_3, rec_4) should appear
+        assert "Title 3" in html
+        assert "Title 4" in html


### PR DESCRIPTION
P0.4 - PDF Preflight:
- Add cleanup_pagebreaks() in report_renderer.py to remove consecutive/orphaned pagebreaks
- Update CSS break-inside rules: avoid for cards/rows, auto for tables/sections
- Integrate cleanup step in render pipeline after PDF-SLIMDOWN

P0.5 - Business Case Single Source of Truth:
- Fix generate_kpi_targets to use capped_effort_hours instead of uncapped
- Ensures scenarios respect solo cap (20h) throughout the pipeline
- ROI formula with OPEX already implemented in Fix-Batch-2

P0.6 - Recommendations Count Consistency:
- Add displayed_count property and validate_count_consistency() method
- Log warning on count mismatch during report generation
- Validates summary count matches actual recommendations

Tests:
- Add test_p04_pdf_preflight.py (13 tests)
- Add test_p05_bc_single_source_truth.py (10 tests)
- Add test_p06_recommendations_count.py (9 tests)