### PR TITLE
fix(debug-503d): prevent bytes-in-JSON crash (Postgres JSONB)

### DIFF
--- a/gpt_analyze.py
+++ b/gpt_analyze.py
@@ -12357,8 +12357,16 @@ def _generate_content_sections(briefing: Dict[str, Any], scores: Dict[str, Any])
 
 
 # -------------------- pipeline (kept from original with minor logging updates) ----------------
-def analyze_briefing(db: Session, briefing_id: int, run_id: str) -> tuple[int, str, Dict[str, Any]]:
-    """Analyze briefing and generate AI report."""
+def analyze_briefing(db: Session, briefing_id: int, run_id: str) -> tuple[int, str, Dict[str, Any], Optional[List[Dict[str, Any]]]]:
+    """Analyze briefing and generate AI report.
+
+    Returns:
+        Tuple of (analysis_id, html, meta, debug_attachments)
+        - analysis_id: ID of the created Analysis record
+        - html: Final rendered HTML
+        - meta: Metadata dict (JSON-safe, stored in DB)
+        - debug_attachments: DEBUG-503D artifacts with bytes (for email only, NOT stored in DB)
+    """
     # === HARD STOP ARCHITECTURE: Initialize error gate ===
     error_gate = ReportErrorGate(run_id=run_id)
     set_error_gate(error_gate)  # Make available to worker threads
