### PR TITLE
feat(fix-498): implement 6 work packages for Report-497 polish

### DIFF
--- a/gpt_analyze.py
+++ b/gpt_analyze.py
@@ -4048,6 +4048,7 @@ def _generate_quickwins_compact_fallback(raw_content: str, branche: str, groesse
     This ensures something reasonable shows even when JSON parsing fails.
 
     Fix-Batch J1: NEVER show error page - always return deterministic Quick Wins.
+    FIX-498 WP4+WP6: Tracks fallback usage for metrics truth.
 
     Args:
         raw_content: Raw content that couldn't be parsed
@@ -4058,6 +4059,12 @@ def _generate_quickwins_compact_fallback(raw_content: str, branche: str, groesse
         Compact HTML table with extracted items or deterministic fallback
     """
     import html as html_module
+
+    # FIX-498 WP4+WP6: Track fallback usage for metrics truth
+    gate = get_error_gate()
+    if gate:
+        gate.increment_fallback()
+        log.warning("[QW-COMPACT-FALLBACK-TRACKED] Fallback count incremented to %d", gate.fallback_count)
 
     # Try to extract any title-like content from the raw JSON
     title_pattern = re.compile(r'"title"\s*:\s*"([^"]+)"', re.IGNORECASE)
@@ -11378,6 +11385,11 @@ def _generate_content_sections(briefing: Dict[str, Any], scores: Dict[str, Any])
     if not qw_html:
         log.warning("⚠️ Kein Quick Wins Content, zeige Fallback-HTML")
         qw_html = _fallback_quick_wins_html(branche=qw_branche, groesse=qw_groesse)
+        # FIX-498 WP4+WP6: Track fallback usage for metrics truth
+        gate = get_error_gate()
+        if gate:
+            gate.increment_fallback()
+            log.warning("[QW-FALLBACK-TRACKED] Fallback count incremented to %d", gate.fallback_count)
 
     # ========== Fix-Batch D: HARD STOP - Suppress raw JSON in Quick Wins ==========
     # CRITICAL: Quick Wins must NEVER contain raw JSON in PDF output
@@ -13040,6 +13052,13 @@ Gib NUR das angeforderte HTML-Fragment aus - keine Fragen, keine Hilfsangebote, 
             sections["BC_INVESTMENT_TOTAL"] = bc_report.investment_total
             sections["BC_FUNDING_EFFECT"] = bc_report.funding_effect
 
+            # FIX-498 WP5: Centralize Payback KPI - use BC Engine 2.0 as single source of truth
+            # This ensures cover page and BC section show the same Payback value
+            sections["PAYBACK_MONTHS"] = realistic.payback_months
+            sections["ROI_12M"] = realistic.roi_12m
+            log.info("[%s] [FIX-498-WP5] Centralized KPIs: PAYBACK_MONTHS=%.1f, ROI_12M=%.1f%%",
+                     run_id, realistic.payback_months, realistic.roi_12m)
+
         log.info("[%s] ✅ G30 Business Case Engine 2.0 generated: investment=%.0f€, ROI=%.1f%%, payback=%.1f months",
                  run_id, bc_report.investment_total,
                  realistic.roi_12m if realistic else 0,
@@ -13851,7 +13870,9 @@ Gib NUR das angeforderte HTML-Fragment aus - keine Fragen, keine Hilfsangebote, 
             reason = "placeholder_pattern" if html_content and len(html_content.strip()) >= 200 else "too_short_or_empty"
             fallback_html = fallback_fn(guard_context)
             sections[section_key] = fallback_html
-            log.warning(f"[{run_id}] [P0.2-SECTION-GUARD] Fallback used section={section_key} reason={reason} original_len={len(html_content or '')}")
+            # FIX-498 WP6: Track fallback usage for metrics truth
+            error_gate.increment_fallback()
+            log.warning(f"[{run_id}] [P0.2-SECTION-GUARD] Fallback used section={section_key} reason={reason} original_len={len(html_content or '')} fallback_count={error_gate.fallback_count}")
         else:
             log.debug(f"[{run_id}] [P0.2-SECTION-GUARD] Section OK: {section_key} len={len(html_content)}")
 

--- a/templates/pdf_template.html
+++ b/templates/pdf_template.html
@@ -3746,6 +3746,58 @@
         }
 
         /* ================================================
+           FIX-498 WP1: ICON SIZE GUARDS
+           Prevent oversized/IMAX icons rendering
+           ================================================ */
+        /* Global icon size limits - prevent any icon from exceeding 120px */
+        [class*="icon"],
+        .icon,
+        .svg-icon,
+        .emoji-icon,
+        .hero-icon,
+        .card-icon,
+        .watermark-icon {
+            max-width: 120px !important;
+            max-height: 120px !important;
+        }
+
+        /* SVG icons - ensure proper sizing and stroke */
+        svg[class*="icon"],
+        .icon svg,
+        [class*="card"] svg {
+            max-width: 64px !important;
+            max-height: 64px !important;
+            fill: currentColor;
+            stroke: currentColor;
+        }
+
+        /* Decorative/watermark background icons */
+        .watermark-icon,
+        .bg-icon,
+        .background-icon,
+        [class*="watermark"] {
+            opacity: 0.08 !important;
+            z-index: -1 !important;
+            pointer-events: none !important;
+        }
+
+        /* Emoji size constraints in cards/boxes */
+        .card-emoji,
+        .box-emoji,
+        [class*="card"] > span:first-child,
+        .svg-decorated-box span[style*="font-size"] {
+            max-width: 48px !important;
+            max-height: 48px !important;
+            font-size: 24px !important;
+        }
+
+        /* Override any inline font-size > 80px on emojis */
+        span[style*="font-size"]:not([class*="score"]):not([class*="grade"]):not([class*="value"]) {
+            max-width: 64px;
+            max-height: 64px;
+        }
+
+        /* ================================================
            TAKEAWAY - Content Quality Pack v1.2
            "Wenn Sie nur eines tun:" individueller Startpunkt
            ================================================ */
@@ -5425,13 +5477,36 @@
 
         /* ============================================
            v13.0: ANTI-LEERSEITE (Empty Page Prevention)
+           FIX-498 WP2: Enhanced empty page prevention
            ============================================ */
         /* ULTRA-AGGRESSIVE: Prevent empty pages by forcing content flow */
         @media print {
             /* Prevent page breaks that would leave empty pages */
             .section:empty,
             .content-section:empty,
-            div:empty {
+            .chapter:empty,
+            section:empty,
+            div:empty:not(.page-break):not(.phase-marker) {
+                display: none !important;
+                page-break-before: auto !important;
+                break-before: auto !important;
+            }
+
+            /* FIX-498 WP2: Empty chapters should not cause page breaks */
+            .chapter:empty,
+            .section.chapter:empty,
+            section.chapter:empty {
+                page-break-before: auto !important;
+                break-before: auto !important;
+                height: 0 !important;
+                padding: 0 !important;
+                margin: 0 !important;
+                display: none !important;
+            }
+
+            /* Sections with only whitespace/empty body */
+            .section-body:empty,
+            .section-body:blank {
                 display: none !important;
             }
 
@@ -5456,6 +5531,13 @@
                 page-break-after: auto !important;
                 margin-bottom: 4px !important;
             }
+        }
+
+        /* FIX-498 WP2: Non-print empty prevention */
+        .chapter:empty,
+        .section:empty,
+        .section-body:empty {
+            display: none !important;
         }
 
         /* ============================================
@@ -6575,7 +6657,8 @@
                 </section>
                 {% endif %}
 
-                <!-- QUICK WINS -->
+                <!-- QUICK WINS - FIX-498 WP2: Conditional render -->
+                {% if QUICK_WINS_HTML and QUICK_WINS_HTML|trim and '<' in QUICK_WINS_HTML %}
                 <section class="section chapter" style="page-break-before: auto;">
                     <div class="section-header">
                         <div class="section-title">
@@ -6592,6 +6675,7 @@
                         {{ QUICK_WINS_HTML|safe }}
                     </div>
                 </section>
+                {% endif %}
                 <!-- SPRINT G19: Branch Profile & Market Intelligence -->
                 {% if BRANCH_PROFILE_HTML %}
                 <section class="section chapter" id="branch-profile">

--- a/templates/pdf_template_en.html
+++ b/templates/pdf_template_en.html
@@ -3664,6 +3664,58 @@
         }
 
         /* ================================================
+           FIX-498 WP1: ICON SIZE GUARDS
+           Prevent oversized/IMAX icons rendering
+           ================================================ */
+        /* Global icon size limits - prevent any icon from exceeding 120px */
+        [class*="icon"],
+        .icon,
+        .svg-icon,
+        .emoji-icon,
+        .hero-icon,
+        .card-icon,
+        .watermark-icon {
+            max-width: 120px !important;
+            max-height: 120px !important;
+        }
+
+        /* SVG icons - ensure proper sizing and stroke */
+        svg[class*="icon"],
+        .icon svg,
+        [class*="card"] svg {
+            max-width: 64px !important;
+            max-height: 64px !important;
+            fill: currentColor;
+            stroke: currentColor;
+        }
+
+        /* Decorative/watermark background icons */
+        .watermark-icon,
+        .bg-icon,
+        .background-icon,
+        [class*="watermark"] {
+            opacity: 0.08 !important;
+            z-index: -1 !important;
+            pointer-events: none !important;
+        }
+
+        /* Emoji size constraints in cards/boxes */
+        .card-emoji,
+        .box-emoji,
+        [class*="card"] > span:first-child,
+        .svg-decorated-box span[style*="font-size"] {
+            max-width: 48px !important;
+            max-height: 48px !important;
+            font-size: 24px !important;
+        }
+
+        /* Override any inline font-size > 80px on emojis */
+        span[style*="font-size"]:not([class*="score"]):not([class*="grade"]):not([class*="value"]) {
+            max-width: 64px;
+            max-height: 64px;
+        }
+
+        /* ================================================
            TAKEAWAY - Content Quality Pack v1.2
            "If you do only one thing:" individual starting point
            ================================================ */
@@ -5303,13 +5355,36 @@
 
         /* ============================================
            v13.0: ANTI-LEERSEITE (Empty Page Prevention)
+           FIX-498 WP2: Enhanced empty page prevention
            ============================================ */
         /* ULTRA-AGGRESSIVE: Prevent empty pages by forcing content flow */
         @media print {
             /* Prevent page breaks that would leave empty pages */
             .section:empty,
             .content-section:empty,
-            div:empty {
+            .chapter:empty,
+            section:empty,
+            div:empty:not(.page-break):not(.phase-marker) {
+                display: none !important;
+                page-break-before: auto !important;
+                break-before: auto !important;
+            }
+
+            /* FIX-498 WP2: Empty chapters should not cause page breaks */
+            .chapter:empty,
+            .section.chapter:empty,
+            section.chapter:empty {
+                page-break-before: auto !important;
+                break-before: auto !important;
+                height: 0 !important;
+                padding: 0 !important;
+                margin: 0 !important;
+                display: none !important;
+            }
+
+            /* Sections with only whitespace/empty body */
+            .section-body:empty,
+            .section-body:blank {
                 display: none !important;
             }
 
@@ -5334,6 +5409,13 @@
                 page-break-after: auto !important;
                 margin-bottom: 4px !important;
             }
+        }
+
+        /* FIX-498 WP2: Non-print empty prevention */
+        .chapter:empty,
+        .section:empty,
+        .section-body:empty {
+            display: none !important;
         }
 
         /* ============================================
@@ -6318,22 +6400,24 @@
                 </section>
                 {% endif %}
 
-                <!-- QUICK WINS -->
+                <!-- QUICK WINS - FIX-498 WP2: Conditional render -->
+                {% if QUICK_WINS_HTML and QUICK_WINS_HTML|trim and '<' in QUICK_WINS_HTML %}
                 <section class="section chapter" style="page-break-before: auto;">
                     <div class="section-header">
                         <div class="section-title">
-                            <span class="section-kicker">Schnelle Effekte</span>
+                            <span class="section-kicker">Quick Effects</span>
                             <h2>Quick Wins</h2>
                         </div>
                         <span class="section-pill">
                             <span class="pill-dot"></span>
-                            3–5 Measuren with sofortigem Hebel
+                            3–5 measures with immediate impact
                         </span>
                     </div>
                     <div class="section-body">
                         {{ QUICK_WINS_HTML|safe }}
                     </div>
                 </section>
+                {% endif %}
                 <!-- SPRINT G19: Branch Profile & Market Intelligence -->
                 {% if BRANCH_PROFILE_HTML %}
                 <section class="section chapter" id="branch-profile">


### PR DESCRIPTION
WP1: Icon size guards (IMAX icons)
- Added CSS guards to prevent icons > 120px
- Watermark icons get proper opacity/z-index
- Emoji size constraints in cards

WP2: Empty page prevention
- Enhanced CSS :empty selectors for sections
- Conditional rendering for QUICK_WINS_HTML
- Empty chapters no longer cause page breaks

WP3: ROADMAP_90D_DECISION_HTML fallback
- Already implemented in FIX-497

WP4: Quick Wins JSON→HTML fallback tracking
- Added increment_fallback() calls when fallbacks used
- Logged [QW-FALLBACK-TRACKED] for metrics truth

WP5: Centralized Payback KPI
- BC Engine 2.0 is now single source of truth
- sections["PAYBACK_MONTHS"] synced with BC_PAYBACK_REALISTIC
- Cover and BC section now show consistent values

WP6: Metrics truth (no fake zeros)
- increment_fallback() called in P0.2 section guards
- Proper logging with fallback_count in messages
- Cover "Quality Summary" will now show real values