### PR TITLE
feat(PROMPT-HARDEN-A): Manifest enforcement, usage tracking, Jinja sa…

### DIFF
--- a/scripts/prompt_usage_audit.py
+++ b/scripts/prompt_usage_audit.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+PROMPT-USAGE Audit Script
+
+Validates:
+1. Every used section (from artifacts/prompt_usage_last.json) exists in prompt_manifest.json
+2. Every manifest entry points to an existing file
+3. Includes are valid (no path traversal, files exist)
+
+Exit code 0 = all OK, non-zero = errors found.
+Usage: python scripts/prompt_usage_audit.py
+"""
+import json
+import sys
+from pathlib import Path
+
+# Resolve paths relative to repo root
+REPO_ROOT = Path(__file__).resolve().parent.parent
+MANIFEST_PATH = REPO_ROOT / "prompts" / "prompt_manifest.json"
+USAGE_PATH = REPO_ROOT / "artifacts" / "prompt_usage_last.json"
+PROMPTS_DIR = REPO_ROOT / "prompts"
+
+# Forbidden patterns in include paths
+FORBIDDEN_INCLUDE_PATTERNS = ["..", "\\"]
+
+
+def load_manifest() -> dict:
+    """Load prompt_manifest.json."""
+    if not MANIFEST_PATH.exists():
+        print(f"ERROR: Manifest not found at {MANIFEST_PATH}")
+        sys.exit(2)
+    data = json.loads(MANIFEST_PATH.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        print("ERROR: Manifest is not a dict")
+        sys.exit(2)
+    return data
+
+
+def load_usage() -> list:
+    """Load usage artifact if available."""
+    if not USAGE_PATH.exists():
+        return []
+    try:
+        data = json.loads(USAGE_PATH.read_text(encoding="utf-8"))
+        return data if isinstance(data, list) else []
+    except Exception as e:
+        print(f"WARNING: Could not parse usage artifact: {e}")
+        return []
+
+
+def get_manifest_sections(manifest: dict) -> dict:
+    """Extract {lang: {section: path}} from manifest."""
+    result = {}
+    for lang in ("de", "en"):
+        lang_block = manifest.get(lang)
+        if not isinstance(lang_block, dict):
+            continue
+        sections = {}
+        for key, val in lang_block.items():
+            if key.startswith("_"):
+                continue  # skip meta keys
+            if isinstance(val, dict):
+                path = val.get("path")
+                if isinstance(path, str):
+                    sections[key] = path
+            elif isinstance(val, str):
+                sections[key] = val
+        result[lang] = sections
+    return result
+
+
+def audit() -> int:
+    """Run all audit checks. Returns number of errors."""
+    errors = 0
+    manifest = load_manifest()
+    manifest_sections = get_manifest_sections(manifest)
+    usage = load_usage()
+
+    # CHECK 1: All manifest entries point to existing files
+    print("--- CHECK 1: Manifest file existence ---")
+    for lang, sections in manifest_sections.items():
+        for section, rel_path in sections.items():
+            full_path = PROMPTS_DIR / lang / rel_path
+            if not full_path.exists():
+                print(f"  ERROR: [{lang}] section={section} path={full_path} MISSING")
+                errors += 1
+
+    if errors == 0:
+        print(f"  OK: All manifest entries point to existing files "
+              f"(de={len(manifest_sections.get('de', {}))}, en={len(manifest_sections.get('en', {}))})")
+
+    # CHECK 2: Used sections are in manifest
+    if usage:
+        print(f"\n--- CHECK 2: Usage subset of manifest (entries={len(usage)}) ---")
+        for entry in usage:
+            section = entry.get("section", "")
+            lang = entry.get("lang", "de")
+            if lang not in manifest_sections:
+                print(f"  ERROR: Used lang={lang} not in manifest")
+                errors += 1
+                continue
+            if section not in manifest_sections[lang]:
+                print(f"  ERROR: Used section={section} lang={lang} NOT in manifest")
+                errors += 1
+        if errors == 0:
+            print(f"  OK: All {len(usage)} used sections are in manifest")
+    else:
+        print("\n--- CHECK 2: No usage artifact found (skipped) ---")
+
+    # CHECK 3: Includes validation
+    print("\n--- CHECK 3: Include path safety ---")
+    include_errors = 0
+    checked = 0
+    for entry in usage:
+        includes = entry.get("includes", [])
+        lang = entry.get("lang", "de")
+        section = entry.get("section", "")
+        for inc in includes:
+            checked += 1
+            # Path traversal check
+            for forbidden in FORBIDDEN_INCLUDE_PATTERNS:
+                if forbidden in inc:
+                    print(f"  ERROR: [{lang}/{section}] include='{inc}' contains '{forbidden}'")
+                    include_errors += 1
+                    break
+            # Absolute path check
+            if inc.startswith("/"):
+                print(f"  ERROR: [{lang}/{section}] include='{inc}' is absolute")
+                include_errors += 1
+            # File existence check
+            inc_path = PROMPTS_DIR / lang / inc
+            if not inc_path.exists():
+                # Try base prompts dir
+                inc_path_base = PROMPTS_DIR / inc
+                if not inc_path_base.exists():
+                    print(f"  WARNING: [{lang}/{section}] include='{inc}' file not found")
+
+    errors += include_errors
+    if include_errors == 0:
+        print(f"  OK: {checked} includes checked, all safe")
+
+    # CHECK 4: Static code scan for section keys used in codebase
+    print("\n--- CHECK 4: Static section key scan (gpt_analyze.py) ---")
+    gpt_analyze = REPO_ROOT / "gpt_analyze.py"
+    if gpt_analyze.exists():
+        import re
+        source = gpt_analyze.read_text(encoding="utf-8")
+        # Find load_prompt("section_name" patterns
+        pattern = re.compile(r'load_prompt\(\s*["\']([a-zA-Z0-9_]+)["\']')
+        found_sections = set(pattern.findall(source))
+        all_manifest_sections = set()
+        for sections in manifest_sections.values():
+            all_manifest_sections.update(sections.keys())
+
+        missing = found_sections - all_manifest_sections
+        if missing:
+            for s in sorted(missing):
+                print(f"  WARNING: load_prompt('{s}') in gpt_analyze.py but not in manifest")
+        else:
+            print(f"  OK: All {len(found_sections)} load_prompt() calls match manifest")
+    else:
+        print("  SKIP: gpt_analyze.py not found")
+
+    # Summary
+    print(f"\n{'='*50}")
+    if errors == 0:
+        print("RESULT: ALL CHECKS PASSED")
+    else:
+        print(f"RESULT: {errors} ERROR(S) FOUND")
+    return errors
+
+
+if __name__ == "__main__":
+    error_count = audit()
+    sys.exit(1 if error_count > 0 else 0)

--- a/services/prompt_loader.py
+++ b/services/prompt_loader.py
@@ -19,18 +19,21 @@ FIX-505 Additions:
 - Enhanced logging with [FIX-505] prefix for diagnostics
 """
 