@@ -14519,7 +14527,8 @@ NUR HTML ausgeben. Keine Erklärungen, keine Markdown-Fences."""
     db.refresh(an)
     
     log.info("[%s] ✅ Analysis created (v5.4.3-PLATIN+++): id=%s", run_id, an.id)
-    return an.id, result["html"], result.get("meta", {})
+    # Return 4 values: debug_attachments contains bytes for email (NOT stored in DB)
+    return an.id, result["html"], result.get("meta", {}), result.get("debug_attachments")
 
 # -------------------- briefing summary for admin ----------------
 def _build_briefing_summary_html(br: Briefing, rep: Report, user_email: str) -> str:
@@ -14651,8 +14660,13 @@ def _extract_scores_from_report(rep: Report) -> Dict[str, int]:
         return default_scores
 
 
-def _send_emails(db: Session, rep: Report, br: Briefing, pdf_url: Optional[str], pdf_bytes: Optional[bytes], run_id: str, meta: Optional[Dict[str, Any]] = None) -> None:
-    """Send emails via Resend API"""
+def _send_emails(db: Session, rep: Report, br: Briefing, pdf_url: Optional[str], pdf_bytes: Optional[bytes], run_id: str, meta: Optional[Dict[str, Any]] = None, debug_attachments: Optional[List[Dict[str, Any]]] = None) -> None:
+    """Send emails via Resend API.
+
+    Args:
+        debug_attachments: DEBUG-503D artifacts (with bytes) for admin email.
+                          Passed separately to avoid storing bytes in DB.
+    """
     # Global Email Kill-Switch
     if os.getenv("DISABLE_EMAILS", "").lower() in ("1", "true", "yes", "on"):
         log.info("[%s] 📧 Emails disabled via DISABLE_EMAILS=1. Skipping user/admin email send.", run_id)
@@ -14691,16 +14705,17 @@ def _send_emails(db: Session, rep: Report, br: Briefing, pdf_url: Optional[str],
         log.warning("[%s] ⚠️ Could not create briefing JSON attachment: %s", run_id, str(e))
 
     # DEBUG-503D: Attach debug artifacts when DEBUG_RENDER=1
-    if meta and meta.get("debug_503d_attachments"):
+    # NOTE: debug_attachments is passed as a parameter (contains bytes), NOT read from meta
+    # This ensures bytes are never stored in meta which gets persisted to Postgres JSONB
+    if debug_attachments:
         try:
-            debug_attachments = meta["debug_503d_attachments"]
             for att in debug_attachments:
                 attachments_admin.append(att)
             total_debug_bytes = sum(len(a.get("content", b"")) for a in debug_attachments)
             log.info(
-                "[%s] [DEBUG-503D][MAIL] attaching 4 artifacts: "
+                "[%s] [DEBUG-503D][MAIL] attaching %d artifacts: "
                 "quick_wins_block.html, risk_matrix_block.html, payback_mentions.txt, quick_wins_keys.json "
-                "(total_bytes=%d)", run_id, total_debug_bytes
+                "(total_bytes=%d)", run_id, len(debug_attachments), total_debug_bytes
             )
         except Exception as debug_exc:
             log.warning("[%s] ⚠️ Could not attach DEBUG-503D artifacts: %s", run_id, str(debug_exc))
@@ -14787,7 +14802,8 @@ def run_briefing_pipeline(db: Session, briefing_id: int, email: Optional[str] = 
         log.info("[%s] 🚀 Starting analysis v5.4.3-PLATIN+++ for briefing_id=%s (worker mode)", run_id, briefing_id)
 
         # Core analysis pipeline
-        an_id, html, meta = analyze_briefing(db, briefing_id, run_id=run_id)
+        # debug_attachments contains bytes for email - NOT stored in DB (would cause JSON serialize error)
+        an_id, html, meta, debug_attachments = analyze_briefing(db, briefing_id, run_id=run_id)
 
         br = db.get(Briefing, briefing_id)
         if not br:
@@ -14869,7 +14885,8 @@ def run_briefing_pipeline(db: Session, briefing_id: int, email: Optional[str] = 
         db.refresh(rep)
 
         # Send notification emails
-        _send_emails(db, rep, br, pdf_url, pdf_bytes, run_id, meta=meta)
+        # Pass debug_attachments (bytes) directly - NOT stored in DB/meta
+        _send_emails(db, rep, br, pdf_url, pdf_bytes, run_id, meta=meta, debug_attachments=debug_attachments)
 
         log.info("[%s] ✅ Pipeline complete for briefing_id=%s", run_id, briefing_id)
 
@@ -14893,7 +14910,8 @@ def run_async(briefing_id: int, email: Optional[str] = None) -> None:
     rep: Optional[Report] = None
     try:
         log.info("[%s] 🚀 Starting analysis v5.4.3-PLATIN+++ for briefing_id=%s", run_id, briefing_id)
-        an_id, html, meta = analyze_briefing(db, briefing_id, run_id=run_id)
+        # debug_attachments contains bytes for email - NOT stored in DB (would cause JSON serialize error)
+        an_id, html, meta, debug_attachments = analyze_briefing(db, briefing_id, run_id=run_id)
         br = db.get(Briefing, briefing_id)
         rep = Report(
             user_id=br.user_id if br else None, 
@@ -14968,7 +14986,8 @@ def run_async(briefing_id: int, email: Optional[str] = None) -> None:
         db.commit()
         db.refresh(rep)
 
-        _send_emails(db, rep, br, pdf_url, pdf_bytes, run_id, meta=meta)
+        # Pass debug_attachments (bytes) directly - NOT stored in DB/meta
+        _send_emails(db, rep, br, pdf_url, pdf_bytes, run_id, meta=meta, debug_attachments=debug_attachments)
 
     except Exception as exc:
         log.error("[%s] ❌ Analysis failed: %s", run_id, exc, exc_info=True)

--- a/services/debug_503d.py
+++ b/services/debug_503d.py
@@ -8,7 +8,12 @@ When DEBUG_RENDER=1, this module builds 4 debug artifacts:
 4. debug_503d_quick_wins_keys.json - Lengths + marker presence for QW keys
 
 These artifacts attach to admin emails for forensic debugging of PDF rendering issues.
+
+IMPORTANT: The raw bytes are passed directly to the email function - they are NEVER
+stored in meta/sections that get persisted to the database (Postgres JSONB can't serialize bytes).
+Only JSON-safe metadata (filenames, sizes, sha256) is stored in meta["debug_503d_summary"].
 """
+import hashlib
 import json
 import logging
 import os
