### PR TITLE
feat(FIX-511): eliminate last STRICT-On blockers (minimal scope)

### DIFF
--- a/gpt_analyze.py
+++ b/gpt_analyze.py
@@ -6664,6 +6664,57 @@ EXPAND_ELIGIBLE_SECTIONS = [
     "unternehmensprofil_markt",
 ]
 
+# FIX-511 CHANGE 1: Healable leak phrases that can be deterministically replaced
+# These phrases appear frequently in LLM output but can be safely replaced with "optional"
+# without needing regeneration or PLATIN fallback
+HEALABLE_LEAK_PHRASES = {
+    "bei bedarf": "optional",
+    "wenn sie möchten": "optional",
+    "falls gewünscht": "optional",
+}
+
+
+def _sanitize_healable_leaks(content: str, section_name: str) -> Tuple[str, Dict[str, int]]:
+    """
+    FIX-511 CHANGE 1: Deterministically sanitize healable leak phrases.
+
+    Replaces common leak phrases with safe alternatives BEFORE leak detection.
+    This prevents unnecessary regeneration and PLATIN fallback for phrases
+    that can be trivially fixed.
+
+    Args:
+        content: HTML content to sanitize
+        section_name: Name of section for logging
+
+    Returns:
+        Tuple of (sanitized_content, replacements_dict)
+        where replacements_dict maps phrase -> count replaced
+    """
+    if not content:
+        return content, {}
+
+    sanitized = content
+    replacements = {}
+    pre_len = len(content)
+
+    for phrase, replacement in HEALABLE_LEAK_PHRASES.items():
+        # Case-insensitive replacement
+        import re
+        pattern = re.compile(re.escape(phrase), re.IGNORECASE)
+        matches = pattern.findall(sanitized)
+        if matches:
+            replacements[phrase] = len(matches)
+            sanitized = pattern.sub(replacement, sanitized)
+
+    if replacements:
+        post_len = len(sanitized)
+        log.info(
+            "[FIX-511][LEAK-SAN] section=%s replaced=%s count=%d pre_len=%d post_len=%d",
+            section_name, replacements, sum(replacements.values()), pre_len, post_len
+        )
+
+    return sanitized, replacements
+
 
 def _detect_leak_phrases(content: str) -> List[str]:
     """
@@ -10727,43 +10778,77 @@ def _generate_content_section(section_name: str, briefing: Dict[str, Any], score
 
             # =========================================================================
             # N4.6 Zero-Leak Policy: Detect and regenerate if leaks found
+            # FIX-511 CHANGE 1: First try deterministic sanitization for healable leaks
             # =========================================================================
-            detected_leaks = _detect_leak_phrases(result)
-            if detected_leaks:
-                log.warning(
-                    "[N4.6] 🚨 Leak phrases detected in %s: %s – regenerating with strict mode",
-                    section_name,
-                    detected_leaks[:3],  # Log first 3 for brevity
-                )
-                # Try regeneration with strict anti-leak directive
-                regenerated = _regenerate_without_leaks(section_name, prompt_text, llm)
 
-                # Check if regenerated content is still leaky
-                regenerated_leaks = _detect_leak_phrases(regenerated)
-                if not regenerated_leaks and regenerated:
-                    log.info("[N4.6] ✅ Regeneration successful – no leaks in %s", section_name)
-                    result = regenerated
-                else:
-                    # PLATIN+++ v5.4: If still leaky, use PLATIN fallback instead of stripping
-                    # Rationale: Stripped content is often broken/incoherent - full fallback is better
-                    log.warning(
-                        "[N4.6] ⚠️ Regeneration still has leaks in %s – using PLATIN fallback (not stripping)",
-                        section_name
+            # FIX-511: First sanitize healable leaks deterministically
+            result, sanitize_replacements = _sanitize_healable_leaks(result, section_name)
+
+            # Now detect remaining leaks
+            detected_leaks = _detect_leak_phrases(result)
+
+            if detected_leaks:
+                # FIX-511: Check if remaining leaks are all healable (shouldn't happen after sanitize, but safety check)
+                healable_leak_set = set(HEALABLE_LEAK_PHRASES.keys())
+                remaining_leak_set = set(leak.lower() for leak in detected_leaks)
+
+                if remaining_leak_set.issubset(healable_leak_set):
+                    # All remaining leaks are healable - sanitize again and accept
+                    result, extra_replacements = _sanitize_healable_leaks(result, section_name)
+                    sanitize_replacements.update(extra_replacements)
+                    healed_list = list(remaining_leak_set)
+                    log.info(
+                        "[FIX-511][LEAK-SAN] healed_leaks=%s accepted_without_fallback=true",
+                        healed_list
                     )
-                    fallback_content = _get_fallback_content(section_name, briefing, scores)
-                    if fallback_content:
-                        log.info("[N4.6] ✅ PLATIN fallback used for %s", section_name)
-                        result = fallback_content
+                else:
+                    # Non-healable leaks detected - use regeneration path
+                    log.warning(
+                        "[N4.6] 🚨 Leak phrases detected in %s: %s – regenerating with strict mode",
+                        section_name,
+                        detected_leaks[:3],  # Log first 3 for brevity
+                    )
+                    # Try regeneration with strict anti-leak directive
+                    regenerated = _regenerate_without_leaks(section_name, prompt_text, llm)
+
+                    # FIX-511: Sanitize regenerated content too
+                    regenerated, _ = _sanitize_healable_leaks(regenerated, section_name)
+
+                    # Check if regenerated content is still leaky
+                    regenerated_leaks = _detect_leak_phrases(regenerated)
+                    if not regenerated_leaks and regenerated:
+                        log.info("[N4.6] ✅ Regeneration successful – no leaks in %s", section_name)
+                        result = regenerated
                     else:
-                        # Last resort: strip only if no fallback available
-                        log.warning("[N4.6] No fallback for %s, stripping leaks as last resort", section_name)
-                        for leak in detected_leaks:
-                            import re as _re_leak
-                            pattern = _re_leak.compile(
-                                r'[^.!?]*' + _re_leak.escape(leak) + r'[^.!?]*[.!?]',
-                                _re_leak.IGNORECASE
-                            )
-                            result = pattern.sub('', result)
+                        # FIX-511: In STRICT mode, NO PLATIN fallback allowed for N4.6 leaks
+                        release_strict_n46 = os.getenv("RELEASE_STRICT_MODE", "0") in ("1", "true", "True")
+
+                        if release_strict_n46:
+                            # FIX-511: STRICT MODE - fail closed, no fallback
+                            error_msg = f"[FIX-511][N4.6] ❌ Section {section_name} still has leaks after regeneration+sanitize in STRICT MODE - blocking"
+                            log.error(error_msg)
+                            log.error("[FIX-511][N4.6] Remaining leaks: %s", regenerated_leaks)
+                            raise RuntimeError(error_msg)
+
+                        # Non-strict: PLATIN fallback allowed
+                        log.warning(
+                            "[N4.6] ⚠️ Regeneration still has leaks in %s – using PLATIN fallback (not stripping)",
+                            section_name
+                        )
+                        fallback_content = _get_fallback_content(section_name, briefing, scores)
+                        if fallback_content:
+                            log.info("[N4.6] ✅ PLATIN fallback used for %s", section_name)
+                            result = fallback_content
+                        else:
+                            # Last resort: strip only if no fallback available
+                            log.warning("[N4.6] No fallback for %s, stripping leaks as last resort", section_name)
+                            for leak in detected_leaks:
+                                import re as _re_leak
+                                pattern = _re_leak.compile(
+                                    r'[^.!?]*' + _re_leak.escape(leak) + r'[^.!?]*[.!?]',
+                                    _re_leak.IGNORECASE
+                                )
+                                result = pattern.sub('', result)
 
             # PLATIN+ Minimalumfang prüfen (dynamisch nach Section-Typ)
             # WICHTIG: Werte sind jetzt in WÖRTERN, nicht Zeichen!
@@ -14341,6 +14426,184 @@ NUR HTML ausgeben. Keine Erklärungen, keine Markdown-Fences."""
         log.error(f"[FIX-499-ROADMAP-REGEN] ❌ All {max_attempts} attempts failed")
         return None
 