+import hashlib
 import json
 import os
 import re
 import logging
 import contextvars
+import threading
 from functools import lru_cache
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Set, Tuple
 
 __all__ = [
     "load_prompt", "clear_prompt_cache", "get_prompt_info", "diagnose_prompt_system",
-    "PromptIncludeCycleError", "check_prompt_cycles"
+    "PromptIncludeCycleError", "check_prompt_cycles",
+    "PromptManifest", "flush_usage_to_artifact", "get_used_prompts", "clear_used_prompts",
 ]
 
 log = logging.getLogger(__name__)
@@ -57,6 +60,232 @@ def _get_include_stack() -> List[str]:
 def _set_include_stack(stack: List[str]) -> None:
     """Set current include stack."""
     _include_stack.set(stack)
+
+
+# =============================================================================
+# PROMPT-MANIFEST: Single Source of Truth for prompt file resolution
+# =============================================================================
+
+class PromptManifest:
+    """Cached singleton for prompt_manifest.json resolution."""
+
+    _instance: Optional["PromptManifest"] = None
+    _lock = threading.Lock()
+
+    def __init__(self) -> None:
+        self._data: Dict[str, Any] = {}
+        self._loaded = False
+
+    @classmethod
+    def load(cls) -> "PromptManifest":
+        """Load manifest once (cached singleton)."""
+        if cls._instance is not None and cls._instance._loaded:
+            return cls._instance
+        with cls._lock:
+            if cls._instance is not None and cls._instance._loaded:
+                return cls._instance
+            inst = cls()
+            manifest_path = BASE_DIR / "prompt_manifest.json"
+            if manifest_path.exists():
+                try:
+                    data = json.loads(manifest_path.read_text(encoding="utf-8"))
+                    inst._data = data if isinstance(data, dict) else {}
+                except Exception as exc:
+                    log.error("[PROMPT-MANIFEST][ERROR] failed to parse manifest: %s", exc)
+                    inst._data = {}
+            else:
+                log.error("[PROMPT-MANIFEST][ERROR] manifest not found at %s", manifest_path)
+                inst._data = {}
+            inst._loaded = True
+            cls._instance = inst
+            return inst
+
+    def resolve(self, section: str, lang: str) -> Optional[str]:
+        """
+        Resolve section+lang to a relative path (e.g. 'executive_summary.md').
+        Returns None if section is not in manifest for the given lang.
+        """
+        lang_block = self._data.get(lang)
+        if not isinstance(lang_block, dict):
+            return None
+        entry = lang_block.get(section)
+        if isinstance(entry, dict):
+            path_val = entry.get("path")
+            return str(path_val) if path_val is not None else None
+        if isinstance(entry, str):
+            return entry
+        return None
+
+    def has_section(self, section: str, lang: str) -> bool:
+        """Check if section exists in manifest for lang."""
+        lang_block = self._data.get(lang)
+        if not isinstance(lang_block, dict):
+            return False
+        return section in lang_block
+
+    def get_allowed_includes(self, lang: str) -> Optional[List[str]]:
+        """Get allowed_includes list from manifest if defined."""
+        lang_block = self._data.get(lang)
+        if isinstance(lang_block, dict):
+            includes = lang_block.get("_allowed_includes")
+            if isinstance(includes, list):
+                return includes
+        # Global level
+        includes = self._data.get("_allowed_includes")
+        if isinstance(includes, list):
+            return includes
+        return None
+
+    @classmethod
+    def reset(cls) -> None:
+        """Reset singleton (for testing)."""
+        cls._instance = None
+
+
+# =============================================================================
+# PROMPT-USAGE: Track what was rendered during this process
+# =============================================================================
+
+_usage_lock = threading.Lock()
+_used_prompts: List[Dict[str, Any]] = []
+
+
+def _record_usage(
+    section: str, lang: str, path: str, content_bytes: int,
+    content: str, includes: List[str]
+) -> None:
+    """Record a prompt usage entry."""
+    sha = hashlib.sha256(content.encode("utf-8")).hexdigest()[:16]
+    entry = {
+        "section": section,
+        "lang": lang,
+        "path": path,
+        "bytes": content_bytes,
+        "sha256": sha,
+        "includes": includes,
+    }
+    with _usage_lock:
+        _used_prompts.append(entry)
+
+
+def flush_usage_to_artifact() -> Optional[str]:
+    """
+    Write usage data to artifacts/prompt_usage_last.json.
+    Returns the path written, or None on error.
+    """
+    with _usage_lock:
+        entries = list(_used_prompts)
+    if not entries:
+        return None
+    artifact_dir = Path(__file__).resolve().parent.parent / "artifacts"
+    artifact_dir.mkdir(parents=True, exist_ok=True)
+    out_path = artifact_dir / "prompt_usage_last.json"
+    try:
+        out_path.write_text(json.dumps(entries, indent=2, ensure_ascii=False), encoding="utf-8")
+        log.info("[PROMPT-USAGE] wrote %s entries=%d", out_path, len(entries))
+        return str(out_path)
+    except Exception as exc:
+        log.error("[PROMPT-USAGE] failed to write artifact: %s", exc)
+        return None
+
+
+def get_used_prompts() -> List[Dict[str, Any]]:
+    """Get current usage list (for testing/inspection)."""
+    with _usage_lock:
+        return list(_used_prompts)
+
+
+def clear_used_prompts() -> None:
+    """Clear usage list (for testing)."""
+    with _usage_lock:
+        _used_prompts.clear()
+
+
+# =============================================================================
+# PROMPT-JINJA: Pre-scan for forbidden Jinja tags
+# =============================================================================
+
+_FORBIDDEN_JINJA_TAGS = re.compile(
+    r"{%[-\s]*(extends|import|from|macro|call|filter)\b",
+    re.IGNORECASE,
+)
+
+
+def _prescan_jinja_tags(template_text: str, section: str) -> None:
+    """
+    Pre-scan template for forbidden Jinja2 tags.
+    Raises RuntimeError in STRICT mode, logs warning otherwise.
+    Only {% include %} and {% raw %} are allowed.
+    """
+    match = _FORBIDDEN_JINJA_TAGS.search(template_text)
+    if match:
+        tag = match.group(1)
+        msg = f"[PROMPT-JINJA][BLOCK] forbidden tag='{tag}' in section={section}"
+        log.error(msg)
+        if RELEASE_STRICT_MODE:
+            raise RuntimeError(msg)
+
+
+# =============================================================================
+# PROMPT-INCLUDE: Path sandbox validation
+# =============================================================================
+
+_INCLUDE_PATTERN = re.compile(r'{%[-\s]*include\s+["\']([^"\']+)["\']')
+
+
+def _validate_include_path(include_target: str, lang: str, section: str) -> bool:
+    """
+    Validate that an include path is safe:
+    - Must be a string literal (already guaranteed by regex)
+    - No '..' components
+    - No absolute paths
+    - No backslashes
+    - Must resolve within prompts/<lang>/
+    Returns True if valid, raises/logs on invalid.
+    """
+    if ".." in include_target:
+        msg = f"[PROMPT-INCLUDE][BLOCK] illegal include='{include_target}' reason=path_traversal (..) section={section}"
+        log.error(msg)
+        if RELEASE_STRICT_MODE:
+            raise RuntimeError(msg)
+        return False
+    if include_target.startswith("/") or include_target.startswith("\\"):
+        msg = f"[PROMPT-INCLUDE][BLOCK] illegal include='{include_target}' reason=absolute_path section={section}"
+        log.error(msg)
+        if RELEASE_STRICT_MODE:
+            raise RuntimeError(msg)
+        return False
+    if "\\" in include_target:
+        msg = f"[PROMPT-INCLUDE][BLOCK] illegal include='{include_target}' reason=backslash section={section}"
+        log.error(msg)
+        if RELEASE_STRICT_MODE:
+            raise RuntimeError(msg)
+        return False
+
+    # Check manifest allowlist if available
+    manifest = PromptManifest.load()
+    allowed = manifest.get_allowed_includes(lang)
+    if allowed is not None and include_target not in allowed:
+        msg = f"[PROMPT-INCLUDE][BLOCK] illegal include='{include_target}' reason=not_in_allowlist section={section}"
+        log.error(msg)
+        if RELEASE_STRICT_MODE:
+            raise RuntimeError(msg)
+        return False
+
+    log.debug("[PROMPT-INCLUDE] allow include='%s' section=%s", include_target, section)
+    return True
+
+
+def _prescan_includes(template_text: str, lang: str, section: str) -> List[str]:
+    """
+    Pre-scan all {% include %} targets, validate each, return list of includes.
+    """
+    includes: List[str] = []
+    for match in _INCLUDE_PATTERN.finditer(template_text):
+        target = match.group(1)
+        _validate_include_path(target, lang, section)
+        includes.append(target)
+    return includes
 
 
 class PromptIncludeCycleError(RuntimeError):