@@ -399,3 +404,83 @@ def build_debug_503d_attachments(
         return []
 
     return attachments
+
+
+def build_debug_503d_summary(attachments: List[Dict[str, Any]]) -> Dict[str, Any]:
+    """
+    Build a JSON-serializable summary of debug attachments for database storage.
+
+    This function extracts metadata from debug attachments (which contain bytes)
+    and returns a JSON-safe dict that can be stored in Postgres JSONB fields.
+
+    IMPORTANT: The raw bytes must NEVER be stored in the database.
+    Only this summary is stored in meta["debug_503d_summary"].
+
+    Args:
+        attachments: List of attachment dicts from build_debug_503d_attachments()
+                     Each has: {filename, content (bytes), mimetype}
+
+    Returns:
+        JSON-serializable dict with metadata:
+        {
+            "artifact_count": 4,
+            "artifacts": [
+                {"filename": "...", "size_bytes": 1234, "sha256": "abc123...", "mimetype": "..."},
+                ...
+            ],
+            "total_bytes": 5678,
+            "captured_at": "2024-01-15T12:00:00Z"
+        }
+    """
+    if not attachments:
+        return {}
+
+    from datetime import datetime
+
+    artifacts_meta = []
+    total_bytes = 0
+
+    for att in attachments:
+        content = att.get("content", b"")
+        if isinstance(content, bytes):
+            size = len(content)
+            sha256 = hashlib.sha256(content).hexdigest()
+            # Optional short preview for text files (first 200 chars)
+            preview = None
+            if att.get("mimetype", "").startswith("text/") or att.get("filename", "").endswith((".txt", ".json", ".html")):
+                try:
+                    text = content.decode("utf-8", errors="replace")
+                    preview = text[:200] + ("..." if len(text) > 200 else "")
+                except Exception:
+                    preview = None
+        else:
+            # Already a string (shouldn't happen, but handle gracefully)
+            size = len(str(content))
+            sha256 = hashlib.sha256(str(content).encode("utf-8")).hexdigest()
+            preview = str(content)[:200] + ("..." if len(str(content)) > 200 else "")
+
+        artifact_info: Dict[str, Any] = {
+            "filename": att.get("filename", "unknown"),
+            "size_bytes": size,
+            "sha256": sha256,
+            "mimetype": att.get("mimetype", "application/octet-stream"),
+        }
+        if preview:
+            artifact_info["preview"] = preview
+
+        artifacts_meta.append(artifact_info)
+        total_bytes += size
+
+    result: Dict[str, Any] = {
+        "artifact_count": len(artifacts_meta),
+        "artifacts": artifacts_meta,
+        "total_bytes": total_bytes,
+        "captured_at": datetime.utcnow().isoformat() + "Z",
+    }
+
+    log.info(
+        "[DEBUG-503D] Built JSON-safe summary: %d artifacts, %d total bytes",
+        len(artifacts_meta), total_bytes
+    )
+
+    return result

--- a/services/report_renderer.py
+++ b/services/report_renderer.py
@@ -23,7 +23,7 @@ from services.html_sanitizer import sanitize_en_locale_tokens
 from services.lang_utils import normalize_lang
 from services.i18n import ui as ui_factory
 from services.locale_rewriter import apply_locale_v2
-from services.debug_503d import build_debug_503d_attachments, is_debug_render_enabled
+from services.debug_503d import build_debug_503d_attachments, build_debug_503d_summary, is_debug_render_enabled
 
 log = logging.getLogger(__name__)
 
@@ -838,7 +838,11 @@ def render(briefing_obj: Any,
     # =========================================================================
     # DEBUG-503D: Build debug attachments when DEBUG_RENDER=1
     # Collect right before return, after all post-processing, when FINAL HTML is ready.
+    # IMPORTANT: Raw bytes are returned separately - they must NEVER be stored in meta
+    # (Postgres JSONB can't serialize bytes objects).
     # =========================================================================
+    debug_attachments_for_email = None  # Will hold bytes for email, NOT persisted to DB
+
     if is_debug_render_enabled():
         # Build canonical KPIs dict for payback mentions
         canonical_kpis = {
@@ -855,7 +859,13 @@ def render(briefing_obj: Any,
         )
 
         if debug_attachments:
-            meta["debug_503d_attachments"] = debug_attachments
+            # Store ONLY JSON-safe summary in meta (for DB persistence)
+            # Contains: filenames, sizes, sha256 hashes, previews - NO raw bytes
+            meta["debug_503d_summary"] = build_debug_503d_summary(debug_attachments)
+
+            # Return raw bytes separately for email attachments (NOT stored in DB)
+            debug_attachments_for_email = debug_attachments
+
             log.info(f"[DEBUG-503D] Collected {len(debug_attachments)} debug artifacts for admin email")
 
-    return {"html": html, "meta": meta or {}}
+    return {"html": html, "meta": meta or {}, "debug_attachments": debug_attachments_for_email}

--- a/tests/test_debug_503d.py
+++ b/tests/test_debug_503d.py
@@ -378,3 +378,173 @@ class TestTemplateMode:
         json_att = next(a for a in attachments if a["filename"] == "debug_503d_quick_wins_keys.json")
         data = json.loads(json_att["content"].decode("utf-8"))
         assert data["template_mode"] == "NONE"
+
+
+class TestDebug503DSummaryJsonSerializable:
+    """Tests for DEBUG-503D JSON serialization safety (prevents bytes-in-JSONB crash)."""
+
+    @pytest.fixture
+    def sample_html_with_anchors(self):
+        """Sample HTML with debug anchors."""
+        return """
+<!DOCTYPE html>
+<html>
+<body>
+    <!-- DEBUG-ANCHOR: QUICK_WINS_DETAIL_START -->
+    <div class="quick-win">Test Quick Win</div>
+    <!-- DEBUG-ANCHOR: QUICK_WINS_DETAIL_END -->
+    <!-- DEBUG-ANCHOR: RISK_MATRIX_START -->
+    <table><tr><td>Risk</td></tr></table>
+    <!-- DEBUG-ANCHOR: RISK_MATRIX_END -->
+    <p>Payback: 6 Monate</p>
+</body>
+</html>
+"""
+
+    @pytest.fixture
+    def sample_sections(self):
+        """Sample sections dict."""
+        return {
+            "QUICK_WINS_HTML": '<div class="quick-win">Content</div>',
+            "QUICK_WINS_HTML_LEFT": "",
+            "QUICK_WINS_HTML_RIGHT": "",
+            "quick_wins": "[]",
+            "PAYBACK_MONTHS": 6.5,
+        }
+
+    @patch.dict(os.environ, {"DEBUG_RENDER": "1"})
+    def test_debug_503d_summary_is_json_serializable(self, sample_html_with_anchors, sample_sections):
+        """
+        Test that build_debug_503d_summary returns JSON-serializable data.
+
+        This is the CRITICAL test for DEBUG-503D Hotfix:
+        - build_debug_503d_attachments returns bytes (for email)
+        - build_debug_503d_summary returns JSON-safe metadata (for DB storage)
+        - The summary must be serializable to prevent "bytes not JSON serializable" error
+        """
+        from services.debug_503d import build_debug_503d_attachments, build_debug_503d_summary
+
+        # Build attachments (contains bytes)
+        attachments = build_debug_503d_attachments(
+            final_html=sample_html_with_anchors,
+            sections=sample_sections,
+            canonical_kpis={"PAYBACK_MONTHS": 6.5}
+        )
+
+        assert len(attachments) == 4, "Should have 4 debug attachments"
+
+        # Build summary (should be JSON-safe)
+        summary = build_debug_503d_summary(attachments)
+
+        # CRITICAL: This must not raise TypeError
+        try:
+            json_str = json.dumps(summary)
+        except TypeError as e:
+            pytest.fail(f"Summary is NOT JSON-serializable: {e}")
+
+        # Verify summary structure
+        assert "artifact_count" in summary
+        assert summary["artifact_count"] == 4
+        assert "artifacts" in summary
+        assert len(summary["artifacts"]) == 4
+        assert "total_bytes" in summary
+        assert "captured_at" in summary
+
+        # Verify each artifact has expected fields
+        for artifact in summary["artifacts"]:
+            assert "filename" in artifact
+            assert "size_bytes" in artifact
+            assert "sha256" in artifact
+            assert "mimetype" in artifact
+            # size_bytes should be an int
+            assert isinstance(artifact["size_bytes"], int)
+            # sha256 should be a string (hex)
+            assert isinstance(artifact["sha256"], str)
+            assert len(artifact["sha256"]) == 64  # SHA256 hex is 64 chars
+
+    @patch.dict(os.environ, {"DEBUG_RENDER": "1"})
+    def test_meta_with_summary_is_json_serializable(self, sample_html_with_anchors, sample_sections):
+        """
+        Test that the meta dict containing debug_503d_summary is JSON-serializable.
+
+        This simulates the actual flow where meta is stored in Analysis.meta (Postgres JSONB).
+        """
+        from services.debug_503d import build_debug_503d_attachments, build_debug_503d_summary
+
+        attachments = build_debug_503d_attachments(
+            final_html=sample_html_with_anchors,
+            sections=sample_sections,
+            canonical_kpis={"PAYBACK_MONTHS": 6.5}
+        )
+
+        # Simulate what report_renderer.py does
+        meta = {
+            "scores": {"overall": 75},
+            "report_id": "test-123",
+            "debug_503d_summary": build_debug_503d_summary(attachments)
+        }
+
+        # This is what would fail with the old code (debug_503d_attachments with bytes)
+        # It must pass now (debug_503d_summary without bytes)
+        try:
+            json_str = json.dumps(meta)
+            parsed = json.loads(json_str)
+        except TypeError as e:
+            pytest.fail(f"Meta dict is NOT JSON-serializable: {e}")
+
+        # Verify round-trip
+        assert parsed["debug_503d_summary"]["artifact_count"] == 4
+
+    @patch.dict(os.environ, {"DEBUG_RENDER": "1"})
+    def test_attachments_contain_bytes_but_summary_does_not(self, sample_html_with_anchors, sample_sections):
+        """
+        Test that attachments contain bytes (for email) but summary does not (for DB).
+
+        This verifies the separation of concerns:
+        - attachments: passed to email function, contain actual bytes
+        - summary: stored in DB meta, contains only metadata strings/numbers
+        """
+        from services.debug_503d import build_debug_503d_attachments, build_debug_503d_summary
+
+        attachments = build_debug_503d_attachments(
+            final_html=sample_html_with_anchors,
+            sections=sample_sections,
+            canonical_kpis={"PAYBACK_MONTHS": 6.5}
+        )
+
+        # Attachments SHOULD contain bytes (this is for email)
+        for att in attachments:
+            assert "content" in att
+            assert isinstance(att["content"], bytes), f"Attachment {att['filename']} content should be bytes"
+
+        # Summary should NOT contain bytes
+        summary = build_debug_503d_summary(attachments)
+
+        def check_no_bytes(obj, path="root"):
+            """Recursively check that no bytes objects exist in the structure."""
+            if isinstance(obj, bytes):
+                pytest.fail(f"Found bytes at {path}")
+            elif isinstance(obj, dict):
+                for k, v in obj.items():
+                    check_no_bytes(v, f"{path}.{k}")
+            elif isinstance(obj, list):
+                for i, v in enumerate(obj):
+                    check_no_bytes(v, f"{path}[{i}]")
+
+        check_no_bytes(summary)
+
+    @patch.dict(os.environ, {"DEBUG_RENDER": "0"})
+    def test_summary_empty_when_disabled(self, sample_html_with_anchors, sample_sections):
+        """Test that summary is empty when DEBUG_RENDER is disabled."""
+        from services.debug_503d import build_debug_503d_attachments, build_debug_503d_summary
+
+        attachments = build_debug_503d_attachments(
+            final_html=sample_html_with_anchors,
+            sections=sample_sections,
+            canonical_kpis={}
+        )
+
+        assert len(attachments) == 0
+
+        summary = build_debug_503d_summary(attachments)
+        assert summary == {}


### PR DESCRIPTION
Problem: Railway run fails at db.commit() with TypeError: "Object of type bytes is not JSON serializable" when DEBUG_RENDER=1 is enabled. The debug artifacts (containing bytes) were being stored in meta dict which gets persisted to Analysis.meta (Postgres JSONB field).

Solution:
- Add build_debug_503d_summary() to create JSON-safe metadata
- Store only JSON-safe summary in meta["debug_503d_summary"] (DB-safe)
- Return raw bytes via result["debug_attachments"] (in-memory only)
- Pass bytes directly to _send_emails() via new parameter
- Never persist bytes to DB

Changes:
- services/debug_503d.py: Add build_debug_503d_summary() function
- services/report_renderer.py: Separate bytes from meta, return separately
- gpt_analyze.py: Extract bytes before DB commit, pass to _send_emails
- tests/test_debug_503d.py: Add 4 JSON serializability tests

The fix ensures:
- DEBUG_RENDER=1 working correctly
- Admin email includes 4 debug attachments
- No TypeError bytes not JSON serializable
- meta dict is fully JSON-serializable for Postgres JSONB