### PR TITLE
feat(FIX-BRANCH-13): 13-branch catalog + En-Dash company size normalizer

### DIFF
--- a/gpt_analyze.py
+++ b/gpt_analyze.py
@@ -8270,30 +8270,60 @@ def _build_prompt_vars(briefing: Dict[str, Any], scores: Dict[str, Any]) -> Dict
     # Core company information needed across all prompts
     # Both uppercase and lowercase variants for compatibility
 
-    # Map unternehmensgroesse to COMPANY_SIZE for roadmap/gamechanger prompts
-    # Frontend V2 sends: "1", "2–10" (en-dash), "11–100" (en-dash)
-    # Prompts use: "solo", "team", "kmu"
-    size_raw = str(briefing.get("unternehmensgroesse", "1")).strip().lower()
-    size_map = {
-        # Frontend V2 values (primary) - what the questionnaire sends
-        "1": "solo",       # 1 (Solo-Selbstständig/Freiberuflich)
-        "2–10": "team",    # 2–10 (Kleines Team) - en-dash U+2013
-        "2-10": "team",    # 2-10 (Kleines Team) - hyphen fallback
-        "11–100": "kmu",   # 11–100 (KMU) - en-dash U+2013
-        "11-100": "kmu",   # 11-100 (KMU) - hyphen fallback
-        # Legacy/normalized values (backward compatibility)
-        "solo": "solo",
-        "klein": "team",
-        "kmu": "kmu",
-        "team": "team",
-        # Additional legacy variants
-        "freiberufler": "solo",
-        "freelancer": "solo",
-        "small": "team",
-        "medium": "kmu",
-        "sme": "kmu",
+    # -------------------------------------------------------------------------
+    # FIX-BRANCH-13: Use canonical normalizers for branch and company size
+    # -------------------------------------------------------------------------
+    from services.branch_mapping import map_frontend_branch_to_engine
+    from services.company_size_normalizer import normalize_company_size
+
+    # Extract raw input values
+    branche_raw = briefing.get("branche", "")
+    unternehmensgroesse_raw = briefing.get("unternehmensgroesse", "1")
+    country = briefing.get("country", briefing.get("land", "Deutschland"))
+    bundesland_raw = briefing.get("bundesland", "")
+    hauptleistung_raw = briefing.get("hauptleistung", "")
+
+    # Normalize branch using canonical 13-branch mapping
+    branche_engine_key = map_frontend_branch_to_engine(branche_raw)
+
+    # Normalize company size using En-Dash robust normalizer
+    size_info = normalize_company_size(str(unternehmensgroesse_raw))
+    company_size_bucket = size_info["bucket"]
+    company_size_min = size_info["min"]
+    company_size_max = size_info["max"]
+
+    # Map bucket to legacy COMPANY_SIZE values for prompts
+    bucket_to_prompt = {"solo": "solo", "small_team": "team", "kmu": "kmu"}
+    company_size = bucket_to_prompt.get(company_size_bucket, "team")
+
+    # -------------------------------------------------------------------------
+    # FIX-BRANCH-13 TASK 3: Log core input fields before prompt rendering
+    # -------------------------------------------------------------------------
+    log.info(
+        "[FIX-BRANCH-13][CORE-INPUTS] branche_raw=%s branche_engine_key=%s "
+        "unternehmensgroesse_raw=%s company_size_bucket=%s "
+        "country=%s bundesland=%s hauptleistung_len=%d",
+        branche_raw,
+        branche_engine_key,
+        unternehmensgroesse_raw,
+        company_size_bucket,
+        country,
+        bundesland_raw,
+        len(hauptleistung_raw) if hauptleistung_raw else 0,
+    )
+
+    # Store in meta for debugging/auditing
+    briefing["_meta_core_inputs"] = {
+        "branche_raw": branche_raw,
+        "branche_engine_key": branche_engine_key,
+        "unternehmensgroesse_raw": str(unternehmensgroesse_raw),
+        "company_size_bucket": company_size_bucket,
+        "company_size_min": company_size_min,
+        "company_size_max": company_size_max,
+        "country": country,
+        "bundesland": bundesland_raw,
+        "hauptleistung_len": len(hauptleistung_raw) if hauptleistung_raw else 0,
     }
-    company_size = size_map.get(size_raw, "team")  # Fallback to "team" if unknown
     
     # Derive size_label (human-readable label for size)
     size_label = briefing.get("UNTERNEHMENSGROESSE_LABEL") or briefing.get("unternehmensgroesse", "")
@@ -8318,26 +8348,34 @@ def _build_prompt_vars(briefing: Dict[str, Any], scores: Dict[str, Any]) -> Dict
         compact_report_mode = (company_size in ["solo", "team"])
 
     # Phase 1B Fix: Normalize branche_label for capitalization
-    branche_raw = briefing.get("BRANCHE_LABEL") or briefing.get("branche", "")
+    branche_label_src = briefing.get("BRANCHE_LABEL") or branche_raw
     # Capitalize first letter if all lowercase (e.g., "beratung" → "Beratung")
-    if branche_raw and branche_raw[0].islower():
-        branche_label = branche_raw.capitalize()
+    if branche_label_src and branche_label_src[0].islower():
+        branche_label = branche_label_src.capitalize()
     else:
-        branche_label = branche_raw
+        branche_label = branche_label_src
 
     base_vars.update({
-        "BRANCHE": briefing.get("branche", ""),
+        "BRANCHE": branche_raw,
         "branche": branche_label,  # Use normalized version
         "BRANCHE_LABEL": branche_label,  # Use normalized version
-        "UNTERNEHMENSGROESSE": briefing.get("unternehmensgroesse", ""),
-        "unternehmensgroesse": briefing.get("unternehmensgroesse", ""),
+        # FIX-BRANCH-13: Add engine key for branch-specific logic
+        "BRANCHE_ENGINE_KEY": branche_engine_key,
+        "branche_engine_key": branche_engine_key,
+        "UNTERNEHMENSGROESSE": str(unternehmensgroesse_raw),
+        "unternehmensgroesse": str(unternehmensgroesse_raw),
         "UNTERNEHMENSGROESSE_LABEL": size_label,
         "size_label": size_label,  # Consistent key for size-sensitive prompts
         "COMPANY_SIZE": company_size,  # For roadmap_90d.md and gamechanger.md
+        # FIX-BRANCH-13: Add detailed company size info
+        "COMPANY_SIZE_BUCKET": company_size_bucket,
+        "company_size_bucket": company_size_bucket,
+        "COMPANY_SIZE_MIN": company_size_min,
+        "COMPANY_SIZE_MAX": company_size_max,
         "COMPACT_REPORT_MODE": compact_report_mode,  # PLATIN+++ v5.4.3: Compact for solo+klein
-        "BUNDESLAND_LABEL": briefing.get("BUNDESLAND_LABEL") or briefing.get("bundesland", ""),
-        "bundesland": briefing.get("bundesland", ""),
-        "HAUPTLEISTUNG": briefing.get("hauptleistung", ""),
+        "BUNDESLAND_LABEL": briefing.get("BUNDESLAND_LABEL") or bundesland_raw,
+        "bundesland": bundesland_raw,
+        "HAUPTLEISTUNG": hauptleistung_raw,
         "JAHRESUMSATZ_LABEL": briefing.get("JAHRESUMSATZ_LABEL", briefing.get("jahresumsatz", "")),
         "INVESTITIONSBUDGET": briefing.get("investitionsbudget", ""),  # For gamechanger.md
     })

--- a/services/branch_mapping.py
+++ b/services/branch_mapping.py
@@ -2,13 +2,17 @@
 """
 Sprint G19.1-MAP: Frontend-Branch to Engine Mapping
 
-Maps the 12 frontend dropdown branch values to the 11 branch profiles
-in branch_profile_engine.py (G19+G19.1).
+Maps the 13 frontend dropdown branch values (canonical per formbuilder_de_SINGLE_FULL.js)
+to the 11 branch profiles in branch_profile_engine.py (G19+G19.1).
 
 The mapping chain:
   Frontend-Value → BRANCH_MAPPING → Branch-Engine-Key
 
-Version: 1.0.0 (Sprint G19.1-MAP)
+13 Canonical branches:
+  marketing, beratung, it, finanzen, handel, bildung, verwaltung,
+  gesundheit, bau, medien, industrie, logistik, gastronomie
+
+Version: 1.1.0 (FIX-BRANCH-13)
 """
 from __future__ import annotations
 
@@ -22,17 +26,34 @@ log = logging.getLogger(__name__)
 # =============================================================================
 
 # Frontend dropdown "value" attributes → internal Branch-Keys from branch_profile_engine.py
+# FIX-BRANCH-13: 13 canonical values from formbuilder_de_SINGLE_FULL.js
 BRANCH_MAPPING: Dict[str, str] = {
+    # =========================================================================
+    # CANONICAL 13 FORM VALUES (formbuilder_de_SINGLE_FULL.js)
+    # =========================================================================
+    "marketing": "marketing",
+    "beratung": "beratung",
+    "it": "it",
+    "finanzen": "finanzen",
+    "handel": "handel",
+    "bildung": "bildung",
+    "verwaltung": "verwaltung",
+    "gesundheit": "gesundheit",
+    "bau": "bauwesen_architektur",
+    "medien": "marketing",  # Medien & Kreativwirtschaft → marketing profile
+    "industrie": "industrie",
+    "logistik": "transport_logistik",
+    "gastronomie": "handel",  # FIX-BRANCH-13: Gastronomie → handel (B2C/Operations-similar)
+    # =========================================================================
+    # LEGACY VALUES (backwards compatibility with existing data)
+    # =========================================================================
     "marketing_werbung": "marketing",
     "beratung_dienstleistungen": "beratung",
     "it_software": "it",
     "finanzen_versicherungen": "finanzen",
     "handel_ecommerce": "handel",
-    "bildung": "bildung",
-    "verwaltung": "verwaltung",
     "gesundheit_pflege": "gesundheit",
     "bauwesen_architektur": "bauwesen_architektur",
-    # Medien & Kreativwirtschaft maps to marketing profile
     "medien_kreativwirtschaft": "marketing",
     "industrie_produktion": "industrie",
     "transport_logistik": "transport_logistik",
@@ -42,93 +63,121 @@ BRANCH_MAPPING: Dict[str, str] = {
 # SYNONYMS FOR LEGACY DATA / ALTERNATE FORMATS
 # =============================================================================
 
-# Text synonyms (labels, alt-data) → frontend value keys
+# Text synonyms (labels, alt-data) → frontend value keys (canonical or legacy)
+# FIX-BRANCH-13: All synonyms now map to canonical 13 form values where possible
 BRANCH_SYNONYMS: Dict[str, str] = {
+    # =========================================================================
+    # GASTRONOMIE & TOURISMUS (FIX-BRANCH-13: new canonical branch)
+    # =========================================================================
+    "gastronomie": "gastronomie",
+    "gastronomie & tourismus": "gastronomie",
+    "gastronomie und tourismus": "gastronomie",
+    "tourismus": "gastronomie",
+    "hotel": "gastronomie",
+    "hotellerie": "gastronomie",
+    "restaurant": "gastronomie",
+    "gastgewerbe": "gastronomie",
+    "gastro": "gastronomie",
+    "hospitality": "gastronomie",
+    "tourism": "gastronomie",
+    "catering": "gastronomie",
+    "eventgastronomie": "gastronomie",
+    "reise": "gastronomie",
+    "reisen": "gastronomie",
+    "travel": "gastronomie",
+    # =========================================================================
     # German labels with & and spaces
-    "marketing & werbung": "marketing_werbung",
-    "marketing und werbung": "marketing_werbung",
-    "beratung & dienstleistungen": "beratung_dienstleistungen",
-    "beratung und dienstleistungen": "beratung_dienstleistungen",
-    "it & software": "it_software",
-    "it und software": "it_software",
-    "finanzen & versicherungen": "finanzen_versicherungen",
-    "finanzen und versicherungen": "finanzen_versicherungen",
-    "handel & e-commerce": "handel_ecommerce",
-    "handel und e-commerce": "handel_ecommerce",
-    "handel & ecommerce": "handel_ecommerce",
-    "gesundheit & pflege": "gesundheit_pflege",
-    "gesundheit und pflege": "gesundheit_pflege",
-    "medien & kreativwirtschaft": "medien_kreativwirtschaft",
-    "medien und kreativwirtschaft": "medien_kreativwirtschaft",
-    "industrie & produktion": "industrie_produktion",
-    "industrie und produktion": "industrie_produktion",
-    "transport & logistik": "transport_logistik",
-    "transport und logistik": "transport_logistik",
-    "bauwesen & architektur": "bauwesen_architektur",
-    "bauwesen und architektur": "bauwesen_architektur",
-    # Short forms and English variants
-    "bau": "bauwesen_architektur",
-    "construction": "bauwesen_architektur",
-    "architecture": "bauwesen_architektur",
-    "architektur": "bauwesen_architektur",
+    # =========================================================================
+    "marketing & werbung": "marketing",
+    "marketing und werbung": "marketing",
+    "beratung & dienstleistungen": "beratung",
+    "beratung und dienstleistungen": "beratung",
+    "it & software": "it",
+    "it und software": "it",
+    "finanzen & versicherungen": "finanzen",
+    "finanzen und versicherungen": "finanzen",
+    "handel & e-commerce": "handel",
+    "handel und e-commerce": "handel",
+    "handel & ecommerce": "handel",
+    "gesundheit & pflege": "gesundheit",
+    "gesundheit und pflege": "gesundheit",
+    "medien & kreativwirtschaft": "medien",
+    "medien und kreativwirtschaft": "medien",
+    "industrie & produktion": "industrie",
+    "industrie und produktion": "industrie",
+    "transport & logistik": "logistik",
+    "transport und logistik": "logistik",
+    "bauwesen & architektur": "bau",
+    "bauwesen und architektur": "bau",
+    # =========================================================================
+    # Legacy underscore format mappings (for backwards compatibility)
+    # =========================================================================
+    "marketing_werbung": "marketing",
+    "beratung_dienstleistungen": "beratung",
+    "it_software": "it",
+    "finanzen_versicherungen": "finanzen",
+    "handel_ecommerce": "handel",
+    "gesundheit_pflege": "gesundheit",
+    "medien_kreativwirtschaft": "medien",
+    "industrie_produktion": "industrie",
+    "transport_logistik": "logistik",
+    "bauwesen_architektur": "bau",
+    # =========================================================================
+    # Short forms and English variants (map to canonical 13 values)
+    # =========================================================================
+    "construction": "bau",
+    "architecture": "bau",
+    "architektur": "bau",
     "public_sector": "verwaltung",
     "public sector": "verwaltung",
     "public": "verwaltung",
     "government": "verwaltung",
     "behoerde": "verwaltung",
     "behörde": "verwaltung",
-    "logistik": "transport_logistik",
-    "transport": "transport_logistik",
-    "logistics": "transport_logistik",
-    "spedition": "transport_logistik",
-    "media": "medien_kreativwirtschaft",
-    "creative": "medien_kreativwirtschaft",
-    "kreativ": "medien_kreativwirtschaft",
-    # Direct engine keys (passthrough)
-    "marketing": "marketing_werbung",
-    "beratung": "beratung_dienstleistungen",
-    "it": "it_software",
-    "finanzen": "finanzen_versicherungen",
-    "handel": "handel_ecommerce",
-    "gesundheit": "gesundheit_pflege",
-    "industrie": "industrie_produktion",
-    # Legacy/alternate formats
-    "consulting": "beratung_dienstleistungen",
-    "dienstleistung": "beratung_dienstleistungen",
-    "dienstleistungen": "beratung_dienstleistungen",
-    "software": "it_software",
-    "tech": "it_software",
-    "technologie": "it_software",
-    "finance": "finanzen_versicherungen",
-    "banking": "finanzen_versicherungen",
-    "versicherung": "finanzen_versicherungen",
-    "retail": "handel_ecommerce",
-    "ecommerce": "handel_ecommerce",
-    "e-commerce": "handel_ecommerce",
-    "einzelhandel": "handel_ecommerce",
-    "health": "gesundheit_pflege",
-    "healthcare": "gesundheit_pflege",
-    "medizin": "gesundheit_pflege",
-    "pharma": "gesundheit_pflege",
-    "pflege": "gesundheit_pflege",
+    "transport": "logistik",
+    "logistics": "logistik",
+    "spedition": "logistik",
+    "media": "medien",
+    "creative": "medien",
+    "kreativ": "medien",
+    # =========================================================================
+    # Legacy/alternate formats (map to canonical 13 values)
+    # =========================================================================
+    "consulting": "beratung",
+    "dienstleistung": "beratung",
+    "dienstleistungen": "beratung",
+    "software": "it",
+    "tech": "it",
+    "technologie": "it",
+    "finance": "finanzen",
+    "banking": "finanzen",
+    "versicherung": "finanzen",
+    "retail": "handel",
+    "ecommerce": "handel",
+    "e-commerce": "handel",
+    "einzelhandel": "handel",
+    "health": "gesundheit",
+    "healthcare": "gesundheit",
+    "medizin": "gesundheit",
+    "pharma": "gesundheit",
+    "pflege": "gesundheit",
     "education": "bildung",
     "training": "bildung",
     "schule": "bildung",
     "hochschule": "bildung",
-    "manufacturing": "industrie_produktion",
-    "produktion": "industrie_produktion",
-    "fertigung": "industrie_produktion",
-    "werbung": "marketing_werbung",
-    "agentur": "marketing_werbung",
-    "medien": "medien_kreativwirtschaft",
-    "immobilien": "bauwesen_architektur",
-    "real_estate": "bauwesen_architektur",
-    "real estate": "bauwesen_architektur",
-    "baugewerbe": "bauwesen_architektur",
-    "warehousing": "transport_logistik",
-    "lager": "transport_logistik",
-    "supply_chain": "transport_logistik",
-    "supply chain": "transport_logistik",
+    "manufacturing": "industrie",
+    "produktion": "industrie",
+    "fertigung": "industrie",
+    "werbung": "marketing",
+    "agentur": "marketing",
+    "immobilien": "bau",
+    "real_estate": "bau",
+    "real estate": "bau",
+    "baugewerbe": "bau",
+    "warehousing": "logistik",
+    "lager": "logistik",
+    "supply_chain": "logistik",
+    "supply chain": "logistik",
     "kommune": "verwaltung",
     "oeffentlich": "verwaltung",
     "öffentlich": "verwaltung",
@@ -276,22 +325,26 @@ def get_frontend_branch_options() -> list[tuple[str, str]]:
     """
     Return list of (value, label) tuples for frontend dropdown.
 
+    FIX-BRANCH-13: Returns the 13 canonical form values from formbuilder_de_SINGLE_FULL.js.
+    These are the exact values used in the questionnaire form.
+
     Returns:
         List of (value, label) tuples for HTML select options
     """
     return [
-        ("marketing_werbung", "Marketing & Werbung"),
-        ("beratung_dienstleistungen", "Beratung & Dienstleistungen"),
-        ("it_software", "IT & Software"),
-        ("finanzen_versicherungen", "Finanzen & Versicherungen"),
-        ("handel_ecommerce", "Handel & E-Commerce"),
+        ("marketing", "Marketing & Werbung"),
+        ("beratung", "Beratung & Dienstleistungen"),
+        ("it", "IT & Software"),
+        ("finanzen", "Finanzen & Versicherungen"),
+        ("handel", "Handel & E-Commerce"),
         ("bildung", "Bildung"),
         ("verwaltung", "Verwaltung"),
-        ("gesundheit_pflege", "Gesundheit & Pflege"),
-        ("bauwesen_architektur", "Bauwesen & Architektur"),
-        ("medien_kreativwirtschaft", "Medien & Kreativwirtschaft"),
-        ("industrie_produktion", "Industrie & Produktion"),
-        ("transport_logistik", "Transport & Logistik"),
+        ("gesundheit", "Gesundheit & Pflege"),
+        ("bau", "Bauwesen & Architektur"),
+        ("medien", "Medien & Kreativwirtschaft"),
+        ("industrie", "Industrie & Produktion"),
+        ("logistik", "Transport & Logistik"),
+        ("gastronomie", "Gastronomie & Tourismus"),
     ]
 
 

--- a/services/company_size_normalizer.py
+++ b/services/company_size_normalizer.py
@@ -1,0 +1,221 @@
+# -*- coding: utf-8 -*-
+"""
+FIX-BRANCH-13 TASK 2: Company Size Normalizer
+
+Normalizes unternehmensgroesse values from the questionnaire form.
+Handles En-Dash (–) vs regular dash (-) robustly.
+
+Form values from formbuilder_de_SINGLE_FULL.js:
+  - "1" → solo
+  - "2–10" (En-Dash U+2013) → small_team
+  - "11–100" (En-Dash U+2013) → kmu
+
+Version: 1.0.0 (FIX-BRANCH-13)
+"""
+from __future__ import annotations
+
+import logging
+import re
+from typing import Dict, Optional, Any
+
+log = logging.getLogger(__name__)
+
+# =============================================================================
+# COMPANY SIZE BUCKETS
+# =============================================================================
+
+# Bucket definitions with employee ranges
+SIZE_BUCKETS = {
+    "solo": {"min": 1, "max": 1, "label_de": "Einzelunternehmer", "label_en": "Solo"},
+    "small_team": {"min": 2, "max": 10, "label_de": "Kleines Team", "label_en": "Small Team"},
+    "kmu": {"min": 11, "max": 100, "label_de": "KMU", "label_en": "SME"},
+}
+
+# Direct value mappings (normalized - all dashes converted to hyphen)
+DIRECT_MAPPINGS = {
+    "1": "solo",
+    "2-10": "small_team",
+    "11-100": "kmu",
+}
+
+
+# =============================================================================
+# NORMALIZATION FUNCTION
+# =============================================================================
+
+def _normalize_dash(value: str) -> str:
+    """
+    Normalize all dash variants to regular hyphen.
+
+    Handles:
+    - En-dash (–, U+2013)
+    - Em-dash (—, U+2014)
+    - Minus sign (−, U+2212)
+    - Regular hyphen-minus (-, U+002D)
+    """
+    if not value:
+        return ""
+
+    # Replace all dash variants with regular hyphen
+    result = value
+    result = result.replace("–", "-")  # En-dash
+    result = result.replace("—", "-")  # Em-dash
+    result = result.replace("−", "-")  # Minus sign
+
+    return result.strip()
+
+
+def normalize_company_size(value: str) -> Dict[str, Any]:
+    """
+    Normalize a company size value from the questionnaire.
+
+    Args:
+        value: Raw company size value (e.g., "2–10", "2-10", "1", "11–100")
+
+    Returns:
+        Dict with:
+            - bucket: "solo" | "small_team" | "kmu"
+            - min: Minimum employee count
+            - max: Maximum employee count
+            - label_de: German label
+            - label_en: English label
+            - raw: Original input value
+            - normalized: Dash-normalized value
+
+    Examples:
+        >>> normalize_company_size("2–10")
+        {"bucket": "small_team", "min": 2, "max": 10, ...}
+
+        >>> normalize_company_size("2-10")
+        {"bucket": "small_team", "min": 2, "max": 10, ...}
+    """
+    if not value:
+        log.warning("[FIX-BRANCH-13] Empty company_size, defaulting to 'solo'")
+        return {
+            "bucket": "solo",
+            "min": 1,
+            "max": 1,
+            "label_de": "Einzelunternehmer",
+            "label_en": "Solo",
+            "raw": value,
+            "normalized": "",
+        }
+
+    # Normalize dashes
+    normalized = _normalize_dash(value)
+
+    # 1) Direct mapping lookup
+    if normalized in DIRECT_MAPPINGS:
+        bucket = DIRECT_MAPPINGS[normalized]
+        bucket_data = SIZE_BUCKETS[bucket]
+        log.debug("[FIX-BRANCH-13] Direct match: '%s' → '%s'", value, bucket)
+        return {
+            "bucket": bucket,
+            "min": bucket_data["min"],
+            "max": bucket_data["max"],
+            "label_de": bucket_data["label_de"],
+            "label_en": bucket_data["label_en"],
+            "raw": value,
+            "normalized": normalized,
+        }
+
+    # 2) Try to parse numeric range
+    range_match = re.match(r'^(\d+)\s*-\s*(\d+)$', normalized)
+    if range_match:
+        min_val = int(range_match.group(1))
+        max_val = int(range_match.group(2))
+
+        # Determine bucket based on range
+        if max_val <= 1:
+            bucket = "solo"
+        elif max_val <= 10:
+            bucket = "small_team"
+        else:
+            bucket = "kmu"
+
+        bucket_data = SIZE_BUCKETS[bucket]
+        log.debug("[FIX-BRANCH-13] Parsed range: '%s' → '%s' (%d-%d)", value, bucket, min_val, max_val)
+        return {
+            "bucket": bucket,
+            "min": min_val,
+            "max": max_val,
+            "label_de": bucket_data["label_de"],
+            "label_en": bucket_data["label_en"],
+            "raw": value,
+            "normalized": normalized,
+        }
+
+    # 3) Try to parse single number
+    single_match = re.match(r'^(\d+)$', normalized)
+    if single_match:
+        num = int(single_match.group(1))
+
+        # Determine bucket based on single value
+        if num <= 1:
+            bucket = "solo"
+        elif num <= 10:
+            bucket = "small_team"
+        else:
+            bucket = "kmu"
+
+        bucket_data = SIZE_BUCKETS[bucket]
+        log.debug("[FIX-BRANCH-13] Parsed single: '%s' → '%s' (count=%d)", value, bucket, num)
+        return {
+            "bucket": bucket,
+            "min": num,
+            "max": num,
+            "label_de": bucket_data["label_de"],
+            "label_en": bucket_data["label_en"],
+            "raw": value,
+            "normalized": normalized,
+        }
+
+    # 4) Try bucket name matching (for backwards compat with "solo", "team", "kmu")
+    lower_val = normalized.lower()
+    if "solo" in lower_val or "einzel" in lower_val or "selbst" in lower_val:
+        bucket = "solo"
+    elif "team" in lower_val or "klein" in lower_val:
+        bucket = "small_team"
+    elif "kmu" in lower_val or "mittel" in lower_val or "sme" in lower_val:
+        bucket = "kmu"
+    else:
+        # Default fallback
+        log.warning("[FIX-BRANCH-13] Unknown company_size '%s', defaulting to 'solo'", value)
+        bucket = "solo"
+
+    bucket_data = SIZE_BUCKETS[bucket]
+    return {
+        "bucket": bucket,
+        "min": bucket_data["min"],
+        "max": bucket_data["max"],
+        "label_de": bucket_data["label_de"],
+        "label_en": bucket_data["label_en"],
+        "raw": value,
+        "normalized": normalized,
+    }
+
+
+def get_company_size_bucket(value: str) -> str:
+    """
+    Get just the bucket name for a company size value.
+
+    Convenience function that returns only the bucket string.
+
+    Args:
+        value: Raw company size value
+
+    Returns:
+        Bucket name: "solo" | "small_team" | "kmu"
+    """
+    return normalize_company_size(value)["bucket"]
+
+
+# =============================================================================
+# MODULE INITIALIZATION
+# =============================================================================
+
+log.info(
+    "[FIX-BRANCH-13] Company Size Normalizer loaded - %d buckets, %d direct mappings",
+    len(SIZE_BUCKETS),
+    len(DIRECT_MAPPINGS),
+)

--- a/services/company_size_normalizer.py
+++ b/services/company_size_normalizer.py
@@ -207,7 +207,8 @@ def get_company_size_bucket(value: str) -> str:
     Returns:
         Bucket name: "solo" | "small_team" | "kmu"
     """
-    return normalize_company_size(value)["bucket"]
+    result = normalize_company_size(value)["bucket"]
+    return str(result)  # Explicit cast for mypy
 
 
 # =============================================================================

--- a/tests/test_branch_catalog_13.py
+++ b/tests/test_branch_catalog_13.py
@@ -1,0 +1,272 @@
+# -*- coding: utf-8 -*-
+"""
+Tests for FIX-BRANCH-13: 13-Branch Catalog and Company Size Normalizer.
+
+These tests verify:
+1. All 13 canonical branch values map correctly (no default-to-beratung)
+2. Gastronomie is properly supported
+3. Company size normalizer handles En-Dash correctly
+4. get_frontend_branch_options() returns exactly 13 entries
+"""
+
+import pytest
+from services.branch_mapping import (
+    map_frontend_branch_to_engine,
+    get_frontend_branch_options,
+    BRANCH_MAPPING,
+    BRANCH_SYNONYMS,
+)
+from services.company_size_normalizer import (
+    normalize_company_size,
+    get_company_size_bucket,
+)
+
+
+# =============================================================================
+# TEST: 13 Canonical Branch Values
+# =============================================================================
+
+class TestCanonical13Branches:
+    """Tests for the 13 canonical branch values."""
+
+    # The 13 canonical form values from formbuilder_de_SINGLE_FULL.js
+    CANONICAL_13 = [
+        "marketing",
+        "beratung",
+        "it",
+        "finanzen",
+        "handel",
+        "bildung",
+        "verwaltung",
+        "gesundheit",
+        "bau",
+        "medien",
+        "industrie",
+        "logistik",
+        "gastronomie",
+    ]
+
+    def test_all_13_canonical_values_map_without_default_fallback(self):
+        """
+        All 13 canonical form values should map to a specific engine key,
+        NOT fall back to 'beratung' as default.
+        """
+        for branch in self.CANONICAL_13:
+            engine_key = map_frontend_branch_to_engine(branch)
+            # The only branches that should map to 'beratung' are:
+            # - 'beratung' itself
+            # - Empty/unknown values (which we're not testing here)
+            if branch != "beratung":
+                assert engine_key != "beratung" or branch == "beratung", (
+                    f"Branch '{branch}' should NOT default to 'beratung', "
+                    f"but got engine_key='{engine_key}'"
+                )
+
+    def test_get_frontend_branch_options_returns_exactly_13(self):
+        """get_frontend_branch_options() should return exactly 13 entries."""
+        options = get_frontend_branch_options()
+        assert len(options) == 13, f"Expected 13 options, got {len(options)}"
+
+    def test_get_frontend_branch_options_includes_gastronomie(self):
+        """get_frontend_branch_options() should include gastronomie."""
+        options = get_frontend_branch_options()
+        values = [opt[0] for opt in options]
+        assert "gastronomie" in values, (
+            f"'gastronomie' not found in options: {values}"
+        )
+
+    def test_all_13_canonical_values_in_frontend_options(self):
+        """All 13 canonical values should be in get_frontend_branch_options()."""
+        options = get_frontend_branch_options()
+        option_values = [opt[0] for opt in options]
+
+        for branch in self.CANONICAL_13:
+            assert branch in option_values, (
+                f"Canonical branch '{branch}' not found in frontend options"
+            )
+
+    def test_all_13_canonical_values_in_branch_mapping(self):
+        """All 13 canonical values should have entries in BRANCH_MAPPING."""
+        for branch in self.CANONICAL_13:
+            assert branch in BRANCH_MAPPING, (
+                f"Canonical branch '{branch}' not found in BRANCH_MAPPING"
+            )
+
+
+# =============================================================================
+# TEST: Gastronomie Branch Support
+# =============================================================================
+
+class TestGastronomieBranch:
+    """Tests for Gastronomie & Tourismus branch support."""
+
+    def test_gastronomie_maps_to_handel(self):
+        """Gastronomie should map to 'handel' engine profile."""
+        engine_key = map_frontend_branch_to_engine("gastronomie")
+        assert engine_key == "handel", (
+            f"'gastronomie' should map to 'handel', got '{engine_key}'"
+        )
+
+    def test_gastronomie_synonyms_map_correctly(self):
+        """All Gastronomie synonyms should map to the gastronomie canonical value."""
+        synonyms = [
+            "gastronomie",
+            "Gastronomie & Tourismus",
+            "gastronomie und tourismus",
+            "tourismus",
+            "hotel",
+            "hotellerie",
+            "restaurant",
+            "gastgewerbe",
+            "gastro",
+            "hospitality",
+        ]
+        for synonym in synonyms:
+            engine_key = map_frontend_branch_to_engine(synonym)
+            # All should map to 'handel' (via gastronomie canonical)
+            assert engine_key == "handel", (
+                f"Synonym '{synonym}' should map to 'handel' via gastronomie, "
+                f"got '{engine_key}'"
+            )
+
+    def test_gastronomie_does_not_default_to_beratung(self):
+        """Gastronomie must NEVER default to 'beratung'."""
+        engine_key = map_frontend_branch_to_engine("gastronomie")
+        assert engine_key != "beratung", (
+            "CRITICAL: 'gastronomie' defaulted to 'beratung'! "
+            "This is the bug FIX-BRANCH-13 was created to fix."
+        )
+
+
+# =============================================================================
+# TEST: Company Size Normalizer (En-Dash Robust)
+# =============================================================================
+
+class TestCompanySizeNormalizer:
+    """Tests for the company size normalizer."""
+
+    def test_en_dash_equals_hyphen_2_10(self):
+        """'2–10' (En-Dash) should equal '2-10' (hyphen)."""
+        result_en = normalize_company_size("2–10")  # En-Dash U+2013
+        result_hy = normalize_company_size("2-10")  # Regular hyphen
+
+        assert result_en["bucket"] == result_hy["bucket"], (
+            f"En-Dash and hyphen should produce same bucket: "
+            f"'{result_en['bucket']}' vs '{result_hy['bucket']}'"
+        )
+        assert result_en["min"] == result_hy["min"]
+        assert result_en["max"] == result_hy["max"]
+
+    def test_en_dash_equals_hyphen_11_100(self):
+        """'11–100' (En-Dash) should equal '11-100' (hyphen)."""
+        result_en = normalize_company_size("11–100")  # En-Dash U+2013
+        result_hy = normalize_company_size("11-100")  # Regular hyphen
+
+        assert result_en["bucket"] == result_hy["bucket"]
+        assert result_en["min"] == result_hy["min"]
+        assert result_en["max"] == result_hy["max"]
+
+    def test_solo_size_value(self):
+        """'1' should map to 'solo' bucket."""
+        result = normalize_company_size("1")
+        assert result["bucket"] == "solo"
+        assert result["min"] == 1
+        assert result["max"] == 1
+
+    def test_small_team_size_value(self):
+        """'2–10' should map to 'small_team' bucket."""
+        result = normalize_company_size("2–10")
+        assert result["bucket"] == "small_team"
+        assert result["min"] == 2
+        assert result["max"] == 10
+
+    def test_kmu_size_value(self):
+        """'11–100' should map to 'kmu' bucket."""
+        result = normalize_company_size("11–100")
+        assert result["bucket"] == "kmu"
+        assert result["min"] == 11
+        assert result["max"] == 100
+
+    def test_legacy_bucket_names(self):
+        """Legacy bucket names should be recognized."""
+        assert get_company_size_bucket("solo") == "solo"
+        assert get_company_size_bucket("team") == "small_team"
+        assert get_company_size_bucket("kmu") == "kmu"
+
+    def test_empty_value_defaults_to_solo(self):
+        """Empty value should default to 'solo'."""
+        result = normalize_company_size("")
+        assert result["bucket"] == "solo"
+
+
+# =============================================================================
+# TEST: Legacy Branch Values (Backwards Compatibility)
+# =============================================================================
+
+class TestLegacyBranchValues:
+    """Tests for backwards compatibility with legacy branch values."""
+
+    LEGACY_TO_ENGINE = {
+        "marketing_werbung": "marketing",
+        "beratung_dienstleistungen": "beratung",
+        "it_software": "it",
+        "finanzen_versicherungen": "finanzen",
+        "handel_ecommerce": "handel",
+        "gesundheit_pflege": "gesundheit",
+        "bauwesen_architektur": "bauwesen_architektur",
+        "medien_kreativwirtschaft": "marketing",
+        "industrie_produktion": "industrie",
+        "transport_logistik": "transport_logistik",
+    }
+
+    def test_legacy_values_still_work(self):
+        """Legacy underscore-format values should still map correctly."""
+        for legacy_value, expected_engine in self.LEGACY_TO_ENGINE.items():
+            engine_key = map_frontend_branch_to_engine(legacy_value)
+            assert engine_key == expected_engine, (
+                f"Legacy value '{legacy_value}' should map to '{expected_engine}', "
+                f"got '{engine_key}'"
+            )
+
+
+# =============================================================================
+# TEST: STRICT Mode Compatibility
+# =============================================================================
+
+class TestStrictModeCompatibility:
+    """Tests to ensure STRICT mode won't have Unknown-Branch-Fallbacks."""
+
+    def test_no_unknown_branch_for_canonical_values(self):
+        """
+        In STRICT mode, there should be no "Unknown branch ... defaulting to 'beratung'"
+        for any of the 13 canonical values.
+        """
+        import logging
+
+        # Capture log output
+        log_capture = []
+        handler = logging.Handler()
+        handler.emit = lambda record: log_capture.append(record.getMessage())
+        logging.getLogger("services.branch_mapping").addHandler(handler)
+
+        canonical_13 = [
+            "marketing", "beratung", "it", "finanzen", "handel", "bildung",
+            "verwaltung", "gesundheit", "bau", "medien", "industrie",
+            "logistik", "gastronomie",
+        ]
+
+        for branch in canonical_13:
+            map_frontend_branch_to_engine(branch)
+
+        # Check no "Unknown branch" warnings for canonical values
+        unknown_warnings = [
+            msg for msg in log_capture
+            if "Unknown branch" in msg and any(b in msg for b in canonical_13)
+        ]
+        assert len(unknown_warnings) == 0, (
+            f"Found 'Unknown branch' warnings for canonical values: {unknown_warnings}"
+        )
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/test_g19_1_branch_mapping.py
+++ b/tests/test_g19_1_branch_mapping.py
@@ -239,12 +239,22 @@ class TestNormalization:
 class TestMappingData:
     """Tests for mapping data completeness."""
 
-    def test_branch_mapping_has_12_entries(self):
-        """Verify BRANCH_MAPPING has exactly 12 frontend entries."""
+    def test_branch_mapping_has_canonical_entries(self):
+        """Verify BRANCH_MAPPING has all 13 canonical + legacy entries."""
         from services.branch_mapping import BRANCH_MAPPING
 
-        assert len(BRANCH_MAPPING) == 12, \
-            f"BRANCH_MAPPING should have 12 entries, has {len(BRANCH_MAPPING)}"
+        # FIX-BRANCH-13: Now 23 entries (13 canonical + 10 legacy)
+        assert len(BRANCH_MAPPING) >= 13, \
+            f"BRANCH_MAPPING should have at least 13 entries, has {len(BRANCH_MAPPING)}"
+
+        # Verify all 13 canonical values are present
+        canonical_13 = [
+            "marketing", "beratung", "it", "finanzen", "handel", "bildung",
+            "verwaltung", "gesundheit", "bau", "medien", "industrie",
+            "logistik", "gastronomie",
+        ]
+        for branch in canonical_13:
+            assert branch in BRANCH_MAPPING, f"Canonical branch '{branch}' missing from BRANCH_MAPPING"
 
     def test_all_engine_keys_are_valid(self):
         """Verify all mapped engine keys exist in branch_profile_engine."""
@@ -304,8 +314,8 @@ class TestHelperFunctions:
 
         options = get_frontend_branch_options()
 
-        # Should return 12 options
-        assert len(options) == 12, f"Expected 12 options, got {len(options)}"
+        # FIX-BRANCH-13: Should return 13 options (canonical form values)
+        assert len(options) == 13, f"Expected 13 options, got {len(options)}"
 
         # Each option should be a (value, label) tuple
         for option in options:
@@ -314,8 +324,10 @@ class TestHelperFunctions:
             value, label = option
             assert isinstance(value, str), f"Value should be string: {value}"
             assert isinstance(label, str), f"Label should be string: {label}"
-            assert "_" in value or value == "bildung" or value == "verwaltung", \
-                f"Value should use underscores: {value}"
+
+        # Verify gastronomie is included (FIX-BRANCH-13)
+        values = [opt[0] for opt in options]
+        assert "gastronomie" in values, "gastronomie should be in frontend options"
 
 
 # =============================================================================


### PR DESCRIPTION
TASK 1: Canonical Branch Catalog (13 branches)
- Updated branch_mapping.py for 13 canonical form values from formbuilder
- Added Gastronomie & Tourismus support (maps to 'handel' profile)
- Added 16 Gastronomie synonyms (hotel, restaurant, tourismus, etc.)
- Updated get_frontend_branch_options() to return 13 canonical values
- Maintained backwards compatibility with legacy underscore format

TASK 2: Company Size Normalizer (En-Dash robust)
- Created services/company_size_normalizer.py
- Handles En-Dash (–, U+2013) vs hyphen (-) transparently
- Supports "1", "2–10", "11–100" from formbuilder_de_SINGLE_FULL.js
- Returns bucket (solo/small_team/kmu), min, max, labels

TASK 3: Core Input Field Logging
- Added [FIX-BRANCH-13][CORE-INPUTS] log line in _build_prompt_vars()
- Logs: branche_raw, branche_engine_key, unternehmensgroesse_raw, company_size_bucket, country, bundesland, hauptleistung_len
- Stores _meta_core_inputs in briefing dict for debugging

Added 17 tests in test_branch_catalog_13.py covering all requirements.

Acceptance Criteria Met:
✅ 13 branch values map correctly (no default-to-beratung fallbacks) ✅ Gastronomie maps to 'handel' (not 'beratung')
✅ En-Dash robust: "2–10" == "2-10"
✅ STRICT mode compatible (no Unknown-Branch warnings for canonical values)