+    # FIX-511 CHANGE 2: Regeneration function for KI_STACK_SUMMARY_HTML
+    def _regenerate_ki_stack_strict(context: Dict[str, Any], briefing: Dict[str, Any], max_attempts: int = 2) -> Optional[str]:
+        """
+        FIX-511: Regenerate KI_STACK_SUMMARY_HTML with strict constraints.
+
+        Must produce:
+        - Min 600 chars
+        - At least 4 bullet points OR 2 paragraphs + 1 bullet list
+        - No codefences
+        - No chat artifacts
+
+        Returns HTML content or None if regeneration fails.
+        """
+        branche = context.get("BRANCHE_LABEL", briefing.get("branche", "Ihrem Unternehmen"))
+
+        KI_STACK_STRICT_PROMPT = f"""Erstellen Sie eine KI-Stack-Empfehlung für {branche}.
+
+STRENGE REGELN (Pflicht):
+- Mindestens 6 konkrete Tool-Empfehlungen als Bulletpoints
+- Jeder Punkt: Tool-Kategorie + konkreter Einsatzzweck
+- Mindestlänge: 600 Zeichen gesamt
+- Sprache: Sie-Form, für Einzelunternehmer geeignet
+- VERBOTEN: Fragen, Chat-Floskeln, "Hier ist...", Code-Blöcke, Markdown
+
+FORMAT (exakt):
+<div class="ki-stack-summary">
+<h3>Empfohlener KI-Stack – Übersicht</h3>
+<ul>
+<li><strong>Textverarbeitung:</strong> [Konkrete Empfehlung]</li>
+<li><strong>Dokumentenanalyse:</strong> [Konkrete Empfehlung]</li>
+<li><strong>Prozessautomatisierung:</strong> [Konkrete Empfehlung]</li>
+<li><strong>Datenvisualisierung:</strong> [Konkrete Empfehlung]</li>
+<li><strong>Qualitätssicherung:</strong> [Konkrete Empfehlung]</li>
+<li><strong>Wissensmanagement:</strong> [Konkrete Empfehlung]</li>
+</ul>
+<p><em>Abschließende Empfehlung zur Tool-Auswahl.</em></p>
+</div>
+
+NUR HTML ausgeben. Keine Erklärungen, keine Markdown-Fences."""
+
+        FORBIDDEN_PATTERNS = [
+            "hier ist", "hier sind", "wie kann ich",
+            "gerne", "natürlich", "?", "```",
+            "frage", "fragen"
+        ]
+
+        for attempt in range(1, max_attempts + 1):
+            try:
+                log.info(f"[FIX-511][SG-REGEN] section=KI_STACK_SUMMARY_HTML attempt={attempt}/{max_attempts} reason=too_short")
+
+                response = _call_openai(
+                    prompt=KI_STACK_STRICT_PROMPT,
+                    temperature=0.5,
+                    max_tokens=1500,
+                    section="ki_stack_summary_strict",
+                )
+
+                if not response:
+                    log.warning(f"[FIX-511][SG-REGEN] KI_STACK attempt {attempt}: Empty response")
+                    continue
+
+                # Validate length
+                if len(response.strip()) < 600:
+                    log.warning(f"[FIX-511][SG-REGEN] KI_STACK attempt {attempt}: Too short ({len(response)} < 600)")
+                    continue
+
+                # Check for forbidden patterns
+                lower_response = response.lower()
+                forbidden_found = [p for p in FORBIDDEN_PATTERNS if p in lower_response]
+                if forbidden_found:
+                    log.warning(f"[FIX-511][SG-REGEN] KI_STACK attempt {attempt}: Forbidden patterns: {forbidden_found}")
+                    continue
+
+                # Check structure (at least 4 bullets)
+                li_count = response.count("<li>")
+                if li_count < 4:
+                    log.warning(f"[FIX-511][SG-REGEN] KI_STACK attempt {attempt}: Not enough bullets ({li_count} < 4)")
+                    continue
+
+                log.info(f"[FIX-511][SG-REGEN] section=KI_STACK_SUMMARY_HTML success len={len(response)} attempts={attempt}")
+                return response
+
+            except Exception as e:
+                log.error(f"[FIX-511][SG-REGEN] KI_STACK attempt {attempt} failed with error: {e}")
+                continue
+
+        log.error(f"[FIX-511][SG-REGEN][FAIL] section=KI_STACK_SUMMARY_HTML after_attempts={max_attempts}")
+        return None
+
+    # FIX-511 CHANGE 2: Regeneration function for GAMECHANGER_DECISION_HTML
+    def _regenerate_gamechanger_strict(context: Dict[str, Any], briefing: Dict[str, Any], max_attempts: int = 2) -> Optional[str]:
+        """
+        FIX-511: Regenerate GAMECHANGER_DECISION_HTML with strict constraints.
+
+        Must produce:
+        - Min 600 chars
+        - At least 4 bullet points OR 2 paragraphs + 1 bullet list
+        - No codefences
+        - No chat artifacts
+
+        Returns HTML content or None if regeneration fails.
+        """
+        branche = context.get("BRANCHE_LABEL", briefing.get("branche", "Ihrem Unternehmen"))
+
+        GAMECHANGER_STRICT_PROMPT = f"""Erstellen Sie strategische KI-Optionen (Gamechanger-Potenziale) für {branche}.
+
+STRENGE REGELN (Pflicht):
+- Mindestens 6 strategische Optionen als Bulletpoints
+- Jeder Punkt: Strategie-Name + konkreter Nutzen
+- Mindestlänge: 600 Zeichen gesamt
+- Sprache: Sie-Form, für Einzelunternehmer geeignet
+- VERBOTEN: Fragen, Chat-Floskeln, "Hier ist...", Code-Blöcke, Markdown
+
+FORMAT (exakt):
+<div class="gamechanger-decision">
+<h3>Strategische KI-Optionen – Gamechanger-Potenziale</h3>
+<ul>
+<li><strong>Automatisierte Kundeninteraktion:</strong> [Konkreter Nutzen für {branche}]</li>
+<li><strong>Prädiktive Analysen:</strong> [Konkreter Nutzen]</li>
+<li><strong>Content-Automatisierung:</strong> [Konkreter Nutzen]</li>
+<li><strong>Prozessoptimierung:</strong> [Konkreter Nutzen]</li>
+<li><strong>Wettbewerbsanalyse:</strong> [Konkreter Nutzen]</li>
+<li><strong>Personalisierung:</strong> [Konkreter Nutzen]</li>
+</ul>
+<p><em>Abschließende Empfehlung zum strategischen Differenzierungspotenzial.</em></p>
+</div>
+
+NUR HTML ausgeben. Keine Erklärungen, keine Markdown-Fences."""
+
+        FORBIDDEN_PATTERNS = [
+            "hier ist", "hier sind", "wie kann ich",
+            "gerne", "natürlich", "?", "```",
+            "frage", "fragen"
+        ]
+
+        for attempt in range(1, max_attempts + 1):
+            try:
+                log.info(f"[FIX-511][SG-REGEN] section=GAMECHANGER_DECISION_HTML attempt={attempt}/{max_attempts} reason=too_short")
+
+                response = _call_openai(
+                    prompt=GAMECHANGER_STRICT_PROMPT,
+                    temperature=0.5,
+                    max_tokens=1500,
+                    section="gamechanger_decision_strict",
+                )
+
+                if not response:
+                    log.warning(f"[FIX-511][SG-REGEN] GAMECHANGER attempt {attempt}: Empty response")
+                    continue
+
+                # Validate length
+                if len(response.strip()) < 600:
+                    log.warning(f"[FIX-511][SG-REGEN] GAMECHANGER attempt {attempt}: Too short ({len(response)} < 600)")
+                    continue
+
+                # Check for forbidden patterns
+                lower_response = response.lower()
+                forbidden_found = [p for p in FORBIDDEN_PATTERNS if p in lower_response]
+                if forbidden_found:
+                    log.warning(f"[FIX-511][SG-REGEN] GAMECHANGER attempt {attempt}: Forbidden patterns: {forbidden_found}")
+                    continue
+
+                # Check structure (at least 4 bullets)
+                li_count = response.count("<li>")
+                if li_count < 4:
+                    log.warning(f"[FIX-511][SG-REGEN] GAMECHANGER attempt {attempt}: Not enough bullets ({li_count} < 4)")
+                    continue
+
+                log.info(f"[FIX-511][SG-REGEN] section=GAMECHANGER_DECISION_HTML success len={len(response)} attempts={attempt}")
+                return response
+
+            except Exception as e:
+                log.error(f"[FIX-511][SG-REGEN] GAMECHANGER attempt {attempt} failed with error: {e}")
+                continue
+
+        log.error(f"[FIX-511][SG-REGEN][FAIL] section=GAMECHANGER_DECISION_HTML after_attempts={max_attempts}")
+        return None
+
     def _fallback_roadmap_decision_html(context: Dict[str, Any]) -> str:
         """Generate deterministic fallback for ROADMAP_90D_DECISION_HTML."""
         branche = context.get("BRANCHE_LABEL", "Ihrem Unternehmen")
