### PR TITLE
fix(FIX-517C): Template scrubber, SOLO_TERM extensions, word-boundary…

### DIFF
--- a/gpt_analyze.py
+++ b/gpt_analyze.py
@@ -14004,8 +14004,9 @@ Gib NUR das angeforderte HTML-Fragment aus - keine Fragen, keine Hilfsangebote, 
                 _prompt_trace_data.clear()
 
     # === SPRINT N2: VALIDATE AND HEAL - Wolf 2025-12 ===
-    # New flow: validate_and_heal() replaces leaked content BEFORE rendering
-    log.info(f"[{run_id}] 🔍 Running report validation with N2 healing...")
+    # FIX-517C TASK 4: Two-stage validation (raw = pre-final-enforcer, final = post-final-enforcer)
+    # Stage 1 (RAW): validate BEFORE final enforcer pass → truthful pre-cleanup metrics
+    log.info(f"[{run_id}] 🔍 Running RAW validation (pre-final-enforcer) with N2 healing...")
     is_valid, validation_errors, healed_count = validate_and_heal(sections, answers)
 
     if healed_count > 0:
@@ -14020,11 +14021,14 @@ Gib NUR das angeforderte HTML-Fragment aus - keine Fragen, keine Hilfsangebote, 
         for err in critical_errors:
             log.error(f"[{run_id}]   [{err.category}] {err.section}: {err.message}")
     if warning_errors:
-        log.warning(f"[{run_id}] ⚠️ Validation warnings: {len(warning_errors)}")
+        log.warning(f"[{run_id}] ⚠️ RAW validation warnings: {len(warning_errors)}")
         for err in warning_errors[:5]:  # Only log first 5 warnings
             log.warning(f"[{run_id}]   [{err.category}] {err.section}: {err.message}")
 
-    # FIX-503B: Store validator warning count for unified metrics
+    # FIX-517C: Store RAW (pre-final-enforcer) counts for diagnostics
+    sections["_VALIDATOR_RAW_WARNING_COUNT"] = len(warning_errors)
+    sections["_VALIDATOR_RAW_CRITICAL_COUNT"] = len(critical_errors)
+    # Legacy keys updated after final validation below
     sections["_VALIDATOR_WARNING_COUNT"] = len(warning_errors)
     sections["_VALIDATOR_CRITICAL_COUNT"] = len(critical_errors)
 
@@ -14455,6 +14459,40 @@ Gib NUR das angeforderte HTML-Fragment aus - keine Fragen, keine Hilfsangebote, 
         log.info(f"[{run_id}] [QUALITY-ENFORCER-RENDER] Applied FINAL quality fixes before render, company_size={company_size_render}")
     except Exception as e:
         log.warning(f"[{run_id}] [QUALITY-ENFORCER-RENDER] Failed: {e}")
+
+    # =========================================================================
+    # FIX-517C TASK 4: Stage 2 (FINAL) validation — post-final-enforcer
+    # This gives the truthful STRICT-readiness metrics (after all enforcers ran)
+    # =========================================================================
+    try:
+        log.info(f"[{run_id}] 🔍 Running FINAL validation (post-enforcer) for STRICT-readiness...")
+        _final_valid, _final_errors, _final_healed = validate_and_heal(sections, answers)
+        _final_critical = [e for e in _final_errors if e.severity == "CRITICAL"]
+        _final_warnings = [e for e in _final_errors if e.severity == "WARNING"]
+
+        # Update legacy keys with FINAL counts (used by STRICT-readiness gate)
+        sections["_VALIDATOR_WARNING_COUNT"] = len(_final_warnings)
+        sections["_VALIDATOR_CRITICAL_COUNT"] = len(_final_critical)
+        # Store explicit FINAL keys for diagnostics
+        sections["_VALIDATOR_FINAL_WARNING_COUNT"] = len(_final_warnings)
+        sections["_VALIDATOR_FINAL_CRITICAL_COUNT"] = len(_final_critical)
+
+        _raw_w = sections.get("_VALIDATOR_RAW_WARNING_COUNT", 0)
+        _raw_c = sections.get("_VALIDATOR_RAW_CRITICAL_COUNT", 0)
+        _delta_w = int(_raw_w) - len(_final_warnings)
+        _delta_c = int(_raw_c) - len(_final_critical)
+        log.info(
+            f"[{run_id}] [FIX-517C][TWO-STAGE] RAW: {_raw_c}C/{_raw_w}W → "
+            f"FINAL: {len(_final_critical)}C/{len(_final_warnings)}W "
+            f"(enforcer fixed: {_delta_c}C/{_delta_w}W)"
+        )
+
+        if _final_warnings:
+            for err in _final_warnings[:3]:
+                log.info(f"[{run_id}]   [FINAL-W] [{err.category}] {err.section}: {err.message}")
+    except Exception as e:
+        log.warning(f"[{run_id}] [FIX-517C][TWO-STAGE] Final validation failed: {e}")
+
     log.info("=" * 80)
 
     # =========================================================================

