### PR TITLE
feat(FIX-506): add Canonical KPI Contract and remove banned patterns

### DIFF
--- a/prompts/de/ai_act_summary.md
+++ b/prompts/de/ai_act_summary.md
@@ -140,7 +140,7 @@ VERBOTEN:
 
     <li><strong>Art.&nbsp;6 – Hochrisiko-Systeme:</strong>
       KI-Systeme, die wesentliche Grundrechte berühren, unterliegen strengen Pflichten
-      (Datenqualität, Protokollierung, Governance). Für {{HAUPTLEISTUNG}} typischerweise
+      (Datenqualität, Protokollierung, Governance). Für {{HAUPTLEISTUNG}} in der Regel
       nicht zutreffend – außer in Branchen wie Gesundheit, Finanzen, Verwaltung.</li>
 
     <li><strong>Art.&nbsp;50 – Transparenzpflichten:</strong>

--- a/prompts/de/business_case.md
+++ b/prompts/de/business_case.md
@@ -5,6 +5,34 @@ Developer:
 <!-- SIZE-AWARE: solo/team/kmu -->
 <!-- INPUT: {{BRANCHE_LABEL}}, {{COMPANY_SIZE}}, {{hauptleistung}}, {{BUNDESLAND_LABEL}}, {{CAPEX_REALISTISCH_EUR}}, {{OPEX_REALISTISCH_EUR}}, {{EINSPARUNG_MONAT_EUR}}, {{PAYBACK_MONTHS}}, {{ROI_12M}}, {{OFFERING_LABEL}} -->
 <!-- TOKEN-BUDGET: 1800 (solo:0.8x=1440, team:1.0x=1800, kmu:1.15x=2070) -->
+<!-- FIX-506: Canonical KPI Contract -->
+<!--
+###############################################################################
+##                    CANONICAL KPI CONTRACT (STRICT)                        ##
+###############################################################################
+
+You MUST NOT:
+- invent, estimate or round KPI values
+- use example numbers beyond provided variables
+- restate KPIs in alternative wording
+
+You MAY ONLY:
+- reference provided canonical variables: {{CAPEX_REALISTISCH_EUR}}, {{OPEX_REALISTISCH_EUR}},
+  {{EINSPARUNG_MONAT_EUR}}, {{PAYBACK_MONTHS}}, {{ROI_12M}}
+- use "rund" for contextual descriptions (NOT "etwa" or "ca.")
+- explain QUALITATIVE benefits WITHOUT inventing numbers
+
+If a KPI is missing: use the provided variable or leave field empty.
+
+BANNED PATTERNS (hard fail in STRICT_MODE):
+- "z. B." / "z.B."
+- "typischerweise"
+- "etwa" (use "rund" instead)
+- "ca."
+- invented percentages or time estimates
+
+###############################################################################
+-->
 <!--
 ###############################################################################
 ##                    HAUPTLEISTUNG INTEGRATION (BALANCIERT)                 ##
@@ -71,7 +99,7 @@ VERBOTEN:
 REALISMUS-REGELN (STRIKT!):
 - KEINE 90%-Effizienzversprechen – realistische 15–30% Einsparungen
 - KEINE erfundenen Zahlen – nur übergebene Variablen nutzen
-- "rund / etwa / ca." zur Einordnung erlaubt
+- "rund" zur Einordnung erlaubt (NICHT "etwa" oder "ca.")
 - KEINE Förderquoten (siehe foerderpotenzial.md)
 - Größe beeinflusst NUR narrative Einordnung, nicht die Zahlen
 
@@ -87,7 +115,7 @@ ANTI-REDUNDANZ:
 
 SPRINT G18 - ANTI-REDUNDANZ (STRIKT!):
 - Datenlage/Data Readiness NICHT erneut beschreiben – gehört in data_readiness.md
-- Maximal EIN kurzer Verweis auf Data Readiness ist erlaubt (z.B. "→ siehe Datenlage")
+- Maximal EIN kurzer Verweis auf Data Readiness ist erlaubt ("→ siehe Datenlage")
 - CAPEX/OPEX-Blöcke nur HIER – nicht in anderen Sections wiederholen
 - Fokus: ROI, Payback, Investition – KEINE Datenlage-Analyse
 