@@ -14428,7 +14691,49 @@ NUR HTML ausgeben. Keine Erklärungen, keine Markdown-Fences."""
                         # Non-strict: allow fallback for development
                         log.warning(f"[{run_id}] [FIX-499] ⚠️ ROADMAP_90D_DECISION_HTML regeneration failed, using fallback (non-strict mode)")
 
-            # Default fallback behavior for other sections (or ROADMAP in non-strict after regen failure)
+            # FIX-511 CHANGE 2: KI_STACK_SUMMARY_HTML gets regeneration instead of fallback
+            elif section_key == "KI_STACK_SUMMARY_HTML":
+                log.warning(f"[{run_id}] [FIX-511][SG-REGEN] section=KI_STACK_SUMMARY_HTML reason={reason} len={len(html_content or '')}")
+
+                regen_result = _regenerate_ki_stack_strict(guard_context, answers, max_attempts=2)
+
+                if regen_result and len(regen_result.strip()) >= 600:
+                    sections[section_key] = regen_result
+                    log.info(f"[{run_id}] [FIX-511][SG-REGEN] ✅ KI_STACK_SUMMARY_HTML regenerated successfully (len={len(regen_result)})")
+                    continue  # Skip fallback, regeneration succeeded
+                else:
+                    # Regeneration failed
+                    if release_strict:
+                        # FIX-511: In strict mode, HARD FAIL - no fallback allowed
+                        error_msg = f"[{run_id}] [FIX-511][SG-REGEN][FAIL] section=KI_STACK_SUMMARY_HTML after_attempts=2 strict=1 - blocking report"
+                        log.error(error_msg)
+                        raise RuntimeError(error_msg)
+                    else:
+                        # Non-strict: allow fallback for development
+                        log.warning(f"[{run_id}] [FIX-511][SG-REGEN][FAIL] section=KI_STACK_SUMMARY_HTML after_attempts=2 strict=0 - using fallback")
+
+            # FIX-511 CHANGE 2: GAMECHANGER_DECISION_HTML gets regeneration instead of fallback
+            elif section_key == "GAMECHANGER_DECISION_HTML":
+                log.warning(f"[{run_id}] [FIX-511][SG-REGEN] section=GAMECHANGER_DECISION_HTML reason={reason} len={len(html_content or '')}")
+
+                regen_result = _regenerate_gamechanger_strict(guard_context, answers, max_attempts=2)
+
+                if regen_result and len(regen_result.strip()) >= 600:
+                    sections[section_key] = regen_result
+                    log.info(f"[{run_id}] [FIX-511][SG-REGEN] ✅ GAMECHANGER_DECISION_HTML regenerated successfully (len={len(regen_result)})")
+                    continue  # Skip fallback, regeneration succeeded
+                else:
+                    # Regeneration failed
+                    if release_strict:
+                        # FIX-511: In strict mode, HARD FAIL - no fallback allowed
+                        error_msg = f"[{run_id}] [FIX-511][SG-REGEN][FAIL] section=GAMECHANGER_DECISION_HTML after_attempts=2 strict=1 - blocking report"
+                        log.error(error_msg)
+                        raise RuntimeError(error_msg)
+                    else:
+                        # Non-strict: allow fallback for development
+                        log.warning(f"[{run_id}] [FIX-511][SG-REGEN][FAIL] section=GAMECHANGER_DECISION_HTML after_attempts=2 strict=0 - using fallback")
+
+            # Default fallback behavior for other sections (or after regen failure in non-strict mode)
             fallback_html = fallback_fn(guard_context)
             sections[section_key] = fallback_html
             # FIX-498 WP6: Track fallback usage for metrics truth

--- a/services/research_pipeline.py
+++ b/services/research_pipeline.py
@@ -468,17 +468,32 @@ def _perplexity_competitor_analysis(
     - Short Query Mode for finance/beratung + EN
     - 2-stage retry mechanism
     - Returns (results, success_flag)
+
+    FIX-511 CHANGE 3:
+    - Dynamic year instead of hardcoded 2025
+    - Clear endpoint/model logging
     """
     if not os.getenv("PERPLEXITY_API_KEY"):
         return [], False
 
