### PR TITLE
feat(FIX-52x): Report-520 Strict-Clean (Solo-Leaks, Zero-Leak, TRUNC,…

### DIFF
--- a/gpt_analyze.py
+++ b/gpt_analyze.py
@@ -12432,13 +12432,16 @@ def _generate_content_sections(briefing: Dict[str, Any], scores: Dict[str, Any])
                         continue  # Skip this key, keep original
 
                 # FIX-515 TASK 1: Cap truncation at max 50% cut to prevent extreme shrinking
+                # FIX-52x: Instead of reverting, cap at 50% (keep at least half)
                 trunc_pct = (1 - len(truncated) / original_len) * 100 if original_len > 0 else 0
                 if trunc_pct > 50:
-                    log.warning(
-                        "[FIX-515][TRUNC] REVERTED section=%s before=%d after=%d delta=%d pct=%.0f%% (>50%% cap)",
-                        key, original_len, len(truncated), len(truncated) - original_len, trunc_pct
+                    # Cap to 50% of original instead of reverting
+                    min_len = int(original_len * 0.5)
+                    truncated = html[:min_len]
+                    log.info(
+                        "[FIX-52x][TRUNC] capped_to_half section=%s before=%d target=%d effective=%d",
+                        key, original_len, len(truncated), min_len
                     )
-                    continue  # Skip: too aggressive
 
                 sections[key] = truncated
                 delta = len(truncated) - original_len
@@ -14583,6 +14586,12 @@ Gib NUR das angeforderte HTML-Fragment aus - keine Fragen, keine Hilfsangebote, 
         # Store explicit FINAL keys for diagnostics
         sections["_VALIDATOR_FINAL_WARNING_COUNT"] = len(_final_warnings)
         sections["_VALIDATOR_FINAL_CRITICAL_COUNT"] = len(_final_critical)
+
+        # FIX-52x: Store full warning list for debug attachment
+        sections["_VALIDATOR_WARNING_LIST"] = [
+            f"[{e.severity}][{e.category}] {e.section}: {e.message}"
+            for e in _final_errors if e.severity in ("WARNING", "CRITICAL")
+        ]
 
         _raw_w = sections.get("_VALIDATOR_RAW_WARNING_COUNT", 0)
         _raw_c = sections.get("_VALIDATOR_RAW_CRITICAL_COUNT", 0)

--- a/services/content_quality_enforcer.py
+++ b/services/content_quality_enforcer.py
@@ -13,6 +13,7 @@ Fixes:
 Wird nach SIEZEN-GUARD aufgerufen, vor Validation.
 """
 
+import os
 import re
 import logging
 
@@ -188,6 +189,18 @@ SOLO_TERM_REPLACEMENTS = [
     (r'\bUnternehmens-IT\b', 'Ihre Technik', 'Unternehmens-IT→Ihre Technik'),
     (r'\bEnterprise-Lösung\b', 'passende Lösung', 'Enterprise-Lösung→passende Lösung'),
     (r'\bEnterprise\b', 'professionelle', 'Enterprise→professionelle'),
+
+    # --- FIX-52x: hard leaks observed in Report-520 ---
+    # Skalierung plural/genitive forms
+    (r'\bSkalierungen\b', 'Erweiterungen', 'FIX-52x: Skalierungen→Erweiterungen'),
+
+    # Audit-Trail space variant
+    (r'\bAudit\s+Trail\b', 'Prüfpfad', 'FIX-52x: Audit Trail→Prüfpfad'),
+
+    # Stack variants with space instead of hyphen
+    (r'\bKI\s+Stack\b', 'KI-Werkzeuge', 'FIX-52x: KI Stack→KI-Werkzeuge'),
+    (r'\bTech\s+Stack\b', 'Technikpaket', 'FIX-52x: Tech Stack→Technikpaket'),
+    (r'\bFull[-\s]?Stack\b', 'End-to-End', 'FIX-52x: Full-Stack→End-to-End'),
 ]
 
 
@@ -340,6 +353,14 @@ def apply_solo_language_normalizer(sections: dict, company_size: str) -> dict:
             total_replacements,
             sections_touched
         )
+
+    # --- FIX-52x: STRICT safety net for remaining solo persona leaks ---
+    if os.getenv("RELEASE_STRICT_MODE") == "1":
+        forbidden = ["Skalierung", "Stakeholder", "Audit-Trail", "Audit Trail", "Stack", "Tech-Stack", "Full-Stack"]
+        all_text = " ".join(str(v) for v in sections.values() if isinstance(v, str))
+        still = [t for t in forbidden if t.lower() in all_text.lower()]
+        if still:
+            raise RuntimeError(f"[FIX-52x][SOLO-LEAK] forbidden terms remain after rewrite: {still}")
 
     return sections
 

--- a/services/debug_503d.py
+++ b/services/debug_503d.py
@@ -431,10 +431,25 @@ def build_debug_503d_attachments(
         })
         total_bytes += len(qw_keys_bytes)
 
+        # 5. FIX-52x: Full validator warnings for strict blockers
+        warnings_list = sections.get("_VALIDATOR_WARNING_LIST", [])
+        if isinstance(warnings_list, list):
+            warnings_payload = "\n".join(warnings_list) if warnings_list else "(none)"
+        else:
+            warnings_payload = "(none)"
+        warnings_bytes = warnings_payload.encode("utf-8")
+        attachments.append({
+            "filename": "debug_52x_validator_warnings.txt",
+            "content": warnings_bytes,
+            "mimetype": "text/plain"
+        })
+        total_bytes += len(warnings_bytes)
+
         # Log the collection (must appear in Railway logs)
         log.info(
-            "[DEBUG-503D][MAIL] attaching 4 artifacts: "
-            "quick_wins_block.html, risk_matrix_block.html, payback_mentions.txt, quick_wins_keys.json "
+            "[DEBUG-503D][MAIL] attaching 5 artifacts: "
+            "quick_wins_block.html, risk_matrix_block.html, payback_mentions.txt, "
+            "quick_wins_keys.json, validator_warnings.txt "
             "(total_bytes=%d)",
             total_bytes
         )

--- a/services/zero_leak_engine.py
+++ b/services/zero_leak_engine.py
@@ -390,7 +390,7 @@ def apply_blacklist_classified(text: str, section_name: str = "") -> BlacklistRe
         # --- FIX-52x: strip prompt-echo prefix lines before critical scan ---
         cleaned, stripped = _strip_prompt_echo_prefix(cleaned, EXECUTIVE_CRITICAL_PHRASES)
         if stripped > 0:
-            logger.info(f"[FIX-52x][ZERO-LEAK] stripped_prompt_echo_lines={stripped} section={section_name} (prefix_only=True)")
+            log.info(f"[FIX-52x][ZERO-LEAK] stripped_prompt_echo_lines={stripped} section={section_name} (prefix_only=True)")
 
         for phrase in EXECUTIVE_CRITICAL_PHRASES:
             pattern = re.compile(re.escape(phrase), re.IGNORECASE)

--- a/services/zero_leak_engine.py
+++ b/services/zero_leak_engine.py
@@ -194,6 +194,31 @@ EXECUTIVE_SECTIONS: List[str] = [
 ]
 
 # =============================================================================
+# --- FIX-52x: strip prompt-echo chat phrases at the very beginning only ---
+def _strip_prompt_echo_prefix(text: str, phrases: List[str]) -> tuple:
+    """
+    Remove prompt-echo phrases that appear only in the first ~400 chars / 6 lines.
+    These are artifacts where the LLM echoes parts of the prompt at the start.
+    Returns (cleaned_text, count_of_removed_lines).
+    """
+    if not text:
+        return text, 0
+    head = text[:400]  # only inspect prefix to avoid hiding real content issues
+    removed = 0
+    for ph in phrases:
+        if ph.lower() in head.lower():
+            # remove the whole line containing the phrase within the prefix
+            lines = text.splitlines()
+            new_lines = []
+            for i, ln in enumerate(lines):
+                if i <= 6 and ph.lower() in ln.lower():
+                    removed += 1
+                    continue
+                new_lines.append(ln)
+            text = "\n".join(new_lines)
+    return text, removed
+
+
 # Fix-Batch A3: EXECUTIVE_CRITICAL_PHRASES
 # =============================================================================
 # These phrases are CRITICAL (fail-closed) ONLY when found in EXECUTIVE_SECTIONS.
@@ -362,6 +387,11 @@ def apply_blacklist_classified(text: str, section_name: str = "") -> BlacklistRe
     # These are CRITICAL only in EXECUTIVE_SECTIONS (causes fail-closed)
     is_executive_section = section_name in EXECUTIVE_SECTIONS
     if is_executive_section:
+        # --- FIX-52x: strip prompt-echo prefix lines before critical scan ---
+        cleaned, stripped = _strip_prompt_echo_prefix(cleaned, EXECUTIVE_CRITICAL_PHRASES)
+        if stripped > 0:
+            logger.info(f"[FIX-52x][ZERO-LEAK] stripped_prompt_echo_lines={stripped} section={section_name} (prefix_only=True)")
+
         for phrase in EXECUTIVE_CRITICAL_PHRASES:
             pattern = re.compile(re.escape(phrase), re.IGNORECASE)
             matches = pattern.findall(cleaned)

--- a/tests/test_debug_503d.py
+++ b/tests/test_debug_503d.py
@@ -80,7 +80,7 @@ class TestDebug503DAttachments:
 
     @patch.dict(os.environ, {"DEBUG_RENDER": "1"})
     def test_returns_4_attachments(self, sample_html_with_anchors, sample_sections, sample_canonical_kpis):
-        """Test that build_debug_503d_attachments returns exactly 4 attachments."""
+        """Test that build_debug_503d_attachments returns exactly 5 attachments."""
         from services.debug_503d import build_debug_503d_attachments
 
         attachments = build_debug_503d_attachments(
@@ -89,7 +89,7 @@ class TestDebug503DAttachments:
             canonical_kpis=sample_canonical_kpis
         )
 
-        assert len(attachments) == 4, f"Expected 4 attachments, got {len(attachments)}"
+        assert len(attachments) == 5, f"Expected 5 attachments, got {len(attachments)}"
 
     @patch.dict(os.environ, {"DEBUG_RENDER": "1"})
     def test_correct_filenames(self, sample_html_with_anchors, sample_sections, sample_canonical_kpis):
@@ -107,6 +107,7 @@ class TestDebug503DAttachments:
             "debug_503d_risk_matrix_block.html",
             "debug_503d_payback_mentions.txt",
             "debug_503d_quick_wins_keys.json",
+            "debug_52x_validator_warnings.txt",
         ]
 
         actual_filenames = [att["filename"] for att in attachments]
@@ -431,7 +432,7 @@ class TestDebug503DSummaryJsonSerializable:
             canonical_kpis={"PAYBACK_MONTHS": 6.5}
         )
 
-        assert len(attachments) == 4, "Should have 4 debug attachments"
+        assert len(attachments) == 5, "Should have 5 debug attachments"
 
         # Build summary (should be JSON-safe)
         summary = build_debug_503d_summary(attachments)

--- a/tests/test_debug_503d.py
+++ b/tests/test_debug_503d.py
@@ -445,9 +445,9 @@ class TestDebug503DSummaryJsonSerializable:
 
         # Verify summary structure
         assert "artifact_count" in summary
-        assert summary["artifact_count"] == 4
+        assert summary["artifact_count"] == 5
         assert "artifacts" in summary
-        assert len(summary["artifacts"]) == 4
+        assert len(summary["artifacts"]) == 5
         assert "total_bytes" in summary
         assert "captured_at" in summary
 
@@ -494,7 +494,7 @@ class TestDebug503DSummaryJsonSerializable:
             pytest.fail(f"Meta dict is NOT JSON-serializable: {e}")
 
         # Verify round-trip
-        assert parsed["debug_503d_summary"]["artifact_count"] == 4
+        assert parsed["debug_503d_summary"]["artifact_count"] == 5
 
     @patch.dict(os.environ, {"DEBUG_RENDER": "1"})
     def test_attachments_contain_bytes_but_summary_does_not(self, sample_html_with_anchors, sample_sections):


### PR DESCRIPTION
… Debug)

P1: Solo-Persona-Leaks auf 0
- Added missing SOLO_TERM_REPLACEMENTS: Skalierungen, Audit Trail (space), KI Stack, Tech Stack, Full-Stack variants
- Added STRICT safety net that raises RuntimeError if forbidden terms remain after solo-rewrite (Skalierung, Stakeholder, Audit-Trail, Stack)

P2: Zero-Leak prompt-echo strip
- Added _strip_prompt_echo_prefix() to remove LLM prompt-echo artifacts from first 6 lines / 400 chars before EXECUTIVE_CRITICAL_PHRASES scan
- Prevents FAIL-CLOSED spam from "Bitte beschreibe kurz" etc.

P3: TRUNC REVERTED → capped_to_half
- Changed truncation >50% behavior from REVERT (warning) to CAP at 50%
- log.info instead of log.warning for successful cap

P4: Full validator warnings in debug attachment
- Store _VALIDATOR_WARNING_LIST in sections for debug extraction
- Added debug_52x_validator_warnings.txt (5th attachment) in debug_503d