### PR TITLE
feat(FIX-52x): Final Solo Polish - 4 priority cleanup functions

### DIFF
--- a/services/content_quality_enforcer.py
+++ b/services/content_quality_enforcer.py
@@ -63,6 +63,7 @@ SOLO_TERM_REPLACEMENTS = [
     (r'\bStack\b', 'Technikpaket', 'Stack→Technikpaket'),
     (r'\bLayers\b', 'Ebenen', 'Layers→Ebenen (Plural)'),
     (r'\bLayer\b', 'Ebene', 'Layer→Ebene'),
+    (r'\bPipelines\b', 'Abläufe', 'Pipelines→Abläufe (Plural)'),
     (r'\bPipeline\b', 'Ablauf', 'Pipeline→Ablauf'),
     (r'\bWorkflow\b', 'Arbeitsablauf', 'Workflow→Arbeitsablauf'),
     (r'\bWorkflows\b', 'Arbeitsabläufe', 'Workflows→Arbeitsabläufe'),
@@ -2261,6 +2262,284 @@ def auto_shorten_redundant_sections(sections: dict) -> dict:
     return sections
 
 
+# =============================================================================
+# FIX-52x FINAL POLISH: Comprehensive Template Phrase Stripper
+# =============================================================================
+
+# Comprehensive list of template phrases that should never appear in output
+_FINAL_TEMPLATE_PHRASES = [
+    # German placeholders
+    r'\bPlatzhalter\b',
+    r'\[Platzhalter[^\]]*\]',
+    r'\[TODO[^\]]*\]',
+    r'\[FIXME[^\]]*\]',
+    r'\[XXX[^\]]*\]',
+    r'\[INSERT[^\]]*\]',
+    r'\[EINFÜGEN[^\]]*\]',
+    # Template markers
+    r'\{\{[^}]+\}\}',  # Jinja2 double braces
+    r'\{%[^%]+%\}',    # Jinja2 blocks
+    r'\$\{[^}]+\}',    # Shell-style vars
+    # Prompt echo patterns
+    r'^Erstelle\s+(?:mir\s+)?(?:einen?\s+)?(?:detaillierten?\s+)?(?:Abschnitt|Text|Analyse)',
+    r'^Schreibe?\s+(?:mir\s+)?(?:einen?\s+)?(?:detaillierten?\s+)?',
+    r'^Generiere\s+(?:mir\s+)?',
+    r'^Verfasse\s+(?:mir\s+)?',
+    r'^Formuliere\s+(?:mir\s+)?',
+    # Meta instructions that leaked
+    r'^\s*Hinweis:\s*Dieser\s+Text',
+    r'^\s*Anweisung:',
+    r'^\s*Prompt:',
+    r'^\s*Aufgabe:',
+    # Common LLM artifacts
+    r'(?i)\bals\s+KI(?:-Assistent)?\b',
+    r'(?i)\bals\s+Sprachmodell\b',
+    r'(?i)\bich\s+(?:kann|darf)\s+(?:nicht|keine)\b.*?(?:rechtliche|medizinische)\s+Beratung',
+]
+
+def strip_template_phrases_final(sections: dict) -> dict:
+    """
+    FIX-52x FINAL POLISH PRIO 1: Comprehensive final cleanup of ALL template
+    phrases across ALL sections. This runs as the LAST step in the pipeline.
+    """
+    import re as regex_module
+
+    total_fixes = 0
+
+    for key, value in list(sections.items()):
+        if not isinstance(value, str) or not value.strip():
+            continue
+        if key.startswith('_'):  # Skip internal keys
+            continue
+
+        original = value
+        html = value
+
+        for pattern in _FINAL_TEMPLATE_PHRASES:
+            try:
+                # For line-anchored patterns, process line by line
+                if pattern.startswith('^'):
+                    lines = html.split('\n')
+                    new_lines = []
+                    for line in lines:
+                        stripped = line.strip()
+                        # Remove HTML tags for matching
+                        text_only = regex_module.sub(r'<[^>]+>', '', stripped)
+                        if not regex_module.search(pattern, text_only, regex_module.IGNORECASE):
+                            new_lines.append(line)
+                    html = '\n'.join(new_lines)
+                else:
+                    # For inline patterns, replace with empty string
+                    html = regex_module.sub(pattern, '', html, flags=regex_module.IGNORECASE)
+            except regex_module.error:
+                continue  # Skip invalid patterns
+
+        # Clean up resulting empty elements
+        html = regex_module.sub(r'<p[^>]*>\s*</p>', '', html)
+        html = regex_module.sub(r'<li[^>]*>\s*</li>', '', html)
+        html = regex_module.sub(r'<div[^>]*>\s*</div>', '', html)
+        html = regex_module.sub(r'\s{3,}', '  ', html)
+
+        if html != original:
+            sections[key] = html
+            total_fixes += 1
+
+    if total_fixes > 0:
+        log.info("[FIX-52x][FINAL-TEMPLATE-STRIP] cleaned %d sections", total_fixes)
+
+    return sections
+
+
+# =============================================================================
+# FIX-52x FINAL POLISH: Paragraph Deduplication
+# =============================================================================
+
+def _dedupe_long_paragraphs(sections: dict) -> dict:
+    """
+    FIX-52x FINAL POLISH PRIO 3: Remove duplicate long paragraphs (>150 chars)
+    that appear multiple times within the same section or across sections.
+    """
+    import re as regex_module
+
+    # Track seen paragraphs globally across all sections
+    global_seen = {}  # normalized_text -> (first_section, first_occurrence)
+    total_removed = 0
+
+    for key, value in list(sections.items()):
+        if not isinstance(value, str) or not value.strip():
+            continue
+        if key.startswith('_'):
+            continue
+
+        html = value
+
+        # Find all paragraphs with their positions
+        para_pattern = r'<p[^>]*>([^<]{150,})</p>'
+        matches = list(regex_module.finditer(para_pattern, html))
+
+        removals = []
+        for match in matches:
+            content = match.group(1)
+            # Normalize: lowercase, collapse whitespace
+            normalized = ' '.join(content.lower().split())
+
+            if normalized in global_seen:
+                # This is a duplicate - mark for removal
+                removals.append((match.start(), match.end()))
+            else:
+                global_seen[normalized] = (key, match.start())
+
+        # Remove duplicates from end to preserve indices
+        for start, end in reversed(removals):
+            html = html[:start] + html[end:]
+            total_removed += 1
+
+        if removals:
+            sections[key] = html
+
+    if total_removed > 0:
+        log.info("[FIX-52x][DEDUPE-PARAGRAPHS] removed %d duplicate paragraphs", total_removed)
+
+    return sections
+
+
+# =============================================================================
+# FIX-52x FINAL POLISH: Trailing Fragment Stripper
+# =============================================================================
+
+def strip_trailing_sentence_fragments(sections: dict) -> dict:
+    """
+    FIX-52x FINAL POLISH PRIO 4: Remove short trailing fragments that look
+    like incomplete sentences at the end of sections.
+
+    Patterns:
+    - Trailing text <30 chars without proper sentence ending
+    - Orphaned conjunctions: "und", "oder", "sowie", "aber"
+    - Dangling colons or commas at end
+    """
+    import re as regex_module
+
+    total_fixes = 0
+
+    for key, value in list(sections.items()):
+        if not isinstance(value, str) or not value.strip():
+            continue
+        if key.startswith('_'):
+            continue
+
+        original = value
+        html = value
+
+        # Pattern 1: Short trailing content after last complete sentence
+        # Match: complete sentence followed by short fragment
+        def fix_trailing(m):
+            full_content = m.group(0)
+            tag_name = m.group(1)
+
+            # Find the last proper sentence ending
+            sentences = regex_module.split(r'([.!?])\s+', full_content)
+            if len(sentences) >= 3:  # At least one complete sentence
+                # Check if trailing part is short fragment
+                trailing = sentences[-1] if sentences[-1] else ''
+                trailing_text = regex_module.sub(r'<[^>]+>', '', trailing).strip()
+
+                if len(trailing_text) < 30 and not regex_module.search(r'[.!?]$', trailing_text):
+                    # Remove trailing fragment, keep sentence ending
+                    proper_end = ''.join(sentences[:-1])
+                    if proper_end and not proper_end.rstrip().endswith(('.', '!', '?')):
+                        proper_end = proper_end.rstrip() + '.'
+                    return proper_end + f'</{tag_name}>'
+
+            return full_content
+
+        # Apply to closing p/div/li tags
+        html = regex_module.sub(
+            r'>([^<]{50,})</([pP]|div|DIV|[lL][iI])>',
+            fix_trailing,
+            html
+        )
+
+        # Pattern 2: Remove dangling conjunctions at very end
+        html = regex_module.sub(
+            r'\s+(?:und|oder|sowie|aber|denn|weil)\s*</([pP]|div|[lL][iI])>',
+            r'.</\1>',
+            html,
+            flags=regex_module.IGNORECASE
+        )
+
+        # Pattern 3: Remove trailing colons/commas before close tag
+        html = regex_module.sub(
+            r'\s*[,:]\s*</([pP]|div|[lL][iI])>',
+            r'.</\1>',
+            html
+        )
+
+        if html != original:
+            sections[key] = html
+            total_fixes += 1
+
+    if total_fixes > 0:
+        log.info("[FIX-52x][TRAILING-FRAGMENT] fixed %d sections", total_fixes)
+
+    return sections
+
+
+# =============================================================================
+# FIX-52x FINAL POLISH: Final Solo Term Rewrite (runs LAST)
+# =============================================================================
+
+def apply_solo_terms_final(sections: dict, company_size: str) -> dict:
+    """
+    FIX-52x FINAL POLISH PRIO 2: Apply solo term replacements as the ABSOLUTE
+    LAST step in the pipeline, after all LLM outputs are finalized.
+
+    This ensures no enterprise terms leak through from any source.
+    """
+    if company_size != "solo":
+        return sections
+
+    import re as regex_module
+
+    total_replacements = 0
+
+    for key, value in list(sections.items()):
+        if not isinstance(value, str) or not value.strip():
+            continue
+        if key.startswith('_'):
+            continue
+
+        original = value
+        text = value
+
+        for pattern, replacement, desc in SOLO_TERM_REPLACEMENTS:
+            try:
+                new_text, count = regex_module.subn(pattern, replacement, text, flags=regex_module.IGNORECASE)
+                if count > 0:
+                    text = new_text
+                    total_replacements += count
+            except regex_module.error:
+                continue
+
+        if text != original:
+            sections[key] = text
+
+    if total_replacements > 0:
+        log.info("[FIX-52x][FINAL-SOLO-TERMS] applied %d replacements", total_replacements)
+
+    # STRICT mode check for remaining forbidden terms
+    if os.getenv("RELEASE_STRICT_MODE") == "1":
+        forbidden = ["Skalierung", "Stakeholder", "Audit-Trail", "Audit Trail",
+                     "Stack", "Tech-Stack", "Full-Stack", "Rollout", "Deployment",
+                     "Pipeline", "Framework", "Dashboard", "KPI", "Modul", "Engine"]
+        all_text = " ".join(str(v) for v in sections.values() if isinstance(v, str))
+        still = [t for t in forbidden if regex_module.search(r'\b' + regex_module.escape(t) + r'\b', all_text, regex_module.IGNORECASE)]
+        if still:
+            # Log warning but don't raise - this is informational
+            log.warning("[FIX-52x][SOLO-LEAK-CHECK] terms still present after final rewrite: %s", still)
+
+    return sections
+
+
 def apply_all_quality_enforcers(sections: dict, hauptleistung: str = "", bundesland: str = "", company_size: str = "") -> dict:
 
     """
@@ -2335,7 +2614,8 @@ def apply_all_quality_enforcers(sections: dict, hauptleistung: str = "", bundesl
     # 10. Open Example Paren Fixer (v14.35.22) - Fix "(z.B." incomplete patterns
     sections = apply_open_example_paren_fixer(sections)
 
-    # 11. Solo Language Normalizer (v14.35.22) - Replace enterprise terms for solo persona
+    # 11. Solo Language Normalizer (v14.35.22) - FIRST PASS enterprise term replacement
+    # NOTE: A final pass runs at the very end to catch any terms introduced by later steps
     if company_size:
         sections = apply_solo_language_normalizer(sections, company_size)
 
@@ -2369,7 +2649,27 @@ def apply_all_quality_enforcers(sections: dict, hauptleistung: str = "", bundesl
     # 18. FIX-520 TASK 2: transparency_box hard-floor (min 60 words)
     sections = _apply_transparency_box_floor(sections)
 
-    log.info("[QUALITY-ENFORCER] Pipeline complete")
+    # =========================================================================
+    # FIX-52x FINAL POLISH: These steps run LAST to catch any artifacts
+    # introduced by earlier LLM-powered or template-based steps
+    # =========================================================================
+
+    # 19. FIX-52x: Deduplicate long identical paragraphs (PRIO 3)
+    sections = _dedupe_long_paragraphs(sections)
+
+    # 20. FIX-52x: Strip trailing sentence fragments (PRIO 4)
+    sections = strip_trailing_sentence_fragments(sections)
+
+    # 21. FIX-52x: Final comprehensive template phrase cleanup (PRIO 1)
+    sections = strip_template_phrases_final(sections)
+
+    # 22. FIX-52x: FINAL solo term replacement (PRIO 2) - ABSOLUTE LAST STEP
+    # This catches any enterprise terms that may have been introduced by
+    # earlier steps (LLM outputs, template expansions, etc.)
+    if company_size:
+        sections = apply_solo_terms_final(sections, company_size)
+
+    log.info("[QUALITY-ENFORCER] Pipeline complete (FIX-52x final polish applied)")
     return sections
 
 

--- a/tests/test_fix52x_final_polish.py
+++ b/tests/test_fix52x_final_polish.py
@@ -1,0 +1,244 @@
+"""
+Tests for FIX-52x Final Polish functions.
+
+These tests verify the final pipeline steps that run LAST to catch
+any artifacts introduced by earlier LLM-powered or template-based steps.
+"""
+
+import pytest
+from services.content_quality_enforcer import (
+    strip_template_phrases_final,
+    _dedupe_long_paragraphs,
+    strip_trailing_sentence_fragments,
+    apply_solo_terms_final,
+    apply_all_quality_enforcers,
+)
+
+
+# =============================================================================
+# PRIO 1: strip_template_phrases_final
+# =============================================================================
+
+class TestStripTemplatePhrasesFinal:
+    """Tests for comprehensive template phrase stripping."""
+
+    def test_removes_platzhalter(self):
+        """Should remove 'Platzhalter' from content."""
+        sections = {
+            "QUICK_WINS_HTML": "<p>Hier ist ein Platzhalter für Text.</p>"
+        }
+        result = strip_template_phrases_final(sections)
+        assert "Platzhalter" not in result["QUICK_WINS_HTML"]
+
+    def test_removes_bracketed_placeholders(self):
+        """Should remove [TODO] and [Platzhalter...] patterns."""
+        sections = {
+            "BUSINESS_CASE_HTML": "<p>Text [TODO: add details] here [Platzhalter einfügen].</p>"
+        }
+        result = strip_template_phrases_final(sections)
+        assert "[TODO" not in result["BUSINESS_CASE_HTML"]
+        assert "[Platzhalter" not in result["BUSINESS_CASE_HTML"]
+
+    def test_removes_jinja2_artifacts(self):
+        """Should remove Jinja2 template markers that leaked."""
+        sections = {
+            "PILOT_PLAN_HTML": "<p>Text with {{variable}} and {% if condition %}.</p>"
+        }
+        result = strip_template_phrases_final(sections)
+        assert "{{" not in result["PILOT_PLAN_HTML"]
+        assert "{%" not in result["PILOT_PLAN_HTML"]
+
+    def test_skips_internal_keys(self):
+        """Should not process keys starting with underscore."""
+        sections = {
+            "_VALIDATOR_WARNING_LIST": ["Platzhalter warning"],
+            "QUICK_WINS_HTML": "<p>Clean content</p>"
+        }
+        result = strip_template_phrases_final(sections)
+        assert "Platzhalter" in str(result["_VALIDATOR_WARNING_LIST"])
+
+    def test_removes_prompt_echo_patterns(self):
+        """Should remove leaked prompt instructions."""
+        sections = {
+            "RECOMMENDATIONS_HTML": "Erstelle mir einen detaillierten Abschnitt über KI.\n<p>Actual content.</p>"
+        }
+        result = strip_template_phrases_final(sections)
+        assert "Erstelle mir" not in result["RECOMMENDATIONS_HTML"]
+
+
+# =============================================================================
+# PRIO 2: apply_solo_terms_final
+# =============================================================================
+
+class TestApplySoloTermsFinal:
+    """Tests for final solo term replacement."""
+
+    def test_replaces_enterprise_terms_for_solo(self):
+        """Should replace enterprise terms for solo persona."""
+        sections = {
+            "QUICK_WINS_HTML": "<p>Nutzen Sie unsere Skalierung und Stakeholder-Management.</p>"
+        }
+        result = apply_solo_terms_final(sections, "solo")
+        assert "Skalierung" not in result["QUICK_WINS_HTML"]
+        assert "Stakeholder" not in result["QUICK_WINS_HTML"]
+        assert "Ausbau" in result["QUICK_WINS_HTML"]
+        assert "Beteiligte" in result["QUICK_WINS_HTML"]
+
+    def test_skips_non_solo_personas(self):
+        """Should not modify content for non-solo personas."""
+        sections = {
+            "QUICK_WINS_HTML": "<p>Nutzen Sie unsere Skalierung.</p>"
+        }
+        result = apply_solo_terms_final(sections, "team")
+        assert "Skalierung" in result["QUICK_WINS_HTML"]
+
+        result = apply_solo_terms_final(sections, "kmu")
+        assert "Skalierung" in result["QUICK_WINS_HTML"]
+
+    def test_replaces_engine_terms(self):
+        """Should replace Engine-related terms."""
+        sections = {
+            "RECOMMENDATIONS_HTML": "<p>Die Risk-Engine und Business-Case-Engine.</p>"
+        }
+        result = apply_solo_terms_final(sections, "solo")
+        assert "Risk-Engine" not in result["RECOMMENDATIONS_HTML"]
+        assert "Business-Case-Engine" not in result["RECOMMENDATIONS_HTML"]
+
+    def test_replaces_stack_terms(self):
+        """Should replace Stack-related terms."""
+        sections = {
+            "PILOT_PLAN_HTML": "<p>Tech-Stack und Tool-Stack aufbauen.</p>"
+        }
+        result = apply_solo_terms_final(sections, "solo")
+        assert "Tech-Stack" not in result["PILOT_PLAN_HTML"]
+        assert "Tool-Stack" not in result["PILOT_PLAN_HTML"]
+
+
+# =============================================================================
+# PRIO 3: _dedupe_long_paragraphs
+# =============================================================================
+
+class TestDedupeLongParagraphs:
+    """Tests for paragraph deduplication."""
+
+    def test_removes_duplicate_paragraphs(self):
+        """Should remove second occurrence of duplicate long paragraphs."""
+        # Long text without any < characters (as the regex requires [^<]{150,})
+        # Must be at least 150 characters
+        long_text = "Dies ist ein langer Absatz mit mehr als 150 Zeichen, der mehrfach vorkommt. Er enthaelt viele Woerter und ist lang genug um erkannt zu werden. Zusaetzlicher Text."
+        assert len(long_text) >= 150, f"Test text must be >= 150 chars, got {len(long_text)}"
+        sections = {
+            "BUSINESS_CASE_HTML": f"<p>{long_text}</p><p>Different content here.</p><p>{long_text}</p>"
+        }
+        result = _dedupe_long_paragraphs(sections)
+        # Should have only one occurrence of the long paragraph
+        count = result["BUSINESS_CASE_HTML"].count(long_text)
+        assert count == 1, f"Expected 1 occurrence but found {count}"
+
+    def test_keeps_short_duplicate_paragraphs(self):
+        """Should not remove duplicates shorter than 150 chars."""
+        short_text = "Kurzer Text."
+        sections = {
+            "QUICK_WINS_HTML": f"<p>{short_text}</p><p>Other content.</p><p>{short_text}</p>"
+        }
+        result = _dedupe_long_paragraphs(sections)
+        # Both short paragraphs should remain
+        assert result["QUICK_WINS_HTML"].count(short_text) == 2
+
+    def test_removes_cross_section_duplicates(self):
+        """Should detect duplicates across different sections."""
+        # Long text without any < characters (minimum 150 chars)
+        long_text = "Dieser Absatz ist lang genug um als Duplikat erkannt zu werden und sollte entfernt werden. Er enthaelt genug Zeichen um die Mindestlaenge zu erreichen."
+        sections = {
+            "BUSINESS_CASE_HTML": f"<p>{long_text}</p>",
+            "PILOT_PLAN_HTML": f"<p>{long_text}</p>"
+        }
+        result = _dedupe_long_paragraphs(sections)
+        # One section should have it removed
+        total_occurrences = (
+            result["BUSINESS_CASE_HTML"].count(long_text) +
+            result["PILOT_PLAN_HTML"].count(long_text)
+        )
+        assert total_occurrences == 1, f"Expected 1 total occurrence but found {total_occurrences}"
+
+
+# =============================================================================
+# PRIO 4: strip_trailing_sentence_fragments
+# =============================================================================
+
+class TestStripTrailingSentenceFragments:
+    """Tests for trailing fragment stripping."""
+
+    def test_fixes_trailing_conjunction(self):
+        """Should fix sentences ending with dangling conjunctions."""
+        sections = {
+            "BUSINESS_CASE_HTML": "<p>Dies ist ein längerer Satz der mit und</p>"
+        }
+        result = strip_trailing_sentence_fragments(sections)
+        assert result["BUSINESS_CASE_HTML"].endswith(".</p>")
+        assert "und</p>" not in result["BUSINESS_CASE_HTML"]
+
+    def test_fixes_trailing_colon(self):
+        """Should fix sentences ending with colon."""
+        sections = {
+            "PILOT_PLAN_HTML": "<p>Hier folgen die nächsten Schritte:</p>"
+        }
+        result = strip_trailing_sentence_fragments(sections)
+        assert result["PILOT_PLAN_HTML"].endswith(".</p>")
+
+    def test_fixes_trailing_comma(self):
+        """Should fix sentences ending with comma."""
+        sections = {
+            "RECOMMENDATIONS_HTML": "<li>Erstens, zweitens, drittens,</li>"
+        }
+        result = strip_trailing_sentence_fragments(sections)
+        assert result["RECOMMENDATIONS_HTML"].endswith(".</li>")
+
+    def test_preserves_proper_sentences(self):
+        """Should not modify properly ended sentences."""
+        sections = {
+            "QUICK_WINS_HTML": "<p>Dies ist ein vollständiger Satz.</p>"
+        }
+        original = sections["QUICK_WINS_HTML"]
+        result = strip_trailing_sentence_fragments(sections)
+        assert result["QUICK_WINS_HTML"] == original
+
+
+# =============================================================================
+# Integration: Full Pipeline
+# =============================================================================
+
+class TestFullPipelineIntegration:
+    """Integration tests for the full quality enforcer pipeline."""
+
+    def test_pipeline_applies_final_polish(self):
+        """Should apply all FIX-52x final polish steps."""
+        sections = {
+            "QUICK_WINS_HTML": "<p>Nutzen Sie unsere Skalierung mit Platzhalter.</p>",
+            "BUSINESS_CASE_HTML": "<p>Der Tech-Stack bietet und</p>",
+        }
+        result = apply_all_quality_enforcers(sections, company_size="solo")
+
+        # Template phrases removed
+        assert "Platzhalter" not in result.get("QUICK_WINS_HTML", "")
+
+        # Solo terms replaced
+        assert "Skalierung" not in result.get("QUICK_WINS_HTML", "")
+        assert "Tech-Stack" not in result.get("BUSINESS_CASE_HTML", "")
+
+    def test_pipeline_runs_solo_terms_last(self):
+        """Solo terms should be replaced even if introduced by earlier steps."""
+        # This simulates a scenario where earlier steps might introduce enterprise terms
+        sections = {
+            "RECOMMENDATIONS_HTML": "<p>Empfehlung: Nutzen Sie Module und Pipelines.</p>",
+        }
+        result = apply_all_quality_enforcers(sections, company_size="solo")
+
+        # Module should be replaced with Baustein
+        assert "Module" not in result.get("RECOMMENDATIONS_HTML", "")
+        # Pipeline should be replaced with Ablauf
+        assert "Pipeline" not in result.get("RECOMMENDATIONS_HTML", "")
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
PRIO 1: strip_template_phrases_final() - Comprehensive final template
        phrase cleanup with expanded pattern list (Platzhalter, Jinja2,
        prompt echos, LLM artifacts)

PRIO 2: apply_solo_terms_final() - Solo term replacement runs LAST in
        pipeline to catch any enterprise terms introduced by earlier steps.
        Added "Pipelines" plural pattern.

PRIO 3: _dedupe_long_paragraphs() - Remove duplicate paragraphs >150 chars
        within and across sections

PRIO 4: strip_trailing_sentence_fragments() - Fix dangling conjunctions,
        trailing colons/commas, and incomplete sentence fragments

Pipeline updated with steps 19-22 as final polish after transparency_box. Added 18 tests in test_fix52x_final_polish.py covering all new functions.