-    topic = f"Wettbewerber und Marktführer KI-Lösungen {branche} Deutschland 2025"
+    # FIX-511 CHANGE 3: Use dynamic year instead of hardcoded 2025
+    current_year = datetime.now(timezone.utc).year
+    topic = f"Wettbewerber und Marktführer KI-Lösungen {branche} Deutschland {current_year}"
 
     # N3-01: Short Query Mode for finance/beratung with EN language
     branche_lower = branche.lower() if branche else ""
     if lang == "en" and any(b in branche_lower for b in SHORT_QUERY_BRANCHES):
         topic = shorten_query(topic)
         log.info("[N3-01] Short Query Mode activated for competitor analysis (EN)")
+
+    # FIX-511 CHANGE 3: Clear endpoint/model logging for transparency
+    pplx_endpoint = os.getenv("PPLX_ENDPOINT", "https://api.perplexity.ai/chat/completions")
+    pplx_model = os.getenv("PERPLEXITY_MODEL") or os.getenv("PPLX_MODEL", "sonar-pro")
+    query_preview = topic[:120] + "..." if len(topic) > 120 else topic
+    log.info(
+        "[PERPLEXITY] endpoint=%s model=%s year=%d query=\"%s\"",
+        pplx_endpoint, pplx_model, current_year, query_preview
+    )
 
     log.info("🔍 Perplexity competitor analysis: %s", topic)
 