@@ -129,7 +157,7 @@ Formulierungen ohne Team-/Abteilungsbegriff verwenden!
   <p>
     Die einmaligen Aufwände für Aufbau und Einführung liegen bei rund
     <strong>{{CAPEX_REALISTISCH_EUR}}&nbsp;€</strong>. Hinzu kommen monatliche Betriebskosten
-    von etwa <strong>{{OPEX_REALISTISCH_EUR}}&nbsp;€</strong> – hauptsächlich für den KI-Einsatz,
+    von rund <strong>{{OPEX_REALISTISCH_EUR}}&nbsp;€</strong> – hauptsächlich für den KI-Einsatz,
     Infrastruktur, Tools und potenzielle Lizenzen.
   </p>
 

--- a/prompts/de/business_case_engine_v2.md
+++ b/prompts/de/business_case_engine_v2.md
@@ -164,7 +164,7 @@ Jedes Szenario enthält:
 **notes**: Kurze Erklärung des Szenarios (max. 100 Zeichen)
 
 ### kpi_targets_6m
-6-Monats-Ziele (ca. 60% des 12-Monats-Potenzials):
+6-Monats-Ziele (rund 60% des 12-Monats-Potenzials):
 - `roi`: ROI nach 6 Monaten (%)
 - `time_savings_hours`: Eingesparte Stunden pro Monat
 - `monthly_savings`: Monatliche Ersparnis in EUR

--- a/prompts/de/costs_overview.md
+++ b/prompts/de/costs_overview.md
@@ -43,7 +43,7 @@ Developer:
 
      ZIEL:
        - Am Ende soll ein CFO oder Geschäftsführender glasklar verstehen:
-           1) Welche Kostenblöcke in seiner Branche typischerweise auftreten.
+           1) Welche Kostenblöcke in seiner Branche in der Regel auftreten.
            2) Wie sich die Unternehmensgröße auf die Kostenstruktur auswirkt.
            3) Wo realistische Einspar- und Konsolidierungspotenziale liegen.
 

--- a/prompts/de/foerderpotenzial.md
+++ b/prompts/de/foerderpotenzial.md
@@ -139,7 +139,7 @@ Formulierungen ohne Team-/Abteilungsbegriff verwenden!
   <h3>2. Wie Fördermittel den Business Case verbessern können</h3>
   <p>
     Programme in {{BUNDESLAND_LABEL}} und auf Bundesebene bezuschussen förderfähige Investitionskosten.
-    Zuschussquoten liegen typischerweise bei <strong>30–50&nbsp;%</strong> der anerkannten Kosten.
+    Zuschussquoten liegen in der Regel bei <strong>30–50&nbsp;%</strong> der anerkannten Kosten.
   </p>
   <ul>
     <li><strong>Kürzere Amortisation:</strong> Durch geringeren Eigenanteil verkürzt sich die Amortisationsdauer.</li>

--- a/prompts/de/gamechanger.md
+++ b/prompts/de/gamechanger.md
@@ -1,6 +1,24 @@
 Developer:
 <!-- PLATIN+++ PROMPT v7.2 - SPRINT INHALTLICHE FINALISIERUNG -->
 <!-- SECTION: gamechanger -->
+<!-- FIX-506: Canonical KPI Contract -->
+<!--
+###############################################################################
+##                    CANONICAL KPI CONTRACT (STRICT)                        ##
+###############################################################################
+
+This section MUST NOT contain KPI values. All financial references:
+→ "Die finanziellen Effekte werden im Business Case dargestellt."
+
+BANNED PATTERNS (hard fail in STRICT_MODE):
+- "z. B." / "z.B."
+- "typischerweise"
+- "etwa"
+- "ca."
+- Any ROI percentage (handled by existing ROI PROHIBITION below)
+
+###############################################################################
+-->
 <!--
 ###############################################################################
 ##                    HAUPTLEISTUNG INTEGRATION (BALANCIERT)                 ##
