### PR TITLE
fix(PROMPT-DEPRIME-A): remove priming tokens and chat phrases from pr…

### DIFF
--- a/prompts/de/executive_decision.md
+++ b/prompts/de/executive_decision.md
@@ -19,17 +19,11 @@ You MAY:
 If a number is required:
 → write: "siehe Business Case / Simulation"
 
-HARD BLACKLIST (Fail-Closed):
-- "wie kann ich dir helfen" / "wie kann ich helfen"
-- "bei Bedarf"
-- "z. B." / "z.B."
-- "angenommen"
-- "typischerweise"
-- "Rollout"
-- "Skalierung"
-- "Modul"
-- "Stack"
-- "1000+"
+DE-PRIMED EXCLUSION (Fail-Closed):
+- Keine Gesprächs-/Assistenzsprache, keine Fragen, keine Anrede.
+- Keine Optionalitätsfloskeln oder Beispielmarker.
+- Keine Technik-/Produktlaunch-Terminologie.
+- Keine erfundenen oder wiederholten KPI-Zahlen.
 
 ###############################################################################
 -->
@@ -37,7 +31,8 @@ AUSGABEREGEL (zwingend): Schreibe ausschließlich deklarative Berichtssätze. Ke
 
 STARTFORMAT: Beginne mit einem neutralen Substantivsatz (wie „Der aktuelle Zustand…", „Die empfohlene Vorgehensweise…", „Der strategische Rahmen…").
 
-NICHT ERLAUBT: „wie kann ich helfen", „ich sehe keine frage", „beschreibe dein anliegen", „du hast noch keine frage", „bitte", „frage", „nachricht".
+AUSGABEREGEL (zwingend):
+Nur deklarative Berichtssätze. Keine Anrede, keine Fragen, keine Meta-Kommentare.
 
 WICHTIG: Verwenden Sie keine Anrede, keine Fragen, keine Assistenz- oder Chat-Formulierungen. Keine Meta-Kommentare über fehlende Eingaben. Schreiben Sie ausschließlich in neutraler Berichtssprache.
 
@@ -61,8 +56,8 @@ CONSTRAINTS:
 - "Sie"-Form (formell)
 - Keine Superlative, keine Hype-Wörter
 - Keine neuen Zahlen/ROI/€-Versprechen
-- Kein Verweis auf "ChatGPT", "KI-Assistent", "wie kann ich helfen"
-- Keine Beratungs-CTAs ("Kontaktieren Sie uns", "Lassen Sie uns...")
+- Kein Verweis auf konkrete Produkt- oder Assistenz-Namen
+- Keine Beratungs-CTAs oder Handlungsaufforderungen
 
 HTML-VERTRAG (verbindlich):
 ERLAUBT: <div>, <p>, <ul>, <li>, <strong>, <span>, <br>
@@ -82,9 +77,7 @@ INHALTLICHE VERDICHTUNG (nutze nur vorhandene Konzepte):
 - "Tool-Zoo / Ad-hoc-Prompts ohne Standards" = No-Go
 - Stop-Regel: max. 2 parallele Initiativen; nach 14 Tagen ohne messbaren Effekt = vereinfachen oder stoppen
 
-OUTPUT-FORMAT (exakt einhalten):
-
-```html
+OUTPUT-FORMAT (exakt einhalten, ohne Markdown/Codeblöcke):
 <div class="exec-decision-box">
   <p><strong>Ihre Entscheidung in 3 Punkten</strong></p>
   <ul>
@@ -93,7 +86,6 @@ OUTPUT-FORMAT (exakt einhalten):
     <li><strong>Risiko & Stop-Signal:</strong> [Wann Sie stoppen und vereinfachen müssen]</li>
   </ul>
 </div>
-```
 
 STIL:
 - Distanziert-professionell, wie ein externer Gutachter
@@ -101,4 +93,4 @@ STIL:
 - Keine Erklärungen, nur Handlungsanweisungen
 
 GUARDRAIL (zwingend):
-Keine Assistenz- oder Chat-Formulierungen (z. B. „wie kann ich helfen", „gerne erkläre ich"). Verwenden Sie ausschließlich Berichtssprache.
+Keine Assistenz-/Dialog-Sprache, keine Fragen, keine Imperative, keine Meta-Kommentare. Ausschließlich neutrale Berichtssprache.

--- a/prompts/de/roadmap_12m.md
+++ b/prompts/de/roadmap_12m.md
@@ -33,7 +33,7 @@ VERBOTEN: <h1>, <h2>, <h3>, <h4>, <section>, <article>
 <!-- WORD_MINIMUM_TEAM: 600 -->
 <!-- WORD_MINIMUM_KMU: 700 -->
 <!--
-ZIEL: 12-Monats-Roadmap als strategische Entscheidungskette (nicht Tool-Rollout).
+ZIEL: 12-Monats-Roadmap als strategische Entscheidungskette (nicht Tool-Umsetzungsplan).
 
 =============================================================================
 SPRACHSHIFT v6.0 — ENTSCHEIDUNGEN STATT IMPLEMENTIERUNGEN:
@@ -60,7 +60,7 @@ LESBARKEIT (v6.1 NEU):
 MINDESTLÄNGE (STRIKT VERPFLICHTEND!):
 - Solo: mind. 500 Wörter (inkl. Q1-Q4 Phasen)
 - Team: mind. 600 Wörter (inkl. Rollen und Standards)
-- KMU: mind. 700 Wörter (inkl. 5-Dimensionen-Rollout)
+- KMU: mind. 700 Wörter (inkl. 5-Dimensionen-Ausbau)
 
 WICHTIG: Diese Mindestlängen sind verpflichtend und werden validiert!
 
@@ -73,7 +73,7 @@ KURZLABELS (VERPFLICHTEND!):
 STRUKTUR NACH GRÖSSE (max 3 Hauptabschnitte):
 - Solo: Zeitbasierte Phasen (Q1, Q2, Q3-4)
 - Team: Zeitbasierte Phasen mit Rollen
-- KMU: Block-Struktur (Tech, Data, Org, Product, Compliance) + Rollout
+- KMU: Block-Struktur (Tech, Data, Org, Product, Compliance) + Ausweitung
 
 LEITENTSCHEIDUNGEN PRO QUARTAL (v6.1 NEU - implizit verankern, nicht als Überschrift):
 - Q1: "Fundament vor Fläche" – Qualität der Basis sichern
@@ -96,7 +96,7 @@ ANTI-REDUNDANZ (STRIKT!):
 PERSONA-VARIATIONEN (COMPANY_SIZE):
 - solo: eigene Workflows, Self-Review, persönliche Routine
 - team: KI-Koordinator, gemeinsame Standards, Review-Runden
-- kmu: Fachbereiche, Governance-Board, Rollout-Plan, Compliance
+- kmu: Fachbereiche, Governance-Board, Ausbauplan, Compliance
 
 SPRINT G5 - PERSONA HARD-GUARDS (STRIKT!):
 {% if COMPANY_SIZE == "solo" %}
@@ -172,14 +172,14 @@ Aufbauend auf den ersten 90 Tagen – Fokus auf Erweiterung im Team.
 **🎯 Meilenstein Jahresende:** Nachweisbarer ROI, Roadmap 2.0 steht.
 
 {% else %}
-Aufbauend auf den ersten 90 Tagen – professioneller Rollout über 5 Dimensionen.
+Aufbauend auf den ersten 90 Tagen – professioneller Ausbau über 5 Dimensionen.
 
 ### Dimension 1: Technologie (Q1–Q2)
-- Tool-Stack finalisieren (Lizenzen, Zugänge, Integrationen)
+- Tool-Set finalisieren (Lizenzen, Zugänge, Integrationen)
 - Datenschnittstellen zu bestehenden Systemen prüfen
 - Technische Dokumentation erstellen
 
-**🎯 Meilenstein:** Tech-Stack stabil, Integrationen funktionsfähig.
+**🎯 Meilenstein:** Tool-Set stabil, Integrationen funktionsfähig.
 
 ### Dimension 2: Daten (Q1–Q2)
 - Relevante Datenquellen identifizieren und anbinden
@@ -190,13 +190,13 @@ Aufbauend auf den ersten 90 Tagen – professioneller Rollout über 5 Dimensione
 
 ### Dimension 3: Organisation (Q2–Q3)
 - KI-Verantwortliche in jedem Fachbereich benennen
-- Schulungskonzept ausrollen
+- Schulungskonzept für alle Bereiche umsetzen
 - Governance-Board etablieren (Quartalsweise Review)
 
 **🎯 Meilenstein:** Klare Verantwortlichkeiten, geschulte Mitarbeitende.
 
 ### Dimension 4: Produkt/Prozess (Q2–Q4)
-- Rollout auf 2–3 weitere Fachbereiche nach Pilot-Erfolg
+- Ausweitung auf 2–3 weitere Fachbereiche nach Pilot-Erfolg
 - Standard Operating Procedures (SOPs) für alle KI-Prozesse
 - Wirkungsmessung pro Bereich (Zeit, Kosten, Qualität)
 
@@ -214,7 +214,7 @@ Aufbauend auf den ersten 90 Tagen – professioneller Rollout über 5 Dimensione
 - Budget-Planung für Jahr 2
 - Roadmap 2.0 mit Erweiterungszielen
 
-**🎯 Meilenstein Jahresende:** Board-Entscheidung für Jahr 2, Rollout-Plan steht.
+**🎯 Meilenstein Jahresende:** Board-Entscheidung für Jahr 2, Ausbauplan steht.
 {% endif %}
 
 ---
@@ -223,14 +223,12 @@ Aufbauend auf den ersten 90 Tagen – professioneller Rollout über 5 Dimensione
 
 <!-- ZERO-LEAK POLICY (N4.6) -->
 <!--
-VERBOTEN – NIEMALS VERWENDEN:
-- Keine Fragen an den Leser ("Haben Sie Fragen?", "Möchten Sie mehr erfahren?")
-- Keine Aufforderungen ("Wenn Sie möchten...", "Kontaktieren Sie uns...")
-- Keine Assistenten-Sprache ("Ich kann Ihnen helfen...", "Gerne erkläre ich...")
-- Keine Angebote ("Bei Bedarf...", "Falls gewünscht...")
-- Keine interaktiven Elemente ("Klicken Sie hier...", "Wählen Sie...")
-- Keine Platzhalter ("[Hier einfügen]", "{{VARIABLE}}" außer definierten)
-- Keine Meta-Kommentare ("Dieser Abschnitt...", "Im Folgenden...")
+DE-PRIMED EXCLUSION (Fail-Closed):
+- Keine Gesprächs-/Assistenzsprache, keine Fragen, keine Anrede, keine Meta-Kommentare.
+- Keine Optionalitätsfloskeln oder Beispiel-/Abkürzungsmarker.
+- Keine Technik-/Produktlaunch-Terminologie.
+- Keine interaktiven Elemente oder Platzhalter (außer definierten Template-Variablen).
+- Keine Aufforderungen oder Handlungs-CTAs.
 
 Der Output ist ein FINALER REPORT-ABSCHNITT, kein Gespräch.
 -->

--- a/prompts/de/roadmap_90d.md
+++ b/prompts/de/roadmap_90d.md
@@ -137,7 +137,7 @@ ZIEL: 90-Tage-Roadmap als Abfolge von ENTSCHEIDUNGEN (nicht Tool-Einführungen).
 SPRACHSHIFT v6.0 — ENTSCHEIDUNGEN STATT IMPLEMENTIERUNGEN:
 =============================================================================
 
-Die Roadmap ist KEINE To-do-Liste für Tool-Rollouts.
+Die Roadmap ist KEINE To-do-Liste für Tool-Auswahl und -Nutzung.
 Die Roadmap ist eine Abfolge von bewussten Entscheidungen.
 
 VERBOTENE FORMULIERUNGEN → ERSETZUNGEN:
@@ -183,7 +183,7 @@ WICHTIG: Bei Unterschreitung wird Section abgelehnt!
 
 BOOSTER-SEKTIONEN (NEU - SPRINT G17.R):
 - Solo: KPI-Tracking & Mini-Dashboard Setup, Micro-Change-Management
-- Team: Team-Kommunikation & Rollout-Rituale, Dokumentation & Wissensspeicher
+- Team: Team-Kommunikation & Umsetzungsrituale, Dokumentation & Wissensspeicher
 - KMU: Change-Kommunikation auf Führungsebene, KPI-Framework für Arbeitsbereiche
 
 PHASEN-STRUKTUR (CONTENT QUALITY PACK v7.0 + PHASE 3 INDIVIDUALISIERUNG):
@@ -202,7 +202,7 @@ PHASE 0 (Woche 1–2): [INDIVIDUELL: Bezug zu {{hauptleistung}}]
 → Beispiel Briefing 369: "Phase 0: Fragebogen-Analyse Setup (Woche 1-2)"
 → Referenz: "Beginnen Sie mit dem 'Startpunkt in 30 Minuten' aus der Zusammenfassung."
 → 3 Bullets: MIT BEZUG zu {{hauptleistung}}, {{KI_GUARDRAILS}}
-→ VERBOTEN: "Minimal-Stack" ohne Kontext!
+→ VERBOTEN: "Minimal-Setup" ohne Kontext!
 
 PHASE 1 (Woche 3–5): [INDIVIDUELL: Bezug zu {{ZEITERSPARNIS_PRIORITAET}}]
 → Überschrift DYNAMISCH: "Phase 1: [Bezug zu {{ZEITERSPARNIS_PRIORITAET}}] Entlastung"
@@ -239,7 +239,7 @@ FORMAT v7.0 (STRIKT):
 
 ANTI-REDUNDANZ (STRIKT!):
 - Quick Wins wurden in quick_wins.md beschrieben → NICHT wiederholen
-- Tools wurden in tools_empfehlungen.md beschrieben → nur referenzieren (→ siehe KI-Stack)
+- Tools wurden in tools_empfehlungen.md beschrieben → nur referenzieren (→ siehe KI-Werkzeuge)
 - Change-Management in org_change.md → Querverweis nutzen
 - Hier: WIE und WANN, nicht WAS
 
@@ -454,7 +454,7 @@ GUARDRAILS: Berücksichtige Leitplanken aus strategischem Kontext.
     <li><strong>Skalierbarkeit:</strong> Dokumentierte Workflows für {{VISION_3_JAHRE}}</li>
   </ul>
 
-  <h3>Team-Kommunikation & Rollout-Rituale</h3>
+  <h3>Team-Kommunikation & Umsetzungsrituale</h3>
   <p>
     Die erfolgreiche KI-Einführung im Bereich erfordert strukturierte Kommunikation und
     wiederkehrende Formate, die Akzeptanz und Kompetenzaufbau fördern. Etablieren Sie
@@ -544,29 +544,29 @@ GUARDRAILS: Berücksichtige Leitplanken aus strategischem Kontext.
     <li>SOPs für KI-Workflows dokumentieren</li>
     <li>QS-Prozess etablieren: Input → KI → Prüfung gemäß {{KI_GUARDRAILS}} → Freigabe</li>
     <li>Styleguide und Qualitätskriterien festlegen</li>
-    <li>Schulungskonzept für Rollout auf weitere Bereiche entwickeln</li>
+    <li>Schulungskonzept für Ausweitung auf weitere Bereiche entwickeln</li>
     <li>KPIs definieren: Zeitersparnis bei {{ZEITERSPARNIS_PRIORITAET}}, Qualität</li>
   </ul>
   <p><strong>Meilenstein:</strong> SOPs dokumentiert, Schulungskonzept fertig, KPIs definiert.</p>
 
-  <h3>Phase 3: Rollout-Entscheidung Richtung {{VISION_3_JAHRE}} (Woche 11–13)</h3>
-  <p><strong>Ziel:</strong> Rollout-Entscheidung und Erweiterungsplan Richtung {{VISION_3_JAHRE}}.</p>
+  <h3>Phase 3: Ausweitungsentscheidung Richtung {{VISION_3_JAHRE}} (Woche 11–13)</h3>
+  <p><strong>Ziel:</strong> Ausweitungsentscheidung und Erweiterungsplan Richtung {{VISION_3_JAHRE}}.</p>
   <ul>
     <li>Business-Case-Validierung anhand Pilotdaten</li>
     <li>Lessons Learned aus dem Pilot zusammenfassen</li>
-    <li>Entscheidung: Rollout Richtung {{VISION_3_JAHRE}}? Ja/Nein/Anpassungen?</li>
-    {% if ki_projekte %}<li>Geplantes Projekt <em>{{ki_projekte}}</em> für unternehmensweiten Rollout evaluieren</li>{% endif %}
+    <li>Entscheidung: Ausweitung Richtung {{VISION_3_JAHRE}}? Ja/Nein/Anpassungen?</li>
+    {% if ki_projekte %}<li>Geplantes Projekt <em>{{ki_projekte}}</em> für unternehmensweite Ausweitung evaluieren</li>{% endif %}
     <li>Priorisiertes Backlog für Erweiterung erstellen</li>
     <li>Ressourcenplanung für Weg zu {{VISION_3_JAHRE}} vorbereiten</li>
   </ul>
-  <p><strong>Meilenstein:</strong> Management-Entscheidung Richtung {{VISION_3_JAHRE}} getroffen, Rollout-Plan steht.</p>
+  <p><strong>Meilenstein:</strong> Management-Entscheidung Richtung {{VISION_3_JAHRE}} getroffen, Ausbauplan steht.</p>
 
   <h3>Erwartete Effekte nach 90 Tagen</h3>
   <ul>
     <li><strong>Zeitersparnis:</strong> 30–50% bei {{ZEITERSPARNIS_PRIORITAET}} im Pilotbereich</li>
     <li><strong>Qualität:</strong> Standardisierte Prozesse, dokumentierte Qualitätskriterien</li>
     <li><strong>Governance:</strong> {{KI_GUARDRAILS}} als klare Regeln, Verantwortlichkeiten dokumentiert</li>
-    <li><strong>Skalierbarkeit:</strong> Erprobte SOPs für Rollout Richtung {{VISION_3_JAHRE}}</li>
+    <li><strong>Skalierbarkeit:</strong> Erprobte SOPs für Ausweitung Richtung {{VISION_3_JAHRE}}</li>
     <li><strong>Business Case:</strong> Validierte ROI auf Basis echter Pilotdaten</li>
     <li><strong>Entscheidungsgrundlage:</strong> Fundierte Basis für {{VISION_3_JAHRE}}-Entscheidung</li>
   </ul>
@@ -596,7 +596,7 @@ GUARDRAILS: Berücksichtige Leitplanken aus strategischem Kontext.
     Transparenz ist der Schlüssel zu nachhaltigem Management-Support.</li>
     <li><strong>Erfolgsgeschichten nutzen:</strong> Dokumentieren Sie konkrete Erfolge
     aus dem Pilotbereich mit messbaren Zahlen. Diese „Proof Points" sind Ihre beste
-    Argumentationsgrundlage für die Rollout-Entscheidung.</li>
+    Argumentationsgrundlage für die Ausweitungsentscheidung.</li>
   </ul>
 
   <h3>KPI-Framework für Arbeitsbereiche</h3>
@@ -668,6 +668,6 @@ GUARDRAILS: Berücksichtige Leitplanken aus strategischem Kontext.
   <p class="small muted">
     Nutzen Sie das <strong>Starter Kit</strong>, um Phase 1 technisch umzusetzen (→ siehe Starter Kit).
     Diese Roadmap verweist auf Quick Wins (→ siehe Sofortmaßnahmen) und
-    Tools (→ siehe KI-Stack). Details zum Change-Management → siehe Veränderungsfähigkeit.
+    Tools (→ siehe KI-Werkzeuge). Details zum Change-Management → siehe Veränderungsfähigkeit.
   </p>
 </section>

--- a/prompts/de/roadmap_90d_decision.md
+++ b/prompts/de/roadmap_90d_decision.md
@@ -19,17 +19,11 @@ You MAY:
 If a number is required:
 → write: "siehe Business Case / Simulation"
 
-HARD BLACKLIST (Fail-Closed):
-- "wie kann ich dir helfen" / "wie kann ich helfen"
-- "bei Bedarf"
-- "z. B." / "z.B."
-- "angenommen"
-- "typischerweise"
-- "Rollout"
-- "Skalierung"
-- "Modul"
-- "Stack"
-- "1000+"
+DE-PRIMED EXCLUSION (Fail-Closed):
+- Keine Gesprächs-/Assistenzsprache, keine Fragen, keine Anrede, keine Meta-Kommentare.
+- Keine Optionalitätsfloskeln oder Beispiel-/Abkürzungsmarker.
+- Keine Technik-/Produktlaunch-Terminologie.
+- Keine erfundenen oder wiederholten KPI-Zahlen; wenn Zahl nötig: "siehe Business Case / Simulation".
 
 ###############################################################################
 -->
@@ -37,7 +31,8 @@ AUSGABEREGEL (zwingend): Schreibe ausschließlich deklarative Berichtssätze. Ke
 
 STARTFORMAT: Beginne mit einem neutralen Substantivsatz (wie „Der aktuelle Zustand…", „Die empfohlene Vorgehensweise…", „Der strategische Rahmen…").
 
-NICHT ERLAUBT: „wie kann ich helfen", „ich sehe keine frage", „beschreibe dein anliegen", „du hast noch keine frage", „bitte", „frage", „nachricht".
+AUSGABEREGEL (zwingend):
+Nur neutrale Berichtssprache. Keine Chat-/Dialog-Floskeln, keine Fragen, keine Meta-Kommentare.
 
 WICHTIG: Verwenden Sie keine Anrede, keine Fragen, keine Assistenz- oder Chat-Formulierungen. Keine Meta-Kommentare über fehlende Eingaben. Schreiben Sie ausschließlich in neutraler Berichtssprache.
 
@@ -86,7 +81,6 @@ Fokus: Was muss entschieden werden, nicht was gemacht werden könnte.
 
 STRUKTUR (exakt einhalten):
 
-```html
 <div class="roadmap-decision">
   <p><strong>90-Tage-Umsetzungs-Roadmap – Entscheidungsfassung</strong></p>
 
@@ -114,7 +108,6 @@ STRUKTUR (exakt einhalten):
     <li><strong>Stop-Regel:</strong> [Wann wird Erweiterung nicht empfohlen]</li>
   </ul>
 </div>
-```
 
 STOP-REGELN (Beispiele zur Orientierung):
 - "Kein messbarer Zeitgewinn nach 14 Tagen → vereinfachen oder stoppen"
@@ -135,4 +128,4 @@ STRIKTE AUSGABEREGEL (verbindlich):
 - Jeder Bullet muss sofort umsetzbar formuliert sein, nicht als Template
 
 GUARDRAIL (zwingend):
-Keine Assistenz- oder Chat-Formulierungen (z. B. „wie kann ich helfen", „gerne erkläre ich"). Verwenden Sie ausschließlich Berichtssprache.
+Keine Assistenz-/Dialog-Sprache, keine Fragen, keine Imperative, keine Meta-Kommentare. Ausschließlich neutrale Berichtssprache.

--- a/tests/test_fix506_banned_patterns.py
+++ b/tests/test_fix506_banned_patterns.py
@@ -224,10 +224,12 @@ class TestHardBlacklist:
         assert "HARD BLACKLIST" in content or "Fail-Closed" in content or "STRIKT" in content
 
     def test_decision_prompts_have_hard_blacklist(self, project_root):
-        """Decision prompts have HARD BLACKLIST section."""
+        """Decision prompts have HARD BLACKLIST or DE-PRIMED EXCLUSION section."""
         for prompt_name in ["executive_decision.md", "roadmap_90d_decision.md", "gamechanger_decision.md"]:
             content = (project_root / f"prompts/de/{prompt_name}").read_text()
-            assert "HARD BLACKLIST" in content, f"{prompt_name} missing HARD BLACKLIST"
+            assert "HARD BLACKLIST" in content or "DE-PRIMED EXCLUSION" in content, (
+                f"{prompt_name} missing HARD BLACKLIST / DE-PRIMED EXCLUSION"
+            )
 
 
 class TestTruncationCleanup:


### PR DESCRIPTION
…ompt files

- executive_decision.md: remove code fences, de-prime GUARDRAIL examples, replace NICHT ERLAUBT with AUSGABEREGEL, abstract chat phrase references
- roadmap_90d_decision.md: HARD BLACKLIST → DE-PRIMED EXCLUSION, NICHT ERLAUBT → AUSGABEREGEL, remove code fences
- roadmap_90d.md: replace all Rollout/Stack tokens (Tool-Rollouts, Rollout-Rituale, Minimal-Stack, KI-Stack, etc.)
- roadmap_12m.md: replace all Rollout/Stack tokens, rewrite ZERO-LEAK POLICY without quoted example phrases

Acceptance criteria verified:
- No backticks in executive_decision.md, roadmap_90d_decision.md
- No rollout|stack|skalierung|modul in roadmap_12m/90d/90d_decision
- No chat/assistant example phrases in any de-primed file