@@ -789,14 +804,17 @@ def _market_fallback_html() -> str:
     Generates fallback HTML when no market insights are available.
 
     SPRINT G14-B: Expanded to 3 substantive paragraphs for better content quality.
+    FIX-511: Dynamic year instead of hardcoded 2025.
     """
-    return '''
+    # FIX-511: Use dynamic year
+    current_year = datetime.now(timezone.utc).year
+    return f'''
 <div class="research-fallback market-fallback">
   <p><strong>Markt-Insights:</strong></p>
   <p>Aktuell keine spezifischen Markt-Insights verfügbar. Der KI-Markt entwickelt sich
      dynamisch – relevante Trends und Wettbewerbsinformationen sollten regelmäßig
      über Branchenpublikationen und Fachmedien verfolgt werden.</p>
-  <p><strong>Aktuelle Markttrends 2025:</strong> Generative KI wird zunehmend in
+  <p><strong>Aktuelle Markttrends {current_year}:</strong> Generative KI wird zunehmend in
      Geschäftsprozessen eingesetzt. Besonders gefragt sind Lösungen für
      Dokumentenverarbeitung, Kundenkommunikation und Prozessautomatisierung.
      KMU profitieren von sinkenden Einstiegskosten und benutzerfreundlichen

--- a/tests/test_fix511_strict_last_blockers.py
+++ b/tests/test_fix511_strict_last_blockers.py
@@ -1,0 +1,339 @@
+"""
+FIX-511: STRICT-On Last Blocker Cleanup Tests
+
+Tests for the three changes that eliminate hard blockers for RELEASE_STRICT_MODE=1:
+
+1. N4.6 Leak Sanitizer - deterministic healing of "bei Bedarf" etc.
+2. Section-Guard Regeneration for KI_STACK + GAMECHANGER
+3. Perplexity Competitor Query with dynamic year
+
+All tests run in minimal test environment (no sqlalchemy dependency).
+Tests use source inspection instead of imports where gpt_analyze has heavy dependencies.
+"""
+import pytest
+import re
+import os
+from datetime import datetime, timezone
+
+
+# Path to gpt_analyze.py for source inspection
+GPT_ANALYZE_PATH = os.path.join(os.path.dirname(__file__), "..", "gpt_analyze.py")
+
+
+def _read_gpt_analyze_source() -> str:
+    """Read gpt_analyze.py source for inspection tests."""
+    with open(GPT_ANALYZE_PATH, "r", encoding="utf-8") as f:
+        return f.read()
+
+
+class TestFix511_LeakSanitizer:
+    """Tests for CHANGE 1: N4.6 deterministic leak sanitizer."""
+
+    def test_sanitize_healable_leaks_function_exists(self):
+        """_sanitize_healable_leaks function should be defined."""
+        source = _read_gpt_analyze_source()
+        assert "def _sanitize_healable_leaks(" in source
+
+    def test_healable_leak_phrases_constant_exists(self):
+        """HEALABLE_LEAK_PHRASES constant should be defined."""
+        source = _read_gpt_analyze_source()
+        assert "HEALABLE_LEAK_PHRASES = {" in source
+
+    def test_healable_leak_phrases_contains_bei_bedarf(self):
+        """HEALABLE_LEAK_PHRASES should contain 'bei bedarf'."""
+        source = _read_gpt_analyze_source()
+        assert '"bei bedarf"' in source.lower()
+
+    def test_healable_leak_phrases_contains_wenn_sie_moechten(self):
+        """HEALABLE_LEAK_PHRASES should contain 'wenn sie möchten'."""
+        source = _read_gpt_analyze_source()
+        assert '"wenn sie möchten"' in source.lower()
+
+    def test_healable_leak_phrases_contains_falls_gewuenscht(self):
+        """HEALABLE_LEAK_PHRASES should contain 'falls gewünscht'."""
+        source = _read_gpt_analyze_source()
+        assert '"falls gewünscht"' in source.lower()
+
+    def test_sanitize_replaces_with_optional(self):
+        """Sanitizer should replace healable phrases with 'optional'."""
+        source = _read_gpt_analyze_source()
+        # All replacements map to "optional"
+        assert '"bei bedarf": "optional"' in source.lower()
+        assert '"wenn sie möchten": "optional"' in source.lower()
+        assert '"falls gewünscht": "optional"' in source.lower()
+
+    def test_sanitize_uses_case_insensitive_regex(self):
+        """Sanitizer should use case-insensitive replacement."""
+        source = _read_gpt_analyze_source()
+        # Check for re.IGNORECASE in the sanitize function
+        # Find the function and check it uses case-insensitive matching
+        sanitize_match = re.search(
+            r'def _sanitize_healable_leaks.*?(?=\ndef |\nclass |\Z)',
+            source,
+            re.DOTALL
+        )
+        assert sanitize_match is not None
+        func_source = sanitize_match.group()
+        assert "re.IGNORECASE" in func_source or "IGNORECASE" in func_source
+
+    def test_sanitize_logs_fix511_pattern(self):
+        """Sanitizer should log with [FIX-511][LEAK-SAN] pattern."""
+        source = _read_gpt_analyze_source()
+        assert "[FIX-511][LEAK-SAN]" in source
+
+
+class TestFix511_N46HealableLeaksNoFallback:
+    """Tests that healable leaks don't trigger PLATIN fallback."""
+
+    def test_healable_leaks_checked_before_regeneration(self):
+        """Healable leaks should be checked before triggering regeneration."""
+        source = _read_gpt_analyze_source()
+        # Should check if remaining leaks are subset of healable
+        assert "remaining_leak_set.issubset(healable_leak_set)" in source
+
+    def test_accepted_without_fallback_logged(self):
+        """Should log 'accepted_without_fallback=true' when healed."""
+        source = _read_gpt_analyze_source()
+        assert "accepted_without_fallback=true" in source
+
+    def test_sanitize_runs_before_leak_detection(self):
+        """Sanitizer should run BEFORE leak detection."""
+        source = _read_gpt_analyze_source()
+        # Find the N4.6 block and verify sanitize comes first
+        n46_block = re.search(
+            r'# N4\.6 Zero-Leak Policy.*?detected_leaks = _detect_leak_phrases',
+            source,
+            re.DOTALL
+        )
+        assert n46_block is not None
+        block_source = n46_block.group()
+        # Sanitize should appear before detect_leak_phrases call
+        assert "_sanitize_healable_leaks" in block_source
+
+
+class TestFix511_SectionGuardRegeneration:
+    """Tests for CHANGE 2: Section-Guard regeneration for KI_STACK + GAMECHANGER."""
+
+    def test_regenerate_ki_stack_strict_function_exists(self):
+        """_regenerate_ki_stack_strict should be defined."""
+        source = _read_gpt_analyze_source()
+        assert "def _regenerate_ki_stack_strict(" in source
+
+    def test_regenerate_gamechanger_strict_function_exists(self):
+        """_regenerate_gamechanger_strict should be defined."""
+        source = _read_gpt_analyze_source()
+        assert "def _regenerate_gamechanger_strict(" in source
+
+    def test_ki_stack_regeneration_has_min_600_chars(self):
+        """KI_STACK regeneration should require min 600 chars."""
+        source = _read_gpt_analyze_source()
+        # Find the KI_STACK regeneration function
+        func_match = re.search(
+            r'def _regenerate_ki_stack_strict.*?(?=\n    def |\Z)',
+            source,
+            re.DOTALL
+        )
+        assert func_match is not None
+        assert "600" in func_match.group()
+
+    def test_gamechanger_regeneration_has_min_600_chars(self):
+        """GAMECHANGER regeneration should require min 600 chars."""
+        source = _read_gpt_analyze_source()
+        func_match = re.search(
+            r'def _regenerate_gamechanger_strict.*?(?=\n    def |\Z)',
+            source,
+            re.DOTALL
+        )
+        assert func_match is not None
+        assert "600" in func_match.group()
+
+    def test_section_guard_handles_ki_stack(self):
+        """Section guard should have special handling for KI_STACK_SUMMARY_HTML."""
+        source = _read_gpt_analyze_source()
+        assert 'section_key == "KI_STACK_SUMMARY_HTML"' in source
+        assert "_regenerate_ki_stack_strict(guard_context, answers" in source
+
+    def test_section_guard_handles_gamechanger(self):
+        """Section guard should have special handling for GAMECHANGER_DECISION_HTML."""
+        source = _read_gpt_analyze_source()
+        assert 'section_key == "GAMECHANGER_DECISION_HTML"' in source
+        assert "_regenerate_gamechanger_strict(guard_context, answers" in source
+
+    def test_sg_regen_log_patterns(self):
+        """[FIX-511][SG-REGEN] log patterns should exist."""
+        source = _read_gpt_analyze_source()
+        assert "[FIX-511][SG-REGEN] section=KI_STACK_SUMMARY_HTML" in source
+        assert "[FIX-511][SG-REGEN] section=GAMECHANGER_DECISION_HTML" in source
+
+    def test_sg_regen_fail_log_pattern(self):
+        """[FIX-511][SG-REGEN][FAIL] pattern should exist."""
+        source = _read_gpt_analyze_source()
+        assert "[FIX-511][SG-REGEN][FAIL]" in source
+
+
+class TestFix511_PerplexityCompetitorQuery:
+    """Tests for CHANGE 3: Perplexity competitor query with dynamic year."""
+
+    def _read_research_pipeline_source(self) -> str:
+        """Read research_pipeline.py source for inspection."""
+        pipeline_path = os.path.join(os.path.dirname(__file__), "..", "services", "research_pipeline.py")
+        with open(pipeline_path, "r", encoding="utf-8") as f:
+            return f.read()
+
+    def test_perplexity_competitor_uses_dynamic_year(self):
+        """Competitor analysis should use datetime for year, not hardcoded 2025."""
+        source = self._read_research_pipeline_source()
+
+        # Find the _perplexity_competitor_analysis function
+        func_match = re.search(
+            r'def _perplexity_competitor_analysis.*?(?=\ndef |\nclass |\Z)',
+            source,
+            re.DOTALL
+        )
+        assert func_match is not None
+        func_source = func_match.group()
+
+        # Should have dynamic year calculation
+        assert "datetime.now(timezone.utc).year" in func_source
+        # Should use variable in topic string
+        assert "Deutschland {current_year}" in func_source
+        # Should NOT have hardcoded 2025 in topic
+        assert 'Deutschland 2025"' not in func_source
+
+    def test_perplexity_logs_endpoint_and_model(self):
+        """Competitor analysis should log endpoint, model, year, query."""
+        source = self._read_research_pipeline_source()
+
+        # Find the _perplexity_competitor_analysis function
+        func_match = re.search(
+            r'def _perplexity_competitor_analysis.*?(?=\ndef |\nclass |\Z)',
+            source,
+            re.DOTALL
+        )
+        assert func_match is not None
+        func_source = func_match.group()
+
+        assert "[PERPLEXITY]" in func_source
+        assert "endpoint=" in func_source
+        assert "model=" in func_source
+        assert "year=" in func_source
+        assert "query=" in func_source
+
+    def test_market_fallback_uses_dynamic_year(self):
+        """Market fallback HTML should use dynamic year."""
+        source = self._read_research_pipeline_source()
+
+        # Find the _market_fallback_html function
+        func_match = re.search(
+            r'def _market_fallback_html.*?(?=\ndef |\nclass |\Z)',
+            source,
+            re.DOTALL
+        )
+        assert func_match is not None
+        func_source = func_match.group()
+
+        # Should use current_year variable
+        assert "current_year" in func_source
+        # Should have the trend heading with dynamic year
+        assert "{current_year}" in func_source
+
+    def test_market_fallback_not_hardcoded_2025(self):
+        """Market fallback should not have hardcoded 2025."""
+        source = self._read_research_pipeline_source()
+
+        # Find the _market_fallback_html function
+        func_match = re.search(
+            r'def _market_fallback_html.*?(?=\ndef |\nclass |\Z)',
+            source,
+            re.DOTALL
+        )
+        assert func_match is not None
+        func_source = func_match.group()
+
+        # Should NOT have hardcoded 2025
+        assert "Aktuelle Markttrends 2025" not in func_source
+        # Should use f-string with current_year
+        assert "{current_year}" in func_source
+
+
+class TestFix511_StrictModeIntegration:
+    """Integration tests for STRICT mode behavior."""
+
+    def test_strict_mode_env_check_in_n46(self):
+        """N4.6 leak handling should check RELEASE_STRICT_MODE."""
+        source = _read_gpt_analyze_source()
+        assert 'release_strict_n46 = os.getenv("RELEASE_STRICT_MODE"' in source
+
+    def test_strict_mode_raises_runtime_error_for_n46_leaks(self):
+        """In STRICT mode, unhealed leaks should raise RuntimeError."""
+        source = _read_gpt_analyze_source()
+        assert "[FIX-511][N4.6] ❌ Section" in source
+        # Should raise RuntimeError after the error message
+        n46_strict_block = re.search(
+            r'\[FIX-511\]\[N4\.6\] ❌.*?raise RuntimeError',
+            source,
+            re.DOTALL
+        )
+        assert n46_strict_block is not None
+
+    def test_strict_mode_blocks_ki_stack_fallback(self):
+        """In STRICT mode, KI_STACK failures should raise RuntimeError."""
+        source = _read_gpt_analyze_source()
+        assert "[FIX-511][SG-REGEN][FAIL] section=KI_STACK_SUMMARY_HTML after_attempts=2 strict=1" in source
+
+    def test_strict_mode_blocks_gamechanger_fallback(self):
+        """In STRICT mode, GAMECHANGER failures should raise RuntimeError."""
+        source = _read_gpt_analyze_source()
+        assert "[FIX-511][SG-REGEN][FAIL] section=GAMECHANGER_DECISION_HTML after_attempts=2 strict=1" in source
+
+
+class TestFix511_ForbiddenLogPatterns:
+    """Tests that forbidden patterns should NOT appear in logs."""
+
+    def _read_research_pipeline_source(self) -> str:
+        """Read research_pipeline.py source for inspection."""
+        pipeline_path = os.path.join(os.path.dirname(__file__), "..", "services", "research_pipeline.py")
+        with open(pipeline_path, "r", encoding="utf-8") as f:
+            return f.read()
+
+    def test_no_hardcoded_2025_in_competitor_query_topic(self):
+        """Topic string should not have hardcoded 2025."""
+        source = self._read_research_pipeline_source()
+
+        # Find the _perplexity_competitor_analysis function
+        func_match = re.search(
+            r'def _perplexity_competitor_analysis.*?(?=\ndef |\nclass |\Z)',
+            source,
+            re.DOTALL
+        )
+        assert func_match is not None
+        func_source = func_match.group()
+
+        # The topic assignment should use {current_year}, not 2025
+        topic_line = [line for line in func_source.split('\n') if 'topic = f"' in line]
+        assert len(topic_line) > 0, "Should have topic assignment with f-string"
+        assert '2025' not in topic_line[0], "Topic should not have hardcoded 2025"
+
+
+class TestFix511_ExpectedLogPatterns:
+    """Tests for expected log patterns that SHOULD appear."""
+
+    def _read_research_pipeline_source(self) -> str:
+        """Read research_pipeline.py source for inspection."""
+        pipeline_path = os.path.join(os.path.dirname(__file__), "..", "services", "research_pipeline.py")
+        with open(pipeline_path, "r", encoding="utf-8") as f:
+            return f.read()
+
+    def test_leak_san_section_replaced_pattern(self):
+        """[FIX-511][LEAK-SAN] section= replaced= pattern should exist."""
+        source = _read_gpt_analyze_source()
+        assert "[FIX-511][LEAK-SAN] section=" in source
+        assert "replaced=" in source
+
+    def test_perplexity_log_has_all_fields(self):
+        """[PERPLEXITY] log should include endpoint, model, year, query."""
+        source = self._read_research_pipeline_source()
+
+        # Should have complete log line
+        log_match = re.search(r'\[PERPLEXITY\].*endpoint=.*model=.*year=.*query=', source)
+        assert log_match is not None, "PERPLEXITY log should have all fields"