@@ -228,7 +246,7 @@ VERBINDLICHE STRUKTUR (4 Blöcke):
    - Bezug auf {{HAUPTUMSATZTREIBER}} und {{WETTBEWERB}} erforderlich
    - Konkrete Denkblockade, nicht "Ineffizienzen"
    - PFLICHT (v7.1): Die obsolet werdende Logik EXPLIZIT benennen
-     (Form: "Nicht mehr X, sondern Y" – z.B. "Nicht mehr reaktive
+     (Form: "Nicht mehr X, sondern Y" – wie "Nicht mehr reaktive
      Einzelfallbearbeitung, sondern proaktive Musteranwendung")
 
 2. TRANSFORMATIONS-IDEE

--- a/prompts/de/org_change.md
+++ b/prompts/de/org_change.md
@@ -87,14 +87,14 @@ REGELN:
     <li>
       <strong>Arbeitsroutinen vereinheitlichen:</strong>
       KI muss an klaren Stellen in den branchentypischen Workflows eingesetzt werden
-      – etwa bei wiederkehrenden Analysen, Dokumentationen, Qualitätskontrollen oder
+      – wie bei wiederkehrenden Analysen, Dokumentationen, Qualitätskontrollen oder
       inhaltlichen Entwürfen. Einheitliche Vorlagen und klare Input-Regeln senken
       Fehlerquoten und steigern die Verlässlichkeit.
     </li>
     <li>
       <strong>Rollen &amp; Verantwortlichkeiten klären:</strong>
       {% if COMPANY_SIZE == "solo" %}
-        Eine klare persönliche Aufteilung der „Hüte“ – z. B. Erstellung, Prüfung, Freigabe –
+        Eine klare persönliche Aufteilung der „Hüte" – wie Erstellung, Prüfung, Freigabe –
         schafft Fokus und Kontrolle.
       {% elif COMPANY_SIZE == "team" %}
         Eine eindeutige Rollenverteilung (Teamlead, KI-Owner, Review-Rolle) vermeidet

--- a/prompts/de/quick_wins.md
+++ b/prompts/de/quick_wins.md
@@ -1,5 +1,36 @@
-# Quick Wins - JSON Output v8.1
+# Quick Wins - JSON Output v8.2
 <!-- Problem #7 FIX: Hauptleistung als Analyse-Kern -->
+<!-- FIX-506: Canonical KPI Contract -->
+
+<!--
+###############################################################################
+##                    CANONICAL KPI CONTRACT (STRICT)                        ##
+###############################################################################
+
+You MUST NOT:
+- invent, estimate or round KPI values
+- use example numbers (e.g., "6-10 h/Monat")
+- use ranges for time savings (e.g., "6–10 Stunden")
+- use "z. B.", "typischerweise", "etwa", "ca."
+- restate KPIs in alternative wording
+
+You MAY ONLY:
+- reference provided canonical variables: {{monatsersparnis_stunden}}, {{STUNDENSATZ_EUR}}
+- use "siehe Business Case" for detailed KPI references
+- explain QUALITATIVE benefits WITHOUT inventing numbers
+
+If a KPI is missing: say "siehe Business Case" or leave field empty.
+
+BANNED PATTERNS (hard fail in STRICT_MODE):
+- "z. B."
+- "typischerweise"
+- "etwa"
+- "ca."
+- "6–10" or any invented range
+- "bei Bedarf"
+
+###############################################################################
+-->
 
 <!--
 ###############################################################################
@@ -107,16 +138,15 @@ Analysiere die Unternehmensdaten und erstelle 3-5 Quick Wins als **JSON Array** 
   {
     "title": "[Aktion] für {{hauptleistung}} (max 60 Zeichen)",
     "icon": "🎯",
-    "time": "6-10 h/Monat",
     "engpass": "Ihr konkreter Zeitfresser/Pain Point aus ZEITERSPARNIS_PRIORITAET",
     "description": "In Ihrem Kerngeschäft besteht das Problem... 2-3 Sätze.",
     "mit_ki": "Für diese Leistung hilft KI konkret durch... Welche Tools? 2-3 Sätze.",
     "steps": [
-      "Konkreter Schritt 1 mit Zeitangabe (z.B. 30min)",
-      "Konkreter Schritt 2 mit Tool-Namen",
-      "Konkreter Schritt 3 mit messbarem Ergebnis"
+      "Konkreter Schritt 1 mit Tool-Namen",
+      "Konkreter Schritt 2 mit messbarem Ergebnis",
+      "Konkreter Schritt 3 zur Validierung"
     ],
-    "zeitersparnis": "6-10 h/Monat = 600-1.000€ (bei {{STUNDENSATZ_EUR}}€/h)"
+    "zeitersparnis": "{{monatsersparnis_stunden}} Std./Monat (bei {{STUNDENSATZ_EUR}}€/h)"
   }
 ]
 ```
@@ -181,7 +211,7 @@ Analysiere die Unternehmensdaten und erstelle 3-5 Quick Wins als **JSON Array** 
 
 - [ ] Valides JSON (keine trailing commas, escaped quotes)
 - [ ] 3-5 Quick Wins im Array
-- [ ] Jeder Quick Win hat alle 8 Felder: title, icon, time, engpass, description, mit_ki, steps, zeitersparnis
+- [ ] Jeder Quick Win hat alle 7 Felder: title, icon, engpass, description, mit_ki, steps, zeitersparnis
 - [ ] Icons sind Emojis (nicht Text)
 - [ ] steps ist Array mit 3-5 Strings
 - [ ] Keine HTML-Tags im JSON
@@ -233,42 +263,39 @@ Analysiere die Unternehmensdaten und erstelle 3-5 Quick Wins als **JSON Array** 
   {
     "title": "Ablauf-Blueprint für Ihre KI-Beratungsprojekte",
     "icon": "🎯",
-    "time": "6-10 h/Monat",
     "engpass": "Entwicklung und Optimierung von Abläufen",
     "description": "Aktuell strukturieren Sie jeden Beratungsablauf (Fragebogen, Auswertung, Report) neu und optimieren ad hoc – das kostet viel Denk- und Dokumentationszeit.",
     "mit_ki": "ChatGPT Plus erstellt mit Ihnen einen wiederverwendbaren Standard-Workflow inkl. Checklisten und Textbausteinen, den Sie nur noch leicht je Kunde anpassen.",
     "steps": [
-      "ChatGPT Plus buchen (15 Min, 20€/Monat)",
-      "Beste bisherige Projekte analysieren (2-3h)",
-      "Standard-Workflow & Checklisten generieren (3-4h)"
+      "ChatGPT Plus buchen (20€/Monat)",
+      "Beste bisherige Projekte analysieren",
+      "Standard-Workflow & Checklisten generieren"
     ],
-    "zeitersparnis": "6-10 h/Monat = X€ (bei {{STUNDENSATZ_EUR}}€/h)"
+    "zeitersparnis": "{{monatsersparnis_stunden}} Std./Monat (bei {{STUNDENSATZ_EUR}}€/h)"
   },
   {
     "title": "Testphase Ihres KI-Fragebogens in erweiterbares MVP",
     "icon": "🚀",
-    "time": "5-8 h/Monat",
     "engpass": "das Projekt mit der Beratung von Unternehmen zur Integration von KI",
     "description": "Sie testen das Angebot manuell, Auswertung und Reports entstehen jedes Mal neu und sind noch nicht als Produktpaket definiert.",
     "mit_ki": "Sie nutzen ChatGPT Plus, um feste Fragebogen-Varianten, Auswertungslogik und Report-Templates zu erstellen und als schlankes Online-MVP zu standardisieren.",
     "steps": [
-      "Beste Testfälle clustern (2h, typische Kundentypen definieren)",
-      "Fragebogen-Varianten mit GPT schärfen (3h)",
-      "Standard-Reportstruktur bauen (3h)"
+      "Beste Testfälle clustern (Kundentypen definieren)",
+      "Fragebogen-Varianten mit GPT schärfen",
+      "Standard-Reportstruktur bauen"
     ],
-    "zeitersparnis": "5-8 h/Monat = X€ (bei {{STUNDENSATZ_EUR}}€/h)"
+    "zeitersparnis": "{{monatsersparnis_stunden}} Std./Monat (bei {{STUNDENSATZ_EUR}}€/h)"
   },
   {
     "title": "KI-Sicherheitsrichtlinie erstellen",
     "icon": "🔒",
-    "time": "2h Setup",
     "engpass": "Security-Score 45/100 (Handlungsbedarf)",
     "description": "Ohne klare Sicherheitsregeln riskieren Sie Datenschutzverletzungen bei der KI-Nutzung.",
     "mit_ki": "Claude Pro hilft Ihnen, eine kompakte Richtlinie zu erstellen: Welche Daten dürfen in KI-Tools? Welche Tools sind freigegeben?",
     "steps": [
-      "Datenklassifikation erstellen (1h)",
-      "Tool-Freigabeliste definieren (30min)",
-      "Prüfregeln dokumentieren (30min)"
+      "Datenklassifikation erstellen",
+      "Tool-Freigabeliste definieren",
+      "Prüfregeln dokumentieren"
     ],
     "zeitersparnis": "Risikominimierung + Compliance"
   }

--- a/prompts/de/recommendations_engine.md
+++ b/prompts/de/recommendations_engine.md
@@ -204,7 +204,7 @@ Auswahl basierend auf:
 
 ```json
 {
-  "summary": "Für Ihr mittelständisches Produktionsunternehmen wurden 7 priorisierte Handlungsempfehlungen identifiziert. Der Fokus liegt auf Tool-Implementierung, Risiko-Mitigation und Förder-Nutzung mit einer Gesamtinvestition von ca. 25.000€.",
+  "summary": "Für Ihr mittelständisches Produktionsunternehmen wurden 7 priorisierte Handlungsempfehlungen identifiziert. Der Fokus liegt auf Tool-Implementierung, Risiko-Mitigation und Förder-Nutzung mit einer Gesamtinvestition von rund 25.000€.",
   "top_3_ids": ["rec1", "rec2", "rec4"],
   "recommendations": [
     {

--- a/prompts/de/strategie_governance.md
+++ b/prompts/de/strategie_governance.md
@@ -121,7 +121,7 @@ GUARDRAILS: Berücksichtige Leitplanken aus strategischem Kontext.
     </li>
     <li>
       <strong>Monetarisierungspotenziale evaluieren (optional):</strong>
-      KI-gestützte Prozesse können neue Erlösquellen erschließen – etwa durch
+      KI-gestützte Prozesse können neue Erlösquellen erschließen – wie durch
       digitale Produkte, erweiterbare Service-Formate oder automatisierte Analysen.
       Eine strategische Bewertung lohnt sich insbesondere bei stabilen Kern-Workflows.
     </li>

--- a/prompts/de/tools_empfehlungen.md
+++ b/prompts/de/tools_empfehlungen.md
@@ -164,7 +164,7 @@ KMU-MODUS - VERBOTEN:
   <ul>
     <li>
       <strong>Formular- oder Fragebogen-Tool</strong> –
-      zur strukturierten Erfassung von Kundendaten und Antworten, etwa über Online-Formulare
+      zur strukturierten Erfassung von Kundendaten und Antworten, wie über Online-Formulare
       mit klaren Skalen und offenen Feldern. Für Solo-Setups reicht eine kompakte Lösung;
       Teams und KMU profitieren von Mehrnutzerfähigkeit und einfachen Auswertungsmöglichkeiten.
     </li>
@@ -182,7 +182,7 @@ KMU-MODUS - VERBOTEN:
     <li>
       <strong>Branchenspezifische Fach-Tools</strong> –
       je nach {{BRANCH_CONTEXT_LABEL}} können zusätzliche Lösungen sinnvoll sein,
-      z.B. für Terminplanung, Dokumentenfreigaben oder Fachanalysen.
+      wie für Terminplanung, Dokumentenfreigaben oder Fachanalysen.
       Diese sollten den Stack ergänzen, nicht verkomplizieren.
     </li>
   </ul>
@@ -303,7 +303,7 @@ KMU-MODUS - VERBOTEN:
           Reduziert manuelle Zwischenschritte, stärkt Sicherheit und Qualität und macht
           den Gesamtprozess erweiterbar – besonders relevant für wachsende Teams und KMU.
         </td>
-        <td>ab etwa 60 Tagen</td>
+        <td>ab rund 60 Tagen</td>
       </tr>
     </tbody>
   </table>

--- a/tests/test_fix506_banned_patterns.py
+++ b/tests/test_fix506_banned_patterns.py
@@ -1,0 +1,152 @@
+# -*- coding: utf-8 -*-
+"""
+FIX-506: Test that banned patterns are not present in rendered prompts.
+
+Tests for Canonical KPI Contract enforcement - no "z. B.", "typischerweise",
+"etwa", or "ca." in LLM output sections.
+"""
+
+import pytest
+import re
+from pathlib import Path
+
+# Banned patterns that should not appear in rendered output
+BANNED_PATTERNS = [
+    r'\bz\.\s*B\.',  # "z. B." or "z.B."
+    r'\btypischerweise\b',
+    r'\betwa\s+(?:bei|für|durch|über|von|zu|am|im|an)',  # "etwa bei", "etwa für", etc.
+    r'\bca\.\s*\d',  # "ca." followed by number
+]
+
+# Files to test (main output-producing prompts)
+CRITICAL_PROMPTS = [
+    "prompts/de/quick_wins.md",
+    "prompts/de/business_case.md",
+    "prompts/de/gamechanger.md",
+    "prompts/de/tools_empfehlungen.md",
+    "prompts/de/foerderpotenzial.md",
+    "prompts/de/ai_act_summary.md",
+    "prompts/de/org_change.md",
+    "prompts/de/strategie_governance.md",
+]
+
+
+def get_output_sections(content: str) -> str:
+    """Extract likely output sections from a prompt template.
+
+    Output sections are HTML blocks between <section> or after role instructions.
+    """
+    # Match HTML sections (likely output)
+    html_pattern = re.compile(r'<section[^>]*>.*?</section>', re.DOTALL | re.IGNORECASE)
+    html_matches = html_pattern.findall(content)
+
+    # Also check for HTML-style content outside comments
+    # Remove comment blocks first
+    content_no_comments = re.sub(r'<!--.*?-->', '', content, flags=re.DOTALL)
+
+    # Combine all potentially output content
+    return '\n'.join(html_matches) + '\n' + content_no_comments
+
+
+class TestBannedPatternsNotInOutput:
+    """Tests that banned patterns don't appear in output sections."""
+
+    @pytest.fixture
+    def project_root(self):
+        """Get project root directory."""
+        return Path(__file__).parent.parent
+
+    def test_quick_wins_no_banned_patterns(self, project_root):
+        """quick_wins.md output sections have no banned patterns."""
+        content = (project_root / "prompts/de/quick_wins.md").read_text()
+        output_content = get_output_sections(content)
+
+        for pattern in BANNED_PATTERNS:
+            matches = re.findall(pattern, output_content, re.IGNORECASE)
+            assert not matches, f"Found banned pattern '{pattern}' in quick_wins.md: {matches}"
+
+    def test_business_case_no_banned_patterns(self, project_root):
+        """business_case.md output sections have no banned patterns."""
+        content = (project_root / "prompts/de/business_case.md").read_text()
+        output_content = get_output_sections(content)
+
+        for pattern in BANNED_PATTERNS:
+            matches = re.findall(pattern, output_content, re.IGNORECASE)
+            assert not matches, f"Found banned pattern '{pattern}' in business_case.md: {matches}"
+
+    def test_gamechanger_no_banned_patterns(self, project_root):
+        """gamechanger.md output sections have no banned patterns."""
+        content = (project_root / "prompts/de/gamechanger.md").read_text()
+        output_content = get_output_sections(content)
+
+        for pattern in BANNED_PATTERNS:
+            matches = re.findall(pattern, output_content, re.IGNORECASE)
+            assert not matches, f"Found banned pattern '{pattern}' in gamechanger.md: {matches}"
+
+    def test_tools_empfehlungen_no_banned_patterns(self, project_root):
+        """tools_empfehlungen.md output sections have no banned patterns."""
+        content = (project_root / "prompts/de/tools_empfehlungen.md").read_text()
+        output_content = get_output_sections(content)
+
+        for pattern in BANNED_PATTERNS:
+            matches = re.findall(pattern, output_content, re.IGNORECASE)
+            assert not matches, f"Found banned pattern '{pattern}' in tools_empfehlungen.md: {matches}"
+
+
+class TestCanonicalKPIContractHeaders:
+    """Tests that Canonical KPI Contract headers are present."""
+
+    @pytest.fixture
+    def project_root(self):
+        """Get project root directory."""
+        return Path(__file__).parent.parent
+
+    def test_quick_wins_has_kpi_contract(self, project_root):
+        """quick_wins.md has Canonical KPI Contract header."""
+        content = (project_root / "prompts/de/quick_wins.md").read_text()
+        assert "CANONICAL KPI CONTRACT" in content
+
+    def test_business_case_has_kpi_contract(self, project_root):
+        """business_case.md has Canonical KPI Contract header."""
+        content = (project_root / "prompts/de/business_case.md").read_text()
+        assert "CANONICAL KPI CONTRACT" in content
+
+    def test_gamechanger_has_kpi_contract(self, project_root):
+        """gamechanger.md has Canonical KPI Contract header."""
+        content = (project_root / "prompts/de/gamechanger.md").read_text()
+        assert "CANONICAL KPI CONTRACT" in content
+
+
+class TestQuickWinsNoInventedNumbers:
+    """Tests that Quick Wins don't have invented time/hour ranges."""
+
+    @pytest.fixture
+    def project_root(self):
+        """Get project root directory."""
+        return Path(__file__).parent.parent
+
+    def test_no_time_field_in_format(self, project_root):
+        """Quick Wins JSON format should not have 'time' field with invented ranges."""
+        content = (project_root / "prompts/de/quick_wins.md").read_text()
+
+        # Check that the JSON format section doesn't have "time": "6-10 h/Monat"
+        assert '"time": "6-10' not in content
+        assert '"time": "5-8' not in content
+
+    def test_zeitersparnis_uses_variable(self, project_root):
+        """Quick Wins zeitersparnis should use canonical variable."""
+        content = (project_root / "prompts/de/quick_wins.md").read_text()
+
+        # Check that zeitersparnis uses the canonical variable
+        assert "{{monatsersparnis_stunden}}" in content
+
+    def test_no_invented_hour_ranges_in_steps(self, project_root):
+        """Quick Wins steps should not have invented time estimates like (2-3h)."""
+        content = (project_root / "prompts/de/quick_wins.md").read_text()
+
+        # Pattern for invented time ranges in steps
+        invented_time_pattern = r'\(\d+-\d+h\)'
+        matches = re.findall(invented_time_pattern, content)
+
+        # There should be no invented time ranges
+        assert not matches, f"Found invented time ranges in steps: {matches}"


### PR DESCRIPTION
- Add Canonical KPI Contract headers to quick_wins.md, business_case.md, gamechanger.md
- Remove banned patterns ("z.B.", "typischerweise", "etwa", "ca.") from output sections
- Replace with allowed alternatives ("wie", "rund", "in der Regel")
- Simplify Quick Wins JSON format: remove "time" field, use {{monatsersparnis_stunden}} variable
- Remove invented time ranges from Quick Wins steps and examples
- Add test suite for banned patterns validation (10 new tests)

Prompts modified:
- quick_wins.md: Full Canonical KPI Contract, simplified JSON format
- business_case.md: Canonical KPI Contract header, "etwa" → "rund"
- gamechanger.md: KPI refs only contract header
- tools_empfehlungen.md: "etwa"/"z.B." → "wie"/"rund"
- foerderpotenzial.md: "typischerweise" → "in der Regel"
- ai_act_summary.md: "typischerweise" → "in der Regel"
- org_change.md: "etwa"/"z.B." → "wie"
- strategie_governance.md: "etwa" → "wie"
- costs_overview.md: "typischerweise" → "in der Regel"
- business_case_engine_v2.md: "ca." → "rund"
- recommendations_engine.md: "ca." → "rund"