### PR TITLE
feat(debug-503d): add debug artifacts as admin mail attachments

### DIFF
--- a/gpt_analyze.py
+++ b/gpt_analyze.py
@@ -14651,7 +14651,7 @@ def _extract_scores_from_report(rep: Report) -> Dict[str, int]:
         return default_scores
 
 
-def _send_emails(db: Session, rep: Report, br: Briefing, pdf_url: Optional[str], pdf_bytes: Optional[bytes], run_id: str) -> None:
+def _send_emails(db: Session, rep: Report, br: Briefing, pdf_url: Optional[str], pdf_bytes: Optional[bytes], run_id: str, meta: Optional[Dict[str, Any]] = None) -> None:
     """Send emails via Resend API"""
     # Global Email Kill-Switch
     if os.getenv("DISABLE_EMAILS", "").lower() in ("1", "true", "yes", "on"):
@@ -14689,7 +14689,22 @@ def _send_emails(db: Session, rep: Report, br: Briefing, pdf_url: Optional[str],
         log.info("[%s] 📎 Added briefing JSON attachment for admin (%d bytes)", run_id, len(bjson))
     except Exception as e:
         log.warning("[%s] ⚠️ Could not create briefing JSON attachment: %s", run_id, str(e))
-    
+
+    # DEBUG-503D: Attach debug artifacts when DEBUG_RENDER=1
+    if meta and meta.get("debug_503d_attachments"):
+        try:
+            debug_attachments = meta["debug_503d_attachments"]
+            for att in debug_attachments:
+                attachments_admin.append(att)
+            total_debug_bytes = sum(len(a.get("content", b"")) for a in debug_attachments)
+            log.info(
+                "[%s] [DEBUG-503D][MAIL] attaching 4 artifacts: "
+                "quick_wins_block.html, risk_matrix_block.html, payback_mentions.txt, quick_wins_keys.json "
+                "(total_bytes=%d)", run_id, total_debug_bytes
+            )
+        except Exception as debug_exc:
+            log.warning("[%s] ⚠️ Could not attach DEBUG-503D artifacts: %s", run_id, str(debug_exc))
+
     # Send to user
     try:
         user_email = None
@@ -14854,7 +14869,7 @@ def run_briefing_pipeline(db: Session, briefing_id: int, email: Optional[str] = 
         db.refresh(rep)
 
         # Send notification emails
-        _send_emails(db, rep, br, pdf_url, pdf_bytes, run_id)
+        _send_emails(db, rep, br, pdf_url, pdf_bytes, run_id, meta=meta)
 
         log.info("[%s] ✅ Pipeline complete for briefing_id=%s", run_id, briefing_id)
 
@@ -14952,9 +14967,9 @@ def run_async(briefing_id: int, email: Optional[str] = None) -> None:
         db.add(rep)
         db.commit()
         db.refresh(rep)
-        
-        _send_emails(db, rep, br, pdf_url, pdf_bytes, run_id)
-        
+
+        _send_emails(db, rep, br, pdf_url, pdf_bytes, run_id, meta=meta)
+
     except Exception as exc:
         log.error("[%s] ❌ Analysis failed: %s", run_id, exc, exc_info=True)
         if rep and hasattr(rep, "status"):

--- a/services/debug_503d.py
+++ b/services/debug_503d.py
@@ -282,7 +282,7 @@ def _build_quick_wins_keys_json(sections: Dict[str, Any]) -> str:
     """
     keys_to_check = ["QUICK_WINS_HTML", "QUICK_WINS_HTML_LEFT", "QUICK_WINS_HTML_RIGHT", "quick_wins"]
 
-    result = {}
+    result: Dict[str, Any] = {}
 
     for key in keys_to_check:
         value = sections.get(key, "")

--- a/services/debug_503d.py
+++ b/services/debug_503d.py
@@ -1,0 +1,401 @@
+"""
+DEBUG-503D: Debug artifact collection for admin email attachments.
+
+When DEBUG_RENDER=1, this module builds 4 debug artifacts:
+1. debug_503d_quick_wins_block.html - Final rendered Quick Wins DETAIL section
+2. debug_503d_risk_matrix_block.html - Final rendered Risk Matrix table with CSS
+3. debug_503d_payback_mentions.txt - Canonical PAYBACK_MONTHS + all occurrences in HTML
+4. debug_503d_quick_wins_keys.json - Lengths + marker presence for QW keys
+
+These artifacts attach to admin emails for forensic debugging of PDF rendering issues.
+"""
+import json
+import logging
+import os
+import re
+from typing import Any, Dict, List, Optional, Tuple
+
+log = logging.getLogger(__name__)
+
+# Max size for HTML snippets (200KB each)
+MAX_SNIPPET_SIZE = 200 * 1024
+
+# Debug anchors that should be in the templates
+QUICK_WINS_START = "<!-- DEBUG-ANCHOR: QUICK_WINS_DETAIL_START -->"
+QUICK_WINS_END = "<!-- DEBUG-ANCHOR: QUICK_WINS_DETAIL_END -->"
+RISK_MATRIX_START = "<!-- DEBUG-ANCHOR: RISK_MATRIX_START -->"
+RISK_MATRIX_END = "<!-- DEBUG-ANCHOR: RISK_MATRIX_END -->"
+
+
+def is_debug_render_enabled() -> bool:
+    """Check if DEBUG_RENDER=1 is set."""
+    return os.getenv("DEBUG_RENDER", "").strip() == "1"
+
+
+def _extract_between_anchors(html: str, start_anchor: str, end_anchor: str, max_size: int = MAX_SNIPPET_SIZE) -> str:
+    """
+    Extract HTML content between two anchor comments.
+
+    Args:
+        html: Full HTML string
+        start_anchor: Start comment marker
+        end_anchor: End comment marker
+        max_size: Maximum size of extracted content
+
+    Returns:
+        Extracted HTML snippet or empty string if anchors not found
+    """
+    start_idx = html.find(start_anchor)
+    if start_idx == -1:
+        return ""
+
+    # Start after the anchor
+    content_start = start_idx + len(start_anchor)
+
+    end_idx = html.find(end_anchor, content_start)
+    if end_idx == -1:
+        # If no end anchor, take reasonable chunk
+        end_idx = min(content_start + max_size, len(html))
+
+    content = html[content_start:end_idx].strip()
+
+    # Enforce max size
+    if len(content) > max_size:
+        content = content[:max_size] + "\n<!-- TRUNCATED -->"
+
+    return content
+
+
+def _build_quick_wins_snippet(final_html: str) -> str:
+    """
+    Extract the Quick Wins DETAIL section from final HTML.
+
+    Looks for DEBUG-ANCHOR markers, falls back to section class matching.
+
+    Returns:
+        HTML snippet for Quick Wins block
+    """
+    # Try anchor-based extraction first
+    content = _extract_between_anchors(final_html, QUICK_WINS_START, QUICK_WINS_END)
+
+    if content:
+        return f"<!-- DEBUG-503D: Quick Wins section extracted via anchors -->\n{content}"
+
+    # Fallback: Find section with Quick Wins heading
+    # Look for the section containing "Quick Wins" h2
+    qw_pattern = r'(<section[^>]*>.*?<h2>Quick Wins</h2>.*?</section>)'
+    match = re.search(qw_pattern, final_html, re.DOTALL | re.IGNORECASE)
+
+    if match:
+        content = match.group(1)
+        if len(content) > MAX_SNIPPET_SIZE:
+            content = content[:MAX_SNIPPET_SIZE] + "\n<!-- TRUNCATED -->"
+        return f"<!-- DEBUG-503D: Quick Wins section extracted via pattern matching -->\n{content}"
+
+    return "<!-- DEBUG-503D: Quick Wins section NOT FOUND in final HTML -->"
+
+
+def _get_risk_matrix_css() -> str:
+    """
+    Return the CSS rules relevant to Risk Matrix rendering.
+
+    These rules are critical for proper PDF rendering and are included
+    inline in the debug snippet.
+    """
+    return """
+<style>
+/* Risk Matrix CSS - FIX-503B */
+.risk-matrix-section {
+    page-break-inside: avoid;
+    margin: 20px 0;
+}
+.risk-matrix-section table {
+    table-layout: auto;
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 10pt;
+}
+.risk-matrix-section td,
+.risk-matrix-section th {
+    padding: 8px;
+    border-bottom: 1px solid #e2e8f0;
+    overflow-wrap: anywhere;
+    word-break: break-word;
+    hyphens: auto;
+    white-space: normal;
+    overflow: visible;
+}
+.table-modern {
+    table-layout: auto;
+    width: 100%;
+    border-collapse: collapse;
+}
+</style>
+"""
+
+
+def _build_risk_matrix_snippet(final_html: str) -> str:
+    """
+    Extract the Risk Matrix table from final HTML with relevant CSS.
+
+    Looks for DEBUG-ANCHOR markers, falls back to class matching.
+
+    Returns:
+        HTML snippet for Risk Matrix with inline CSS
+    """
+    # Try anchor-based extraction first
+    content = _extract_between_anchors(final_html, RISK_MATRIX_START, RISK_MATRIX_END)
+
+    if content:
+        return f"<!-- DEBUG-503D: Risk Matrix extracted via anchors -->\n{_get_risk_matrix_css()}\n{content}"
+
+    # Fallback: Find risk-matrix-section div
+    rm_pattern = r'(<div[^>]*class="[^"]*risk-matrix-section[^"]*"[^>]*>.*?</div>)'
+    match = re.search(rm_pattern, final_html, re.DOTALL | re.IGNORECASE)
+
+    if match:
+        content = match.group(1)
+        if len(content) > MAX_SNIPPET_SIZE:
+            content = content[:MAX_SNIPPET_SIZE] + "\n<!-- TRUNCATED -->"
+        return f"<!-- DEBUG-503D: Risk Matrix extracted via class matching -->\n{_get_risk_matrix_css()}\n{content}"
+
+    # Second fallback: Find table with Risiko-Matrix heading
+    rm_pattern2 = r'(<div[^>]*>.*?Risiko-Matrix.*?<table.*?</table>.*?</div>)'
+    match2 = re.search(rm_pattern2, final_html, re.DOTALL | re.IGNORECASE)
+
+    if match2:
+        content = match2.group(1)
+        if len(content) > MAX_SNIPPET_SIZE:
+            content = content[:MAX_SNIPPET_SIZE] + "\n<!-- TRUNCATED -->"
+        return f"<!-- DEBUG-503D: Risk Matrix extracted via pattern matching -->\n{_get_risk_matrix_css()}\n{content}"
+
+    return f"<!-- DEBUG-503D: Risk Matrix NOT FOUND in final HTML -->\n{_get_risk_matrix_css()}"
+
+
+def _format_payback_de(value: Any) -> str:
+    """Format PAYBACK_MONTHS value in German locale."""
+    if value is None or value == "":
+        return "N/A"
+
+    try:
+        num = float(value)
+        # German formatting: comma as decimal separator
+        if num == int(num):
+            return f"{int(num)}"
+        return f"{num:.1f}".replace(".", ",")
+    except (ValueError, TypeError):
+        return str(value)
+
+
+def _build_payback_mentions(final_html: str, canonical_kpis: Optional[Dict[str, Any]] = None) -> str:
+    """
+    Build payback mentions report.
+
+    First line: canonical PAYBACK_MONTHS value (formatted de).
+    Then: every occurrence of Payback/Amortisation with +/-80 chars context.
+
+    Args:
+        final_html: Final rendered HTML
+        canonical_kpis: Dict with PAYBACK_MONTHS value
+
+    Returns:
+        Text report of payback mentions
+    """
+    lines = []
+
+    # First line: canonical value
+    payback_val = None
+    if canonical_kpis:
+        payback_val = canonical_kpis.get("PAYBACK_MONTHS")
+
+    lines.append(f"CANONICAL PAYBACK_MONTHS: {_format_payback_de(payback_val)}")
+    lines.append("")
+    lines.append("=" * 60)
+    lines.append("PAYBACK/AMORTISATION MENTIONS IN FINAL HTML:")
+    lines.append("=" * 60)
+    lines.append("")
+
+    # Pattern for payback/amortisation mentions
+    pattern = re.compile(r'\b(payback|amortisation|amortisierung)\b', re.IGNORECASE)
+
+    # Calculate line numbers
+    html_lines = final_html.split('\n')
+    char_offset = 0
+    line_offsets = []  # (start_char, end_char, line_num)
+
+    for line_num, line in enumerate(html_lines, 1):
+        line_offsets.append((char_offset, char_offset + len(line), line_num))
+        char_offset += len(line) + 1  # +1 for newline
+
+    def get_line_number(pos: int) -> int:
+        """Get line number for character position."""
+        for start, end, line_num in line_offsets:
+            if start <= pos < end + 1:  # +1 to include newline
+                return line_num
+        return -1
+
+    # Find all matches
+    matches_found = 0
+    for match in pattern.finditer(final_html):
+        matches_found += 1
+        pos = match.start()
+        line_num = get_line_number(pos)
+
+        # Extract context: +/- 80 chars
+        ctx_start = max(0, pos - 80)
+        ctx_end = min(len(final_html), pos + len(match.group()) + 80)
+        context = final_html[ctx_start:ctx_end]
+
+        # Clean up context for readability
+        context = context.replace('\n', ' ').replace('\r', ' ')
+        context = re.sub(r'\s+', ' ', context)
+
+        # Mark the match position
+        match_start_in_ctx = pos - ctx_start
+        match_end_in_ctx = match_start_in_ctx + len(match.group())
+
+        # Build context string with markers
+        marked_context = (
+            context[:match_start_in_ctx] +
+            ">>>" + context[match_start_in_ctx:match_end_in_ctx] + "<<<" +
+            context[match_end_in_ctx:]
+        )
+
+        lines.append(f"[Line {line_num:5d}] ...{marked_context}...")
+        lines.append("")
+
+    lines.append("=" * 60)
+    lines.append(f"TOTAL MATCHES: {matches_found}")
+
+    return "\n".join(lines)
+
+
+def _build_quick_wins_keys_json(sections: Dict[str, Any]) -> str:
+    """
+    Build JSON with lengths + marker presence for Quick Wins keys.
+
+    Args:
+        sections: Dict with QUICK_WINS_HTML, QUICK_WINS_HTML_LEFT, QUICK_WINS_HTML_RIGHT, quick_wins
+
+    Returns:
+        JSON string with debug info
+    """
+    keys_to_check = ["QUICK_WINS_HTML", "QUICK_WINS_HTML_LEFT", "QUICK_WINS_HTML_RIGHT", "quick_wins"]
+
+    result = {}
+
+    for key in keys_to_check:
+        value = sections.get(key, "")
+        if value is None:
+            value = ""
+        value_str = str(value)
+
+        result[key] = {
+            "len": len(value_str),
+            "has_quick_win_class": 'class="quick-win' in value_str,
+            "has_rendered_marker": 'data-qw-json-rendered="true"' in value_str,
+        }
+
+    # Determine template_mode
+    right_len = len(str(sections.get("QUICK_WINS_HTML_RIGHT", "") or ""))
+    left_len = len(str(sections.get("QUICK_WINS_HTML_LEFT", "") or ""))
+    full_len = len(str(sections.get("QUICK_WINS_HTML", "") or ""))
+
+    if right_len > 0:
+        template_mode = "LEFT_RIGHT"
+    elif left_len > 0:
+        template_mode = "LEFT_ONLY"
+    elif full_len > 0:
+        template_mode = "FULL"
+    else:
+        template_mode = "NONE"
+
+    result["template_mode"] = template_mode
+
+    # Add timestamp for reference
+    from datetime import datetime
+    result["captured_at"] = datetime.utcnow().isoformat() + "Z"
+
+    return json.dumps(result, indent=2, ensure_ascii=False)
+
+
+def build_debug_503d_attachments(
+    final_html: str,
+    sections: Dict[str, Any],
+    canonical_kpis: Optional[Dict[str, Any]] = None
+) -> List[Dict[str, Any]]:
+    """
+    Build DEBUG-503D artifacts for admin email attachments.
+
+    This function should be called right before PDF render, after all post-processing,
+    when FINAL HTML is ready. This ensures attachments reflect exactly what the PDF
+    renderer uses.
+
+    Args:
+        final_html: The final rendered HTML (after all post-processing)
+        sections: Dict with section data including QUICK_WINS_HTML variants
+        canonical_kpis: Dict with canonical KPI values (PAYBACK_MONTHS, etc.)
+
+    Returns:
+        List of attachment dicts: [{filename, content (bytes), mimetype}, ...]
+    """
+    if not is_debug_render_enabled():
+        return []
+
+    attachments = []
+    total_bytes = 0
+
+    try:
+        # 1. Quick Wins block HTML
+        qw_html = _build_quick_wins_snippet(final_html)
+        qw_bytes = qw_html.encode("utf-8")
+        attachments.append({
+            "filename": "debug_503d_quick_wins_block.html",
+            "content": qw_bytes,
+            "mimetype": "text/html"
+        })
+        total_bytes += len(qw_bytes)
+
+        # 2. Risk Matrix block HTML
+        rm_html = _build_risk_matrix_snippet(final_html)
+        rm_bytes = rm_html.encode("utf-8")
+        attachments.append({
+            "filename": "debug_503d_risk_matrix_block.html",
+            "content": rm_bytes,
+            "mimetype": "text/html"
+        })
+        total_bytes += len(rm_bytes)
+
+        # 3. Payback mentions txt
+        payback_txt = _build_payback_mentions(final_html, canonical_kpis)
+        payback_bytes = payback_txt.encode("utf-8")
+        attachments.append({
+            "filename": "debug_503d_payback_mentions.txt",
+            "content": payback_bytes,
+            "mimetype": "text/plain"
+        })
+        total_bytes += len(payback_bytes)
+
+        # 4. Quick Wins keys JSON
+        qw_keys_json = _build_quick_wins_keys_json(sections)
+        qw_keys_bytes = qw_keys_json.encode("utf-8")
+        attachments.append({
+            "filename": "debug_503d_quick_wins_keys.json",
+            "content": qw_keys_bytes,
+            "mimetype": "application/json"
+        })
+        total_bytes += len(qw_keys_bytes)
+
+        # Log the collection (must appear in Railway logs)
+        log.info(
+            "[DEBUG-503D][MAIL] attaching 4 artifacts: "
+            "quick_wins_block.html, risk_matrix_block.html, payback_mentions.txt, quick_wins_keys.json "
+            "(total_bytes=%d)",
+            total_bytes
+        )
+
+    except Exception as e:
+        log.error("[DEBUG-503D] Failed to build debug attachments: %s", str(e))
+        return []
+
+    return attachments

--- a/services/report_renderer.py
+++ b/services/report_renderer.py
@@ -23,6 +23,7 @@ from services.html_sanitizer import sanitize_en_locale_tokens
 from services.lang_utils import normalize_lang
 from services.i18n import ui as ui_factory
 from services.locale_rewriter import apply_locale_v2
+from services.debug_503d import build_debug_503d_attachments, is_debug_render_enabled
 
 log = logging.getLogger(__name__)
 
@@ -833,5 +834,28 @@ def render(briefing_obj: Any,
     # Add report metadata for PDF footer
     meta["report_id"] = ctx.get("report_id", "")
     meta["report_date"] = ctx.get("report_date", "")
+
+    # =========================================================================
+    # DEBUG-503D: Build debug attachments when DEBUG_RENDER=1
+    # Collect right before return, after all post-processing, when FINAL HTML is ready.
+    # =========================================================================
+    if is_debug_render_enabled():
+        # Build canonical KPIs dict for payback mentions
+        canonical_kpis = {
+            "PAYBACK_MONTHS": sections.get("PAYBACK_MONTHS"),
+            "CAPEX_REALISTISCH_EUR": sections.get("CAPEX_REALISTISCH_EUR"),
+            "OPEX_REALISTISCH_EUR": sections.get("OPEX_REALISTISCH_EUR"),
+            "EINSPARUNG_MONAT_EUR": sections.get("EINSPARUNG_MONAT_EUR"),
+        }
+
+        debug_attachments = build_debug_503d_attachments(
+            final_html=html,
+            sections=sections,
+            canonical_kpis=canonical_kpis
+        )
+
+        if debug_attachments:
+            meta["debug_503d_attachments"] = debug_attachments
+            log.info(f"[DEBUG-503D] Collected {len(debug_attachments)} debug artifacts for admin email")
 
     return {"html": html, "meta": meta or {}}

--- a/services/risk_engine_v2.py
+++ b/services/risk_engine_v2.py
@@ -1063,6 +1063,7 @@ def risk_report_to_html(
     # L1: Added colgroup for column width control, class for CSS targeting
     # FIX-503B: Changed to table-layout:auto for better text wrapping in WeasyPrint
     if report.risk_matrix:
+        html_parts.append('<!-- DEBUG-ANCHOR: RISK_MATRIX_START -->')
         html_parts.append(f'''
         <div class="risk-block matrix-block risk-matrix-section" style="margin-bottom:20px;">
             <p style="margin:0 0 12px 0;font-weight:600;color:#1e293b;">{labels["matrix_title"]}</p>
@@ -1099,6 +1100,7 @@ def risk_report_to_html(
                 ''')
 
         html_parts.append('</table></div>')
+        html_parts.append('<!-- DEBUG-ANCHOR: RISK_MATRIX_END -->')
 
     # Consolidated Score Block
     html_parts.append(f'''

--- a/templates/pdf_template.html
+++ b/templates/pdf_template.html
@@ -6659,6 +6659,7 @@
 
                 <!-- QUICK WINS - FIX-498 WP2: Conditional render -->
                 {% if QUICK_WINS_HTML and QUICK_WINS_HTML|trim and '<' in QUICK_WINS_HTML %}
+                <!-- DEBUG-ANCHOR: QUICK_WINS_DETAIL_START -->
                 <section class="section chapter" style="page-break-before: auto;">
                     <div class="section-header">
                         <div class="section-title">
@@ -6675,6 +6676,7 @@
                         {{ QUICK_WINS_HTML|safe }}
                     </div>
                 </section>
+                <!-- DEBUG-ANCHOR: QUICK_WINS_DETAIL_END -->
                 {% endif %}
                 <!-- SPRINT G19: Branch Profile & Market Intelligence -->
                 {% if BRANCH_PROFILE_HTML %}

--- a/templates/pdf_template_en.html
+++ b/templates/pdf_template_en.html
@@ -6402,6 +6402,7 @@
 
                 <!-- QUICK WINS - FIX-498 WP2: Conditional render -->
                 {% if QUICK_WINS_HTML and QUICK_WINS_HTML|trim and '<' in QUICK_WINS_HTML %}
+                <!-- DEBUG-ANCHOR: QUICK_WINS_DETAIL_START -->
                 <section class="section chapter" style="page-break-before: auto;">
                     <div class="section-header">
                         <div class="section-title">
@@ -6417,6 +6418,7 @@
                         {{ QUICK_WINS_HTML|safe }}
                     </div>
                 </section>
+                <!-- DEBUG-ANCHOR: QUICK_WINS_DETAIL_END -->
                 {% endif %}
                 <!-- SPRINT G19: Branch Profile & Market Intelligence -->
                 {% if BRANCH_PROFILE_HTML %}

--- a/tests/test_debug_503d.py
+++ b/tests/test_debug_503d.py
@@ -1,0 +1,380 @@
+# -*- coding: utf-8 -*-
+"""
+Tests for DEBUG-503D artifact collection module.
+
+Tests verify:
+1. build_debug_503d_attachments returns 4 attachments with correct filenames
+2. quick_wins_keys.json contains expected fields
+3. payback_mentions.txt includes canonical line
+"""
+import json
+import os
+import pytest
+from unittest.mock import patch
+
+
+class TestDebug503DAttachments:
+    """Tests for build_debug_503d_attachments function."""
+
+    @pytest.fixture
+    def sample_html_with_anchors(self):
+        """Sample HTML with debug anchors."""
+        return """
+<!DOCTYPE html>
+<html>
+<head><title>Test Report</title></head>
+<body>
+    <!-- DEBUG-ANCHOR: QUICK_WINS_DETAIL_START -->
+    <section class="section chapter">
+        <div class="section-header">
+            <h2>Quick Wins</h2>
+        </div>
+        <div class="section-body">
+            <div class="quick-win" data-qw-json-rendered="true">
+                <h3>Quick Win 1</h3>
+                <p>Description with Payback: 6 Monate</p>
+            </div>
+        </div>
+    </section>
+    <!-- DEBUG-ANCHOR: QUICK_WINS_DETAIL_END -->
+
+    <!-- DEBUG-ANCHOR: RISK_MATRIX_START -->
+    <div class="risk-block matrix-block risk-matrix-section">
+        <p>Risiko-Matrix</p>
+        <table class="table-modern" style="table-layout:auto;">
+            <tr><td>Risiko</td><td>L</td><td>I</td><td>Score</td></tr>
+            <tr><td>Risk 1</td><td>3</td><td>4</td><td>12</td></tr>
+        </table>
+    </div>
+    <!-- DEBUG-ANCHOR: RISK_MATRIX_END -->
+
+    <p>Amortisation in 8 Monaten erwartet.</p>
+    <p>Payback period is approximately 6-8 months.</p>
+</body>
+</html>
+"""
+
+    @pytest.fixture
+    def sample_sections(self):
+        """Sample sections dict."""
+        return {
+            "QUICK_WINS_HTML": '<div class="quick-win" data-qw-json-rendered="true">Content</div>',
+            "QUICK_WINS_HTML_LEFT": "",
+            "QUICK_WINS_HTML_RIGHT": "",
+            "quick_wins": "[{\"title\": \"Test\"}]",
+            "PAYBACK_MONTHS": 6.5,
+            "CAPEX_REALISTISCH_EUR": 15000,
+            "OPEX_REALISTISCH_EUR": 500,
+            "EINSPARUNG_MONAT_EUR": 2500,
+        }
+
+    @pytest.fixture
+    def sample_canonical_kpis(self):
+        """Sample canonical KPIs dict."""
+        return {
+            "PAYBACK_MONTHS": 6.5,
+            "CAPEX_REALISTISCH_EUR": 15000,
+            "OPEX_REALISTISCH_EUR": 500,
+            "EINSPARUNG_MONAT_EUR": 2500,
+        }
+
+    @patch.dict(os.environ, {"DEBUG_RENDER": "1"})
+    def test_returns_4_attachments(self, sample_html_with_anchors, sample_sections, sample_canonical_kpis):
+        """Test that build_debug_503d_attachments returns exactly 4 attachments."""
+        from services.debug_503d import build_debug_503d_attachments
+
+        attachments = build_debug_503d_attachments(
+            final_html=sample_html_with_anchors,
+            sections=sample_sections,
+            canonical_kpis=sample_canonical_kpis
+        )
+
+        assert len(attachments) == 4, f"Expected 4 attachments, got {len(attachments)}"
+
+    @patch.dict(os.environ, {"DEBUG_RENDER": "1"})
+    def test_correct_filenames(self, sample_html_with_anchors, sample_sections, sample_canonical_kpis):
+        """Test that attachments have correct filenames."""
+        from services.debug_503d import build_debug_503d_attachments
+
+        attachments = build_debug_503d_attachments(
+            final_html=sample_html_with_anchors,
+            sections=sample_sections,
+            canonical_kpis=sample_canonical_kpis
+        )
+
+        expected_filenames = [
+            "debug_503d_quick_wins_block.html",
+            "debug_503d_risk_matrix_block.html",
+            "debug_503d_payback_mentions.txt",
+            "debug_503d_quick_wins_keys.json",
+        ]
+
+        actual_filenames = [att["filename"] for att in attachments]
+        assert actual_filenames == expected_filenames, f"Filenames mismatch: {actual_filenames}"
+
+    @patch.dict(os.environ, {"DEBUG_RENDER": "1"})
+    def test_quick_wins_keys_json_fields(self, sample_html_with_anchors, sample_sections, sample_canonical_kpis):
+        """Test that quick_wins_keys.json contains expected fields."""
+        from services.debug_503d import build_debug_503d_attachments
+
+        attachments = build_debug_503d_attachments(
+            final_html=sample_html_with_anchors,
+            sections=sample_sections,
+            canonical_kpis=sample_canonical_kpis
+        )
+
+        # Find the JSON attachment
+        json_att = next(a for a in attachments if a["filename"] == "debug_503d_quick_wins_keys.json")
+        data = json.loads(json_att["content"].decode("utf-8"))
+
+        # Check required keys exist
+        expected_keys = [
+            "QUICK_WINS_HTML",
+            "QUICK_WINS_HTML_LEFT",
+            "QUICK_WINS_HTML_RIGHT",
+            "quick_wins",
+            "template_mode",
+            "captured_at",
+        ]
+        for key in expected_keys:
+            assert key in data, f"Missing key: {key}"
+
+        # Check each QW key has required fields
+        for qw_key in ["QUICK_WINS_HTML", "QUICK_WINS_HTML_LEFT", "QUICK_WINS_HTML_RIGHT", "quick_wins"]:
+            assert "len" in data[qw_key], f"Missing 'len' in {qw_key}"
+            assert "has_quick_win_class" in data[qw_key], f"Missing 'has_quick_win_class' in {qw_key}"
+            assert "has_rendered_marker" in data[qw_key], f"Missing 'has_rendered_marker' in {qw_key}"
+
+    @patch.dict(os.environ, {"DEBUG_RENDER": "1"})
+    def test_quick_wins_keys_template_mode(self, sample_html_with_anchors, sample_sections, sample_canonical_kpis):
+        """Test template_mode detection in quick_wins_keys.json."""
+        from services.debug_503d import build_debug_503d_attachments
+
+        attachments = build_debug_503d_attachments(
+            final_html=sample_html_with_anchors,
+            sections=sample_sections,
+            canonical_kpis=sample_canonical_kpis
+        )
+
+        json_att = next(a for a in attachments if a["filename"] == "debug_503d_quick_wins_keys.json")
+        data = json.loads(json_att["content"].decode("utf-8"))
+
+        # With QUICK_WINS_HTML set and LEFT/RIGHT empty, should be FULL
+        assert data["template_mode"] == "FULL", f"Expected FULL, got {data['template_mode']}"
+
+    @patch.dict(os.environ, {"DEBUG_RENDER": "1"})
+    def test_payback_mentions_canonical_line(self, sample_html_with_anchors, sample_sections, sample_canonical_kpis):
+        """Test that payback_mentions.txt includes canonical PAYBACK_MONTHS line."""
+        from services.debug_503d import build_debug_503d_attachments
+
+        attachments = build_debug_503d_attachments(
+            final_html=sample_html_with_anchors,
+            sections=sample_sections,
+            canonical_kpis=sample_canonical_kpis
+        )
+
+        txt_att = next(a for a in attachments if a["filename"] == "debug_503d_payback_mentions.txt")
+        content = txt_att["content"].decode("utf-8")
+
+        # Check canonical line exists (German format: 6,5)
+        assert "CANONICAL PAYBACK_MONTHS:" in content
+        assert "6,5" in content, f"Expected German formatted '6,5' in content"
+
+    @patch.dict(os.environ, {"DEBUG_RENDER": "1"})
+    def test_payback_mentions_finds_occurrences(self, sample_html_with_anchors, sample_sections, sample_canonical_kpis):
+        """Test that payback_mentions.txt finds Payback/Amortisation occurrences."""
+        from services.debug_503d import build_debug_503d_attachments
+
+        attachments = build_debug_503d_attachments(
+            final_html=sample_html_with_anchors,
+            sections=sample_sections,
+            canonical_kpis=sample_canonical_kpis
+        )
+
+        txt_att = next(a for a in attachments if a["filename"] == "debug_503d_payback_mentions.txt")
+        content = txt_att["content"].decode("utf-8")
+
+        # Should find "Payback" and "Amortisation" occurrences
+        # Check that markers >>> and <<< are present (they mark match positions)
+        assert ">>>" in content and "<<<" in content
+        assert "TOTAL MATCHES:" in content
+        # Check that matches were actually found
+        assert "TOTAL MATCHES: 0" not in content, "Should find at least one Payback/Amortisation occurrence"
+
+    @patch.dict(os.environ, {"DEBUG_RENDER": "1"})
+    def test_quick_wins_snippet_extraction(self, sample_html_with_anchors, sample_sections, sample_canonical_kpis):
+        """Test that quick_wins_block.html extracts content via anchors."""
+        from services.debug_503d import build_debug_503d_attachments
+
+        attachments = build_debug_503d_attachments(
+            final_html=sample_html_with_anchors,
+            sections=sample_sections,
+            canonical_kpis=sample_canonical_kpis
+        )
+
+        html_att = next(a for a in attachments if a["filename"] == "debug_503d_quick_wins_block.html")
+        content = html_att["content"].decode("utf-8")
+
+        # Should contain the Quick Wins section content
+        assert "Quick Wins" in content or "quick-win" in content
+        assert "anchors" in content.lower() or "section" in content.lower()
+
+    @patch.dict(os.environ, {"DEBUG_RENDER": "1"})
+    def test_risk_matrix_snippet_has_css(self, sample_html_with_anchors, sample_sections, sample_canonical_kpis):
+        """Test that risk_matrix_block.html includes CSS styles."""
+        from services.debug_503d import build_debug_503d_attachments
+
+        attachments = build_debug_503d_attachments(
+            final_html=sample_html_with_anchors,
+            sections=sample_sections,
+            canonical_kpis=sample_canonical_kpis
+        )
+
+        html_att = next(a for a in attachments if a["filename"] == "debug_503d_risk_matrix_block.html")
+        content = html_att["content"].decode("utf-8")
+
+        # Should contain CSS styles
+        assert "<style>" in content
+        assert "table-layout" in content
+
+    @patch.dict(os.environ, {"DEBUG_RENDER": "0"})
+    def test_returns_empty_when_disabled(self, sample_html_with_anchors, sample_sections, sample_canonical_kpis):
+        """Test that no attachments are returned when DEBUG_RENDER is not '1'."""
+        from services.debug_503d import build_debug_503d_attachments
+
+        attachments = build_debug_503d_attachments(
+            final_html=sample_html_with_anchors,
+            sections=sample_sections,
+            canonical_kpis=sample_canonical_kpis
+        )
+
+        assert len(attachments) == 0, "Should return empty list when DEBUG_RENDER != 1"
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_returns_empty_when_env_not_set(self, sample_html_with_anchors, sample_sections, sample_canonical_kpis):
+        """Test that no attachments are returned when DEBUG_RENDER env var is not set."""
+        # Ensure DEBUG_RENDER is not set
+        if "DEBUG_RENDER" in os.environ:
+            del os.environ["DEBUG_RENDER"]
+
+        from services.debug_503d import build_debug_503d_attachments
+
+        attachments = build_debug_503d_attachments(
+            final_html=sample_html_with_anchors,
+            sections=sample_sections,
+            canonical_kpis=sample_canonical_kpis
+        )
+
+        assert len(attachments) == 0, "Should return empty list when DEBUG_RENDER not set"
+
+    @patch.dict(os.environ, {"DEBUG_RENDER": "1"})
+    def test_attachments_have_mimetype(self, sample_html_with_anchors, sample_sections, sample_canonical_kpis):
+        """Test that all attachments have mimetype field."""
+        from services.debug_503d import build_debug_503d_attachments
+
+        attachments = build_debug_503d_attachments(
+            final_html=sample_html_with_anchors,
+            sections=sample_sections,
+            canonical_kpis=sample_canonical_kpis
+        )
+
+        for att in attachments:
+            assert "mimetype" in att, f"Attachment {att['filename']} missing mimetype"
+            assert att["mimetype"] is not None
+
+
+class TestIsDebugRenderEnabled:
+    """Tests for is_debug_render_enabled function."""
+
+    @patch.dict(os.environ, {"DEBUG_RENDER": "1"})
+    def test_enabled_with_1(self):
+        from services.debug_503d import is_debug_render_enabled
+        assert is_debug_render_enabled() is True
+
+    @patch.dict(os.environ, {"DEBUG_RENDER": "0"})
+    def test_disabled_with_0(self):
+        from services.debug_503d import is_debug_render_enabled
+        assert is_debug_render_enabled() is False
+
+    @patch.dict(os.environ, {"DEBUG_RENDER": "true"})
+    def test_disabled_with_true_string(self):
+        """DEBUG_RENDER only activates with '1', not 'true'."""
+        from services.debug_503d import is_debug_render_enabled
+        assert is_debug_render_enabled() is False
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_disabled_when_not_set(self):
+        if "DEBUG_RENDER" in os.environ:
+            del os.environ["DEBUG_RENDER"]
+        from services.debug_503d import is_debug_render_enabled
+        assert is_debug_render_enabled() is False
+
+
+class TestTemplateMode:
+    """Tests for template_mode detection in quick_wins_keys.json."""
+
+    @patch.dict(os.environ, {"DEBUG_RENDER": "1"})
+    def test_left_right_mode(self):
+        """Test LEFT_RIGHT mode when QUICK_WINS_HTML_RIGHT has content."""
+        from services.debug_503d import build_debug_503d_attachments
+
+        sections = {
+            "QUICK_WINS_HTML": "",
+            "QUICK_WINS_HTML_LEFT": "left content",
+            "QUICK_WINS_HTML_RIGHT": "right content",
+            "quick_wins": "",
+        }
+
+        attachments = build_debug_503d_attachments(
+            final_html="<html></html>",
+            sections=sections,
+            canonical_kpis={}
+        )
+
+        json_att = next(a for a in attachments if a["filename"] == "debug_503d_quick_wins_keys.json")
+        data = json.loads(json_att["content"].decode("utf-8"))
+        assert data["template_mode"] == "LEFT_RIGHT"
+
+    @patch.dict(os.environ, {"DEBUG_RENDER": "1"})
+    def test_left_only_mode(self):
+        """Test LEFT_ONLY mode when only QUICK_WINS_HTML_LEFT has content."""
+        from services.debug_503d import build_debug_503d_attachments
+
+        sections = {
+            "QUICK_WINS_HTML": "",
+            "QUICK_WINS_HTML_LEFT": "left content",
+            "QUICK_WINS_HTML_RIGHT": "",
+            "quick_wins": "",
+        }
+
+        attachments = build_debug_503d_attachments(
+            final_html="<html></html>",
+            sections=sections,
+            canonical_kpis={}
+        )
+
+        json_att = next(a for a in attachments if a["filename"] == "debug_503d_quick_wins_keys.json")
+        data = json.loads(json_att["content"].decode("utf-8"))
+        assert data["template_mode"] == "LEFT_ONLY"
+
+    @patch.dict(os.environ, {"DEBUG_RENDER": "1"})
+    def test_none_mode(self):
+        """Test NONE mode when no Quick Wins content."""
+        from services.debug_503d import build_debug_503d_attachments
+
+        sections = {
+            "QUICK_WINS_HTML": "",
+            "QUICK_WINS_HTML_LEFT": "",
+            "QUICK_WINS_HTML_RIGHT": "",
+            "quick_wins": "",
+        }
+
+        attachments = build_debug_503d_attachments(
+            final_html="<html></html>",
+            sections=sections,
+            canonical_kpis={}
+        )
+
+        json_att = next(a for a in attachments if a["filename"] == "debug_503d_quick_wins_keys.json")
+        data = json.loads(json_att["content"].decode("utf-8"))
+        assert data["template_mode"] == "NONE"


### PR DESCRIPTION
When DEBUG_RENDER=1 env var is set, attach 4 debug artifacts to admin notification emails for forensic debugging of PDF rendering issues:

1. debug_503d_quick_wins_block.html - Final rendered Quick Wins section
2. debug_503d_risk_matrix_block.html - Final rendered Risk Matrix with CSS
3. debug_503d_payback_mentions.txt - Canonical PAYBACK_MONTHS + all occurrences
4. debug_503d_quick_wins_keys.json - Lengths + marker presence for QW keys

Implementation:
- Add services/debug_503d.py with build_debug_503d_attachments() helper
- Add DEBUG-ANCHOR comments to templates for reliable extraction
- Integrate into report_renderer.py to collect artifacts after post-processing
- Hook into _send_emails() in gpt_analyze.py to attach to admin emails
- Add comprehensive unit tests (18 tests)

Artifacts are only collected when DEBUG_RENDER=1, keeping normal pipeline behavior unchanged when the flag is off.