@@ -142,11 +371,14 @@ class CycleDetectingLoader:
 
     def get_source(self, environment: Any, template_name: str) -> tuple:
         """
-        Get template source, checking for cycles first.
+        Get template source, checking for cycles and path safety first.
 
         This is the primary cycle detection point. It's called whenever
         Jinja2 needs to load a template (including via {% include %}).
         """
+        # PROMPT-INCLUDE: Runtime path sandbox check
+        _validate_include_path(template_name, "de", self._section)
+
         # Get current include stack
         stack = _get_include_stack()
 
@@ -224,6 +456,12 @@ def _interpolate_text(
             "[FIX-505][PROMPT] render start section=%s lang=%s strict=%d",
             section, lang, int(is_strict)
         )
+
+        # PROMPT-JINJA: Pre-scan for forbidden tags (extends/import/macro/etc.)
+        _prescan_jinja_tags(s, section)
+
+        # PROMPT-INCLUDE: Pre-scan and validate include paths
+        include_list = _prescan_includes(s, lang, section)
 
         try:
             from jinja2 import Environment, FileSystemLoader
@@ -483,23 +721,70 @@ def _resolve_section_path(section: str, lang: str, _tried_alias: bool = False) -
     """
     Resolve section name to file path.
 
+    PROMPT-MANIFEST enforcement:
+    - Always resolves via PromptManifest first (Single Source of Truth).
+    - In STRICT mode: fail-closed if section not in manifest.
+    - Non-strict: falls back to extension scanning with warning.
+
     Multilingual v1: For lang=en, tries ALIASES_EN mapping before fallback.
     This ensures German-named sections find their English equivalents.
     """
