### PR TITLE
fix(FIX-520): PromptVars backfill, transparency_box floor, Payback re…

### DIFF
--- a/gpt_analyze.py
+++ b/gpt_analyze.py
@@ -8562,7 +8562,43 @@ def _build_prompt_vars(briefing: Dict[str, Any], scores: Dict[str, Any]) -> Dict
     for _sc, _dim, _desc in _dim_scores_sorted[:3]:
         _risk_bullets.append(f"• {_dim} ({_sc}/100): {_desc}")
     base_vars["TOP_RISKS"] = "\n".join(_risk_bullets)
-    
+
+    # ===== FIX-520 TASK 1: Ensure required prompt vars exist (STRICT-safe) =====
+    # Prevents Legacy-Fallback for data_readiness, foerderpotenzial,
+    # ki_aktivitaeten_ziele, transparency_box prompts.
+    _FIX520_DEFAULT = "keine Angabe"
+
+    # Short labels from generate_short_labels (BRANCH_CONTEXT_LABEL etc.)
+    base_vars.setdefault("BRANCH_CORE_LABEL", short_labels.get("BRANCH_CORE_LABEL", branche))
+    base_vars.setdefault("BRANCH_CONTEXT_LABEL", short_labels.get("BRANCH_CONTEXT_LABEL", branche))
+    base_vars.setdefault("BRANCH_SHORT_LABEL", short_labels.get("BRANCH_SHORT_LABEL", branche))
+    base_vars.setdefault("OFFERING_LABEL", short_labels.get("OFFERING_LABEL", hauptleistung))
+
+    # Label fields derived from briefing (Patch03 stores them in briefing dict)
+    base_vars.setdefault("AUTOMATISIERUNGSGRAD_LABEL",
+                         briefing.get("AUTOMATISIERUNGSGRAD_LABEL") or briefing.get("automatisierungsgrad") or _FIX520_DEFAULT)
+    base_vars.setdefault("DATENQUELLEN_LABELS",
+                         briefing.get("DATENQUELLEN_LABELS") or briefing.get("datenquellen") or _FIX520_DEFAULT)
+    base_vars.setdefault("PROZESSE_PAPIERLOS_LABEL",
+                         briefing.get("PROZESSE_PAPIERLOS_LABEL") or briefing.get("prozesse_papierlos") or _FIX520_DEFAULT)
+    base_vars.setdefault("REGULIERTE_BRANCHE_LABELS",
+                         briefing.get("REGULIERTE_BRANCHE_LABELS") or briefing.get("regulierte_branche") or _FIX520_DEFAULT)
+    base_vars.setdefault("IT_INFRASTRUKTUR_LABEL",
+                         briefing.get("IT_INFRASTRUKTUR_LABEL") or briefing.get("it_infrastruktur") or _FIX520_DEFAULT)
+    base_vars.setdefault("VORHANDENE_TOOLS_LABELS",
+                         briefing.get("VORHANDENE_TOOLS_LABELS") or briefing.get("vorhandene_tools") or _FIX520_DEFAULT)
+
+    # TOOLS_AKTUELL: used by ki_aktivitaeten_ziele prompt
+    base_vars.setdefault("TOOLS_AKTUELL",
+                         briefing.get("VORHANDENE_TOOLS_LABELS") or briefing.get("vorhandene_tools") or _FIX520_DEFAULT)
+
+    # FOERDERPROGRAMME_HTML: not available at prompt-build time (generated later in pipeline)
+    base_vars.setdefault("FOERDERPROGRAMME_HTML", "")
+
+    # Lowercase aliases for prompts that use them
+    base_vars.setdefault("labels", base_vars.get("DATENQUELLEN_LABELS", _FIX520_DEFAULT))
+    base_vars.setdefault("data_sources", base_vars.get("DATENQUELLEN_LABELS", _FIX520_DEFAULT))
+
     # ===== BLOCK 10: JSON Dumps =====
     # Complex data structures for advanced prompts
     base_vars.update({
@@ -10727,13 +10763,13 @@ def _generate_content_section(section_name: str, briefing: Dict[str, Any], score
     # v7.0 DEBUG: Log which path is being used for quick_wins
     # =========================================================================
     if section_name == "quick_wins":
-        log.warning("=" * 80)
-        log.warning("🔍 QUICK_WINS DEBUG START")
-        log.warning(f"USE_PROMPT_SYSTEM={USE_PROMPT_SYSTEM}")
-        log.warning(f"prompt_key={prompt_key}")
-        log.warning(f"_prompt_enhancer initialized: {bool(_prompt_enhancer)}")
-        log.warning(f"Briefing has zeitersparnis_prioritaet: {bool(briefing.get('zeitersparnis_prioritaet', ''))}")
-        log.warning(f"Briefing has ki_projekte: {bool(briefing.get('ki_projekte', ''))}")
+        log.info("=" * 80)
+        log.info("🔍 QUICK_WINS DEBUG START")
+        log.info(f"USE_PROMPT_SYSTEM={USE_PROMPT_SYSTEM}")
+        log.info(f"prompt_key={prompt_key}")
+        log.info(f"_prompt_enhancer initialized: {bool(_prompt_enhancer)}")
+        log.info(f"Briefing has zeitersparnis_prioritaet: {bool(briefing.get('zeitersparnis_prioritaet', ''))}")
+        log.info(f"Briefing has ki_projekte: {bool(briefing.get('ki_projekte', ''))}")
 
     if USE_PROMPT_SYSTEM and prompt_key and _prompt_enhancer:
         try:
@@ -11093,9 +11129,9 @@ Gib den erweiterten HTML-Inhalt aus (mindestens {min_words} Wörter):
 
             # v7.0 DEBUG: Log success end for quick_wins
             if section_name == "quick_wins":
-                log.warning("✅ QUICK_WINS: PromptEnhancer path completed successfully!")
-                log.warning("🔍 QUICK_WINS DEBUG END")
-                log.warning("=" * 80)
+                log.info("✅ QUICK_WINS: PromptEnhancer path completed successfully!")
+                log.info("🔍 QUICK_WINS DEBUG END")
+                log.info("=" * 80)
 
             return result
 
@@ -11371,14 +11407,14 @@ Gesamt {overall}/100 • Governance {governance}/100 • Sicherheit {security}/1
 
     # v7.0 DEBUG: Log legacy response for quick_wins
     if section_name == "quick_wins":
-        log.warning(f"🤖 LEGACY GPT response length: {len(out)}")
-        log.warning(f"LEGACY response starts: {out[:500]}...")
+        log.info(f"🤖 LEGACY GPT response length: {len(out)}")
+        log.info(f"LEGACY response starts: {out[:500]}...")
         has_div = '<div class="quick-win">' in out
         has_blockquote = '<blockquote>' in out
-        log.warning(f"Contains div.quick-win: {has_div}")
-        log.warning(f"Contains blockquote: {has_blockquote}")
-        log.warning("🔍 QUICK_WINS DEBUG END")
-        log.warning("=" * 80)
+        log.info(f"Contains div.quick-win: {has_div}")
+        log.info(f"Contains blockquote: {has_blockquote}")
+        log.info("🔍 QUICK_WINS DEBUG END")
+        log.info("=" * 80)
 
     out = _clean_html(out)
     if _needs_repair(out):

--- a/gpt_analyze.py
+++ b/gpt_analyze.py
@@ -8580,12 +8580,48 @@ def _build_prompt_vars(briefing: Dict[str, Any], scores: Dict[str, Any]) -> Dict
     
     # Log size context for verification
     if not base_vars.get("size_label"):
-        log.warning("⚠️ size_label not recognized, using fallback. unternehmensgroesse=%s", 
+        log.warning("⚠️ size_label not recognized, using fallback. unternehmensgroesse=%s",
                    briefing.get("unternehmensgroesse", "N/A"))
     else:
-        log.debug("📊 Size context: size_label=%s, COMPANY_SIZE=%s", 
+        log.debug("📊 Size context: size_label=%s, COMPANY_SIZE=%s",
                  base_vars.get("size_label"), base_vars.get("COMPANY_SIZE"))
-    
+
+    # ===== FIX-520 TASK 1: Ensure required prompt vars exist (STRICT-safe) =====
+    # Prevents Legacy-Fallback for data_readiness, foerderpotenzial,
+    # ki_aktivitaeten_ziele, transparency_box prompts.
+    _FIX520_DEFAULT = "keine Angabe"
+
+    # Short labels (BRANCH_CONTEXT_LABEL etc.) — use branche_label as fallback
+    base_vars.setdefault("BRANCH_CORE_LABEL", briefing.get("BRANCH_CORE_LABEL") or branche_label)
+    base_vars.setdefault("BRANCH_CONTEXT_LABEL", briefing.get("BRANCH_CONTEXT_LABEL") or branche_label)
+    base_vars.setdefault("BRANCH_SHORT_LABEL", briefing.get("BRANCH_SHORT_LABEL") or branche_label)
+    base_vars.setdefault("OFFERING_LABEL", briefing.get("OFFERING_LABEL") or hauptleistung)
+
+    # Label fields derived from briefing (Patch03 stores them in briefing dict)
+    base_vars.setdefault("AUTOMATISIERUNGSGRAD_LABEL",
+                         briefing.get("AUTOMATISIERUNGSGRAD_LABEL") or briefing.get("automatisierungsgrad") or _FIX520_DEFAULT)
+    base_vars.setdefault("DATENQUELLEN_LABELS",
+                         briefing.get("DATENQUELLEN_LABELS") or briefing.get("datenquellen") or _FIX520_DEFAULT)
+    base_vars.setdefault("PROZESSE_PAPIERLOS_LABEL",
+                         briefing.get("PROZESSE_PAPIERLOS_LABEL") or briefing.get("prozesse_papierlos") or _FIX520_DEFAULT)
+    base_vars.setdefault("REGULIERTE_BRANCHE_LABELS",
+                         briefing.get("REGULIERTE_BRANCHE_LABELS") or briefing.get("regulierte_branche") or _FIX520_DEFAULT)
+    base_vars.setdefault("IT_INFRASTRUKTUR_LABEL",
+                         briefing.get("IT_INFRASTRUKTUR_LABEL") or briefing.get("it_infrastruktur") or _FIX520_DEFAULT)
+    base_vars.setdefault("VORHANDENE_TOOLS_LABELS",
+                         briefing.get("VORHANDENE_TOOLS_LABELS") or briefing.get("vorhandene_tools") or _FIX520_DEFAULT)
+
+    # TOOLS_AKTUELL: used by ki_aktivitaeten_ziele prompt
+    base_vars.setdefault("TOOLS_AKTUELL",
+                         briefing.get("VORHANDENE_TOOLS_LABELS") or briefing.get("vorhandene_tools") or _FIX520_DEFAULT)
+
+    # FOERDERPROGRAMME_HTML: not available at prompt-build time (generated later in pipeline)
+    base_vars.setdefault("FOERDERPROGRAMME_HTML", "")
+
+    # Lowercase aliases for prompts that use them
+    base_vars.setdefault("labels", base_vars.get("DATENQUELLEN_LABELS", _FIX520_DEFAULT))
+    base_vars.setdefault("data_sources", base_vars.get("DATENQUELLEN_LABELS", _FIX520_DEFAULT))
+
     return base_vars
 # -------------------- 🎯 NEW: Better fallbacks when GPT fails ----------------
 def _get_fallback_content(section_key: str, briefing: Dict[str, Any], scores: Dict[str, Any]) -> str:
@@ -8618,42 +8654,6 @@ def _get_fallback_content(section_key: str, briefing: Dict[str, Any], scores: Di
     short_labels = generate_short_labels(briefing, lang=briefing_lang)
     branch_core_label = short_labels.get("BRANCH_CORE_LABEL", branche)
     offering_label = short_labels.get("OFFERING_LABEL", "")
-
-    # ===== FIX-520 TASK 1: Ensure required prompt vars exist (STRICT-safe) =====
-    # Prevents Legacy-Fallback for data_readiness, foerderpotenzial,
-    # ki_aktivitaeten_ziele, transparency_box prompts.
-    _FIX520_DEFAULT = "keine Angabe"
-
-    # Short labels from generate_short_labels (BRANCH_CONTEXT_LABEL etc.)
-    base_vars.setdefault("BRANCH_CORE_LABEL", short_labels.get("BRANCH_CORE_LABEL", branche))
-    base_vars.setdefault("BRANCH_CONTEXT_LABEL", short_labels.get("BRANCH_CONTEXT_LABEL", branche))
-    base_vars.setdefault("BRANCH_SHORT_LABEL", short_labels.get("BRANCH_SHORT_LABEL", branche))
-    base_vars.setdefault("OFFERING_LABEL", short_labels.get("OFFERING_LABEL", hauptleistung))
-
-    # Label fields derived from briefing (Patch03 stores them in briefing dict)
-    base_vars.setdefault("AUTOMATISIERUNGSGRAD_LABEL",
-                         briefing.get("AUTOMATISIERUNGSGRAD_LABEL") or briefing.get("automatisierungsgrad") or _FIX520_DEFAULT)
-    base_vars.setdefault("DATENQUELLEN_LABELS",
-                         briefing.get("DATENQUELLEN_LABELS") or briefing.get("datenquellen") or _FIX520_DEFAULT)
-    base_vars.setdefault("PROZESSE_PAPIERLOS_LABEL",
-                         briefing.get("PROZESSE_PAPIERLOS_LABEL") or briefing.get("prozesse_papierlos") or _FIX520_DEFAULT)
-    base_vars.setdefault("REGULIERTE_BRANCHE_LABELS",
-                         briefing.get("REGULIERTE_BRANCHE_LABELS") or briefing.get("regulierte_branche") or _FIX520_DEFAULT)
-    base_vars.setdefault("IT_INFRASTRUKTUR_LABEL",
-                         briefing.get("IT_INFRASTRUKTUR_LABEL") or briefing.get("it_infrastruktur") or _FIX520_DEFAULT)
-    base_vars.setdefault("VORHANDENE_TOOLS_LABELS",
-                         briefing.get("VORHANDENE_TOOLS_LABELS") or briefing.get("vorhandene_tools") or _FIX520_DEFAULT)
-
-    # TOOLS_AKTUELL: used by ki_aktivitaeten_ziele prompt
-    base_vars.setdefault("TOOLS_AKTUELL",
-                         briefing.get("VORHANDENE_TOOLS_LABELS") or briefing.get("vorhandene_tools") or _FIX520_DEFAULT)
-
-    # FOERDERPROGRAMME_HTML: not available at prompt-build time (generated later in pipeline)
-    base_vars.setdefault("FOERDERPROGRAMME_HTML", "")
-
-    # Lowercase aliases for prompts that use them
-    base_vars.setdefault("labels", base_vars.get("DATENQUELLEN_LABELS", _FIX520_DEFAULT))
-    base_vars.setdefault("data_sources", base_vars.get("DATENQUELLEN_LABELS", _FIX520_DEFAULT))
 
     # 🎯 Size-Erkennung (solo/team/kmu) wie im Briefing spezifiziert
     size_raw = (briefing.get("UNTERNEHMENSGROESSE_LABEL") or briefing.get("unternehmensgroesse") or "").lower()

--- a/gpt_analyze.py
+++ b/gpt_analyze.py
@@ -8563,42 +8563,6 @@ def _build_prompt_vars(briefing: Dict[str, Any], scores: Dict[str, Any]) -> Dict
         _risk_bullets.append(f"• {_dim} ({_sc}/100): {_desc}")
     base_vars["TOP_RISKS"] = "\n".join(_risk_bullets)
 
-    # ===== FIX-520 TASK 1: Ensure required prompt vars exist (STRICT-safe) =====
-    # Prevents Legacy-Fallback for data_readiness, foerderpotenzial,
-    # ki_aktivitaeten_ziele, transparency_box prompts.
-    _FIX520_DEFAULT = "keine Angabe"
-
-    # Short labels from generate_short_labels (BRANCH_CONTEXT_LABEL etc.)
-    base_vars.setdefault("BRANCH_CORE_LABEL", short_labels.get("BRANCH_CORE_LABEL", branche))
-    base_vars.setdefault("BRANCH_CONTEXT_LABEL", short_labels.get("BRANCH_CONTEXT_LABEL", branche))
-    base_vars.setdefault("BRANCH_SHORT_LABEL", short_labels.get("BRANCH_SHORT_LABEL", branche))
-    base_vars.setdefault("OFFERING_LABEL", short_labels.get("OFFERING_LABEL", hauptleistung))
-
-    # Label fields derived from briefing (Patch03 stores them in briefing dict)
-    base_vars.setdefault("AUTOMATISIERUNGSGRAD_LABEL",
-                         briefing.get("AUTOMATISIERUNGSGRAD_LABEL") or briefing.get("automatisierungsgrad") or _FIX520_DEFAULT)
-    base_vars.setdefault("DATENQUELLEN_LABELS",
-                         briefing.get("DATENQUELLEN_LABELS") or briefing.get("datenquellen") or _FIX520_DEFAULT)
-    base_vars.setdefault("PROZESSE_PAPIERLOS_LABEL",
-                         briefing.get("PROZESSE_PAPIERLOS_LABEL") or briefing.get("prozesse_papierlos") or _FIX520_DEFAULT)
-    base_vars.setdefault("REGULIERTE_BRANCHE_LABELS",
-                         briefing.get("REGULIERTE_BRANCHE_LABELS") or briefing.get("regulierte_branche") or _FIX520_DEFAULT)
-    base_vars.setdefault("IT_INFRASTRUKTUR_LABEL",
-                         briefing.get("IT_INFRASTRUKTUR_LABEL") or briefing.get("it_infrastruktur") or _FIX520_DEFAULT)
-    base_vars.setdefault("VORHANDENE_TOOLS_LABELS",
-                         briefing.get("VORHANDENE_TOOLS_LABELS") or briefing.get("vorhandene_tools") or _FIX520_DEFAULT)
-
-    # TOOLS_AKTUELL: used by ki_aktivitaeten_ziele prompt
-    base_vars.setdefault("TOOLS_AKTUELL",
-                         briefing.get("VORHANDENE_TOOLS_LABELS") or briefing.get("vorhandene_tools") or _FIX520_DEFAULT)
-
-    # FOERDERPROGRAMME_HTML: not available at prompt-build time (generated later in pipeline)
-    base_vars.setdefault("FOERDERPROGRAMME_HTML", "")
-
-    # Lowercase aliases for prompts that use them
-    base_vars.setdefault("labels", base_vars.get("DATENQUELLEN_LABELS", _FIX520_DEFAULT))
-    base_vars.setdefault("data_sources", base_vars.get("DATENQUELLEN_LABELS", _FIX520_DEFAULT))
-
     # ===== BLOCK 10: JSON Dumps =====
     # Complex data structures for advanced prompts
     base_vars.update({
@@ -8654,6 +8618,42 @@ def _get_fallback_content(section_key: str, briefing: Dict[str, Any], scores: Di
     short_labels = generate_short_labels(briefing, lang=briefing_lang)
     branch_core_label = short_labels.get("BRANCH_CORE_LABEL", branche)
     offering_label = short_labels.get("OFFERING_LABEL", "")
+
+    # ===== FIX-520 TASK 1: Ensure required prompt vars exist (STRICT-safe) =====
+    # Prevents Legacy-Fallback for data_readiness, foerderpotenzial,
+    # ki_aktivitaeten_ziele, transparency_box prompts.
+    _FIX520_DEFAULT = "keine Angabe"
+
+    # Short labels from generate_short_labels (BRANCH_CONTEXT_LABEL etc.)
+    base_vars.setdefault("BRANCH_CORE_LABEL", short_labels.get("BRANCH_CORE_LABEL", branche))
+    base_vars.setdefault("BRANCH_CONTEXT_LABEL", short_labels.get("BRANCH_CONTEXT_LABEL", branche))
+    base_vars.setdefault("BRANCH_SHORT_LABEL", short_labels.get("BRANCH_SHORT_LABEL", branche))
+    base_vars.setdefault("OFFERING_LABEL", short_labels.get("OFFERING_LABEL", hauptleistung))
+
+    # Label fields derived from briefing (Patch03 stores them in briefing dict)
+    base_vars.setdefault("AUTOMATISIERUNGSGRAD_LABEL",
+                         briefing.get("AUTOMATISIERUNGSGRAD_LABEL") or briefing.get("automatisierungsgrad") or _FIX520_DEFAULT)
+    base_vars.setdefault("DATENQUELLEN_LABELS",
+                         briefing.get("DATENQUELLEN_LABELS") or briefing.get("datenquellen") or _FIX520_DEFAULT)
+    base_vars.setdefault("PROZESSE_PAPIERLOS_LABEL",
+                         briefing.get("PROZESSE_PAPIERLOS_LABEL") or briefing.get("prozesse_papierlos") or _FIX520_DEFAULT)
+    base_vars.setdefault("REGULIERTE_BRANCHE_LABELS",
+                         briefing.get("REGULIERTE_BRANCHE_LABELS") or briefing.get("regulierte_branche") or _FIX520_DEFAULT)
+    base_vars.setdefault("IT_INFRASTRUKTUR_LABEL",
+                         briefing.get("IT_INFRASTRUKTUR_LABEL") or briefing.get("it_infrastruktur") or _FIX520_DEFAULT)
+    base_vars.setdefault("VORHANDENE_TOOLS_LABELS",
+                         briefing.get("VORHANDENE_TOOLS_LABELS") or briefing.get("vorhandene_tools") or _FIX520_DEFAULT)
+
+    # TOOLS_AKTUELL: used by ki_aktivitaeten_ziele prompt
+    base_vars.setdefault("TOOLS_AKTUELL",
+                         briefing.get("VORHANDENE_TOOLS_LABELS") or briefing.get("vorhandene_tools") or _FIX520_DEFAULT)
+
+    # FOERDERPROGRAMME_HTML: not available at prompt-build time (generated later in pipeline)
+    base_vars.setdefault("FOERDERPROGRAMME_HTML", "")
+
+    # Lowercase aliases for prompts that use them
+    base_vars.setdefault("labels", base_vars.get("DATENQUELLEN_LABELS", _FIX520_DEFAULT))
+    base_vars.setdefault("data_sources", base_vars.get("DATENQUELLEN_LABELS", _FIX520_DEFAULT))
 
     # 🎯 Size-Erkennung (solo/team/kmu) wie im Briefing spezifiziert
     size_raw = (briefing.get("UNTERNEHMENSGROESSE_LABEL") or briefing.get("unternehmensgroesse") or "").lower()

--- a/services/content_quality_enforcer.py
+++ b/services/content_quality_enforcer.py
@@ -406,7 +406,7 @@ def apply_product_name_safety_net(sections: dict) -> dict:
                 total_fixes += count
 
     if total_fixes > 0:
-        log.warning(f"[SAFETY-NET] Total product name mutations fixed: {total_fixes}")
+        log.info(f"[SAFETY-NET] Total product name mutations fixed: {total_fixes}")
 
     return sections
 
@@ -2006,6 +2006,63 @@ def apply_canonical_payback_enforcer(sections: dict) -> dict:
     return sections
 
 
+def _apply_transparency_box_floor(sections: dict) -> dict:
+    """
+    FIX-520 TASK 2: Hard floor for transparency_box section.
+
+    If transparency_box content is less than 60 words, replace with a
+    deterministic minimum that passes SECTION_TOO_SHORT validation.
+    """
+    _TB_KEYS = ["TRANSPARENCY_BOX_HTML", "transparency_box"]
+    for key in _TB_KEYS:
+        content = sections.get(key)
+        if not content or not isinstance(content, str):
+            continue
+
+        # Strip HTML tags for word count
+        text_only = re.sub(r'<[^>]+>', '', content).strip()
+        word_count = len(text_only.split())
+
+        if word_count < 60:
+            # Derive context from sections if available
+            _datenquellen = (
+                sections.get("DATENQUELLEN_LABELS")
+                or sections.get("datenquellen")
+                or "Fragebogen-Antworten"
+            )
+            _branch = (
+                sections.get("BRANCH_CONTEXT_LABEL")
+                or sections.get("BRANCHE_LABEL")
+                or sections.get("branche")
+                or "Ihrer Branche"
+            )
+            _report_date = sections.get("report_date") or sections.get("TODAY") or ""
+
+            replacement = (
+                '<div class="transparency-box">'
+                '<h3>Transparenz &amp; Methodik</h3>'
+                '<ul>'
+                f'<li><strong>Datenbasis:</strong> {_datenquellen}</li>'
+                f'<li><strong>Branchenkontext:</strong> {_branch}</li>'
+                '<li><strong>Methodik:</strong> KI-gestützte Analyse Ihrer Fragebogen-Antworten, '
+                'angereichert mit branchenspezifischem Kontext und aktuellen Förderdaten.</li>'
+                '<li><strong>Validierung:</strong> Alle Kennzahlen (ROI, Payback, Zeitersparnis) '
+                'basieren auf konservativen Annahmen und sollten vor Umsetzung validiert werden.</li>'
+                '<li><strong>Hinweis:</strong> Dieser Report ersetzt keine individuelle Fachberatung. '
+                'Die Empfehlungen dienen als strukturierte Entscheidungsgrundlage für Ihre '
+                'KI-Strategie und sollten im Kontext Ihrer spezifischen Situation bewertet werden.</li>'
+                '</ul>'
+                '</div>'
+            )
+            sections[key] = replacement
+            log.info(
+                "[FIX-520][TRANSPARENCY-FLOOR] section=%s replaced: %d words < 60 minimum",
+                key, word_count
+            )
+
+    return sections
+
+
 def apply_all_quality_enforcers(sections: dict, hauptleistung: str = "", bundesland: str = "", company_size: str = "") -> dict:
 
     """
@@ -2102,6 +2159,9 @@ def apply_all_quality_enforcers(sections: dict, hauptleistung: str = "", bundesl
     # 17. FIX-514: Placeholder Scrub (remove "Platzhalter" from recommendations)
     sections = apply_placeholder_scrub(sections)
 
+    # 18. FIX-520 TASK 2: transparency_box hard-floor (min 60 words)
+    sections = _apply_transparency_box_floor(sections)
+
     log.info("[QUALITY-ENFORCER] Pipeline complete")
     return sections
 
@@ -2129,7 +2189,7 @@ def fix_ai_act_consistency(html: str) -> tuple[str, int]:
         # Entferne "Hochrisiko" wenn "minimal" definiert ist
         result = re.sub(r'\bHochrisiko\b', 'geringes Risiko', result)
         fixes += 1
-        log.warning("[AI-ACT-CONSISTENCY] Fixed contradiction: Hochrisiko → geringes Risiko (weil Risikoklasse minimal)")
+        log.info("[AI-ACT-CONSISTENCY] Fixed contradiction: Hochrisiko → geringes Risiko (weil Risikoklasse minimal)")
     
     return result, fixes
 
@@ -2158,7 +2218,7 @@ def apply_ai_act_consistency(sections: dict) -> dict:
     has_hochrisiko = bool(re.search(r"\bHochrisiko\b", all_ai_act_text, re.IGNORECASE))
     
     if has_minimal and has_hochrisiko:
-        log.warning("[AI-ACT-CONSISTENCY] Global contradiction detected - fixing all sections")
+        log.info("[AI-ACT-CONSISTENCY] Global contradiction detected - fixing all sections")
         for key in ai_act_keys:
             if key in sections and sections[key] and "Hochrisiko" in str(sections[key]):
                 sections[key] = re.sub(r"\bHochrisiko\b", "geringes Risiko", str(sections[key]))
@@ -2933,9 +2993,10 @@ def enforce_kennzahlenblock_kpis(html: str, canonical_kpis: dict) -> tuple[str, 
                 pb_de = pb_de[:-2]
 
             # Pattern: standalone Payback mentions (not in scenario context)
-            # "Payback: 11 Monate" or "Payback11 Monate" or "Amortisation: 9,5 Monate"
+            # FIX-520: Extended to catch: "Payback11 Monate", "Payback: 11 Mon.",
+            # "Payback-Zeit: 11 Mo.", "Amortisation 9,5 Monate"
             payback_pattern = re.compile(
-                r'((?:Payback|Amortisation|Amortisierung)[:\s]+)(\d+(?:[,\.]\d+)?)\s*(Monate?)',
+                r'((?:Payback(?:-Zeit)?|Amortisation|Amortisierung)[:\s]*)(\d+(?:[,\.]\d+)?)\s*(Monate?|Mon\.?|Mo\.?|months?)',
                 re.IGNORECASE
             )
 


### PR DESCRIPTION
…gex, noise reduction

TASK 1: Backfill missing prompt vars (BRANCH_CONTEXT_LABEL, AUTOMATISIERUNGSGRAD_LABEL, DATENQUELLEN_LABELS, etc.) to prevent Legacy-Fallback in STRICT mode.

TASK 2: Hard-floor for transparency_box — deterministic 60+ word replacement when LLM output is too short, preventing SECTION_TOO_SHORT validation failures.

TASK 3: Extended Kennzahlenblock Payback regex to catch "Payback-Zeit", "Mon.", "Mo.", and zero-separator cases (e.g. "Payback11 Monate").

TASK 4: Downgraded fix-applied log messages from WARNING to INFO:
- [SAFETY-NET] product name mutations
- [AI-ACT-CONSISTENCY] contradiction fixes
- QuickWins debug start/end messages