### PR TITLE
fix(fix-501): Quick Wins Strict Pass - ensure markers always recognized

### DIFF
--- a/gpt_analyze.py
+++ b/gpt_analyze.py
@@ -3512,17 +3512,19 @@ def _quick_wins_simple_json_to_html(raw: str) -> Optional[str]:
             return None
 
         # Build HTML
-        # FIX-500: Add marker to indicate proper JSON→HTML rendering
-        li_items = "\n    ".join(f"<li>{item}</li>" for item in items)
-        html_out = f'''<div class="quick-wins-container" data-qw-json-rendered="true">
-<div class="quick-wins">
+        # FIX-501: Add class="quick-win" to each item AND container marker
+        # This ensures validators recognize the structure from ANY check
+        li_items = "\n    ".join(
+            f'<li class="quick-win" data-qw-json-rendered="true">{item}</li>'
+            for item in items
+        )
+        html_out = f'''<div class="quick-wins-container quick-wins" data-qw-json-rendered="true">
   <ul>
     {li_items}
   </ul>
-</div>
 </div>'''
 
-        log.info("[quick_wins] ✅ Simple JSON converted to HTML (%d items)", len(items))
+        log.info("[quick_wins] ✅ Simple JSON converted to HTML (%d items, markers: quick-win, data-qw-json-rendered)", len(items))
         return html_out
 
     except json.JSONDecodeError as e:
@@ -3722,7 +3724,7 @@ def _build_quick_wins_html(quick_wins: list, branche: str = "Unbekannt", groesse
         steps_html += '</ol>'
 
         html += f"""
-<div class="quick-win-card" style="border: 2px solid #3b82f6; border-radius: 12px; padding: 0; margin-bottom: 30px; page-break-inside: avoid; background: white;">
+<div class="quick-win quick-win-card" data-qw-json-rendered="true" style="border: 2px solid #3b82f6; border-radius: 12px; padding: 0; margin-bottom: 30px; page-break-inside: avoid; background: white;">
 
     <!-- Header (Tabelle für Layout) -->
     <table style="width: 100%; border-collapse: collapse; background: #3b82f6; border-radius: 10px 10px 0 0;">
@@ -3938,9 +3940,10 @@ def _enforce_quickwins_no_raw_json(qw_html: str, branche: str, groesse: str) -> 
     3. If valid JSON cannot be rendered, FAIL (not fallback)
     4. NEVER returns raw JSON to the PDF
 
-    FIX-500: If data-qw-json-rendered="true" marker is present, this HTML was
-    already properly rendered from JSON by _build_quick_wins_html() or
-    _quick_wins_simple_json_to_html(). Skip all validation and return as-is.
+    FIX-501: Priority check order:
+    1. If data-qw-json-rendered marker present → return immediately (already rendered)
+    2. If class="quick-win" present → return immediately (valid structure)
+    3. Only then check for raw JSON that needs conversion
 
     Args:
         qw_html: Current Quick Wins HTML output
@@ -3951,12 +3954,28 @@ def _enforce_quickwins_no_raw_json(qw_html: str, branche: str, groesse: str) -> 
         Clean HTML without raw JSON
     """
     if not qw_html:
+        log.warning("[QW-VALIDATOR] Empty qw_html, using fallback")
         return _fallback_quick_wins_html(branche, groesse)
 
-    # FIX-500: Check for proper JSON→HTML rendering marker
-    # If present, HTML was already properly rendered - skip all validation
-    if 'data-qw-json-rendered="true"' in qw_html:
-        log.debug("[QW-VALIDATOR] ✅ data-qw-json-rendered marker found - skipping validation")
+    # FIX-501: Detailed detection logging
+    has_rendered_marker = 'data-qw-json-rendered="true"' in qw_html
+    has_quick_win_class = 'class="quick-win' in qw_html  # Matches quick-win, quick-win-card, quick-wins
+    html_len = len(qw_html)
+
+    log.info(
+        "[QW-VALIDATOR] Checking: len=%d, has_rendered_marker=%s, has_quick_win_class=%s",
+        html_len, has_rendered_marker, has_quick_win_class
+    )
+
+    # FIX-501: PRIORITY 1 - If JSON was rendered to HTML, skip ALL validation
+    # This is the AUTHORITATIVE check - if marker present, HTML is valid
+    if has_rendered_marker:
+        log.info("[QW-VALIDATOR] ✅ data-qw-json-rendered marker found - PASS (skipping validation)")
+        return qw_html
+
+    # FIX-501: PRIORITY 2 - If class="quick-win" present, HTML structure is valid
+    if has_quick_win_class:
+        log.info("[QW-VALIDATOR] ✅ class=\"quick-win*\" found - PASS (valid structure)")
         return qw_html
 
     stripped = qw_html.strip()
@@ -3986,18 +4005,22 @@ def _enforce_quickwins_no_raw_json(qw_html: str, branche: str, groesse: str) -> 
     has_json_markers = any(marker in qw_html for marker in json_markers)
 
     # Valid HTML markers that indicate proper rendering
-    # FIX-500: Extended list to catch all valid Quick Wins HTML patterns
+    # FIX-501: Use substring matching for flexibility (class="quick-win matches quick-win, quick-win-card, quick-wins)
     html_markers = [
-        '<div class="quick-win-card"',    # From _build_quick_wins_html
-        '<div class="quick-win">',        # Alternative marker
-        'class="quick-wins"',             # From _quick_wins_simple_json_to_html
-        'class="quick-wins-container"',   # FIX-500: Container marker
-        'data-qw-json-rendered',          # FIX-500: JSON rendered marker
+        'class="quick-win',               # FIX-501: Matches quick-win, quick-win-card, quick-wins, quick-wins-container
+        'data-qw-json-rendered',          # FIX-501: JSON rendered marker
     ]
     has_html_structure = any(marker in qw_html for marker in html_markers)
 
+    # FIX-501: Log what we found for debugging
+    log.debug(
+        "[QW-VALIDATOR] Secondary check: has_html_structure=%s, has_json_markers=%s, is_json_array=%s",
+        has_html_structure, has_json_markers, is_json_array
+    )
+
     # If we have proper HTML structure and no JSON markers, output is clean
     if has_html_structure and not has_json_markers and not is_json_array:
+        log.info("[QW-VALIDATOR] ✅ Secondary check PASS: HTML structure found, no JSON markers")
         return qw_html
 
     # Fix-Batch A1: If JSON array detected, MUST render it (not optional recovery)
@@ -11410,7 +11433,13 @@ def _generate_content_sections(briefing: Dict[str, Any], scores: Dict[str, Any])
         if simple_json_html:
             qw_html = simple_json_html
             qw_json_valid = True
-            log.info("[FIX-499-QW] ✅ Simple JSON converted to HTML successfully")
+            # FIX-501: Log marker presence for debugging
+            has_marker = 'class="quick-win' in qw_html
+            has_rendered = 'data-qw-json-rendered' in qw_html
+            log.info(
+                "[FIX-501-QW] ✅ Simple JSON→HTML: len=%d, has_quick_win_class=%s, has_rendered_marker=%s",
+                len(qw_html), has_marker, has_rendered
+            )
         else:
             # Try complex JSON parsing (expects full structured objects)
             quick_wins_list = _parse_quick_wins_json(qw_raw)
@@ -11418,7 +11447,13 @@ def _generate_content_sections(briefing: Dict[str, Any], scores: Dict[str, Any])
             if quick_wins_list:
                 qw_html = _build_quick_wins_html(quick_wins_list, branche=qw_branche, groesse=qw_groesse)
                 qw_json_valid = True
-                log.info("[FIX-499-QW] ✅ Complex JSON parsed and rendered (%d Cards)", len(quick_wins_list))
+                # FIX-501: Log marker presence for debugging
+                has_marker = 'class="quick-win' in qw_html
+                has_rendered = 'data-qw-json-rendered' in qw_html
+                log.info(
+                    "[FIX-501-QW] ✅ Complex JSON→HTML: %d cards, len=%d, has_quick_win_class=%s, has_rendered_marker=%s",
+                    len(quick_wins_list), len(qw_html), has_marker, has_rendered
+                )
             else:
                 # FIX-499: JSON was detected but couldn't be parsed - this is an error, not a fallback situation
                 log.error("[FIX-499-QW] ❌ JSON detected but parsing failed")
@@ -11446,7 +11481,13 @@ def _generate_content_sections(briefing: Dict[str, Any], scores: Dict[str, Any])
                 # Already valid HTML, just post-process
                 qw_html = _remove_duplicate_context_banners(qw_raw)
                 qw_html = _enforce_quick_win_css_classes(qw_html)
-            log.info("[FIX-499-QW] ✅ HTML content processed")
+            # FIX-501: Log more context about what was processed
+            has_marker = 'class="quick-win' in qw_html if qw_html else False
+            has_rendered = 'data-qw-json-rendered' in qw_html if qw_html else False
+            log.info(
+                "[FIX-501-QW] ✅ HTML content processed: len=%d, has_quick_win_class=%s, has_rendered_marker=%s",
+                len(qw_html) if qw_html else 0, has_marker, has_rendered
+            )
         elif qw_raw:
             # Raw content but not JSON or HTML - log warning with snippet
             log.warning(

--- a/tests/test_fix499_strict_blockers.py
+++ b/tests/test_fix499_strict_blockers.py
@@ -95,8 +95,9 @@ class TestQuickWinsJsonFix:
         result = _quick_wins_simple_json_to_html(raw)
 
         assert result is not None
-        assert 'class="quick-wins"' in result
-        assert '<li>' in result
+        # FIX-501: Check for class substring (may be combined with other classes)
+        assert 'quick-wins' in result
+        assert '<li' in result
         assert 'Quick Win 1' in result
 
     def test_complex_json_to_html_produces_valid_markup(self):
@@ -117,7 +118,8 @@ class TestQuickWinsJsonFix:
         assert len(quick_wins) == 3
 
         html = _build_quick_wins_html(quick_wins, branche="IT", groesse="solo")
-        assert 'class="quick-win-card"' in html
+        # FIX-501: Check for class substring (may be combined: "quick-win quick-win-card")
+        assert 'quick-win-card' in html
 
     def test_validator_recognizes_quick_win_card_class(self):
         """Test that validator recognizes quick-win-card class."""
@@ -226,8 +228,9 @@ class TestFix500QuickWinsValidatorProof:
 
         # Check for the JSON-rendered marker
         assert 'data-qw-json-rendered="true"' in html
-        assert 'class="quick-wins-container"' in html
-        assert 'class="quick-win-card"' in html
+        assert 'quick-wins-container' in html
+        # FIX-501: Check for class substring (may be combined: "quick-win quick-win-card")
+        assert 'quick-win-card' in html
 
     def test_simple_json_to_html_includes_rendered_marker(self):
         """Test that _quick_wins_simple_json_to_html includes data-qw-json-rendered marker."""
@@ -241,7 +244,8 @@ class TestFix500QuickWinsValidatorProof:
 
         assert html is not None
         assert 'data-qw-json-rendered="true"' in html
-        assert 'class="quick-wins-container"' in html
+        # FIX-501: Check for substring (may be combined with other classes)
+        assert 'quick-wins-container' in html
 
     def test_validator_respects_rendered_marker(self):
         """Test that validator skips validation when data-qw-json-rendered marker present."""

--- a/tests/test_fix501_quickwins_strict.py
+++ b/tests/test_fix501_quickwins_strict.py
@@ -1,0 +1,235 @@
+"""
+FIX-501: Tests for Quick Wins Strict Pass.
+
+Ensures Quick Wins never fails on "HTML structure" check when JSON is valid.
+All rendered Quick Wins HTML must contain:
+- class="quick-win" (on each card/item)
+- data-qw-json-rendered="true" marker
+
+Tests cover:
+1. JSON input → render → output contains required markers
+2. Validator respects markers and passes in strict mode
+3. Regression: missing markers raise explicit error (not generic fallback)
+4. No code path reaches [QW-FALLBACK] in strict mode when JSON parsed
+"""
+import os
+import pytest
+import re
+from unittest.mock import patch
+
+
+class TestFix501QuickWinsMarkers:
+    """Test that JSON→HTML rendering includes required markers."""
+
+    def test_build_quick_wins_html_has_quick_win_class(self):
+        """Test that _build_quick_wins_html includes class='quick-win' on each card."""
+        try:
+            from gpt_analyze import _build_quick_wins_html
+        except ImportError:
+            pytest.skip("gpt_analyze dependencies not available")
+
+        quick_wins = [
+            {"title": "Test 1", "icon": "🎯", "time": "1h", "engpass": "E1",
+             "description": "D1", "mit_ki": "K1", "steps": ["S1"], "zeitersparnis": "2h/w"},
+            {"title": "Test 2", "icon": "🚀", "time": "2h", "engpass": "E2",
+             "description": "D2", "mit_ki": "K2", "steps": ["S2"], "zeitersparnis": "3h/w"},
+            {"title": "Test 3", "icon": "💡", "time": "3h", "engpass": "E3",
+             "description": "D3", "mit_ki": "K3", "steps": ["S3"], "zeitersparnis": "4h/w"},
+        ]
+        html = _build_quick_wins_html(quick_wins, branche="IT", groesse="solo")
+
+        # Must have class="quick-win" (not just quick-win-card)
+        assert 'class="quick-win' in html, "Missing class='quick-win' in output"
+        # Must have data-qw-json-rendered marker
+        assert 'data-qw-json-rendered="true"' in html, "Missing data-qw-json-rendered marker"
+        # Should have 3 cards
+        assert html.count('class="quick-win quick-win-card"') == 3, "Expected 3 quick-win cards"
+
+    def test_simple_json_to_html_has_quick_win_class(self):
+        """Test that _quick_wins_simple_json_to_html includes class='quick-win' markers."""
+        try:
+            from gpt_analyze import _quick_wins_simple_json_to_html
+        except ImportError:
+            pytest.skip("gpt_analyze dependencies not available")
+
+        raw = '["Quick Win 1", "Quick Win 2", "Quick Win 3"]'
+        html = _quick_wins_simple_json_to_html(raw)
+
+        assert html is not None
+        # Must have class="quick-win" on items
+        assert 'class="quick-win' in html, "Missing class='quick-win' in output"
+        # Must have data-qw-json-rendered marker
+        assert 'data-qw-json-rendered="true"' in html, "Missing data-qw-json-rendered marker"
+
+    def test_complex_json_with_title_icon_time(self):
+        """Test JSON with title/icon/time fields (as seen in Railway log)."""
+        try:
+            from gpt_analyze import _parse_quick_wins_json, _build_quick_wins_html
+        except ImportError:
+            pytest.skip("gpt_analyze dependencies not available")
+
+        # Simulate the JSON format mentioned in the briefing
+        raw = '''[
+            {"title": "KI-Textassistent", "icon": "🤖", "time": "1h/Tag"},
+            {"title": "E-Mail-Automatisierung", "icon": "📧", "time": "30min/Tag"},
+            {"title": "Dokumentenanalyse", "icon": "📄", "time": "2h/Woche"}
+        ]'''
+
+        quick_wins = _parse_quick_wins_json(raw)
+        assert quick_wins is not None
+        assert len(quick_wins) == 3
+
+        html = _build_quick_wins_html(quick_wins, branche="IT", groesse="solo")
+        assert 'class="quick-win quick-win-card"' in html
+        assert 'data-qw-json-rendered="true"' in html
+
+
+class TestFix501ValidatorStrictMode:
+    """Test that validator passes when markers are present."""
+
+    def test_validator_passes_with_rendered_marker(self):
+        """Test that validator returns HTML unchanged when marker present."""
+        try:
+            from gpt_analyze import _enforce_quickwins_no_raw_json
+        except ImportError:
+            pytest.skip("gpt_analyze dependencies not available")
+
+        html = '''<div class="quick-wins-container quick-wins" data-qw-json-rendered="true">
+<ul><li class="quick-win" data-qw-json-rendered="true">Test</li></ul>
+</div>'''
+
+        result = _enforce_quickwins_no_raw_json(html, "IT", "solo")
+        assert result == html, "Validator should return HTML unchanged"
+
+    def test_validator_passes_with_quick_win_class(self):
+        """Test that validator passes when class='quick-win' present."""
+        try:
+            from gpt_analyze import _enforce_quickwins_no_raw_json
+        except ImportError:
+            pytest.skip("gpt_analyze dependencies not available")
+
+        html = '''<div class="quick-win quick-win-card" style="border: 2px solid blue;">
+<h3>Quick Win Title</h3>
+</div>'''
+
+        result = _enforce_quickwins_no_raw_json(html, "IT", "solo")
+        assert result == html, "Validator should return HTML unchanged"
+
+    def test_validator_no_exception_in_strict_mode_with_markers(self):
+        """Test that strict mode doesn't raise when markers present."""
+        try:
+            from gpt_analyze import _enforce_quickwins_no_raw_json
+        except ImportError:
+            pytest.skip("gpt_analyze dependencies not available")
+
+        os.environ["RELEASE_STRICT_MODE"] = "1"
+        try:
+            html = '''<div class="quick-win" data-qw-json-rendered="true">Content</div>'''
+            result = _enforce_quickwins_no_raw_json(html, "IT", "solo")
+            assert result == html
+        finally:
+            os.environ.pop("RELEASE_STRICT_MODE", None)
+
+
+class TestFix501ValidatorRegressions:
+    """Test that missing markers are handled correctly."""
+
+    def test_validator_raises_in_strict_mode_without_markers(self):
+        """Test that missing markers raise RuntimeError in strict mode."""
+        try:
+            from gpt_analyze import _enforce_quickwins_no_raw_json
+        except ImportError:
+            pytest.skip("gpt_analyze dependencies not available")
+
+        os.environ["RELEASE_STRICT_MODE"] = "1"
+        try:
+            # HTML without any quick-win markers
+            html = '''<div class="some-other-class">Content without markers</div>'''
+            with pytest.raises(RuntimeError) as exc_info:
+                _enforce_quickwins_no_raw_json(html, "IT", "solo")
+            assert "STRICT MODE" in str(exc_info.value)
+        finally:
+            os.environ.pop("RELEASE_STRICT_MODE", None)
+
+    def test_validator_substring_match_quick_win(self):
+        """Test that class='quick-win' prefix matches various patterns."""
+        # The validator should match:
+        # - class="quick-win"
+        # - class="quick-win-card"
+        # - class="quick-wins"
+        # - class="quick-wins-container"
+
+        patterns_to_match = [
+            'class="quick-win"',
+            'class="quick-win-card"',
+            'class="quick-wins"',
+            'class="quick-wins-container"',
+            'class="quick-win quick-win-card"',
+        ]
+
+        check_string = 'class="quick-win'  # The substring we check for
+
+        for pattern in patterns_to_match:
+            html = f'<div {pattern}>Test</div>'
+            assert check_string in html, f"Pattern {pattern} should match check"
+
+
+class TestFix501NoFallbackPath:
+    """Test that no fallback path is reached when JSON is valid."""
+
+    def test_json_path_sets_markers(self):
+        """Test that JSON processing path sets all required markers."""
+        try:
+            from gpt_analyze import _quick_wins_simple_json_to_html, _build_quick_wins_html, _parse_quick_wins_json
+        except ImportError:
+            pytest.skip("gpt_analyze dependencies not available")
+
+        # Test simple JSON path
+        simple_html = _quick_wins_simple_json_to_html('["A", "B", "C"]')
+        assert simple_html is not None
+        assert 'data-qw-json-rendered="true"' in simple_html
+        assert 'class="quick-win' in simple_html
+
+        # Test complex JSON path
+        complex_json = '[{"title": "T1"}, {"title": "T2"}, {"title": "T3"}]'
+        quick_wins = _parse_quick_wins_json(complex_json)
+        complex_html = _build_quick_wins_html(quick_wins, branche="IT", groesse="solo")
+        assert 'data-qw-json-rendered="true"' in complex_html
+        assert 'class="quick-win' in complex_html
+
+    def test_full_flow_json_to_validator(self):
+        """Test complete flow: JSON → HTML → Validator passes."""
+        try:
+            from gpt_analyze import _build_quick_wins_html, _parse_quick_wins_json, _enforce_quickwins_no_raw_json
+        except ImportError:
+            pytest.skip("gpt_analyze dependencies not available")
+
+        os.environ["RELEASE_STRICT_MODE"] = "1"
+        try:
+            # Simulate LLM response
+            json_response = '''[
+                {"title": "KI-Tool einrichten", "icon": "🔧", "time": "2h"},
+                {"title": "Training durchführen", "icon": "📚", "time": "4h"},
+                {"title": "Prozesse optimieren", "icon": "⚡", "time": "1h"}
+            ]'''
+
+            # Parse and render
+            quick_wins = _parse_quick_wins_json(json_response)
+            assert quick_wins is not None
+
+            html = _build_quick_wins_html(quick_wins, branche="IT", groesse="solo")
+
+            # Verify markers before validator
+            assert 'class="quick-win' in html
+            assert 'data-qw-json-rendered="true"' in html
+
+            # Validator should pass without exception
+            result = _enforce_quickwins_no_raw_json(html, "IT", "solo")
+            assert result == html
+
+        finally:
+            os.environ.pop("RELEASE_STRICT_MODE", None)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
Root cause: Validator checked for specific HTML patterns but generated HTML used different classes (quick-win-card vs quick-win).

TASK 1: Add class="quick-win" marker to each card
- _build_quick_wins_html(): Changed from class="quick-win-card" to class="quick-win quick-win-card" with data-qw-json-rendered="true"
- _quick_wins_simple_json_to_html(): Each <li> now has class="quick-win" and data-qw-json-rendered="true" markers

TASK 2: Fix validator early return and detection
- _enforce_quickwins_no_raw_json(): Added priority check order:
  1. data-qw-json-rendered marker → return immediately
  2. class="quick-win" prefix → return immediately (matches -card, -s)
  3. Only then check for raw JSON conversion
- Use substring match 'class="quick-win' to catch all variants

TASK 3: Fix misleading log lines
- Added detailed detection logging with marker presence info
- Log format: len, has_quick_win_class, has_rendered_marker
- Changed prefix from FIX-499-QW to FIX-501-QW for new code

Tests: Added test_fix501_quickwins_strict.py with 10 tests covering:
- Marker presence in rendered HTML
- Validator passes in strict mode with markers
- Missing markers raise explicit error
- Full JSON→HTML→Validator flow