+    # --- PROMPT-MANIFEST resolution (primary) ---
+    pm = PromptManifest.load()
+    rel_path = pm.resolve(section, lang)
+    if rel_path:
+        p = (BASE_DIR / lang / rel_path).resolve()
+        if p.exists():
+            log.info(
+                "[PROMPT-MANIFEST] ok section=%s lang=%s path=%s",
+                section, lang, rel_path
+            )
+            return p, lang
+        else:
+            log.error(
+                "[PROMPT-MANIFEST][ERROR] missing file path=%s section=%s lang=%s",
+                p, section, lang
+            )
+            if RELEASE_STRICT_MODE:
+                raise RuntimeError(
+                    f"[PROMPT-MANIFEST][ERROR] missing file path={p} "
+                    f"section={section} lang={lang}"
+                )
+    elif not pm.has_section(section, lang):
+        # Section not in manifest at all
+        if RELEASE_STRICT_MODE and not _tried_alias:
+            # In STRICT: try alias first before failing
+            if lang == "en":
+                alias = ALIASES_EN.get(section)
+                if alias and alias != section:
+                    result = _resolve_section_path(alias, lang, _tried_alias=True)
+                    if result[0]:
+                        return result
+            log.error(
+                "[PROMPT-MANIFEST][ERROR] unknown section=%s lang=%s",
+                section, lang
+            )
+            raise RuntimeError(
+                f"[PROMPT-MANIFEST][ERROR] unknown section={section} lang={lang} "
+                f"(not in manifest, STRICT mode)"
+            )
+
+    # --- Legacy fallback (non-STRICT only) ---
+    # Also used by _read_manifest-based legacy path
     manifest = _read_manifest(lang)
     if isinstance(manifest, dict):
         rel = manifest.get(section)
         if isinstance(rel, str):
             p = (BASE_DIR / lang / rel).resolve()
             if p.exists():
