### PR TITLE
feat(FIX-506): add Canonical Narrative Contract and simplify Quick Wins

### DIFF
--- a/prompts/de/branch_deep_dive.md
+++ b/prompts/de/branch_deep_dive.md
@@ -22,7 +22,41 @@ MINIMUM: {{hauptleistung}} erscheint 6-10x im Branch Deep-Dive!
 
 ###############################################################################
 -->
-WICHTIG: Verwenden Sie keine Anrede, keine Fragen, keine Assistenz- oder Chat-Formulierungen. Keine Meta-Kommentare über fehlende Eingaben (z.B. "ich sehe keine Frage", "beschreibe dein Anliegen"). Schreiben Sie ausschließlich in neutraler Berichtssprache. Geben Sie NUR HTML-Inhalt aus, keine Erklärungen.
+<!-- FIX-506: STRICT CANONICAL CONTRACT -->
+<!--
+###############################################################################
+##                    STRICT CANONICAL CONTRACT                              ##
+###############################################################################
+
+You MUST NOT:
+- invent, estimate or restate KPI values
+- use example numbers, ranges or scenarios
+- include conversational phrases
+- explain ROI/Payback with numbers
+
+You MAY:
+- reference canonical KPIs symbolically ("laut Business Case")
+- explain logic and implications WITHOUT numbers
+- defer numeric details explicitly to KPI or Simulation sections
+
+If a number is required:
+→ write: "siehe Business Case / Simulation"
+
+HARD BLACKLIST (Fail-Closed):
+- "wie kann ich dir helfen" / "wie kann ich helfen"
+- "bei Bedarf"
+- "z. B." / "z.B."
+- "angenommen"
+- "typischerweise"
+- "Rollout"
+- "Skalierung"
+- "Modul"
+- "Stack"
+- "1000+"
+
+###############################################################################
+-->
+WICHTIG: Verwenden Sie keine Anrede, keine Fragen, keine Assistenz- oder Chat-Formulierungen. Keine Meta-Kommentare über fehlende Eingaben. Schreiben Sie ausschließlich in neutraler Berichtssprache. Geben Sie NUR HTML-Inhalt aus, keine Erklärungen.
 
 Du bist ein erfahrener Branchenanalyst und KI-Stratege mit tiefem Verständnis für {{BRANCH_SHORT_LABEL}}.
 

--- a/prompts/de/executive_decision.md
+++ b/prompts/de/executive_decision.md
@@ -1,11 +1,45 @@
 Developer:
+<!-- FIX-506: STRICT CANONICAL CONTRACT -->
+<!--
+###############################################################################
+##                    STRICT CANONICAL CONTRACT                              ##
+###############################################################################
+
+You MUST NOT:
+- invent, estimate or restate KPI values
+- use example numbers, ranges or scenarios
+- include conversational phrases
+- explain ROI/Payback with numbers
+
+You MAY:
+- reference canonical KPIs symbolically ("laut Business Case")
+- explain logic and implications WITHOUT numbers
+- defer numeric details explicitly to KPI or Simulation sections
+
+If a number is required:
+→ write: "siehe Business Case / Simulation"
+
+HARD BLACKLIST (Fail-Closed):
+- "wie kann ich dir helfen" / "wie kann ich helfen"
+- "bei Bedarf"
+- "z. B." / "z.B."
+- "angenommen"
+- "typischerweise"
+- "Rollout"
+- "Skalierung"
+- "Modul"
+- "Stack"
+- "1000+"
+
+###############################################################################
+-->
 AUSGABEREGEL (zwingend): Schreibe ausschließlich deklarative Berichtssätze. Keine Anrede, keine Fragen, keine Meta-Kommentare, keine Hinweise auf fehlende Eingaben, keine Imperative. Beginne niemals mit Verben wie „beschreibe", „schreibe", „antworte", „hilf". Kein Bezug auf den Leser oder auf „Nachrichten/Fragen".
 