--- a/services/content_quality_enforcer.py
+++ b/services/content_quality_enforcer.py
@@ -66,7 +66,12 @@ SOLO_TERM_REPLACEMENTS = [
     (r'\bskalierbar\b', 'erweiterbar', 'skalierbar→erweiterbar'),
 
     # Corporate governance terms
+    (r'\bStakeholdern\b', 'Beteiligten', 'Stakeholdern→Beteiligten (Dativ)'),
+    (r'\bStakeholders\b', 'Beteiligte', 'Stakeholders→Beteiligte (EN Plural)'),
     (r'\bStakeholder\b', 'Beteiligte', 'Stakeholder→Beteiligte'),
+    (r'\bAudit-Trail\b', 'Prüfpfad', 'Audit-Trail→Prüfpfad'),
+    (r'\bRoadmap-Engine\b', 'Roadmap-Ansatz', 'Roadmap-Engine→Roadmap-Ansatz'),
+    (r'\bEngine\b(?!ering)', 'Ansatz', 'Engine→Ansatz (nicht Engineering)'),
     (r'\bGovernance-Struktur\b', 'Ordnungsrahmen', 'Governance-Struktur→Ordnungsrahmen'),
     (r'\bGovernance\b', 'Steuerung', 'Governance→Steuerung'),
     (r'\bCompliance-Framework\b', 'Regelwerk', 'Compliance-Framework→Regelwerk'),
@@ -2027,7 +2032,10 @@ def apply_all_quality_enforcers(sections: dict, hauptleistung: str = "", bundesl
     """
     log.info("[QUALITY-ENFORCER] Starting quality enforcement pipeline...")
 
-    # 0. P0.1: Stray Prefix Remover (leading "?" and artifacts)
+    # 0. FIX-517C: Universal Template Phrase Scrub (ALL personas, BEFORE validation)
+    sections = scrub_template_phrases_all_sections(sections)
+
+    # 0.5 P0.1: Stray Prefix Remover (leading "?" and artifacts)
     sections = apply_stray_prefix_remover(sections)
 
     # 1. ROI-Filter
@@ -3429,5 +3437,100 @@ def apply_placeholder_scrub(sections: dict) -> dict:
     if removed > 0:
         sections[key] = result
         log.info("[FIX-514][PLACEHOLDER-SCRUB] removed_blocks=%d", removed)
+
+    return sections
+
+
+# =============================================================================
+# FIX-517C TASK 1: Universal Template Phrase Scrubber (ALL sections, ALL personas)
+# =============================================================================
+# Deterministic removal of template/placeholder patterns BEFORE validation.
+# This prevents false STRICT template_phrase hits from LLM-generated artifacts.
+
+_TEMPLATE_PHRASE_PATTERNS = [
+    # Bracketed placeholders: [Platzhalter: ...], [TODO: ...], [TBD], [TEMPLATE]
+    (re.compile(r'\[Platzhalter(?::\s*[^\]]*?)?\]', re.IGNORECASE), ''),
+    (re.compile(r'\[TODO(?::\s*[^\]]*?)?\]', re.IGNORECASE), ''),
+    (re.compile(r'\[TBD\]', re.IGNORECASE), ''),
+    (re.compile(r'\[TEMPLATE\]', re.IGNORECASE), ''),
+    (re.compile(r'\[Beispieltext(?::\s*[^\]]*?)?\]', re.IGNORECASE), ''),
+    (re.compile(r'\[Mustertext(?::\s*[^\]]*?)?\]', re.IGNORECASE), ''),
+    # Mustache/Jinja-style template variables: {{variable}}, {{ variable }}
+    (re.compile(r'\{\{\s*\w+\s*\}\}'), ''),
+    # German template instructions that LLMs sometimes leave in
+    (re.compile(r'\bHier steht Ihr Text\b', re.IGNORECASE), ''),
+    (re.compile(r'\bFügen Sie hier[^.]*ein\.?', re.IGNORECASE), ''),
+    (re.compile(r'\bBitte ersetzen Sie[^.]*\.?', re.IGNORECASE), ''),
+    (re.compile(r'\bLorem ipsum[^.]*\.?', re.IGNORECASE), ''),
+    # Explicit "Platzhalter" / "Beispieltext" / "Mustertext" as inline words (all sections)
+    (re.compile(r'\bPlatzhalter\b', re.IGNORECASE), 'konkreter Vorschlag'),
+    (re.compile(r'\bBeispieltext\b', re.IGNORECASE), ''),
+    (re.compile(r'\bMustertext\b', re.IGNORECASE), ''),
+    (re.compile(r'\bDummy-?Text\b', re.IGNORECASE), ''),
+]
+
+# All LLM-generated sections to scrub
+_TEMPLATE_SCRUB_SECTIONS = [
+    "EXECUTIVE_SUMMARY_HTML", "EXECUTIVE_DECISION_HTML", "RECOMMENDATIONS_HTML",
+    "QUICK_WINS_HTML", "QUICK_WINS_HTML_LEFT", "QUICK_WINS_HTML_RIGHT",
+    "ROADMAP_90D_HTML", "ROADMAP_90D_DECISION_HTML", "ROADMAP_12M_HTML",
+    "GAMECHANGER_HTML", "GAMECHANGER_DECISION_HTML",
+    "FOERDERPOTENZIAL_HTML", "RISKS_HTML", "ORG_CHANGE_HTML",
+    "KI_SKILLPLAN_HTML", "BUSINESS_CASE_HTML", "AI_ACT_HTML", "AI_ACT_SUMMARY_HTML",
+    "TOOLS_HTML", "TOOLS_EMPFEHLUNGEN_HTML", "DATA_STRATEGY_HTML", "DATA_READINESS_HTML",
+    "GOVERNANCE_HTML", "STRATEGIE_GOVERNANCE_HTML", "KI_STACK_SUMMARY_HTML",
+    "BRANCH_DEEP_DIVE_HTML", "TOP_3_MASSNAHMEN_HTML", "MONETARISIERUNG_HTML",
+    "TEMPLATES_START_HTML", "KICKOFF_VORLAGE_HTML", "PROMPT_FRAMEWORK_HTML",
+    "TECHNOLOGIE_PROZESSE_HTML", "WETTBEWERB_BENCHMARK_HTML", "UNTERNEHMENSPROFIL_MARKT_HTML",
+]
+
+
+def scrub_template_phrases_all_sections(sections: dict) -> dict:
+    """
+    FIX-517C TASK 1: Universal template phrase scrubber.
+
+    Removes placeholder/template artifacts from ALL LLM-generated sections
+    regardless of persona. Runs BEFORE validation to prevent false STRICT hits.
+
+    Patterns removed:
+    - [Platzhalter: ...], [TODO: ...], [TBD], [TEMPLATE]
+    - {{variable}} mustache-style placeholders
+    - German template instructions ("Hier steht Ihr Text", "Fügen Sie hier...")
+    - Standalone "Platzhalter", "Beispieltext", "Mustertext" words
+
+    Returns:
+        sections: Cleaned dict
+    """
+    total_removals = 0
+    sections_touched = 0
+
+    for section_key in _TEMPLATE_SCRUB_SECTIONS:
+        content = sections.get(section_key)
+        if not content or not isinstance(content, str):
+            continue
+
+        section_removals = 0
+        modified = content
+
+        for pattern, replacement in _TEMPLATE_PHRASE_PATTERNS:
+            new_text, count = pattern.subn(replacement, modified)
+            if count > 0:
+                modified = new_text
+                section_removals += count
+
+        if section_removals > 0:
+            # Clean up resulting double spaces and empty tags
+            modified = re.sub(r'\s{2,}', ' ', modified)
+            modified = re.sub(r'\s+([.,;:!?])', r'\1', modified)
+            modified = re.sub(r'<(p|li|div)[^>]*>\s*</(p|li|div)>', '', modified)
+            sections[section_key] = modified
+            sections_touched += 1
+            total_removals += section_removals
+
+    if total_removals > 0:
+        log.info(
+            "[FIX-517C][TEMPLATE-SCRUB] removed=%d template phrases in %d sections",
+            total_removals, sections_touched
+        )
 
     return sections

--- a/services/report_validator.py
+++ b/services/report_validator.py
@@ -1219,10 +1219,35 @@ class ReportValidator:
                     # Only report first leak per section
                     break
 
+    @staticmethod
+    def _term_hit(term: str, text: str) -> bool:
+        """
+        FIX-517C TASK 3: Word-boundary matching for SIZE_MISMATCH terms.
+
+        Uses \\b word-boundary regex instead of simple substring `in` check.
+        This prevents false positives like "Engine" matching "Engineering".
+
+        Args:
+            term: The forbidden term to search for
+            text: The text content to search in
+
+        Returns:
+            True if term is found as a standalone word/phrase
+        """
+        # Escape regex metacharacters in term, then wrap with word boundaries
+        escaped = re.escape(term)
+        # Special case: "Engine" must NOT match "Engineering"
+        # re.escape preserves the term, \b handles word boundaries correctly
+        pattern = r'\b' + escaped + r'\b'
+        return bool(re.search(pattern, text, re.IGNORECASE))
+
     def _check_size_specific_issues(self) -> None:
         """
         SPRINT N: Enhanced size-specific validation with HARD_STOP support.
         Checks for forbidden terms and triggers CRITICAL errors when configured.
+
+        FIX-517C: Uses _term_hit() with word-boundary matching to avoid
+        false positives (e.g. "Engine" in "Engineering").
         """
         # Normalize company_size
         size_key = self.company_size.lower() if self.company_size else "kmu"
@@ -1240,9 +1265,8 @@ class ReportValidator:
         for section_name, content in self.sections.items():
             if not isinstance(content, str):
                 continue
-            lower = content.lower()
             for term in forbidden_terms:
-                if term.lower() in lower:
+                if self._term_hit(term, content):
                     # SPRINT N: Use CRITICAL severity if HARD_STOP is enabled
                     severity = "CRITICAL" if self.HARD_STOP_ON_SIZE_MISMATCH else "WARNING"
                     self.errors.append(


### PR DESCRIPTION
… matching, two-stage validation

TASK 1: Add scrub_template_phrases_all_sections() — universal template/placeholder removal for ALL sections and personas before validation. Catches [Platzhalter], {{vars}}, [TODO], Lorem ipsum, and German template instructions.

TASK 2: Extend SOLO_TERM_REPLACEMENTS with missing variants:
- Stakeholdern→Beteiligten (dative), Stakeholders→Beteiligte (EN plural)
- Audit-Trail→Prüfpfad, Roadmap-Engine→Roadmap-Ansatz
- Engine→Ansatz (with negative lookahead to skip Engineering)

TASK 3: Add _term_hit() with word-boundary regex in report_validator.py. Replaces simple substring `in` check to prevent false positives (e.g. "Engine" no longer matches "Engineering").

TASK 4: Two-stage validation (raw+final) in gpt_analyze.py. RAW = pre-final-enforcer, FINAL = post-final-enforcer. STRICT-readiness now uses FINAL counts for truthful metrics. Both stages stored in meta for diagnostics.