### PR DESCRIPTION
Three targeted changes for RELEASE_STRICT_MODE=1 readiness:

CHANGE 1 - N4.6 "bei Bedarf" deterministic healing:
- Added HEALABLE_LEAK_PHRASES constant with 3 phrases
- Added _sanitize_healable_leaks() function that replaces: "bei Bedarf" → "optional", "wenn Sie möchten" → "optional", "falls gewünscht" → "optional"
- Sanitizer runs BEFORE leak detection (no regeneration needed)
- If only healable leaks remain, accept without PLATIN fallback
- STRICT mode: RuntimeError if non-healable leaks after sanitize+regen
- Logs: [FIX-511][LEAK-SAN] healed_leaks=... accepted_without_fallback=true

CHANGE 2 - Section-Guard regeneration for KI_STACK + GAMECHANGER:
- Added _regenerate_ki_stack_strict() (min 600 chars, 4+ bullets)
- Added _regenerate_gamechanger_strict() (min 600 chars, 4+ bullets)
- Section guard now tries regeneration (max 2 attempts) before fallback
- STRICT mode: RuntimeError if regeneration fails
- Logs: [FIX-511][SG-REGEN] section=... success/FAIL

CHANGE 3 - Perplexity competitor query dynamic year + logging:
- Replaced hardcoded "2025" with datetime.now(timezone.utc).year
- Added clear log: [PERPLEXITY] endpoint=... model=... year=... query="..."
- Updated _market_fallback_html() to use dynamic year

Tests: 30 new tests (all passing)