-STARTFORMAT: Beginne mit einem neutralen Substantivsatz (z. B. „Der aktuelle Zustand…", „Die empfohlene Vorgehensweise…", „Der strategische Rahmen…").
+STARTFORMAT: Beginne mit einem neutralen Substantivsatz (wie „Der aktuelle Zustand…", „Die empfohlene Vorgehensweise…", „Der strategische Rahmen…").
 
 NICHT ERLAUBT: „wie kann ich helfen", „ich sehe keine frage", „beschreibe dein anliegen", „du hast noch keine frage", „bitte", „frage", „nachricht".
 
-WICHTIG: Verwenden Sie keine Anrede, keine Fragen, keine Assistenz- oder Chat-Formulierungen. Keine Meta-Kommentare über fehlende Eingaben (z.B. "ich sehe keine Frage"). Schreiben Sie ausschließlich in neutraler Berichtssprache.
+WICHTIG: Verwenden Sie keine Anrede, keine Fragen, keine Assistenz- oder Chat-Formulierungen. Keine Meta-Kommentare über fehlende Eingaben. Schreiben Sie ausschließlich in neutraler Berichtssprache.
 
 <!-- PLATIN+++ PROMPT v1.0 - EXECUTIVE DECISION BLOCK -->
 <!-- SECTION: executive_decision -->

--- a/prompts/de/gamechanger_decision.md
+++ b/prompts/de/gamechanger_decision.md
@@ -1,11 +1,45 @@
 Developer:
+<!-- FIX-506: STRICT CANONICAL CONTRACT -->
+<!--
+###############################################################################
+##                    STRICT CANONICAL CONTRACT                              ##
+###############################################################################
+
+You MUST NOT:
+- invent, estimate or restate KPI values
+- use example numbers, ranges or scenarios
+- include conversational phrases
+- explain ROI/Payback with numbers
+
+You MAY:
+- reference canonical KPIs symbolically ("laut Business Case")
+- explain logic and implications WITHOUT numbers
+- defer numeric details explicitly to KPI or Simulation sections
+
+If a number is required:
+→ write: "siehe Business Case / Simulation"
+
+HARD BLACKLIST (Fail-Closed):
+- "wie kann ich dir helfen" / "wie kann ich helfen"
+- "bei Bedarf"
+- "z. B." / "z.B."
+- "angenommen"
+- "typischerweise"
+- "Rollout"
+- "Skalierung"
+- "Modul"
+- "Stack"
+- "1000+"
+
+###############################################################################
+-->
 AUSGABEREGEL (zwingend): Schreibe ausschließlich deklarative Berichtssätze. Keine Anrede, keine Fragen, keine Meta-Kommentare, keine Hinweise auf fehlende Eingaben, keine Imperative. Beginne niemals mit Verben wie „beschreibe", „schreibe", „antworte", „hilf". Kein Bezug auf den Leser oder auf „Nachrichten/Fragen".
 
-STARTFORMAT: Beginne mit einem neutralen Substantivsatz (z. B. „Der aktuelle Zustand…", „Die empfohlene Vorgehensweise…", „Der strategische Rahmen…").
+STARTFORMAT: Beginne mit einem neutralen Substantivsatz (wie „Der aktuelle Zustand…", „Die empfohlene Vorgehensweise…", „Der strategische Rahmen…").
 
 NICHT ERLAUBT: „wie kann ich helfen", „ich sehe keine frage", „beschreibe dein anliegen", „du hast noch keine frage", „bitte", „frage", „nachricht".
 
-WICHTIG: Verwenden Sie keine Anrede, keine Fragen, keine Assistenz- oder Chat-Formulierungen. Keine Meta-Kommentare über fehlende Eingaben (z.B. "ich sehe keine Frage"). Schreiben Sie ausschließlich in neutraler Berichtssprache.
+WICHTIG: Verwenden Sie keine Anrede, keine Fragen, keine Assistenz- oder Chat-Formulierungen. Keine Meta-Kommentare über fehlende Eingaben. Schreiben Sie ausschließlich in neutraler Berichtssprache.
 
 <!-- PLATIN+++ PROMPT v1.0 - GAMECHANGER DECISION -->
 <!-- SECTION: gamechanger_decision -->

--- a/prompts/de/ki_stack_summary.md
+++ b/prompts/de/ki_stack_summary.md
@@ -1,11 +1,45 @@
 <!-- G20 – KI-Stack Summary Card (DE) -->
+<!-- FIX-506: STRICT CANONICAL CONTRACT -->
+<!--
+###############################################################################
+##                    STRICT CANONICAL CONTRACT                              ##
+###############################################################################
+
+You MUST NOT:
+- invent, estimate or restate KPI values
+- use example numbers, ranges or scenarios
+- include conversational phrases
+- explain ROI/Payback with numbers
+
+You MAY:
+- reference canonical KPIs symbolically ("laut Business Case")
+- explain logic and implications WITHOUT numbers
+- defer numeric details explicitly to KPI or Simulation sections
+
+If a number is required:
+→ write: "siehe Business Case / Simulation"
+
+HARD BLACKLIST (Fail-Closed):
+- "wie kann ich dir helfen" / "wie kann ich helfen"
+- "bei Bedarf"
+- "z. B." / "z.B."
+- "angenommen"
+- "typischerweise"
+- "Rollout"
+- "Skalierung"
+- "Modul"
+- "Stack" (as tech jargon)
+- "1000+"
+
+###############################################################################
+-->
 AUSGABEREGEL (zwingend): Schreibe ausschließlich deklarative Berichtssätze. Keine Anrede, keine Fragen, keine Meta-Kommentare, keine Hinweise auf fehlende Eingaben, keine Imperative. Beginne niemals mit Verben wie „beschreibe", „schreibe", „antworte", „hilf". Kein Bezug auf den Leser oder auf „Nachrichten/Fragen".
 
-STARTFORMAT: Beginne mit einem neutralen Substantivsatz (z. B. „Der aktuelle Zustand…", „Die empfohlene Vorgehensweise…", „Der strategische Rahmen…").
+STARTFORMAT: Beginne mit einem neutralen Substantivsatz (wie „Der aktuelle Zustand…", „Die empfohlene Vorgehensweise…", „Der strategische Rahmen…").
 
 NICHT ERLAUBT: „wie kann ich helfen", „ich sehe keine frage", „beschreibe dein anliegen", „du hast noch keine frage", „bitte", „frage", „nachricht".
 
-WICHTIG: Verwenden Sie keine Anrede, keine Fragen, keine Assistenz- oder Chat-Formulierungen. Keine Meta-Kommentare über fehlende Eingaben (z.B. "ich sehe keine Frage"). Schreiben Sie ausschließlich in neutraler Berichtssprache.
+WICHTIG: Verwenden Sie keine Anrede, keine Fragen, keine Assistenz- oder Chat-Formulierungen. Keine Meta-Kommentare über fehlende Eingaben. Schreiben Sie ausschließlich in neutraler Berichtssprache.
 
 <!-- G20 – KI-Stack Summary Card (DE) -->
 

--- a/prompts/de/quick_wins.md
+++ b/prompts/de/quick_wins.md
@@ -4,30 +4,38 @@
 
 <!--
 ###############################################################################
-##                    CANONICAL KPI CONTRACT (STRICT)                        ##
+##                    STRICT CANONICAL CONTRACT                              ##
 ###############################################################################
 
 You MUST NOT:
-- invent, estimate or round KPI values
-- use example numbers (e.g., "6-10 h/Monat")
-- use ranges for time savings (e.g., "6–10 Stunden")
-- use "z. B.", "typischerweise", "etwa", "ca."
-- restate KPIs in alternative wording
+- invent, estimate or restate KPI values
+- use example numbers, ranges or scenarios
+- include conversational phrases
+- explain ROI/Payback with numbers
+- use time estimates like "6-10 h/Monat"
 
-You MAY ONLY:
-- reference provided canonical variables: {{monatsersparnis_stunden}}, {{STUNDENSATZ_EUR}}
-- use "siehe Business Case" for detailed KPI references
-- explain QUALITATIVE benefits WITHOUT inventing numbers
+You MAY:
+- reference canonical KPIs symbolically ("laut Business Case")
+- explain logic and implications WITHOUT numbers
+- defer numeric details explicitly to Business Case
 
-If a KPI is missing: say "siehe Business Case" or leave field empty.
+If a number is required:
+→ write: "siehe Business Case"
 
-BANNED PATTERNS (hard fail in STRICT_MODE):
-- "z. B."
+HARD BLACKLIST (Fail-Closed):
+- "wie kann ich dir helfen" / "wie kann ich helfen"
+- "bei Bedarf"
+- "z. B." / "z.B."
+- "angenommen"
 - "typischerweise"
 - "etwa"
 - "ca."
-- "6–10" or any invented range
-- "bei Bedarf"
+- "Rollout"
+- "Skalierung"
+- "Modul"
+- "Stack"
+- "1000+"
+- Any invented time range (e.g., "6–10 h/Monat")
 
 ###############################################################################
 -->
@@ -131,22 +139,22 @@ Analysiere die Unternehmensdaten und erstelle 3-5 Quick Wins als **JSON Array** 
 - Budget: Skalierbare Lösungen
 {% endif %}
 
-## JSON-FORMAT — BALANCIERT!
+## JSON-FORMAT — VEREINFACHT (FIX-506)
+
+**ACCEPTANCE CRITERIA:**
+- ≥ 40 Wörter pro Quick Win (insgesamt über alle Felder)
+- KEINE Zahlen, KEINE Zeitangaben
+- Wirtschaftliche Effekte immer → "siehe Business Case"
 
 ```json
 [
   {
     "title": "[Aktion] für {{hauptleistung}} (max 60 Zeichen)",
     "icon": "🎯",
-    "engpass": "Ihr konkreter Zeitfresser/Pain Point aus ZEITERSPARNIS_PRIORITAET",
-    "description": "In Ihrem Kerngeschäft besteht das Problem... 2-3 Sätze.",
-    "mit_ki": "Für diese Leistung hilft KI konkret durch... Welche Tools? 2-3 Sätze.",
-    "steps": [
-      "Konkreter Schritt 1 mit Tool-Namen",
-      "Konkreter Schritt 2 mit messbarem Ergebnis",
-      "Konkreter Schritt 3 zur Validierung"
-    ],
-    "zeitersparnis": "{{monatsersparnis_stunden}} Std./Monat (bei {{STUNDENSATZ_EUR}}€/h)"
+    "problem": "Welcher Engpass besteht konkret? Beschreibe den Pain Point aus ZEITERSPARNIS_PRIORITAET in 2-3 Sätzen.",
+    "wirkung": "Konkreter Nutzen OHNE Zahlen: Was verbessert sich qualitativ? 2-3 Sätze über die Wirkung auf Arbeitsqualität, Konsistenz, Entlastung.",
+    "umsetzung": "1–2 klare Schritte zur Umsetzung, Tool-Namen nennen, aber KEINE Zeitschätzungen.",
+    "hinweis": "Wirtschaftliche Effekte siehe Business Case"
   }
 ]
 ```
@@ -211,13 +219,16 @@ Analysiere die Unternehmensdaten und erstelle 3-5 Quick Wins als **JSON Array** 
 
 - [ ] Valides JSON (keine trailing commas, escaped quotes)
 - [ ] 3-5 Quick Wins im Array
-- [ ] Jeder Quick Win hat alle 7 Felder: title, icon, engpass, description, mit_ki, steps, zeitersparnis
+- [ ] Jeder Quick Win hat alle 6 Felder: title, icon, problem, wirkung, umsetzung, hinweis
 - [ ] Icons sind Emojis (nicht Text)
-- [ ] steps ist Array mit 3-5 Strings
 - [ ] Keine HTML-Tags im JSON
 - [ ] Quick Win #1 zitiert ZEITERSPARNIS_PRIORITAET
 - [ ] Tool-Namen sind KONKRET (nicht "KI-Tools")
 - [ ] Guardrails werden beachten (falls vorhanden)
+- [ ] **≥ 40 Wörter pro Quick Win (insgesamt)**
+- [ ] **KEINE Zahlen in problem/wirkung/umsetzung**
+- [ ] **KEINE Zeitangaben oder Stundenangaben**
+- [ ] hinweis verweist auf Business Case
 
 ### ⚠️ HAUPTLEISTUNG BALANCIERTE CHECKS:
 - [ ] Quick Win #1: title UND description referenzieren {{hauptleistung}} (2x)
@@ -256,48 +267,33 @@ Analysiere die Unternehmensdaten und erstelle 3-5 Quick Wins als **JSON Array** 
 
 ---
 
-## BEISPIEL (Beratungsbranche)
+## BEISPIEL (Beratungsbranche) — NEUES FORMAT
 
 ```json
 [
   {
     "title": "Ablauf-Blueprint für Ihre KI-Beratungsprojekte",
     "icon": "🎯",
-    "engpass": "Entwicklung und Optimierung von Abläufen",
-    "description": "Aktuell strukturieren Sie jeden Beratungsablauf (Fragebogen, Auswertung, Report) neu und optimieren ad hoc – das kostet viel Denk- und Dokumentationszeit.",
-    "mit_ki": "ChatGPT Plus erstellt mit Ihnen einen wiederverwendbaren Standard-Workflow inkl. Checklisten und Textbausteinen, den Sie nur noch leicht je Kunde anpassen.",
-    "steps": [
-      "ChatGPT Plus buchen (20€/Monat)",
-      "Beste bisherige Projekte analysieren",
-      "Standard-Workflow & Checklisten generieren"
-    ],
-    "zeitersparnis": "{{monatsersparnis_stunden}} Std./Monat (bei {{STUNDENSATZ_EUR}}€/h)"
+    "problem": "Aktuell strukturieren Sie jeden Beratungsablauf – Fragebogen, Auswertung, Report – individuell neu und optimieren ad hoc. Das kostet erhebliche Denk- und Dokumentationszeit und führt zu inkonsistenten Ergebnissen zwischen verschiedenen Projekten.",
+    "wirkung": "Mit einem standardisierten Workflow entstehen konsistente Beratungsergebnisse. Wiederverwendbare Checklisten und Textbausteine reduzieren den Aufwand bei Neuprojekten erheblich. Die Qualität steigt durch bewährte Prozessschritte.",
+    "umsetzung": "ChatGPT Plus nutzen, um aus Ihren besten bisherigen Projekten einen wiederverwendbaren Standard-Workflow mit Checklisten und Textbausteinen zu generieren.",
+    "hinweis": "Wirtschaftliche Effekte siehe Business Case"
   },
   {
     "title": "Testphase Ihres KI-Fragebogens in erweiterbares MVP",
     "icon": "🚀",
-    "engpass": "das Projekt mit der Beratung von Unternehmen zur Integration von KI",
-    "description": "Sie testen das Angebot manuell, Auswertung und Reports entstehen jedes Mal neu und sind noch nicht als Produktpaket definiert.",
-    "mit_ki": "Sie nutzen ChatGPT Plus, um feste Fragebogen-Varianten, Auswertungslogik und Report-Templates zu erstellen und als schlankes Online-MVP zu standardisieren.",
-    "steps": [
-      "Beste Testfälle clustern (Kundentypen definieren)",
-      "Fragebogen-Varianten mit GPT schärfen",
-      "Standard-Reportstruktur bauen"
-    ],
-    "zeitersparnis": "{{monatsersparnis_stunden}} Std./Monat (bei {{STUNDENSATZ_EUR}}€/h)"
+    "problem": "Sie testen das Angebot manuell, Auswertung und Reports entstehen jedes Mal neu. Das Produktpaket ist noch nicht definiert, was die Wiederholbarkeit und Skalierbarkeit Ihres Angebots einschränkt.",
+    "wirkung": "Feste Fragebogen-Varianten und Report-Templates schaffen ein standardisiertes Produktpaket. Die Auswertungslogik wird reproduzierbar. Neue Kunden erhalten schneller professionelle Ergebnisse.",
+    "umsetzung": "Beste Testfälle clustern und Kundentypen definieren. Fragebogen-Varianten mit GPT schärfen und Standard-Reportstruktur aufbauen.",
+    "hinweis": "Wirtschaftliche Effekte siehe Business Case"
   },
   {
     "title": "KI-Sicherheitsrichtlinie erstellen",
     "icon": "🔒",
-    "engpass": "Security-Score 45/100 (Handlungsbedarf)",
-    "description": "Ohne klare Sicherheitsregeln riskieren Sie Datenschutzverletzungen bei der KI-Nutzung.",
-    "mit_ki": "Claude Pro hilft Ihnen, eine kompakte Richtlinie zu erstellen: Welche Daten dürfen in KI-Tools? Welche Tools sind freigegeben?",
-    "steps": [
-      "Datenklassifikation erstellen",
-      "Tool-Freigabeliste definieren",
-      "Prüfregeln dokumentieren"
-    ],
-    "zeitersparnis": "Risikominimierung + Compliance"
+    "problem": "Ohne klare Sicherheitsregeln riskieren Sie Datenschutzverletzungen bei der KI-Nutzung. Mitarbeiter wissen nicht, welche Daten in welche Tools eingegeben werden dürfen.",
+    "wirkung": "Eine kompakte Richtlinie schafft Klarheit über erlaubte Datenverarbeitung. Freigabelisten verhindern unbeabsichtigte Datenschutzverletzungen. Das Compliance-Risiko sinkt spürbar.",
+    "umsetzung": "Datenklassifikation erstellen, Tool-Freigabeliste definieren, Prüfregeln dokumentieren – Claude Pro unterstützt bei der Formulierung.",
+    "hinweis": "Risikominimierung und Compliance-Absicherung"
   }
 ]
 ```

--- a/prompts/de/roadmap_90d_decision.md
+++ b/prompts/de/roadmap_90d_decision.md
@@ -1,11 +1,45 @@
 Developer:
+<!-- FIX-506: STRICT CANONICAL CONTRACT -->
+<!--
+###############################################################################
+##                    STRICT CANONICAL CONTRACT                              ##
+###############################################################################
+
+You MUST NOT:
+- invent, estimate or restate KPI values
+- use example numbers, ranges or scenarios
+- include conversational phrases
+- explain ROI/Payback with numbers
+
+You MAY:
+- reference canonical KPIs symbolically ("laut Business Case")
+- explain logic and implications WITHOUT numbers
+- defer numeric details explicitly to KPI or Simulation sections
+
+If a number is required:
+→ write: "siehe Business Case / Simulation"
+
+HARD BLACKLIST (Fail-Closed):
+- "wie kann ich dir helfen" / "wie kann ich helfen"
+- "bei Bedarf"
+- "z. B." / "z.B."
+- "angenommen"
+- "typischerweise"
+- "Rollout"
+- "Skalierung"
+- "Modul"
+- "Stack"
+- "1000+"
+
+###############################################################################
+-->
 AUSGABEREGEL (zwingend): Schreibe ausschließlich deklarative Berichtssätze. Keine Anrede, keine Fragen, keine Meta-Kommentare, keine Hinweise auf fehlende Eingaben, keine Imperative. Beginne niemals mit Verben wie „beschreibe", „schreibe", „antworte", „hilf". Kein Bezug auf den Leser oder auf „Nachrichten/Fragen".
 
-STARTFORMAT: Beginne mit einem neutralen Substantivsatz (z. B. „Der aktuelle Zustand…", „Die empfohlene Vorgehensweise…", „Der strategische Rahmen…").
+STARTFORMAT: Beginne mit einem neutralen Substantivsatz (wie „Der aktuelle Zustand…", „Die empfohlene Vorgehensweise…", „Der strategische Rahmen…").
 
 NICHT ERLAUBT: „wie kann ich helfen", „ich sehe keine frage", „beschreibe dein anliegen", „du hast noch keine frage", „bitte", „frage", „nachricht".
 
-WICHTIG: Verwenden Sie keine Anrede, keine Fragen, keine Assistenz- oder Chat-Formulierungen. Keine Meta-Kommentare über fehlende Eingaben (z.B. "ich sehe keine Frage"). Schreiben Sie ausschließlich in neutraler Berichtssprache.
+WICHTIG: Verwenden Sie keine Anrede, keine Fragen, keine Assistenz- oder Chat-Formulierungen. Keine Meta-Kommentare über fehlende Eingaben. Schreiben Sie ausschließlich in neutraler Berichtssprache.
 
 <!-- PLATIN+++ PROMPT v1.0 - ROADMAP 90D DECISION -->
 <!-- SECTION: roadmap_90d_decision -->

--- a/tests/test_fix506_banned_patterns.py
+++ b/tests/test_fix506_banned_patterns.py
@@ -93,32 +93,32 @@ class TestBannedPatternsNotInOutput:
             assert not matches, f"Found banned pattern '{pattern}' in tools_empfehlungen.md: {matches}"
 
 
-class TestCanonicalKPIContractHeaders:
-    """Tests that Canonical KPI Contract headers are present."""
+class TestCanonicalContractHeaders:
+    """Tests that Canonical Contract headers are present."""
 
     @pytest.fixture
     def project_root(self):
         """Get project root directory."""
         return Path(__file__).parent.parent
 
-    def test_quick_wins_has_kpi_contract(self, project_root):
-        """quick_wins.md has Canonical KPI Contract header."""
+    def test_quick_wins_has_contract(self, project_root):
+        """quick_wins.md has STRICT CANONICAL CONTRACT header."""
         content = (project_root / "prompts/de/quick_wins.md").read_text()
-        assert "CANONICAL KPI CONTRACT" in content
+        assert "STRICT CANONICAL CONTRACT" in content
 
-    def test_business_case_has_kpi_contract(self, project_root):
+    def test_business_case_has_contract(self, project_root):
         """business_case.md has Canonical KPI Contract header."""
         content = (project_root / "prompts/de/business_case.md").read_text()
-        assert "CANONICAL KPI CONTRACT" in content
+        assert "CANONICAL KPI CONTRACT" in content or "STRICT CANONICAL CONTRACT" in content
 
-    def test_gamechanger_has_kpi_contract(self, project_root):
+    def test_gamechanger_has_contract(self, project_root):
         """gamechanger.md has Canonical KPI Contract header."""
         content = (project_root / "prompts/de/gamechanger.md").read_text()
-        assert "CANONICAL KPI CONTRACT" in content
+        assert "CANONICAL KPI CONTRACT" in content or "STRICT CANONICAL CONTRACT" in content
 
 
-class TestQuickWinsNoInventedNumbers:
-    """Tests that Quick Wins don't have invented time/hour ranges."""
+class TestQuickWinsSimplifiedFormat:
+    """Tests that Quick Wins use the new simplified format (FIX-506)."""
 
     @pytest.fixture
     def project_root(self):
@@ -133,20 +133,94 @@ class TestQuickWinsNoInventedNumbers:
         assert '"time": "6-10' not in content
         assert '"time": "5-8' not in content
 
-    def test_zeitersparnis_uses_variable(self, project_root):
-        """Quick Wins zeitersparnis should use canonical variable."""
+    def test_has_new_simplified_fields(self, project_root):
+        """Quick Wins should have new simplified fields: problem, wirkung, umsetzung, hinweis."""
         content = (project_root / "prompts/de/quick_wins.md").read_text()
 
-        # Check that zeitersparnis uses the canonical variable
-        assert "{{monatsersparnis_stunden}}" in content
+        # Check for the new field names in format section
+        assert '"problem":' in content
+        assert '"wirkung":' in content
+        assert '"umsetzung":' in content
+        assert '"hinweis":' in content
 
-    def test_no_invented_hour_ranges_in_steps(self, project_root):
-        """Quick Wins steps should not have invented time estimates like (2-3h)."""
+    def test_hinweis_references_business_case(self, project_root):
+        """Quick Wins hinweis should reference Business Case."""
         content = (project_root / "prompts/de/quick_wins.md").read_text()
 
-        # Pattern for invented time ranges in steps
+        # Check that hinweis references Business Case
+        assert "siehe Business Case" in content
+
+    def test_no_invented_hour_ranges(self, project_root):
+        """Quick Wins should not have invented time estimates like (2-3h) or 6-10 h/Monat."""
+        content = (project_root / "prompts/de/quick_wins.md").read_text()
+
+        # Remove comment blocks to check only active content
+        content_no_comments = re.sub(r'<!--.*?-->', '', content, flags=re.DOTALL)
+
+        # Pattern for invented time ranges
         invented_time_pattern = r'\(\d+-\d+h\)'
-        matches = re.findall(invented_time_pattern, content)
+        matches = re.findall(invented_time_pattern, content_no_comments)
 
         # There should be no invented time ranges
-        assert not matches, f"Found invented time ranges in steps: {matches}"
+        assert not matches, f"Found invented time ranges: {matches}"
+
+    def test_min_40_words_requirement_documented(self, project_root):
+        """Quick Wins should document ≥40 words per Quick Win requirement."""
+        content = (project_root / "prompts/de/quick_wins.md").read_text()
+
+        # Check for the word count requirement
+        assert "40 Wörter" in content or "≥ 40" in content
+
+
+class TestDecisionPromptsHaveCanonicalContract:
+    """Tests that decision prompts have STRICT CANONICAL CONTRACT."""
+
+    @pytest.fixture
+    def project_root(self):
+        """Get project root directory."""
+        return Path(__file__).parent.parent
+
+    def test_executive_decision_has_contract(self, project_root):
+        """executive_decision.md has STRICT CANONICAL CONTRACT."""
+        content = (project_root / "prompts/de/executive_decision.md").read_text()
+        assert "STRICT CANONICAL CONTRACT" in content
+
+    def test_roadmap_90d_decision_has_contract(self, project_root):
+        """roadmap_90d_decision.md has STRICT CANONICAL CONTRACT."""
+        content = (project_root / "prompts/de/roadmap_90d_decision.md").read_text()
+        assert "STRICT CANONICAL CONTRACT" in content
+
+    def test_gamechanger_decision_has_contract(self, project_root):
+        """gamechanger_decision.md has STRICT CANONICAL CONTRACT."""
+        content = (project_root / "prompts/de/gamechanger_decision.md").read_text()
+        assert "STRICT CANONICAL CONTRACT" in content
+
+    def test_ki_stack_summary_has_contract(self, project_root):
+        """ki_stack_summary.md has STRICT CANONICAL CONTRACT."""
+        content = (project_root / "prompts/de/ki_stack_summary.md").read_text()
+        assert "STRICT CANONICAL CONTRACT" in content
+
+    def test_branch_deep_dive_has_contract(self, project_root):
+        """branch_deep_dive.md has STRICT CANONICAL CONTRACT."""
+        content = (project_root / "prompts/de/branch_deep_dive.md").read_text()
+        assert "STRICT CANONICAL CONTRACT" in content
+
+
+class TestHardBlacklist:
+    """Tests that hard blacklist phrases are documented in prompts."""
+
+    @pytest.fixture
+    def project_root(self):
+        """Get project root directory."""
+        return Path(__file__).parent.parent
+
+    def test_quick_wins_has_hard_blacklist(self, project_root):
+        """quick_wins.md has HARD BLACKLIST section."""
+        content = (project_root / "prompts/de/quick_wins.md").read_text()
+        assert "HARD BLACKLIST" in content or "Fail-Closed" in content
+
+    def test_decision_prompts_have_hard_blacklist(self, project_root):
+        """Decision prompts have HARD BLACKLIST section."""
+        for prompt_name in ["executive_decision.md", "roadmap_90d_decision.md", "gamechanger_decision.md"]:
+            content = (project_root / f"prompts/de/{prompt_name}").read_text()
+            assert "HARD BLACKLIST" in content, f"{prompt_name} missing HARD BLACKLIST"


### PR DESCRIPTION
Add STRICT CANONICAL CONTRACT headers with Hard Blacklist (Fail-Closed):
- executive_decision.md
- roadmap_90d_decision.md
- gamechanger_decision.md
- ki_stack_summary.md
- branch_deep_dive.md

Hard Blacklist includes:
- "wie kann ich dir helfen" / "wie kann ich helfen"
- "bei Bedarf"
- "z. B." / "z.B."
- "angenommen"
- "typischerweise"
- "Rollout", "Skalierung", "Modul", "Stack"
- "1000+"

Quick Wins format simplified (FIX-506):
- Removed: time, engpass, description, mit_ki, steps, zeitersparnis fields
- Added: problem, wirkung, umsetzung, hinweis fields
- New acceptance: ≥40 words per Quick Win, NO numbers/time estimates
- hinweis always references "siehe Business Case"

Decision prompts updated:
- Declarative report-style language only
- No conversational phrases or questions
- No CTAs or reader address

Tests expanded: 19 tests for banned patterns and new format