### PR TITLE
feat(FIX-512): QuickWins STRICT-blocker kill-switch via deterministic…

### DIFF
--- a/gpt_analyze.py
+++ b/gpt_analyze.py
@@ -169,6 +169,7 @@ from services.ai_act_module import (
 from services.quickwins_renderer import (
     render_quickwins_premium_json,
     detect_quickwins_template_mode,
+    normalize_quickwins_to_html,
 )
 
 # ==================== PHASE 4: LIVE DATA INTEGRATION ====================
@@ -4079,26 +4080,23 @@ def _enforce_quickwins_no_raw_json(qw_html: str, branche: str, groesse: str) -> 
             log.info("[QW-JSON-RENDER] ✅ Built %d Quick Wins from extracted titles", len(minimal_qw))
             return _build_quick_wins_html(minimal_qw, branche=branche, groesse=groesse)
 
-        # Last resort for JSON that couldn't be parsed - use compact fallback with extracted content
-        # FIX-500: In STRICT mode, this is a hard error - no fallback allowed
+        # FIX-512: Instead of STRICT blocker, normalize the content deterministically
         release_strict = os.getenv("RELEASE_STRICT_MODE", "0") in ("1", "true", "True")
-        if release_strict:
-            error_msg = "[QW-FALLBACK] ❌ JSON present but unparseable in STRICT MODE - blocking"
-            log.error(error_msg)
-            raise RuntimeError(error_msg)
-        log.warning("[QW-FALLBACK] JSON present but unparseable - using compact fallback")
+        log.info("[FIX-512] JSON unparseable - attempting deterministic normalization (strict=%s)", release_strict)
+        normalized, meta = normalize_quickwins_to_html(qw_html, strict=release_strict)
+        if normalized:
+            return normalized
+        log.warning("[QW-FALLBACK] JSON unparseable, normalization empty - using compact fallback")
         return _generate_quickwins_compact_fallback(qw_html, branche, groesse)
 
-    # Fix-Batch G: REMOVED soft-fail wrap path - always use compact fallback instead
-    # If no HTML structure and no JSON, generate compact fallback (never wrap raw content)
+    # Fix-Batch G / FIX-512: If no HTML structure, normalize deterministically
     if not has_html_structure:
-        # FIX-500: In STRICT mode, this is a hard error - no fallback allowed
         release_strict = os.getenv("RELEASE_STRICT_MODE", "0") in ("1", "true", "True")
-        if release_strict:
-            error_msg = "[QW-FALLBACK] ❌ No HTML structure in STRICT MODE - blocking"
-            log.error(error_msg)
-            raise RuntimeError(error_msg)
-        log.info("[QW-FALLBACK] No HTML structure - generating compact fallback")
+        log.info("[FIX-512] No HTML structure - attempting deterministic normalization (strict=%s)", release_strict)
+        normalized, meta = normalize_quickwins_to_html(qw_html, strict=release_strict)
+        if normalized:
+            return normalized
+        log.info("[QW-FALLBACK] Normalization empty - generating compact fallback")
         return _generate_quickwins_compact_fallback(qw_html, branche, groesse)
 
     return qw_html

--- a/services/quickwins_renderer.py
+++ b/services/quickwins_renderer.py
@@ -783,7 +783,7 @@ def _inject_markers_into_html(html_content: str) -> str:
     return modified
 
 
-def normalize_quickwins_to_html(raw: str, strict: bool = False) -> tuple:
+def normalize_quickwins_to_html(raw: str, strict: bool = False) -> tuple[str, dict]:
     """
     FIX-512: Deterministic QuickWins normalization (Text/Bullets → HTML).
 

--- a/services/quickwins_renderer.py
+++ b/services/quickwins_renderer.py
@@ -686,3 +686,199 @@ def apply_quickwins_fullwidth_enhancement(sections: dict) -> dict:
         sections["QUICK_WINS_HTML"] = enhanced
 
     return sections
+
+
+# =============================================================================
+# FIX-512: QuickWins Deterministic Normalization (Text/Bullets → HTML)
+# =============================================================================
+# Kill-switch for STRICT blocker: instead of aborting on missing HTML structure,
+# deterministically normalize plain-text/bullets/bare-HTML to valid QW HTML.
+
+_BULLET_PATTERN = re.compile(r'^\s*(?:[-•*]|\d+[.)]\s)', re.MULTILINE)
+
+
+def _extract_items_from_text(raw: str) -> list:
+    """
+    FIX-512: Extract meaningful items from plain-text/bullet content.
+
+    Returns list of stripped item strings.
+    """
+    lines = raw.strip().splitlines()
+    items = []
+    for line in lines:
+        # Strip bullet/number prefix
+        cleaned = re.sub(r'^\s*(?:[-•*]|\d+[.)]\s*)\s*', '', line).strip()
+        # Skip empty or too-short lines
+        if cleaned and len(cleaned) >= 10:
+            items.append(cleaned)
+    # If no bullet items found, try splitting by sentence-like chunks
+    if not items:
+        for line in lines:
+            stripped = line.strip()
+            if stripped and len(stripped) >= 10:
+                items.append(stripped)
+    return items
+
+
+def _render_items_as_html(items: list) -> str:
+    """
+    FIX-512: Render extracted items as Quick Wins HTML list.
+    """
+    import html as html_module
+
+    li_items = []
+    for item in items[:6]:
+        escaped = html_module.escape(item)
+        li_items.append(
+            f'  <li class="quick-win" data-qw-json-rendered="true">{escaped}</li>'
+        )
+
+    inner = "\n".join(li_items)
+    return (
+        f'<div class="quick-wins-container" data-qw-json-rendered="true">\n'
+        f'<ul class="quick-wins-list">\n{inner}\n</ul>\n'
+        f'</div>'
+    )
+
+
+def _inject_markers_into_html(html_content: str) -> str:
+    """
+    FIX-512: Inject class="quick-win" and data-qw-json-rendered markers into
+    existing HTML that lacks them.
+    """
+    modified = html_content
+
+    # Inject container wrapper if no quick-wins-container
+    if 'quick-wins-container' not in modified:
+        modified = (
+            f'<div class="quick-wins-container" data-qw-json-rendered="true">\n'
+            f'{modified}\n</div>'
+        )
+    elif 'data-qw-json-rendered' not in modified:
+        # Add marker to existing container
+        modified = modified.replace(
+            'class="quick-wins-container"',
+            'class="quick-wins-container" data-qw-json-rendered="true"',
+            1
+        )
+
+    # Inject class="quick-win" on <li> or card divs if missing
+    if 'class="quick-win' not in modified:
+        # Try to add to <li> elements
+        modified = re.sub(
+            r'<li(?![^>]*class=)([^>]*)>',
+            r'<li class="quick-win"\1>',
+            modified,
+            count=6
+        )
+        # If still no quick-win class (no <li>s), try <div> items
+        if 'class="quick-win' not in modified:
+            modified = re.sub(
+                r'<div(?![^>]*class=)([^>]*)>',
+                r'<div class="quick-win"\1>',
+                modified,
+                count=1
+            )
+
+    return modified
+
+
+def normalize_quickwins_to_html(raw: str, strict: bool = False) -> tuple:
+    """
+    FIX-512: Deterministic QuickWins normalization (Text/Bullets → HTML).
+
+    Converts any raw Quick Wins content (JSON, bare HTML, plain text/bullets)
+    into valid HTML with class="quick-win" and data-qw-json-rendered="true".
+
+    Args:
+        raw: Raw Quick Wins content (JSON, HTML, or plain text)
+        strict: If True and normalization fails, raise RuntimeError
+
+    Returns:
+        Tuple of (normalized_html, meta_dict) where meta_dict contains:
+        - path: "JSON" | "HTML" | "TEXT_BULLETS"
+        - items: number of items found
+        - has_marker: bool
+        - has_class: bool
+        - len: output length
+    """
+    if not raw or not raw.strip():
+        if strict:
+            raise RuntimeError(
+                "[QW-NORMALIZE] ❌ unable to normalize quick_wins to HTML in STRICT mode "
+                "(reason=empty_input)"
+            )
+        return "", {"path": "EMPTY", "items": 0, "has_marker": False, "has_class": False, "len": 0}
+
+    stripped = raw.strip()
+    path = "UNKNOWN"
+    result_html = ""
+
+    # --- Path 1: JSON (starts with [ or {) ---
+    if stripped.startswith(('[', '{')):
+        path = "JSON"
+        rendered = render_quickwins_premium_json(stripped)
+        if rendered:
+            result_html = rendered
+        else:
+            # Try simpler JSON extraction
+            import json
+            try:
+                cleaned = stripped
+                if cleaned.startswith("```"):
+                    cleaned = re.sub(r'^```(?:json)?\s*', '', cleaned)
+                    cleaned = re.sub(r'\s*```$', '', cleaned)
+                data = json.loads(cleaned)
+                if isinstance(data, list) and len(data) > 0:
+                    items_text = []
+                    for item in data:
+                        if isinstance(item, dict):
+                            title = item.get("title") or item.get("titel") or item.get("name", "")
+                            if title:
+                                items_text.append(str(title))
+                    if items_text:
+                        result_html = _render_items_as_html(items_text)
+            except (json.JSONDecodeError, TypeError, KeyError):
+                pass
+
+    # --- Path 2: HTML (contains tags) ---
+    elif '<' in stripped and '>' in stripped and re.search(r'<\w+[\s>]', stripped):
+        path = "HTML"
+        result_html = _inject_markers_into_html(stripped)
+
+    # --- Path 3: Plain text / bullets ---
+    if not result_html:
+        if path == "UNKNOWN":
+            path = "TEXT_BULLETS"
+        items = _extract_items_from_text(stripped)
+        if items:
+            result_html = _render_items_as_html(items)
+
+    # --- Validate result ---
+    has_marker = 'data-qw-json-rendered="true"' in result_html
+    has_class = 'class="quick-win' in result_html
+
+    # Count items
+    item_count = result_html.count('class="quick-win')
+
+    meta = {
+        "path": path,
+        "items": item_count,
+        "has_marker": has_marker,
+        "has_class": has_class,
+        "len": len(result_html),
+    }
+
+    # STRICT validation
+    if strict and (item_count < 3 or len(result_html) < 250):
+        raise RuntimeError(
+            f"[QW-NORMALIZE] ❌ unable to normalize quick_wins to HTML in STRICT mode "
+            f"(reason=insufficient_content items={item_count} len={len(result_html)})"
+        )
+
+    log.info(
+        "[FIX-512-QW] normalize path=%s items=%d has_marker=%s has_class=%s len=%d",
+        path, item_count, has_marker, has_class, len(result_html)
+    )
+
+    return result_html, meta

--- a/tests/test_fix501_quickwins_strict.py
+++ b/tests/test_fix501_quickwins_strict.py
@@ -147,7 +147,7 @@ class TestFix501ValidatorRegressions:
             html = '''<div class="some-other-class">Content without markers</div>'''
             with pytest.raises(RuntimeError) as exc_info:
                 _enforce_quickwins_no_raw_json(html, "IT", "solo")
-            assert "STRICT MODE" in str(exc_info.value)
+            assert "STRICT" in str(exc_info.value).upper()
         finally:
             os.environ.pop("RELEASE_STRICT_MODE", None)
 

--- a/tests/test_fix512_quickwins_normalize.py
+++ b/tests/test_fix512_quickwins_normalize.py
@@ -1,0 +1,217 @@
+# -*- coding: utf-8 -*-
+"""
+FIX-512: Tests for QuickWins Deterministic Normalization.
+
+Ensures that normalize_quickwins_to_html() correctly converts:
+1. Plain text/bullets → HTML with class="quick-win" and data-qw-json-rendered="true"
+2. HTML without markers → markers are injected
+3. STRICT mode + empty/garbage → raises with [QW-NORMALIZE] prefix (not [QW-FALLBACK])
+
+MUST NOT HAPPEN after FIX-512:
+- [QW-FALLBACK] ❌ No HTML structure in STRICT MODE - blocking
+"""
+import pytest
+
+
+class TestFix512TextBulletsToHtml:
+    """Test that plain text/bullets are normalized to valid Quick Wins HTML."""
+
+    def test_bullet_list_produces_html_with_markers(self):
+        """Bullet list → HTML with class='quick-win' and data-qw-json-rendered='true'."""
+        from services.quickwins_renderer import normalize_quickwins_to_html
+
+        raw = (
+            "- Automatisierung der E-Mail-Sortierung spart 3h pro Woche\n"
+            "- KI-gestützte Angebotserstellung in 10 Minuten statt 2 Stunden\n"
+            "- Automatische Terminplanung mit KI-Assistent einrichten\n"
+            "- Kundenfeedback per KI-Analyse auswerten und priorisieren\n"
+            "- Wöchentliche Reports automatisch generieren lassen\n"
+        )
+
+        html, meta = normalize_quickwins_to_html(raw)
+
+        assert 'class="quick-win"' in html
+        assert 'data-qw-json-rendered="true"' in html
+        assert meta["path"] == "TEXT_BULLETS"
+        assert meta["items"] >= 4
+        assert meta["has_marker"] is True
+        assert meta["has_class"] is True
+
+    def test_numbered_list_produces_html(self):
+        """Numbered list items are also normalized."""
+        from services.quickwins_renderer import normalize_quickwins_to_html
+
+        raw = (
+            "1. Automatisierung der E-Mail-Sortierung spart 3h pro Woche\n"
+            "2. KI-gestützte Angebotserstellung in 10 Minuten statt 2 Stunden\n"
+            "3. Automatische Terminplanung mit KI-Assistent einrichten\n"
+            "4. Kundenfeedback per KI-Analyse auswerten und priorisieren\n"
+        )
+
+        html, meta = normalize_quickwins_to_html(raw)
+
+        assert 'class="quick-win"' in html
+        assert 'data-qw-json-rendered="true"' in html
+        assert meta["items"] >= 4
+
+    def test_plain_text_lines_produce_html(self):
+        """Plain text lines (no bullets) are also normalized."""
+        from services.quickwins_renderer import normalize_quickwins_to_html
+
+        raw = (
+            "Automatisierung der E-Mail-Sortierung spart 3h pro Woche\n"
+            "KI-gestützte Angebotserstellung in 10 Minuten statt 2 Stunden\n"
+            "Automatische Terminplanung mit KI-Assistent einrichten\n"
+            "Kundenfeedback per KI-Analyse auswerten und priorisieren\n"
+        )
+
+        html, meta = normalize_quickwins_to_html(raw)
+
+        assert 'class="quick-win"' in html
+        assert 'data-qw-json-rendered="true"' in html
+        assert meta["items"] >= 4
+
+    def test_min_4_items_in_output(self):
+        """At least 4 items should be rendered when input has enough lines."""
+        from services.quickwins_renderer import normalize_quickwins_to_html
+
+        raw = (
+            "• Prozessautomatisierung für wiederkehrende Aufgaben\n"
+            "• KI-gestützte Textgenerierung für Kundenkommunikation\n"
+            "• Automatische Datenanalyse und Reporting einführen\n"
+            "• Workflow-Optimierung durch intelligente Vorlagen\n"
+            "• Zeitersparnis bei der Dokumentenverwaltung\n"
+        )
+
+        html, meta = normalize_quickwins_to_html(raw)
+
+        # Count <li> items
+        li_count = html.count("<li")
+        assert li_count >= 4, f"Expected >=4 items, got {li_count}"
+
+
+class TestFix512HtmlMarkerInjection:
+    """Test that bare HTML gets markers injected."""
+
+    def test_html_without_markers_gets_injected(self):
+        """HTML missing class/marker gets them injected."""
+        from services.quickwins_renderer import normalize_quickwins_to_html
+
+        raw = (
+            '<div class="quick-wins-container">'
+            "<ul>"
+            "<li>Automatisierung der E-Mail-Sortierung</li>"
+            "<li>KI-gestützte Angebotserstellung verkürzen</li>"
+            "<li>Automatische Terminplanung einrichten</li>"
+            "<li>Kundenfeedback per KI-Analyse auswerten</li>"
+            "</ul>"
+            "</div>"
+        )
+
+        html, meta = normalize_quickwins_to_html(raw)
+
+        assert meta["path"] == "HTML"
+        assert 'data-qw-json-rendered="true"' in html
+        assert 'class="quick-win' in html
+
+    def test_html_with_existing_markers_unchanged(self):
+        """HTML already having markers is returned with markers intact."""
+        from services.quickwins_renderer import normalize_quickwins_to_html
+
+        raw = (
+            '<div class="quick-wins-container" data-qw-json-rendered="true">'
+            '<ul><li class="quick-win">Item 1 long enough text here</li>'
+            '<li class="quick-win">Item 2 long enough text here</li>'
+            '<li class="quick-win">Item 3 long enough text here</li>'
+            '<li class="quick-win">Item 4 long enough text here</li></ul>'
+            "</div>"
+        )
+
+        html, meta = normalize_quickwins_to_html(raw)
+
+        assert meta["path"] == "HTML"
+        assert meta["has_marker"] is True
+        assert meta["has_class"] is True
+
+
+class TestFix512StrictMode:
+    """Test STRICT mode behavior."""
+
+    def test_strict_empty_raises_qw_normalize(self):
+        """STRICT mode + empty input → raise with [QW-NORMALIZE] prefix."""
+        from services.quickwins_renderer import normalize_quickwins_to_html
+
+        with pytest.raises(RuntimeError) as exc_info:
+            normalize_quickwins_to_html("", strict=True)
+
+        assert "[QW-NORMALIZE]" in str(exc_info.value)
+        assert "[QW-FALLBACK]" not in str(exc_info.value)
+
+    def test_strict_garbage_raises_qw_normalize(self):
+        """STRICT mode + garbage (too few items) → raise with [QW-NORMALIZE]."""
+        from services.quickwins_renderer import normalize_quickwins_to_html
+
+        with pytest.raises(RuntimeError) as exc_info:
+            normalize_quickwins_to_html("ab\ncd\n", strict=True)
+
+        assert "[QW-NORMALIZE]" in str(exc_info.value)
+        assert "[QW-FALLBACK]" not in str(exc_info.value)
+
+    def test_strict_valid_bullets_no_raise(self):
+        """STRICT mode + valid bullets → no error, valid HTML returned."""
+        from services.quickwins_renderer import normalize_quickwins_to_html
+
+        raw = (
+            "- Automatisierung der E-Mail-Sortierung spart 3h pro Woche\n"
+            "- KI-gestützte Angebotserstellung in 10 Minuten statt 2 Stunden\n"
+            "- Automatische Terminplanung mit KI-Assistent einrichten\n"
+            "- Kundenfeedback per KI-Analyse auswerten und priorisieren\n"
+            "- Wöchentliche Reports automatisch generieren lassen\n"
+        )
+
+        html, meta = normalize_quickwins_to_html(raw, strict=True)
+
+        assert meta["items"] >= 4
+        assert 'class="quick-win"' in html
+        assert 'data-qw-json-rendered="true"' in html
+
+
+class TestFix512NoQwFallbackInStrict:
+    """Regression: [QW-FALLBACK] must never appear in STRICT mode after FIX-512."""
+
+    def test_enforce_no_qw_fallback_raise_on_text(self):
+        """_enforce_quickwins_no_raw_json with text/bullets in STRICT does NOT raise [QW-FALLBACK]."""
+        import os
+        from unittest.mock import patch
+
+        try:
+            from gpt_analyze import _enforce_quickwins_no_raw_json
+        except ImportError:
+            pytest.skip("gpt_analyze dependencies not available")
+
+        raw = (
+            "- Automatisierung der E-Mail-Sortierung spart 3h pro Woche\n"
+            "- KI-gestützte Angebotserstellung in 10 Minuten statt 2 Stunden\n"
+            "- Automatische Terminplanung mit KI-Assistent einrichten\n"
+            "- Kundenfeedback per KI-Analyse auswerten und priorisieren\n"
+        )
+
+        with patch.dict(os.environ, {"RELEASE_STRICT_MODE": "1"}):
+            # This must NOT raise - FIX-512 normalizes instead of blocking
+            result = _enforce_quickwins_no_raw_json(raw, "IT-Beratung", "solo")
+
+        assert 'class="quick-win' in result or 'data-qw-json-rendered' in result
+
+    def test_enforce_no_qw_fallback_prefix_ever(self):
+        """After FIX-512, no code path should produce [QW-FALLBACK] ❌ ... STRICT MODE."""
+        import inspect
+
+        try:
+            from gpt_analyze import _enforce_quickwins_no_raw_json
+        except ImportError:
+            pytest.skip("gpt_analyze dependencies not available")
+
+        source = inspect.getsource(_enforce_quickwins_no_raw_json)
+        assert '[QW-FALLBACK] ❌' not in source, (
+            "_enforce_quickwins_no_raw_json still contains [QW-FALLBACK] ❌ error prefix"
+        )


### PR DESCRIPTION
… normalization

Change 1/3: Add normalize_quickwins_to_html() to services/quickwins_renderer.py
- Path JSON: parse via render_quickwins_premium_json or extract titles
- Path HTML: inject class="quick-win" + data-qw-json-rendered markers
- Path TEXT_BULLETS: extract items from bullet/numbered/plain lines → <ul>
- STRICT validation: raise [QW-NORMALIZE] (not [QW-FALLBACK]) on insufficient content
- Log line: [FIX-512-QW] normalize path=<...> items=N has_marker=X has_class=Y len=Z

Change 2/3: Replace STRICT blocker in gpt_analyze.py
- Remove [QW-FALLBACK] ❌ RuntimeError raises in _enforce_quickwins_no_raw_json
- Call normalize_quickwins_to_html(qw_html, strict=RELEASE_STRICT_MODE) instead
- Pipeline no longer aborts on missing HTML structure

Change 3/3: Add tests/test_fix512_quickwins_normalize.py (11 tests)
- TEXT_BULLETS → HTML with markers, min 4 items
- HTML without markers → markers injected
- STRICT + empty/garbage → [QW-NORMALIZE] error (not [QW-FALLBACK])
- Regression: source code no longer contains [QW-FALLBACK] ❌ prefix