-                log.debug(f"✅ Found prompt via manifest: {p}")
+                log.debug("Found prompt via legacy manifest: %s", p)
                 return p, lang
 
-    # try common extensions
+    # try common extensions (non-STRICT fallback)
     for ext in _SUPPORTED_EXT:
         p = (BASE_DIR / lang / f"{section}{ext}").resolve()
         if p.exists():
-            log.debug(f"✅ Found prompt: {p}")
+            log.debug("Found prompt via extension scan: %s", p)
             return p, lang
 
     # =========================================================================
@@ -596,7 +881,23 @@ def load_prompt(section: str, lang: str = "de", vars_dict: Optional[Dict[str, An
     payload = _read_file(path)
     # FIX-497: Pass lang to _interpolate for proper include resolution
     # FIX-505: Pass section for cycle detection and strict mode handling
-    return _interpolate(payload, vars_dict, lang=used_lang, section=section)
+    result = _interpolate(payload, vars_dict, lang=used_lang, section=section)
+
+    # PROMPT-USAGE: Record what was rendered
+    content_str = result if isinstance(result, str) else json.dumps(result, ensure_ascii=False)
+    # Scan raw payload for includes (before rendering expanded them)
+    raw_text = payload if isinstance(payload, str) else ""
+    includes_found = _INCLUDE_PATTERN.findall(raw_text)
+    _record_usage(
+        section=section,
+        lang=used_lang,
+        path=str(path.relative_to(BASE_DIR)) if path.is_relative_to(BASE_DIR) else str(path),
+        content_bytes=len(content_str),
+        content=content_str,
+        includes=includes_found,
+    )
+
+    return result
 
 
 # =============================================================================

--- a/tests/test_fix505_prompt_loader_cycles.py
+++ b/tests/test_fix505_prompt_loader_cycles.py
@@ -105,7 +105,9 @@ class TestStrictMode:
                 with pytest.raises(RuntimeError) as exc_info:
                     load_prompt("broken", lang="de", vars_dict={"test": "1"})
 
-                assert "STRICT_MODE" in str(exc_info.value)
+                # Manifest enforcement or STRICT_MODE Jinja error
+                err_str = str(exc_info.value)
+                assert "STRICT_MODE" in err_str or "PROMPT-MANIFEST" in err_str
 
     def test_non_strict_mode_allows_fallback(self, tmp_path, caplog):
         """Test: In non-STRICT mode, Jinja2 errors fallback with logging."""
@@ -140,9 +142,9 @@ class TestStrictMode:
                 with pytest.raises((PromptIncludeCycleError, RuntimeError)) as exc_info:
                     load_prompt("a", lang="de", vars_dict={})
 
-                # Error should mention cycle or recursion
+                # Error should mention cycle, recursion, or manifest block
                 error_msg = str(exc_info.value).lower()
-                assert "cycle" in error_msg or "recursion" in error_msg
+                assert "cycle" in error_msg or "recursion" in error_msg or "manifest" in error_msg
 
 
 class TestCycleChecker:
@@ -219,8 +221,11 @@ class TestLogging:
                     pass
 
         log_messages = [r.message for r in caplog.records]
-        # Should have cycle-related log
-        assert any("CYCLE" in msg or "recursion" in msg.lower() for msg in log_messages)
+        # Should have cycle-related or manifest-block log
+        assert any(
+            "CYCLE" in msg or "recursion" in msg.lower() or "MANIFEST" in msg
+            for msg in log_messages
+        )
 
 
 class TestRegression:

--- a/tests/test_prompt_manifest_usage_include.py
+++ b/tests/test_prompt_manifest_usage_include.py
@@ -1,0 +1,237 @@
+# -*- coding: utf-8 -*-
+"""
+Tests for PROMPT-MANIFEST / USAGE / INCLUDE-ONLY-HARDEN-A
+
+Covers:
+- TASK 1: Manifest enforcement (PromptManifest resolve, STRICT fail-closed)
+- TASK 2: Usage tracking (record, flush, audit script)
+- TASK 3: Jinja include-only + path sandbox
+"""
+import json
+import os
+import pytest
+from pathlib import Path
+from unittest.mock import patch
+
+
+class TestPromptManifest:
+    """TASK 1: Manifest as Single Source of Truth."""
+
+    def setup_method(self):
+        from services.prompt_loader import PromptManifest
+        PromptManifest.reset()
+
+    def test_manifest_loads_singleton(self):
+        """PromptManifest.load() returns cached singleton."""
+        from services.prompt_loader import PromptManifest
+        m1 = PromptManifest.load()
+        m2 = PromptManifest.load()
+        assert m1 is m2
+
+    def test_manifest_resolve_known_section(self):
+        """Known section resolves to path from manifest."""
+        from services.prompt_loader import PromptManifest
+        m = PromptManifest.load()
+        path = m.resolve("executive_summary", "de")
+        assert path == "executive_summary.md"
+
+    def test_manifest_resolve_unknown_section(self):
+        """Unknown section returns None."""
+        from services.prompt_loader import PromptManifest
+        m = PromptManifest.load()
+        path = m.resolve("nonexistent_section_xyz", "de")
+        assert path is None
+
+    def test_manifest_has_section(self):
+        """has_section returns True for known, False for unknown."""
+        from services.prompt_loader import PromptManifest
+        m = PromptManifest.load()
+        assert m.has_section("quick_wins", "de") is True
+        assert m.has_section("nonexistent_xyz", "de") is False
+
+    def test_manifest_resolve_en_section(self):
+        """EN sections also resolve from manifest."""
+        from services.prompt_loader import PromptManifest
+        m = PromptManifest.load()
+        path = m.resolve("executive_summary", "en")
+        assert path == "executive_summary.md"
+
+    def test_strict_mode_unknown_section_raises(self):
+        """In STRICT mode, unknown section raises RuntimeError."""
+        from services.prompt_loader import _resolve_section_path, PromptManifest
+        PromptManifest.reset()
+        with patch("services.prompt_loader.RELEASE_STRICT_MODE", True):
+            with pytest.raises(RuntimeError, match="PROMPT-MANIFEST.*unknown section"):
+                _resolve_section_path("totally_fake_section_999", "de")
+
+    def test_non_strict_unknown_section_returns_none(self):
+        """In non-STRICT mode, unknown section falls through to None."""
+        from services.prompt_loader import _resolve_section_path, PromptManifest
+        PromptManifest.reset()
+        with patch("services.prompt_loader.RELEASE_STRICT_MODE", False):
+            path, lang = _resolve_section_path("totally_fake_section_999", "de")
+            assert path is None
+
+    def test_manifest_log_present_in_source(self):
+        """prompt_loader.py must contain [PROMPT-MANIFEST] ok log."""
+        source = Path("services/prompt_loader.py").read_text()
+        assert "[PROMPT-MANIFEST] ok section=" in source
+
+    def test_manifest_error_log_present(self):
+        """prompt_loader.py must contain [PROMPT-MANIFEST][ERROR] log."""
+        source = Path("services/prompt_loader.py").read_text()
+        assert "[PROMPT-MANIFEST][ERROR]" in source
+
+
+class TestPromptUsageTracking:
+    """TASK 2: Usage tracking."""
+
+    def setup_method(self):
+        from services.prompt_loader import clear_used_prompts
+        clear_used_prompts()
+
+    def test_record_usage_appends(self):
+        """_record_usage adds entries to used_prompts."""
+        from services.prompt_loader import _record_usage, get_used_prompts
+        _record_usage("test_section", "de", "de/test.md", 100, "hello", [])
+        entries = get_used_prompts()
+        assert len(entries) == 1
+        assert entries[0]["section"] == "test_section"
+        assert entries[0]["lang"] == "de"
+        assert entries[0]["bytes"] == 100
+        assert "sha256" in entries[0]
+
+    def test_record_usage_includes_sha256(self):
+        """Usage entry must have sha256 hash."""
+        from services.prompt_loader import _record_usage, get_used_prompts
+        _record_usage("s", "de", "p", 5, "test content", ["inc.md"])
+        entry = get_used_prompts()[0]
+        assert len(entry["sha256"]) == 16  # truncated sha256
+        assert entry["includes"] == ["inc.md"]
+
+    def test_flush_creates_artifact(self):
+        """flush_usage_to_artifact writes JSON file."""
+        from services.prompt_loader import (
+            _record_usage, flush_usage_to_artifact, clear_used_prompts
+        )
+        _record_usage("executive_summary", "de", "de/executive_summary.md", 200, "content", [])
+
+        result = flush_usage_to_artifact()
+
+        # It should have written to artifacts/prompt_usage_last.json
+        assert result is not None
+        assert Path(result).exists()
+        data = json.loads(Path(result).read_text())
+        assert len(data) >= 1
+        assert data[-1]["section"] == "executive_summary"
+
+        # Clean up so audit script test passes
+        Path(result).unlink(missing_ok=True)
+
+    def test_clear_used_prompts(self):
+        """clear_used_prompts empties the list."""
+        from services.prompt_loader import _record_usage, get_used_prompts, clear_used_prompts
+        _record_usage("s", "de", "p", 10, "x", [])
+        assert len(get_used_prompts()) == 1
+        clear_used_prompts()
+        assert len(get_used_prompts()) == 0
+
+    def test_audit_script_exits_zero(self):
+        """scripts/prompt_usage_audit.py must exit 0."""
+        import subprocess
+        result = subprocess.run(
+            ["python", "scripts/prompt_usage_audit.py"],
+            capture_output=True, text=True, timeout=30
+        )
+        assert result.returncode == 0, f"Audit failed:\n{result.stdout}\n{result.stderr}"
+
+
+class TestJinjaIncludeOnly:
+    """TASK 3: Jinja include-only enforcement + path sandbox."""
+
+    def test_forbidden_extends_blocked(self):
+        """{% extends %} must be blocked."""
+        from services.prompt_loader import _prescan_jinja_tags
+        with patch("services.prompt_loader.RELEASE_STRICT_MODE", True):
+            with pytest.raises(RuntimeError, match="PROMPT-JINJA.*forbidden tag.*extends"):
+                _prescan_jinja_tags('{% extends "base.html" %}', "test")
+
+    def test_forbidden_import_blocked(self):
+        """{% import %} must be blocked."""
+        from services.prompt_loader import _prescan_jinja_tags
+        with patch("services.prompt_loader.RELEASE_STRICT_MODE", True):
+            with pytest.raises(RuntimeError, match="PROMPT-JINJA.*forbidden tag.*import"):
+                _prescan_jinja_tags('{% import "macros.html" as m %}', "test")
+
+    def test_forbidden_from_blocked(self):
+        """{% from %} must be blocked."""
+        from services.prompt_loader import _prescan_jinja_tags
+        with patch("services.prompt_loader.RELEASE_STRICT_MODE", True):
+            with pytest.raises(RuntimeError, match="PROMPT-JINJA.*forbidden tag.*from"):
+                _prescan_jinja_tags('{% from "x.html" import y %}', "test")
+
+    def test_forbidden_macro_blocked(self):
+        """{% macro %} must be blocked."""
+        from services.prompt_loader import _prescan_jinja_tags
+        with patch("services.prompt_loader.RELEASE_STRICT_MODE", True):
+            with pytest.raises(RuntimeError, match="PROMPT-JINJA.*forbidden tag.*macro"):
+                _prescan_jinja_tags('{% macro input(name) %}...{% endmacro %}', "test")
+
+    def test_include_allowed(self):
+        """{% include %} must NOT be blocked."""
+        from services.prompt_loader import _prescan_jinja_tags
+        # Should not raise
+        _prescan_jinja_tags('{% include "fragment.md" %}', "test")
+
+    def test_raw_allowed(self):
+        """{% raw %} must NOT be blocked."""
+        from services.prompt_loader import _prescan_jinja_tags
+        _prescan_jinja_tags('{% raw %}...{% endraw %}', "test")
+
+    def test_include_path_traversal_blocked(self):
+        """Include with '..' must be blocked."""
+        from services.prompt_loader import _validate_include_path
+        with patch("services.prompt_loader.RELEASE_STRICT_MODE", True):
+            with pytest.raises(RuntimeError, match="PROMPT-INCLUDE.*BLOCK.*path_traversal"):
+                _validate_include_path("../etc/passwd", "de", "test")
+
+    def test_include_absolute_path_blocked(self):
+        """Include with absolute path must be blocked."""
+        from services.prompt_loader import _validate_include_path
+        with patch("services.prompt_loader.RELEASE_STRICT_MODE", True):
+            with pytest.raises(RuntimeError, match="PROMPT-INCLUDE.*BLOCK.*absolute_path"):
+                _validate_include_path("/etc/passwd", "de", "test")
+
+    def test_include_backslash_blocked(self):
+        """Include with backslash must be blocked."""
+        from services.prompt_loader import _validate_include_path
+        with patch("services.prompt_loader.RELEASE_STRICT_MODE", True):
+            with pytest.raises(RuntimeError, match="PROMPT-INCLUDE.*BLOCK.*backslash"):
+                _validate_include_path("foo\\bar.md", "de", "test")
+
+    def test_include_normal_path_allowed(self):
+        """Normal include path (e.g. 'prompt_framework.md') is allowed."""
+        from services.prompt_loader import _validate_include_path, PromptManifest
+        PromptManifest.reset()
+        with patch("services.prompt_loader.RELEASE_STRICT_MODE", False):
+            result = _validate_include_path("prompt_framework.md", "de", "test")
+            assert result is True
+
+    def test_prescan_includes_returns_list(self):
+        """_prescan_includes returns list of include targets."""
+        from services.prompt_loader import _prescan_includes, PromptManifest
+        PromptManifest.reset()
+        with patch("services.prompt_loader.RELEASE_STRICT_MODE", False):
+            text = '{% include "a.md" %}\n{% include "b.md" %}'
+            result = _prescan_includes(text, "de", "test")
+            assert result == ["a.md", "b.md"]
+
+    def test_source_has_prompt_include_log(self):
+        """prompt_loader.py must contain [PROMPT-INCLUDE] allow log."""
+        source = Path("services/prompt_loader.py").read_text()
+        assert "[PROMPT-INCLUDE] allow" in source
+
+    def test_source_has_prompt_jinja_block_log(self):
+        """prompt_loader.py must contain [PROMPT-JINJA][BLOCK] log."""
+        source = Path("services/prompt_loader.py").read_text()
+        assert "[PROMPT-JINJA][BLOCK]" in source


### PR DESCRIPTION
…ndbox

TASK 1 - Manifest as Single Source of Truth:
- PromptManifest class (cached singleton) resolves sections via prompt_manifest.json
- STRICT mode: fail-closed if section not in manifest (RuntimeError)
- [PROMPT-MANIFEST] ok/ERROR log lines for diagnostics

TASK 2 - Usage Tracking:
- _record_usage() tracks section/lang/path/bytes/sha256/includes per render
- flush_usage_to_artifact() writes artifacts/prompt_usage_last.json
- scripts/prompt_usage_audit.py validates manifest<->usage consistency (exit 0/1)

TASK 3 - Jinja include-only + path sandbox:
- _prescan_jinja_tags() blocks extends/import/from/macro/call/filter
- _validate_include_path() blocks .., absolute paths, backslashes
- CycleDetectingLoader.get_source() enforces path sandbox at runtime
- [PROMPT-JINJA][BLOCK] and [PROMPT-INCLUDE][BLOCK] log lines

Tests: 27 new tests + 3 updated regression tests (118 total passing)