### PR TITLE
feat(FIX-523A): Prompt Hygiene audit + de-prime high-impact prompts +…

### DIFF
--- a/docs/PROMPT_AUDIT_523A.md
+++ b/docs/PROMPT_AUDIT_523A.md
@@ -1,0 +1,1693 @@
+# FIX-523A Prompt Audit Report
+
+## Summary
+
+- **Total files scanned:** 106
+- **Clean files:** 28
+- **Files with violations:** 78
+- **Total violations:** 291
+
+### Violations by Category
+
+- **CHAT_PHRASE:** 6
+- **CODE_FENCE:** 86
+- **EXPLICIT_BLACKLIST:** 5
+- **PLACEHOLDER_BAIT:** 36
+- **TYPO_QUOTE:** 158
+
+## Files with Violations
+
+### prompts/de/_hauptleistung_context.md
+
+**Violations:** 1
+
+- **Line 10** [TYPO_QUOTE]: Typographic quote found: '
+  ```
+  {% raw %}{% include '_hauptleistung_context.md' %}{% endraw %}
+  ```
+
+### prompts/de/_solo_language_rules.md
+
+**Violations:** 2
+
+- **Line 10** [TYPO_QUOTE]: Typographic quote found: '
+  ```
+  {% include '_solo_language_rules.md' %}
+  ```
+- **Line 59** [TYPO_QUOTE]: Typographic quote found: '
+  ```
+  **DON'T:**
+  ```
+
+### prompts/de/ai_act_summary.md
+
+**Violations:** 2
+
+- **Line 32** [TYPO_QUOTE]: Typographic quote found: „
+  ```
+         - Kurzteil: „Was bedeutet das für Unternehmen dieser Größe?" (size-aware).
+  ```
+- **Line 110** [TYPO_QUOTE]: Typographic quote found: „
+  ```
+    <h3>Relevanz für „{{HAUPTLEISTUNG}}" in der Branche {{BRANCHE_LABEL}}</h3>
+  ```
+
+### prompts/de/automation_roadmap_engine.md
+
+**Violations:** 2
+
+- **Line 122** [CODE_FENCE]: Code fence found - may prime LLM to output code blocks
+  ```
+  ```json
+  ```
+- **Line 174** [CODE_FENCE]: Code fence found - may prime LLM to output code blocks
+  ```
+  ```
+  ```
+
+**Unresolved variables:** business_case, ki_reifegrad, funding_data, ki_anwendung, hauptherausforderungen, strategy_plan, risk_report_v3, tools_data
+
+### prompts/de/benchmark_engine.md
+
+**Violations:** 2
+
+- **Line 114** [CODE_FENCE]: Code fence found - may prime LLM to output code blocks
+  ```
+  ```json
+  ```
+- **Line 191** [CODE_FENCE]: Code fence found - may prime LLM to output code blocks
+  ```
+  ```
+  ```
+
+**Unresolved variables:** ki_reifegrad, funding_data, ki_anwendung, auto_report, hauptherausforderungen, strategy_plan, kpi_data, risk_report_v3, tools_data
+
+### prompts/de/branch_deep_dive.md
+
+**Violations:** 6
+
+- **Line 33** [TYPO_QUOTE]: Typographic quote found: , r
+  ```
+  - use example numbers, ranges or scenarios
+  ```
+- **Line 45** [EXPLICIT_BLACKLIST]: Explicit blacklist naming forbidden words - may prime those words
+  ```
+  HARD BLACKLIST (Fail-Closed):
+  ```
+- **Line 46** [CHAT_PHRASE]: Chat phrase pattern found: \bwie kann ich (?:dir|Ihnen) helfen\b
+  ```
+  - "wie kann ich dir helfen" / "wie kann ich helfen"
+  ```
+- **Line 227** [CODE_FENCE]: Code fence found - may prime LLM to output code blocks
+  ```
+  ```html
+  ```
+- **Line 324** [CODE_FENCE]: Code fence found - may prime LLM to output code blocks
+  ```
+  ```
+  ```
+- **Line 346** [PLACEHOLDER_BAIT]: Placeholder pattern in non-comment: \{variable\}
+  ```
+  - Keine Platzhalter ("[Hier einfügen]", "{{VARIABLE}}" außer definierten)
+  ```
+
+**Unresolved variables:** BRANCH_SHORT_LABEL, VARIABLE
+
+### prompts/de/business_case.md
+
+**Violations:** 1
+
+- **Line 63** [TYPO_QUOTE]: Typographic quote found: , r
+  ```
+  ZIEL: Klarer, realistischer Business Case mit ROI, CAPEX/OPEX.
+  ```
+
+**Unresolved variables:** EINSPARUNG_MONAT_EUR, CAPEX_REALISTISCH_EUR, ROI_12M, PAYBACK_MONTHS, OPEX_REALISTISCH_EUR
+
+### prompts/de/business_case_engine_v2.md
+
+**Violations:** 4
+
+- **Line 64** [CODE_FENCE]: Code fence found - may prime LLM to output code blocks
+  ```
+  ```json
+  ```
+- **Line 113** [CODE_FENCE]: Code fence found - may prime LLM to output code blocks
+  ```
+  ```
+  ```
+- **Line 230** [CODE_FENCE]: Code fence found - may prime LLM to output code blocks
+  ```
+  ```json
+  ```
+- **Line 279** [CODE_FENCE]: Code fence found - may prime LLM to output code blocks
+  ```
+  ```
+  ```
+
+**Unresolved variables:** STRATEGY_SUMMARY, TOOLS_SUMMARY, COMPANY_NAME, BRANCH_DEEP_DIVE_SUMMARY, BRANCH_LABEL, MATURITY_LEVEL, EINSPARUNG_STUNDEN_MONAT, EINSPARUNG_MONAT_EUR, BRANCH_SHORT_LABEL, FUNDING_SUMMARY, ROI_12M, RISK_SUMMARY, PAYBACK_MONTHS, SIZE_LABEL
+
+### prompts/de/business_case_simulation.md
+
+**Violations:** 6
+
+- **Line 84** [CODE_FENCE]: Code fence found - may prime LLM to output code blocks
+  ```
+  ```json
+  ```
+- **Line 110** [CODE_FENCE]: Code fence found - may prime LLM to output code blocks
+  ```
+  ```
+  ```
+- **Line 211** [CODE_FENCE]: Code fence found - may prime LLM to output code blocks
+  ```
+  ```json
+  ```
+- **Line 237** [CODE_FENCE]: Code fence found - may prime LLM to output code blocks
+  ```
+  ```
+  ```
+- **Line 241** [CODE_FENCE]: Code fence found - may prime LLM to output code blocks
+  ```
+  ```json
+  ```
+- **Line 267** [CODE_FENCE]: Code fence found - may prime LLM to output code blocks
+  ```
+  ```
+  ```
+
+**Unresolved variables:** BC_INVESTMENT_TOTAL, BRANCH_LABEL, BC_CONSERVATIVE_ROI, AUTO_PHASE_1_COUNT, AUTO_AVG_POTENTIAL, BRANCH_SHORT_LABEL, BC_REALISTIC_PAYBACK, RISK_RESIDUAL_SCORE, MATURITY_LEVEL, RISK_RESIDUAL_GRADE, AI_ACT_CONFORMITY, BC_REALISTIC_SAVINGS, SIZE_LABEL, AI_ACT_MISSING_CONTROLS, TOOLS_SUMMARY, COMPANY_NAME, AUTO_QUICK_WINS, DPIA_REQUIRED, FUNDING_SUMMARY, COMPLIANCE_STATUS, BC_OPTIMISTIC_ROI, BC_REALISTIC_ROI, BC_OPTIMISTIC_PAYBACK, BC_CONSERVATIVE_PAYBACK, AUTO_PROCESS_COUNT
+
+### prompts/de/costs_overview.md
+
+**Violations:** 1
+
+- **Line 19** [TYPO_QUOTE]: Typographic quote found: „
+  ```
+         - Regieanweisungen, Platzhaltertexte, Beispieltexte wie „xxx".
+  ```
+
+### prompts/de/data_readiness.md
+
+**Violations:** 2
+
+- **Line 86** [TYPO_QUOTE]: Typographic quote found: „
+  ```
+      <li>Daten sind häufig auf mehrere Systeme verteilt, ohne einheitliche Struktur oder zentrale „Si
+  ```
+- **Line 96** [TYPO_QUOTE]: Typographic quote found: „
+  ```
+      <li><strong>KI-Pilotprojekt mit „sauberem“ Datenschnitt starten:</strong> Einen Prozess wählen, 
+  ```
+
+### prompts/de/executive_decision.md
+
+**Violations:** 4
+
+- **Line 10** [TYPO_QUOTE]: Typographic quote found: , r
+  ```
+  - use example numbers, ranges or scenarios
+  ```
+- **Line 30** [TYPO_QUOTE]: Typographic quote found: „
+  ```
+  AUSGABEREGEL (zwingend): Schreibe ausschließlich deklarative Berichtssätze. Keine Anrede, keine Frag
+  ```
+- **Line 32** [TYPO_QUOTE]: Typographic quote found: „
+  ```
+  STARTFORMAT: Beginne mit einem neutralen Substantivsatz (wie „Der aktuelle Zustand…", „Die empfohlen
+  ```
+- **Line 84** [PLACEHOLDER_BAIT]: Placeholder pattern in non-comment: \[ein 
+  ```
+      <li><strong>Tun:</strong> [Ein konkreter Standard-Workflow, der sofort umsetzbar ist]</li>
+  ```
+
+### prompts/de/executive_summary.md
+
+**Violations:** 6
+
+- **Line 162** [PLACEHOLDER_BAIT]: Placeholder pattern in non-comment: \[konkret
+  ```
+  - FORMAT: "[Branche] mit {{hauptleistung}} steht vor [konkreter Herausforderung basierend auf {{ZEIT
+  ```
+- **Line 164** [TYPO_QUOTE]: Typographic quote found: , r
+  ```
+    • "Ein Beratungsunternehmen mit {{hauptleistung}} steht vor der Aufgabe, repetitive Analysen zu au
+  ```
+- **Line 309** [TYPO_QUOTE]: Typographic quote found: „
+  ```
+  **„Wenn Sie nur eines tun:"** beginnt.
+  ```
+- **Line 316** [TYPO_QUOTE]: Typographic quote found: „
+  ```
+  - **keine allgemeinen Aussagen** enthalten (z. B. „Starten Sie mit KI" ist unzulässig).
+  ```
+- **Line 329** [TYPO_QUOTE]: Typographic quote found: „
+  ```
+  „Wenn Sie nur eines tun: Starten Sie mit einer internen KI-Assistenz für Regelwerks- und Risikoanaly
+  ```
+- **Line 332** [TYPO_QUOTE]: Typographic quote found: „
+  ```
+  „Wenn Sie nur eines tun: Standardisieren Sie einen wiederkehrenden Analyse- oder Reporting-Workflow 
+  ```
+
+**Unresolved variables:** STRATEGISCHE_ZIELE
+
+### prompts/de/foerderpotenzial.md
+
+**Violations:** 1
+
+- **Line 188** [PLACEHOLDER_BAIT]: Placeholder pattern in non-comment: \{variable\}
+  ```
+  - Keine Platzhalter ("[Hier einfügen]", "{{VARIABLE}}" außer definierten)
+  ```
+
+**Unresolved variables:** EINSPARUNG_MONAT_EUR, CAPEX_REALISTISCH_EUR, VARIABLE, ROI_12M, PAYBACK_MONTHS, OPEX_REALISTISCH_EUR
+
+### prompts/de/funding_engine_v2.md
+
+**Violations:** 2
+
+- **Line 58** [CODE_FENCE]: Code fence found - may prime LLM to output code blocks
+  ```
+  ```json
+  ```
+- **Line 83** [CODE_FENCE]: Code fence found - may prime LLM to output code blocks
+  ```
+  ```
+  ```
+
+**Unresolved variables:** AI_ACT_RISK_LEVEL, BRANCH_LABEL, SIZE_LABEL, MATURITY_LEVEL
+
+### prompts/de/gamechanger.md
+
+**Violations:** 9
+
+- **Line 155** [TYPO_QUOTE]: Typographic quote found: '
+  ```
+  {% include '_hauptleistung_context.md' %}
+  ```
+- **Line 198** [TYPO_QUOTE]: Typographic quote found: '
+  ```
+              Der Weg zu '{{VISION_3_JAHRE}}' beginnt mit Standardisierung der Auswertungslogik."
+  ```
+- **Line 324** [TYPO_QUOTE]: Typographic quote found: '
+  ```
+  {% include '_solo_language_rules.md' %}
+  ```
+- **Line 339** [EXPLICIT_BLACKLIST]: Explicit blacklist naming forbidden words - may prime those words
+  ```
+  VERBOTENE BEGRIFFE FÜR SOLO (Null-Toleranz):
+  ```
+- **Line 376** [PLACEHOLDER_BAIT]: Placeholder pattern in non-comment: \[konkret
+  ```
+        - Format: "Bisher: [konkretes Problem bei {{hauptleistung}}]"
+  ```
+- **Line 399** [PLACEHOLDER_BAIT]: Placeholder pattern in non-comment: \[konkret
+  ```
+        - Format: "Stattdessen: [konkreter Ansatz] → Weg zu {{VISION_3_JAHRE}}"
+  ```
+- **Line 556** [TYPO_QUOTE]: Typographic quote found: „
+  ```
+  - direkte Ansprache („Sie", „du", „wir")
+  ```
+- **Line 557** [TYPO_QUOTE]: Typographic quote found: „
+  ```
+  - Hilfsangebote („helfen", „unterstützen", „begleiten")
+  ```
+- **Line 558** [TYPO_QUOTE]: Typographic quote found: „
+  ```
+  - Call-to-Actions („bei Bedarf", „kontaktieren", „anfragen")
+  ```
+
+**Unresolved variables:** GESCHAEFTSMODELL_EVOLUTION, industry, core_service, WETTBEWERB
+
+### prompts/de/gamechanger_decision.md
+
+**Violations:** 16
+
+- **Line 10** [TYPO_QUOTE]: Typographic quote found: , r
+  ```
+  - use example numbers, ranges or scenarios
+  ```
+- **Line 22** [EXPLICIT_BLACKLIST]: Explicit blacklist naming forbidden words - may prime those words
+  ```
+  HARD BLACKLIST (Fail-Closed):
+  ```
+- **Line 23** [CHAT_PHRASE]: Chat phrase pattern found: \bwie kann ich (?:dir|Ihnen) helfen\b
+  ```
+  - "wie kann ich dir helfen" / "wie kann ich helfen"
+  ```
+- **Line 36** [TYPO_QUOTE]: Typographic quote found: „
+  ```
+  AUSGABEREGEL (zwingend): Schreibe ausschließlich deklarative Berichtssätze. Keine Anrede, keine Frag
+  ```
+- **Line 38** [TYPO_QUOTE]: Typographic quote found: „
+  ```
+  STARTFORMAT: Beginne mit einem neutralen Substantivsatz (wie „Der aktuelle Zustand…", „Die empfohlen
+  ```
+- **Line 40** [TYPO_QUOTE]: Typographic quote found: „
+  ```
+  NICHT ERLAUBT: „wie kann ich helfen", „ich sehe keine frage", „beschreibe dein anliegen", „du hast n
+  ```
+- **Line 52** [TYPO_QUOTE]: Typographic quote found: , r
+  ```
+  Externer Senior-Berater (Top-Beratung), ruhig, klar, strategisch.
+  ```
+- **Line 89** [CODE_FENCE]: Code fence found - may prime LLM to output code blocks
+  ```
+  ```html
+  ```
+- **Line 101** [PLACEHOLDER_BAIT]: Placeholder pattern in non-comment: \[1 Satz\]
+  ```
+      <li><strong>Erweiterung:</strong> [1 Satz]</li>
+  ```
+- **Line 102** [PLACEHOLDER_BAIT]: Placeholder pattern in non-comment: \[1 Satz\]
+  ```
+      <li><strong>Qualität & Governance:</strong> [1 Satz]</li>
+  ```
+- **Line 103** [PLACEHOLDER_BAIT]: Placeholder pattern in non-comment: \[1 Satz\]
+  ```
+      <li><strong>Marktfähigkeit / IP:</strong> [1 Satz]</li>
+  ```
+- **Line 110** [PLACEHOLDER_BAIT]: Placeholder pattern in non-comment: \[konkret
+  ```
+    <p>[Konkreter Einstieg, kein 12-Monats-Horizont – 2-3 Sätze]</p>
+  ```
+- **Line 112** [CODE_FENCE]: Code fence found - may prime LLM to output code blocks
+  ```
+  ```
+  ```
+- **Line 118** [TYPO_QUOTE]: Typographic quote found: „
+  ```
+  - Der Leser soll sagen: „Das ist kein Report – das ist ein erweiterbares Entscheidungsprodukt."
+  ```
+- **Line 121** [PLACEHOLDER_BAIT]: Placeholder pattern in non-comment: \[1 Satz\]
+  ```
+  - KEINE Platzhalter wie [1 Satz], [2-3 Sätze], {variable}, {{token}}
+  ```
+- **Line 128** [TYPO_QUOTE]: Typographic quote found: „
+  ```
+  Keine Assistenz- oder Chat-Formulierungen (z. B. „wie kann ich helfen", „gerne erkläre ich"). Verwen
+  ```
+
+**Unresolved variables:** token
+
+### prompts/de/ki_aktivitaeten_ziele.md
+
+**Violations:** 2
+
+- **Line 21** [TYPO_QUOTE]: Typographic quote found: „
+  ```
+         - Keine Platzhaltertexte („Platzhalter", „TODO" oder andere Template-Marker).
+  ```
+- **Line 25** [TYPO_QUOTE]: Typographic quote found: „
+  ```
+         - Wenn eine Pflichtvariable fehlerhaft oder nicht lesbar ist → „Fehler: Datenquelle nicht ver
+  ```
+
+**Unresolved variables:** TOOLS_AKTUELL
+
+### prompts/de/ki_stack_summary.md
+
+**Violations:** 9
+
+- **Line 10** [TYPO_QUOTE]: Typographic quote found: , r
+  ```
+  - use example numbers, ranges or scenarios
+  ```
+- **Line 22** [EXPLICIT_BLACKLIST]: Explicit blacklist naming forbidden words - may prime those words
+  ```
+  HARD BLACKLIST (Fail-Closed):
+  ```
+- **Line 23** [CHAT_PHRASE]: Chat phrase pattern found: \bwie kann ich (?:dir|Ihnen) helfen\b
+  ```
+  - "wie kann ich dir helfen" / "wie kann ich helfen"
+  ```
+- **Line 36** [TYPO_QUOTE]: Typographic quote found: „
+  ```
+  AUSGABEREGEL (zwingend): Schreibe ausschließlich deklarative Berichtssätze. Keine Anrede, keine Frag
+  ```
+- **Line 38** [TYPO_QUOTE]: Typographic quote found: „
+  ```
+  STARTFORMAT: Beginne mit einem neutralen Substantivsatz (wie „Der aktuelle Zustand…", „Die empfohlen
+  ```
+- **Line 40** [TYPO_QUOTE]: Typographic quote found: „
+  ```
+  NICHT ERLAUBT: „wie kann ich helfen", „ich sehe keine frage", „beschreibe dein anliegen", „du hast n
+  ```
+- **Line 47** [TYPO_QUOTE]: Typographic quote found: „
+  ```
+  Erzeuge eine kompakte, C-Level-taugliche „KI-Stack Summary Card" als HTML-Block ohne <h1> oder <h2>.
+  ```
+- **Line 153** [CODE_FENCE]: Code fence found - may prime LLM to output code blocks
+  ```
+  ```html
+  ```
+- **Line 214** [CODE_FENCE]: Code fence found - may prime LLM to output code blocks
+  ```
+  ```
+  ```
+
+**Unresolved variables:** BRANCH_SHORT_LABEL
+
+### prompts/de/next_actions.md
+
+**Violations:** 1
+
+- **Line 86** [PLACEHOLDER_BAIT]: Placeholder pattern in non-comment: \[konkret
+  ```
+    <strong>[Konkrete Aktion]</strong> (Woche [X–Y])<br/>
+  ```
+
+### prompts/de/org_change.md
+
+**Violations:** 2
+
+- **Line 9** [TYPO_QUOTE]: Typographic quote found: „
+  ```
+  ZIEL: Präziser Abschnitt „Veränderungsfähigkeit & Lernen".
+  ```
+- **Line 97** [TYPO_QUOTE]: Typographic quote found: „
+  ```
+          Eine klare persönliche Aufteilung der „Hüte" – wie Erstellung, Prüfung, Freigabe –
+  ```
+
+**Unresolved variables:** ki_kompetenz, score_befaehigung, score_nutzen, score_sicherheit
+
+### prompts/de/quick_wins.md
+
+**Violations:** 5
+
+- **Line 23** [TYPO_QUOTE]: Typographic quote found: „
+  ```
+  - Wenn wirtschaftliche Details naheliegen: schreibe **nur** sinngemäß „siehe Business Case" (ohne Za
+  ```
+- **Line 26** [TYPO_QUOTE]: Typographic quote found: „
+  ```
+  - Formelle Anrede **„Sie"**, keine Du-Form.
+  ```
+- **Line 27** [CHAT_PHRASE]: Chat phrase pattern found: \bhier (?:sind|ist|haben Sie)\b
+  ```
+  - Kein Chat-Smalltalk, keine Meta-Sätze („gern", „natürlich", „hier sind…").
+  ```
+- **Line 27** [TYPO_QUOTE]: Typographic quote found: „
+  ```
+  - Kein Chat-Smalltalk, keine Meta-Sätze („gern", „natürlich", „hier sind…").
+  ```
+- **Line 30** [TYPO_QUOTE]: Typographic quote found: „
+  ```
+  - Keine vagen Floskeln; nutze **„optional"** statt unverbindlicher Formulierungen.
+  ```
+
+### prompts/de/recommendations.md
+
+**Violations:** 3
+
+- **Line 282** [PLACEHOLDER_BAIT]: Placeholder pattern in non-comment: \[konkret
+  ```
+        <p class="muss-detail">Für Ihr Kerngeschäft: [Konkrete Umsetzungsschritte]</p>
+  ```
+- **Line 298** [PLACEHOLDER_BAIT]: Placeholder pattern in non-comment: \[konkret
+  ```
+        <p class="muss-detail">Qualitätscheck für diesen Bereich: [Konkrete Checkliste]</p>
+  ```
+- **Line 345** [PLACEHOLDER_BAIT]: Placeholder pattern in non-comment: \{variable\}
+  ```
+  - Keine Platzhalter ("[Hier einfügen]", "{{VARIABLE}}" außer definierten)
+  ```
+
+**Unresolved variables:** VARIABLE
+
+### prompts/de/recommendations_engine.md
+
+**Violations:** 5
+
+- **Line 69** [CODE_FENCE]: Code fence found - may prime LLM to output code blocks
+  ```
+  ```json
+  ```
+- **Line 90** [CODE_FENCE]: Code fence found - may prime LLM to output code blocks
+  ```
+  ```
+  ```
+- **Line 205** [CODE_FENCE]: Code fence found - may prime LLM to output code blocks
+  ```
+  ```json
+  ```
+- **Line 227** [TYPO_QUOTE]: Typographic quote found: '
+  ```
+        "description": "Bereiten Sie den Förderantrag für 'go-digital' vor. Fördersumme bis zu 50% der
+  ```
+- **Line 310** [CODE_FENCE]: Code fence found - may prime LLM to output code blocks
+  ```
+  ```
+  ```
+
+**Unresolved variables:** STRATEGY_SUMMARY, TOOLS_SUMMARY, COMPANY_NAME, EINSPARUNG_STUNDEN_MONAT, BRANCH_LABEL, MATURITY_LEVEL, PAYBACK_MONTHS, BRANCH_SHORT_LABEL, FUNDING_SUMMARY, ROI_12M, RISK_SUMMARY, BUSINESS_CASE_SUMMARY, SIZE_LABEL
+
+### prompts/de/risk_engine_v2.md
+
+**Violations:** 4
+
+- **Line 49** [CODE_FENCE]: Code fence found - may prime LLM to output code blocks
+  ```
+  ```json
+  ```
+- **Line 90** [CODE_FENCE]: Code fence found - may prime LLM to output code blocks
+  ```
+  ```
+  ```
+- **Line 156** [CODE_FENCE]: Code fence found - may prime LLM to output code blocks
+  ```
+  ```json
+  ```
+- **Line 229** [CODE_FENCE]: Code fence found - may prime LLM to output code blocks
+  ```
+  ```
+  ```
+
+**Unresolved variables:** STRATEGY_SUMMARY, TOOLS_SUMMARY, COMPANY_NAME, BRANCH_DEEP_DIVE_SUMMARY, BRANCH_LABEL, MATURITY_LEVEL, EINSPARUNG_STUNDEN_MONAT, BRANCH_SHORT_LABEL, FUNDING_SUMMARY, ROI_12M, PAYBACK_MONTHS, SIZE_LABEL
+
+### prompts/de/risk_engine_v3.md
+
+**Violations:** 2
+
+- **Line 61** [CODE_FENCE]: Code fence found - may prime LLM to output code blocks
+  ```
+  ```json
+  ```
+- **Line 98** [CODE_FENCE]: Code fence found - may prime LLM to output code blocks
+  ```
+  ```
+  ```
+
+**Unresolved variables:** automatisierte_entscheidungen, datentypen, ai_act_class, ki_anwendung, dsgvo_risk_level, vendor_risk_score
+
+### prompts/de/risks.md
+
+**Violations:** 3
+
+- **Line 120** [TYPO_QUOTE]: Typographic quote found: „
+  ```
+        KI „on top" scheitert. Maßnahme: Kleine Piloten mit klarem Umfang.
+  ```
+- **Line 160** [TYPO_QUOTE]: Typographic quote found: „
+  ```
+        Unklare KI-Rolle. Maßnahme: Dokumentation „Wo unterstützt KI?".
+  ```
+- **Line 256** [PLACEHOLDER_BAIT]: Placeholder pattern in non-comment: \{variable\}
+  ```
+  - Keine Platzhalter ("[Hier einfügen]", "{{VARIABLE}}" außer definierten)
+  ```
+
+**Unresolved variables:** VARIABLE, score_sicherheit
+
+### prompts/de/roadmap_90d.md
+
+**Violations:** 9
+
+- **Line 201** [PLACEHOLDER_BAIT]: Placeholder pattern in non-comment: \[Bezug zu
+  ```
+  → Überschrift DYNAMISCH: "Phase 0: [Bezug zu {{hauptleistung}}] Setup"
+  ```
+- **Line 203** [TYPO_QUOTE]: Typographic quote found: '
+  ```
+  → Referenz: "Beginnen Sie mit dem 'Startpunkt in 30 Minuten' aus der Zusammenfassung."
+  ```
+- **Line 208** [PLACEHOLDER_BAIT]: Placeholder pattern in non-comment: \[Bezug zu
+  ```
+  → Überschrift DYNAMISCH: "Phase 1: [Bezug zu {{ZEITERSPARNIS_PRIORITAET}}] Entlastung"
+  ```
+- **Line 346** [TYPO_QUOTE]: Typographic quote found: „
+  ```
+      quantitativ (z. B. „12 LinkedIn-Posts statt 4 ohne KI").</li>
+  ```
+- **Line 366** [TYPO_QUOTE]: Typographic quote found: „
+  ```
+      Gewohnheiten. Beispiel: „Nach dem Morgenkaffee starte ich mit dem KI-gestützten
+  ```
+- **Line 367** [TYPO_QUOTE]: Typographic quote found: „
+  ```
+      E-Mail-Entwurf" oder „Vor jedem Kundengespräch lasse ich mir eine Gesprächsvorbereitung
+  ```
+- **Line 369** [TYPO_QUOTE]: Typographic quote found: „
+  ```
+      <li><strong>Selbstkontrolle ohne Druck:</strong> Führen Sie eine „Erfolgs-Checkliste" mit
+  ```
+- **Line 598** [TYPO_QUOTE]: Typographic quote found: „
+  ```
+      aus dem Pilotbereich mit messbaren Zahlen. Diese „Proof Points" sind Ihre beste
+  ```
+- **Line 633** [TYPO_QUOTE]: Typographic quote found: , r
+  ```
+          <li><em>Datenschutz-Konformität:</em> Null-Toleranz bei Verstößen, regelmäßige
+  ```
+
+### prompts/de/roadmap_90d_decision.md
+
+**Violations:** 7
+
+- **Line 10** [TYPO_QUOTE]: Typographic quote found: , r
+  ```
+  - use example numbers, ranges or scenarios
+  ```
+- **Line 30** [TYPO_QUOTE]: Typographic quote found: „
+  ```
+  AUSGABEREGEL (zwingend): Schreibe ausschließlich deklarative Berichtssätze. Keine Anrede, keine Frag
+  ```
+- **Line 32** [TYPO_QUOTE]: Typographic quote found: „
+  ```
+  STARTFORMAT: Beginne mit einem neutralen Substantivsatz (wie „Der aktuelle Zustand…", „Die empfohlen
+  ```
+- **Line 90** [PLACEHOLDER_BAIT]: Placeholder pattern in non-comment: \[Max\. \d
+  ```
+      <li><strong>Umsetzung:</strong> [Max. 2-3 konkrete Schritte]</li>
+  ```
+- **Line 98** [PLACEHOLDER_BAIT]: Placeholder pattern in non-comment: \[Max\. \d
+  ```
+      <li><strong>Umsetzung:</strong> [Max. 2-3 konkrete Schritte]</li>
+  ```
+- **Line 106** [PLACEHOLDER_BAIT]: Placeholder pattern in non-comment: \[Max\. \d
+  ```
+      <li><strong>Umsetzung:</strong> [Max. 2-3 konkrete Schritte]</li>
+  ```
+- **Line 124** [PLACEHOLDER_BAIT]: Placeholder pattern in non-comment: \[1 Satz\]
+  ```
+  - KEINE Platzhalter wie [1 Satz], [Max. 2-3 Schritte], {variable}, {{token}}
+  ```
+
+**Unresolved variables:** token
+
+### prompts/de/templates_start.md
+
+**Violations:** 1
+
+- **Line 47** [PLACEHOLDER_BAIT]: Placeholder pattern in non-comment: \[konkret
+  ```
+  Aufgabe: [Konkrete Aufgabe in 1 Satz].
+  ```
+
+### prompts/de/tools_empfehlungen.md
+
+**Violations:** 1
+
+- **Line 13** [TYPO_QUOTE]: Typographic quote found: '
+  ```
+  {% include '_hauptleistung_context.md' %}
+  ```
+
+**Unresolved variables:** BRANCH_SHORT_LABEL
+
+### prompts/de/tools_engine_v4.md
+
+**Violations:** 2
+
+- **Line 73** [CODE_FENCE]: Code fence found - may prime LLM to output code blocks
+  ```
+  ```json
+  ```
+- **Line 88** [CODE_FENCE]: Code fence found - may prime LLM to output code blocks
+  ```
+  ```
+  ```
+
+**Unresolved variables:** BRANCH_SHORT_LABEL, TOOL_CATEGORY, SIZE_LABEL, TOOL_NAME
+
+### prompts/de/top_3_massnahmen.md
+
+**Violations:** 2
+
+- **Line 40** [CHAT_PHRASE]: Chat phrase pattern found: \bhier (?:sind|ist|haben Sie)\b
+  ```
+  - Einleitungen wie "Hier sind die Top-3..."
+  ```
+- **Line 41** [CHAT_PHRASE]: Chat phrase pattern found: \bbitte beschreib(?:e|en)\b
+  ```
+  - Chat-Phrasen wie "Wie kann ich helfen?" oder "Bitte beschreibe..."
+  ```
+
+### prompts/de/transparency_box.md
+
+**Violations:** 1
+
+- **Line 70** [TYPO_QUOTE]: Typographic quote found: , r
+  ```
+        Ihrer Situation (neue Tools, geänderte Teamgröße, regulatorische Updates) empfehlen wir
+  ```
+
+### prompts/de/unternehmensprofil_markt.md
+
+**Violations:** 4
+
+- **Line 21** [TYPO_QUOTE]: Typographic quote found: „
+  ```
+         - Verwende „Nicht angegeben" oder einen neutralen generischen Ersatz.
+  ```
+- **Line 35** [TYPO_QUOTE]: Typographic quote found: „
+  ```
+           - Schreibe „Nicht angegeben“ an der passenden Stelle.
+  ```
+- **Line 59** [TYPO_QUOTE]: Typographic quote found: „
+  ```
+         - KEINE Platzhaltertexte im sichtbaren Output (z. B. „Titel …“, „Beispiel …“).
+  ```
+- **Line 171** [PLACEHOLDER_BAIT]: Placeholder pattern in non-comment: \{variable\}
+  ```
+  - Keine Platzhalter ("[Hier einfügen]", "{{VARIABLE}}" außer definierten)
+  ```
+
+**Unresolved variables:** GESCHAEFTSMODELL_EVOLUTION, VARIABLE
+
+### prompts/de/vendor_audit_engine.md
+
+**Violations:** 2
+
+- **Line 88** [CODE_FENCE]: Code fence found - may prime LLM to output code blocks
+  ```
+  ```json
+  ```
+- **Line 133** [CODE_FENCE]: Code fence found - may prime LLM to output code blocks
+  ```
+  ```
+  ```
+
+**Unresolved variables:** risk_report_v2, ai_act_class, ki_anwendung, dsgvo_risk_level, risk_report_v3, tools_data
+
+### prompts/de/wettbewerb_benchmark.md
+
+**Violations:** 3
+
+- **Line 20** [TYPO_QUOTE]: Typographic quote found: „
+  ```
+    > Top 10% → „stark über Branchenniveau"
+  ```
+- **Line 21** [TYPO_QUOTE]: Typographic quote found: „
+  ```
+    zwischen Ø und Top 10% → „über Branchenniveau"
+  ```
+- **Line 22** [TYPO_QUOTE]: Typographic quote found: „
+  ```
+    < Ø → „unter Branchendurchschnitt"
+  ```
+
+**Unresolved variables:** score_sicherheit, score_gesamt, RESEARCH_PROVENANCE_HTML, score_befaehigung, score_nutzen
+
+### prompts/en/_hauptleistung_context.md
+
+**Violations:** 2
+
+- **Line 6** [TYPO_QUOTE]: Typographic quote found: '
+  ```
+  customer's main service. Addresses Problem #7:
+  ```
+- **Line 10** [TYPO_QUOTE]: Typographic quote found: '
+  ```
+  {% raw %}{% include '_hauptleistung_context.md' %}{% endraw %}
+  ```
+
+### prompts/en/_solo_language_rules.md
+
+**Violations:** 2
+
+- **Line 10** [TYPO_QUOTE]: Typographic quote found: '
+  ```
+  {% include '_solo_language_rules.md' %}
+  ```
+- **Line 59** [TYPO_QUOTE]: Typographic quote found: '
+  ```
+  **DON'T:**
+  ```
+
+### prompts/en/ai_act_summary.md
+
+**Violations:** 1
+
+- **Line 220** [TYPO_QUOTE]: Typographic quote found: , r
+  ```
+      <li>Formulate an internal mini-guideline: data, review, approvals, usage limits.</li>
+  ```
+
+### prompts/en/ai_policy_mini.md
+
+**Violations:** 3
+
+- **Line 21** [TYPO_QUOTE]: Typographic quote found: , r
+  ```
+  - team: Clear roles (creator, reviewer), hand‑off rules
+  ```
+- **Line 22** [TYPO_QUOTE]: Typographic quote found: , r
+  ```
+  - kmu: Structured policy, responsibilities and documentation obligations
+  ```
+- **Line 32** [TYPO_QUOTE]: Typographic quote found: , r
+  ```
+  - Complements the Risks section (risks there, rules here)
+  ```
+
+### prompts/en/automation_roadmap_engine.md
+
+**Violations:** 4
+
+- **Line 99** [TYPO_QUOTE]: Typographic quote found: , r
+  ```
+  - `analytics_reporting`: analytics, dashboards, reports
+  ```
+- **Line 101** [TYPO_QUOTE]: Typographic quote found: , r
+  ```
+  - `quality_assurance`: quality assurance, reviews
+  ```
+- **Line 122** [CODE_FENCE]: Code fence found - may prime LLM to output code blocks
+  ```
+  ```json
+  ```
+- **Line 174** [CODE_FENCE]: Code fence found - may prime LLM to output code blocks
+  ```
+  ```
+  ```
+
+**Unresolved variables:** business_case, ki_reifegrad, funding_data, ki_anwendung, hauptherausforderungen, strategy_plan, risk_report_v3, tools_data
+
+### prompts/en/benchmark_engine.md
+
+**Violations:** 2
+
+- **Line 113** [CODE_FENCE]: Code fence found - may prime LLM to output code blocks
+  ```
+  ```json
+  ```
+- **Line 190** [CODE_FENCE]: Code fence found - may prime LLM to output code blocks
+  ```
+  ```
+  ```
+
+**Unresolved variables:** ki_reifegrad, funding_data, ki_anwendung, auto_report, hauptherausforderungen, strategy_plan, kpi_data, risk_report_v3, tools_data
+
+### prompts/en/branch_deep_dive.md
+
+**Violations:** 5
+
+- **Line 11** [TYPO_QUOTE]: Typographic quote found: '
+  ```
+  Analyze the user's concrete main service:
+  ```
+- **Line 170** [CODE_FENCE]: Code fence found - may prime LLM to output code blocks
+  ```
+  ```html
+  ```
+- **Line 267** [CODE_FENCE]: Code fence found - may prime LLM to output code blocks
+  ```
+  ```
+  ```
+- **Line 286** [TYPO_QUOTE]: Typographic quote found: '
+  ```
+  - No assistant language ("I can help you...", "I'm happy to explain...")
+  ```
+- **Line 289** [PLACEHOLDER_BAIT]: Placeholder pattern in non-comment: \{variable\}
+  ```
+  - No placeholders ("[Insert here]", "{{VARIABLE}}" except defined ones)
+  ```
+
+**Unresolved variables:** BRANCH_SHORT_LABEL, VARIABLE
+
+### prompts/en/business_case.md
+
+**Violations:** 3
+
+- **Line 12** [TYPO_QUOTE]: Typographic quote found: , r
+  ```
+  GOAL: Clear, realistic business case with ROI, CAPEX/OPEX.
+  ```
+- **Line 28** [TYPO_QUOTE]: Typographic quote found: '
+  ```
+  - In foerderpotenzial.md only reference these numbers, don't repeat
+  ```
+- **Line 125** [TYPO_QUOTE]: Typographic quote found: , r
+  ```
+      <li>Digital products (automated analyses, reports)</li>
+  ```
+
+**Unresolved variables:** EINSPARUNG_MONAT_EUR, CAPEX_REALISTISCH_EUR, ROI_12M, PAYBACK_MONTHS, OPEX_REALISTISCH_EUR
+
+### prompts/en/business_case_engine_v2.md
+
+**Violations:** 4
+
+- **Line 64** [CODE_FENCE]: Code fence found - may prime LLM to output code blocks
+  ```
+  ```json
+  ```
+- **Line 113** [CODE_FENCE]: Code fence found - may prime LLM to output code blocks
+  ```
+  ```
+  ```
+- **Line 230** [CODE_FENCE]: Code fence found - may prime LLM to output code blocks
+  ```
+  ```json
+  ```
+- **Line 279** [CODE_FENCE]: Code fence found - may prime LLM to output code blocks
+  ```
+  ```
+  ```
+
+**Unresolved variables:** STRATEGY_SUMMARY, TOOLS_SUMMARY, COMPANY_NAME, BRANCH_DEEP_DIVE_SUMMARY, BRANCH_LABEL, MATURITY_LEVEL, EINSPARUNG_STUNDEN_MONAT, EINSPARUNG_MONAT_EUR, BRANCH_SHORT_LABEL, FUNDING_SUMMARY, ROI_12M, RISK_SUMMARY, PAYBACK_MONTHS, SIZE_LABEL
+
+### prompts/en/business_case_simulation.md
+
+**Violations:** 6
+
+- **Line 84** [CODE_FENCE]: Code fence found - may prime LLM to output code blocks
+  ```
+  ```json
+  ```
+- **Line 110** [CODE_FENCE]: Code fence found - may prime LLM to output code blocks
+  ```
+  ```
+  ```
+- **Line 211** [CODE_FENCE]: Code fence found - may prime LLM to output code blocks
+  ```
+  ```json
+  ```
+- **Line 237** [CODE_FENCE]: Code fence found - may prime LLM to output code blocks
+  ```
+  ```
+  ```
+- **Line 241** [CODE_FENCE]: Code fence found - may prime LLM to output code blocks
+  ```
+  ```json
+  ```
+- **Line 267** [CODE_FENCE]: Code fence found - may prime LLM to output code blocks
+  ```
+  ```
+  ```
+
+**Unresolved variables:** BC_INVESTMENT_TOTAL, BRANCH_LABEL, BC_CONSERVATIVE_ROI, AUTO_PHASE_1_COUNT, AUTO_AVG_POTENTIAL, BRANCH_SHORT_LABEL, BC_REALISTIC_PAYBACK, RISK_RESIDUAL_SCORE, MATURITY_LEVEL, RISK_RESIDUAL_GRADE, AI_ACT_CONFORMITY, BC_REALISTIC_SAVINGS, SIZE_LABEL, AI_ACT_MISSING_CONTROLS, TOOLS_SUMMARY, COMPANY_NAME, AUTO_QUICK_WINS, DPIA_REQUIRED, FUNDING_SUMMARY, COMPLIANCE_STATUS, BC_OPTIMISTIC_ROI, BC_REALISTIC_ROI, BC_OPTIMISTIC_PAYBACK, BC_CONSERVATIVE_PAYBACK, AUTO_PROCESS_COUNT
+
+### prompts/en/competition_benchmark.md
+
+**Violations:** 1
+
+- **Line 180** [TYPO_QUOTE]: Typographic quote found: , r
+  ```
+          Clarify roles (AI owner, reviewer), uniform templates and short review loops.
+  ```
+
+**Unresolved variables:** score_sicherheit, score_gesamt, RESEARCH_PROVENANCE_HTML, score_befaehigung, score_nutzen
+
+### prompts/en/data_readiness.md
+
+**Violations:** 4
+
+- **Line 40** [TYPO_QUOTE]: Typographic quote found: , r
+  ```
+      * Focus: binding data governance, interfaces, roles and responsibilities.
+  ```
+- **Line 77** [TYPO_QUOTE]: Typographic quote found: , r
+  ```
+      <li>In regulated areas ({{REGULIERTE_BRANCHE_LABELS}}) data protection, retention and access rig
+  ```
+- **Line 98** [TYPO_QUOTE]: Typographic quote found: , r
+  ```
+      <li><strong>Clarify data protection & access rights:</strong> Define responsibilities, roles and
+  ```
+- **Line 104** [TYPO_QUOTE]: Typographic quote found: , r
+  ```
+      For sustainable scaling, however, structure, responsibilities and data quality
+  ```
+
+### prompts/en/exec_snapshot.md
+
+**Violations:** 6
+
+- **Line 34** [TYPO_QUOTE]: Typographic quote found: , r
+  ```
+  5. **Summarise the risk situation** by mentioning the highest priority risk category from the risk e
+  ```
+- **Line 47** [TYPO_QUOTE]: Typographic quote found: , r
+  ```
+  Deliver a single HTML fragment using `<div>`, `<p>`, `<ul>`, `<li>`, `<strong>` and `<span>` tags on
+  ```
+- **Line 52** [TYPO_QUOTE]: Typographic quote found: , r
+  ```
+  - **Clarity:** Each sentence must be crisp and free from filler words. Avoid questions, rhetorical d
+  ```
+- **Line 54** [TYPO_QUOTE]: Typographic quote found: , r
+  ```
+  - **Safety & compliance:** Respect {{KI_GUARDRAILS}}, avoid high‑risk use cases and ensure complianc
+  ```
+- **Line 58** [CODE_FENCE]: Code fence found - may prime LLM to output code blocks
+  ```
+  ```
+  ```
+- **Line 76** [CODE_FENCE]: Code fence found - may prime LLM to output code blocks
+  ```
+  ```
+  ```
+
+**Unresolved variables:** COMPANY_NAME, BRANCH_LABEL, MATURITY_LEVEL, BRANCH_SHORT_LABEL, SIZE_LABEL
+
+### prompts/en/executive_decision.md
+
+**Violations:** 2
+
+- **Line 52** [CODE_FENCE]: Code fence found - may prime LLM to output code blocks
+  ```
+  ```html
+  ```
+- **Line 61** [CODE_FENCE]: Code fence found - may prime LLM to output code blocks
+  ```
+  ```
+  ```
+
+### prompts/en/executive_summary.md
+
+**Violations:** 4
+
+- **Line 55** [TYPO_QUOTE]: Typographic quote found: '
+  ```
+  USER'S CORE BUSINESS (PRIMARY):
+  ```
+- **Line 69** [TYPO_QUOTE]: Typographic quote found: , r
+  ```
+  - If {{ZEITERSPARNIS_PRIORITAET}} is available, relate decisions to it
+  ```
+- **Line 174** [TYPO_QUOTE]: Typographic quote found: '
+  ```
+  The decision concerns the direction of one's own work.
+  ```
+- **Line 277** [TYPO_QUOTE]: Typographic quote found: , r
+  ```
+  → EXAMPLE: "Core recommendation → From custom code to templates: Questionnaire library, prompt stand
+  ```
+
+**Unresolved variables:** STRATEGISCHE_ZIELE
+
+### prompts/en/foerderpotenzial.md
+
+**Violations:** 2
+
+- **Line 195** [TYPO_QUOTE]: Typographic quote found: '
+  ```
+  - No assistant language ("I can help you...", "I'm happy to explain...")
+  ```
+- **Line 198** [PLACEHOLDER_BAIT]: Placeholder pattern in non-comment: \{variable\}
+  ```
+  - No placeholders ("[Insert here]", "{{VARIABLE}}" except defined ones)
+  ```
+
+**Unresolved variables:** EINSPARUNG_MONAT_EUR, CAPEX_REALISTISCH_EUR, VARIABLE, ROI_12M, PAYBACK_MONTHS, OPEX_REALISTISCH_EUR
+
+### prompts/en/funding_engine_v2.md
+
+**Violations:** 7
+
+- **Line 25** [TYPO_QUOTE]: Typographic quote found: , r
+  ```
+  1. **Identify suitable programmes:** Select **3–5 funding programmes** that best fit the company’s s
+  ```
+- **Line 29** [TYPO_QUOTE]: Typographic quote found: , r
+  ```
+     - `provider` – the issuing body (e.g. BMWK, regional ministry, EU Commission, private foundation)
+  ```
+- **Line 54** [CODE_FENCE]: Code fence found - may prime LLM to output code blocks
+  ```
+  ```json
+  ```
+- **Line 77** [CODE_FENCE]: Code fence found - may prime LLM to output code blocks
+  ```
+  ```
+  ```
+- **Line 89** [TYPO_QUOTE]: Typographic quote found: , r
+  ```
+  5. **No placeholders:** Do not output variable names or indicate missing data. If no suitable progra
+  ```
+- **Line 93** [CODE_FENCE]: Code fence found - may prime LLM to output code blocks
+  ```
+  ```
+  ```
+- **Line 131** [CODE_FENCE]: Code fence found - may prime LLM to output code blocks
+  ```
+  ```
+  ```
+
+**Unresolved variables:** COMPANY_NAME, BRANCH_LABEL, MATURITY_LEVEL, HAUPTHERAUSFORDERUNGEN, BRANCH_SHORT_LABEL, SIZE_LABEL
+
+### prompts/en/funding_potential.md
+
+**Violations:** 1
+
+- **Line 76** [TYPO_QUOTE]: Typographic quote found: , r
+  ```
+      <li><strong>Project description:</strong> Document goals, measures, timeline and anticipated ben
+  ```
+
+**Unresolved variables:** EINSPARUNG_MONAT_EUR, CAPEX_REALISTISCH_EUR, ROI_12M, PAYBACK_MONTHS, OPEX_REALISTISCH_EUR
+
+### prompts/en/gamechanger.md
+
+**Violations:** 8
+
+- **Line 82** [TYPO_QUOTE]: Typographic quote found: '
+  ```
+  {% include '_hauptleistung_context.md' %}
+  ```
+- **Line 89** [TYPO_QUOTE]: Typographic quote found: '
+  ```
+  The Gamechanger MUST incorporate the user's concrete briefing data.
+  ```
+- **Line 100** [TYPO_QUOTE]: Typographic quote found: '
+  ```
+  - {{VISION_3_JAHRE}} = User's long-term vision
+  ```
+- **Line 110** [TYPO_QUOTE]: Typographic quote found: '
+  ```
+  ❌ FORBIDDEN: "Processes are inefficient and don't scale"
+  ```
+- **Line 125** [TYPO_QUOTE]: Typographic quote found: '
+  ```
+              The path to '{{VISION_3_JAHRE}}' begins with standardizing the evaluation logic."
+  ```
+- **Line 235** [TYPO_QUOTE]: Typographic quote found: '
+  ```
+  {% include '_solo_language_rules.md' %}
+  ```
+- **Line 247** [TYPO_QUOTE]: Typographic quote found: , r
+  ```
+  - NO organizational terms (team, department, rollout, etc.)
+  ```
+- **Line 250** [EXPLICIT_BLACKLIST]: Explicit blacklist naming forbidden words - may prime those words
+  ```
+  FORBIDDEN TERMS FOR SOLO (Zero Tolerance):
+  ```
+
+**Unresolved variables:** GESCHAEFTSMODELL_EVOLUTION, industry, core_service, WETTBEWERB
+
+### prompts/en/gamechanger_decision.md
+
+**Violations:** 3
+
+- **Line 54** [CODE_FENCE]: Code fence found - may prime LLM to output code blocks
+  ```
+  ```html
+  ```
+- **Line 77** [CODE_FENCE]: Code fence found - may prime LLM to output code blocks
+  ```
+  ```
+  ```
+- **Line 86** [PLACEHOLDER_BAIT]: Placeholder pattern in non-comment: \{variable\}
+  ```
+  - NO placeholders such as [1 sentence], [2‑3 sentences], {variable}, {{token}} in the output
+  ```
+
+**Unresolved variables:** token
+
+### prompts/en/ki_stack_summary.md
+
+**Violations:** 4
+
+- **Line 70** [TYPO_QUOTE]: Typographic quote found: , r
+  ```
+    - Focus on collaboration, roles, first governance approaches and simple standards.
+  ```
+- **Line 74** [TYPO_QUOTE]: Typographic quote found: , r
+  ```
+    - Focus on scaling, standardisation, responsibilities and risk management.
+  ```
+- **Line 116** [CODE_FENCE]: Code fence found - may prime LLM to output code blocks
+  ```
+  ```html
+  ```
+- **Line 172** [CODE_FENCE]: Code fence found - may prime LLM to output code blocks
+  ```
+  ```
+  ```
+
+**Unresolved variables:** BRANCH_SHORT_LABEL
+
+### prompts/en/next_actions.md
+
+**Violations:** 1
+
+- **Line 21** [TYPO_QUOTE]: Typographic quote found: '
+  ```
+  - {{VISION_3_JAHRE}} = The user's long‑term vision
+  ```
+
+### prompts/en/org_change.md
+
+**Violations:** 3
+
+- **Line 96** [TYPO_QUOTE]: Typographic quote found: , r
+  ```
+          A clear personal division of the “hats” – for example creation, review and approval – create
+  ```
+- **Line 98** [TYPO_QUOTE]: Typographic quote found: , r
+  ```
+          A clear division of roles (team lead, AI owner, review role) avoids duplicate work and ensur
+  ```
+- **Line 105** [TYPO_QUOTE]: Typographic quote found: , r
+  ```
+        Short feedback loops, structured notes and a compact standard help to transform successful AI 
+  ```
+
+**Unresolved variables:** ki_kompetenz, score_befaehigung, score_nutzen, score_sicherheit
+
+### prompts/en/quick_wins.md
+
+**Violations:** 6
+
+- **Line 69** [CODE_FENCE]: Code fence found - may prime LLM to output code blocks
+  ```
+  ```json
+  ```
+- **Line 86** [CODE_FENCE]: Code fence found - may prime LLM to output code blocks
+  ```
+  ```
+  ```
+- **Line 152** [TYPO_QUOTE]: Typographic quote found: '
+  ```
+  **Customer's main service:** "Online shop for office furniture"
+  ```
+- **Line 164** [CODE_FENCE]: Code fence found - may prime LLM to output code blocks
+  ```
+  ```json
+  ```
+- **Line 171** [TYPO_QUOTE]: Typographic quote found: , r
+  ```
+      "description": "Currently you structure each consulting process (questionnaire, evaluation, repo
+  ```
+- **Line 209** [CODE_FENCE]: Code fence found - may prime LLM to output code blocks
+  ```
+  ```
+  ```
+
+**Unresolved variables:** STUNDENSATZ_EUR
+
+### prompts/en/recommendations.md
+
+**Violations:** 4
+
+- **Line 144** [TYPO_QUOTE]: Typographic quote found: '
+  ```
+    - Measure 1: {{ZEITERSPARNIS_PRIORITAET}} (user's biggest time drain)
+  ```
+- **Line 145** [TYPO_QUOTE]: Typographic quote found: '
+  ```
+    - Measure 2: {{hauptleistung}} (user's concrete core service)
+  ```
+- **Line 218** [TYPO_QUOTE]: Typographic quote found: '
+  ```
+  - No assistant language ("I can help you...", "I'm happy to explain...")
+  ```
+- **Line 221** [PLACEHOLDER_BAIT]: Placeholder pattern in non-comment: \{variable\}
+  ```
+  - No placeholders ("[Insert here]", "{{VARIABLE}}" except defined ones)
+  ```
+
+**Unresolved variables:** VARIABLE
+
+### prompts/en/recommendations_engine.md
+
+**Violations:** 7
+
+- **Line 65** [CODE_FENCE]: Code fence found - may prime LLM to output code blocks
+  ```
+  ```json
+  ```
+- **Line 86** [CODE_FENCE]: Code fence found - may prime LLM to output code blocks
+  ```
+  ```
+  ```
+- **Line 93** [TYPO_QUOTE]: Typographic quote found: , r
+  ```
+  - Focal areas (tools, risks, funding)
+  ```
+- **Line 200** [CODE_FENCE]: Code fence found - may prime LLM to output code blocks
+  ```
+  ```json
+  ```
+- **Line 202** [TYPO_QUOTE]: Typographic quote found: , r
+  ```
+    "summary": "For your medium‑sized manufacturing company seven prioritised recommendations were ide
+  ```
+- **Line 222** [TYPO_QUOTE]: Typographic quote found: '
+  ```
+        "description": "Prepare the funding application for 'go‑digital'. Funding of up to 50% of cons
+  ```
+- **Line 305** [CODE_FENCE]: Code fence found - may prime LLM to output code blocks
+  ```
+  ```
+  ```
+
+**Unresolved variables:** STRATEGY_SUMMARY, TOOLS_SUMMARY, COMPANY_NAME, EINSPARUNG_STUNDEN_MONAT, BRANCH_LABEL, MATURITY_LEVEL, PAYBACK_MONTHS, BRANCH_SHORT_LABEL, FUNDING_SUMMARY, ROI_12M, RISK_SUMMARY, BUSINESS_CASE_SUMMARY, SIZE_LABEL
+
+### prompts/en/risk_engine_v2.md
+
+**Violations:** 5
+
+- **Line 53** [CODE_FENCE]: Code fence found - may prime LLM to output code blocks
+  ```
+  ```json
+  ```
+- **Line 94** [CODE_FENCE]: Code fence found - may prime LLM to output code blocks
+  ```
+  ```
+  ```
+- **Line 108** [TYPO_QUOTE]: Typographic quote found: , r
+  ```
+  For `high_risk`: documentation, risk management, logging, human oversight
+  ```
+- **Line 160** [CODE_FENCE]: Code fence found - may prime LLM to output code blocks
+  ```
+  ```json
+  ```
+- **Line 233** [CODE_FENCE]: Code fence found - may prime LLM to output code blocks
+  ```
+  ```
+  ```
+
+**Unresolved variables:** STRATEGY_SUMMARY, TOOLS_SUMMARY, COMPANY_NAME, BRANCH_DEEP_DIVE_SUMMARY, BRANCH_LABEL, MATURITY_LEVEL, EINSPARUNG_STUNDEN_MONAT, BRANCH_SHORT_LABEL, FUNDING_SUMMARY, ROI_12M, PAYBACK_MONTHS, SIZE_LABEL
+
+### prompts/en/risk_engine_v3.md
+
+**Violations:** 4
+
+- **Line 47** [CODE_FENCE]: Code fence found - may prime LLM to output code blocks
+  ```
+  ```json
+  ```
+- **Line 91** [CODE_FENCE]: Code fence found - may prime LLM to output code blocks
+  ```
+  ```
+  ```
+- **Line 104** [CODE_FENCE]: Code fence found - may prime LLM to output code blocks
+  ```
+  ```
+  ```
+- **Line 167** [CODE_FENCE]: Code fence found - may prime LLM to output code blocks
+  ```
+  ```
+  ```
+
+**Unresolved variables:** HIGH_PRIORITY_RISKS, COMPANY_NAME, RISK_MATRIX, BRANCH_LABEL, MATURITY_LEVEL, BRANCH_SHORT_LABEL, MITIGATION_STRATEGIES, SIZE_LABEL
+
+### prompts/en/risks.md
+
+**Violations:** 6
+
+- **Line 87** [TYPO_QUOTE]: Typographic quote found: '
+  ```
+  ✅ <li><strong>Lack of transparency:</strong> Customers don't understand AI decisions.
+  ```
+- **Line 220** [TYPO_QUOTE]: Typographic quote found: , r
+  ```
+          <td>Template standards, review loops, clear communication of benefits and limits.</td>
+  ```
+- **Line 231** [TYPO_QUOTE]: Typographic quote found: , r
+  ```
+          <td>Incorrect information in customer documents, reputation damage</td>
+  ```
+- **Line 241** [TYPO_QUOTE]: Typographic quote found: , r
+  ```
+      {{OFFERING_LABEL}}. In the next step, risks should be prioritized
+  ```
+- **Line 254** [TYPO_QUOTE]: Typographic quote found: '
+  ```
+  - No assistant language ("I can help you...", "I'm happy to explain...")
+  ```
+- **Line 257** [PLACEHOLDER_BAIT]: Placeholder pattern in non-comment: \{variable\}
+  ```
+  - No placeholders ("[Insert here]", "{{VARIABLE}}" except defined ones)
+  ```
+
+**Unresolved variables:** VARIABLE, score_sicherheit
+
+### prompts/en/roadmap_12m.md
+
+**Violations:** 4
+
+- **Line 94** [TYPO_QUOTE]: Typographic quote found: , r
+  ```
+  - Team: AI coordinator, shared standards, review rounds
+  ```
+- **Line 95** [TYPO_QUOTE]: Typographic quote found: , r
+  ```
+  - SME: departments, governance board, rollout plan, compliance
+  ```
+- **Line 225** [TYPO_QUOTE]: Typographic quote found: , r
+  ```
+  <p><em>🎯 End‑of‑year milestone:</em> Board decision for year 2, rollout plan in place.</p>
+  ```
+- **Line 240** [PLACEHOLDER_BAIT]: Placeholder pattern in non-comment: \{variable\}
+  ```
+  - No placeholders (“[Insert here]”, “{{VARIABLE}}” except defined ones) 
+  ```
+
+**Unresolved variables:** VARIABLE
+
+### prompts/en/roadmap_90d.md
+
+**Violations:** 6
+
+- **Line 59** [TYPO_QUOTE]: Typographic quote found: , r
+  ```
+  Instead of generic steps, refer to the user's concrete work.
+  ```
+- **Line 289** [TYPO_QUOTE]: Typographic quote found: , r
+  ```
+      <li>Assess the quality of {{hauptleistung}} results: error rate, rework effort</li>
+  ```
+- **Line 446** [TYPO_QUOTE]: Typographic quote found: , r
+  ```
+      <li><strong>Prompt library:</strong> Collect all working prompt templates in a shared storage (N
+  ```
+- **Line 454** [TYPO_QUOTE]: Typographic quote found: , r
+  ```
+      <li><strong>Document lessons learned:</strong> After each phase (setup, relief, productive use) 
+  ```
+- **Line 513** [TYPO_QUOTE]: Typographic quote found: , r
+  ```
+    <p><strong>Milestone:</strong> Management decision towards {{VISION_3_JAHRE}} made, rollout plan r
+  ```
+- **Line 519** [TYPO_QUOTE]: Typographic quote found: , r
+  ```
+      <li><strong>Governance:</strong> {{KI_GUARDRAILS}} as clear rules, responsibilities documented</
+  ```
+
+### prompts/en/roadmap_90d_decision.md
+
+**Violations:** 10
+
+- **Line 14** [TYPO_QUOTE]: Typographic quote found: '
+  ```
+  NOT ALLOWED: "how can I help", "I don't see a question", "describe your request", "you haven't asked
+  ```
+- **Line 16** [TYPO_QUOTE]: Typographic quote found: '
+  ```
+  IMPORTANT: Use no address, no questions, no assistant or chat phrasing. No meta-commentary about mis
+  ```
+- **Line 49** [CODE_FENCE]: Code fence found - may prime LLM to output code blocks
+  ```
+  ```html
+  ```
+- **Line 56** [PLACEHOLDER_BAIT]: Placeholder pattern in non-comment: \[Max\. \d
+  ```
+      <li><strong>Implementation:</strong> [Max. 2-3 concrete steps]</li>
+  ```
+- **Line 64** [PLACEHOLDER_BAIT]: Placeholder pattern in non-comment: \[Max\. \d
+  ```
+      <li><strong>Implementation:</strong> [Max. 2-3 concrete steps]</li>
+  ```
+- **Line 72** [PLACEHOLDER_BAIT]: Placeholder pattern in non-comment: \[Max\. \d
+  ```
+      <li><strong>Implementation:</strong> [Max. 2-3 concrete steps]</li>
+  ```
+- **Line 77** [CODE_FENCE]: Code fence found - may prime LLM to output code blocks
+  ```
+  ```
+  ```
+- **Line 91** [PLACEHOLDER_BAIT]: Placeholder pattern in non-comment: \[Max\. \d
+  ```
+  - NO placeholders like [1 sentence], [Max. 2-3 steps], {variable}, {{token}}
+  ```
+- **Line 98** [TYPO_QUOTE]: Typographic quote found: '
+  ```
+  No assistant or chat formulations (e.g., "how can I help", "I'd be happy to explain"). Use report la
+  ```
+- **Line 117** [TYPO_QUOTE]: Typographic quote found: , r
+  ```
+      <li><strong>Stop Rule:</strong> If quality deviations exceed 20% or adoption fails to materialis
+  ```
+
+**Unresolved variables:** token
+
+### prompts/en/strategy_governance.md
+
+**Violations:** 3
+
+- **Line 15** [TYPO_QUOTE]: Typographic quote found: , r
+  ```
+  - [✓] Provide a bullet list describing current status across five areas: guidelines & policy, change
+  ```
+- **Line 20** [TYPO_QUOTE]: Typographic quote found: , r
+  ```
+  - [✓] Do not duplicate governance content in other prompts (org_change, risks) and respect guardrail
+  ```
+- **Line 49** [TYPO_QUOTE]: Typographic quote found: , r
+  ```
+        <strong>Responsibilities &amp; Competencies:</strong> The appointment of a data protection off
+  ```
+
+**Unresolved variables:** DATENSCHUTZ_LABEL, MELDEWEGE_LABEL, LOESCHREGELN_LABEL, BRANCH_SHORT_LABEL, DATENSCHUTZBEAUFTRAGTER_LABEL, FOLGENABSCHAETZUNG_LABEL
+
+### prompts/en/technologie_prozesse.md
+
+**Violations:** 3
+
+- **Line 34** [TYPO_QUOTE]: Typographic quote found: , r
+  ```
+        <tr><td>Backend</td><td>Prompt orchestration, report builder and business case logic</td></tr>
+  ```
+- **Line 35** [TYPO_QUOTE]: Typographic quote found: , r
+  ```
+        <tr><td>AI/Analysis</td><td>Multi‑layer prompt analysis, research integration and industry con
+  ```
+- **Line 46** [TYPO_QUOTE]: Typographic quote found: , r
+  ```
+      <li>AI generates the report sections (Executive Summary, 90‑day roadmap, risks, business case, e
+  ```
+
+### prompts/en/technology_processes.md
+
+**Violations:** 3
+
+- **Line 35** [TYPO_QUOTE]: Typographic quote found: , r
+  ```
+        <tr><td>Backend</td><td>Prompt orchestration, report builder and business case logic</td></tr>
+  ```
+- **Line 36** [TYPO_QUOTE]: Typographic quote found: , r
+  ```
+        <tr><td>AI/Analysis</td><td>Multi‑layer prompt analysis, research integration and industry con
+  ```
+- **Line 47** [TYPO_QUOTE]: Typographic quote found: , r
+  ```
+      <li>AI generates the report sections (Executive Summary, 90‑day roadmap, risks, business case, e
+  ```
+
+### prompts/en/tools_empfehlungen.md
+
+**Violations:** 5
+
+- **Line 31** [TYPO_QUOTE]: Typographic quote found: , r
+  ```
+        - Focus: Audit trail, versioning, review mechanisms
+  ```
+- **Line 144** [TYPO_QUOTE]: Typographic quote found: , r
+  ```
+      Add subsections for data platforms, risk & compliance tools, and
+  ```
+- **Line 175** [TYPO_QUOTE]: Typographic quote found: , r
+  ```
+      Policy management, data protection controls, risk monitoring, and audit capabilities.
+  ```
+- **Line 234** [TYPO_QUOTE]: Typographic quote found: '
+  ```
+  - No assistant language ("I can help you...", "I'm happy to explain...")
+  ```
+- **Line 237** [PLACEHOLDER_BAIT]: Placeholder pattern in non-comment: \{variable\}
+  ```
+  - No placeholders ("[Insert here]", "{{VARIABLE}}" except defined ones)
+  ```
+
+**Unresolved variables:** BRANCH_SHORT_LABEL, VARIABLE
+
+### prompts/en/tools_engine_v4.md
+
+**Violations:** 2
+
+- **Line 73** [CODE_FENCE]: Code fence found - may prime LLM to output code blocks
+  ```
+  ```json
+  ```
+- **Line 88** [CODE_FENCE]: Code fence found - may prime LLM to output code blocks
+  ```
+  ```
+  ```
+
+**Unresolved variables:** BRANCH_SHORT_LABEL, TOOL_CATEGORY, SIZE_LABEL, TOOL_NAME
+
+### prompts/en/tools_recommendations.md
+
+**Violations:** 3
+
+- **Line 18** [TYPO_QUOTE]: Typographic quote found: , r
+  ```
+    * **Team:** Five clusters: (1) Collaboration & shared workspace, (2) Core process tools for {{OFFE
+  ```
+- **Line 96** [TYPO_QUOTE]: Typographic quote found: , r
+  ```
+      Require audit trails for AI interactions, versioning systems for prompts and models, and defined
+  ```
+- **Line 116** [TYPO_QUOTE]: Typographic quote found: , r
+  ```
+      Implement enterprise‑grade compliance and governance modules: policy management, data protection
+  ```
+
+**Unresolved variables:** BRANCH_SHORT_LABEL
+
+### prompts/en/unternehmensprofil_markt.md
+
+**Violations:** 4
+
+- **Line 32** [TYPO_QUOTE]: Typographic quote found: , r
+  ```
+           - Specific market shares, revenues, names of competitors
+  ```
+- **Line 90** [TYPO_QUOTE]: Typographic quote found: , r
+  ```
+        increased digitalization, rising expectations for quality and speed, as well as
+  ```
+- **Line 98** [TYPO_QUOTE]: Typographic quote found: , r
+  ```
+        <li><strong>Key Drivers:</strong> Industry-typical drivers include cost pressure, skills short
+  ```
+- **Line 171** [PLACEHOLDER_BAIT]: Placeholder pattern in non-comment: \{variable\}
+  ```
+  - No placeholders ("[Insert here]", "{{VARIABLE}}" except defined ones)
+  ```
+
+**Unresolved variables:** GESCHAEFTSMODELL_EVOLUTION, VARIABLE
+
+### prompts/en/vendor_audit_engine.md
+
+**Violations:** 2
+
+- **Line 88** [CODE_FENCE]: Code fence found - may prime LLM to output code blocks
+  ```
+  ```json
+  ```
+- **Line 133** [CODE_FENCE]: Code fence found - may prime LLM to output code blocks
+  ```
+  ```
+  ```
+
+**Unresolved variables:** risk_report_v2, ai_act_class, ki_anwendung, dsgvo_risk_level, risk_report_v3, tools_data
+
+### prompts/en/wettbewerb_benchmark.md
+
+**Violations:** 1
+
+- **Line 179** [TYPO_QUOTE]: Typographic quote found: , r
+  ```
+          Clarify roles (AI owner, reviewer), uniform templates and short review loops.
+  ```
+
+**Unresolved variables:** score_sicherheit, score_gesamt, RESEARCH_PROVENANCE_HTML, score_befaehigung, score_nutzen
+
+## Fix Hints
+
+- **CODE_FENCE:** Remove code fences from prompt output examples; describe structure in prose
+- **CHAT_PHRASE:** Remove conversational language from prompts
+- **EXPLICIT_BLACKLIST:** Replace explicit forbidden-word lists with general rules
+- **PLACEHOLDER_BAIT:** Replace [placeholder] patterns with concrete descriptions
+- **HTML_ENTITY:** Replace &uuml; etc. with actual UTF-8 characters (ü)
+- **TYPO_QUOTE:** Replace „  with ASCII quotes (")

--- a/prompts/de/executive_decision.md
+++ b/prompts/de/executive_decision.md
@@ -77,15 +77,20 @@ INHALTLICHE VERDICHTUNG (nutze nur vorhandene Konzepte):
 - "Tool-Zoo / Ad-hoc-Prompts ohne Standards" = No-Go
 - Stop-Regel: max. 2 parallele Initiativen; nach 14 Tagen ohne messbaren Effekt = vereinfachen oder stoppen
 
-OUTPUT-FORMAT (exakt einhalten, ohne Markdown/Codeblöcke):
-<div class="exec-decision-box">
-  <p><strong>Ihre Entscheidung in 3 Punkten</strong></p>
-  <ul>
-    <li><strong>Tun:</strong> [Ein konkreter Standard-Workflow, der sofort umsetzbar ist]</li>
-    <li><strong>Lassen:</strong> [Was Sie ab sofort nicht mehr tun sollten]</li>
-    <li><strong>Risiko & Stop-Signal:</strong> [Wann Sie stoppen und vereinfachen müssen]</li>
-  </ul>
-</div>
+OUTPUT (HTML ONLY, exakt einhalten):
+
+Genau ein Outer-Container: div.exec-decision-box
+
+Reihenfolge:
+- p > strong: "Ihre Entscheidung in 3 Punkten"
+- ul mit genau 3 li
+
+Jeder li startet mit strong Label und danach ein vollständiger Satz:
+- "Tun:" — ein konkreter Standard-Workflow, der sofort umsetzbar ist
+- "Lassen:" — was Sie ab sofort nicht mehr tun sollten
+- "Risiko & Stop-Signal:" — wann Sie stoppen und vereinfachen müssen
+
+Keine eckigen Klammern, keine geschweiften Klammern, keine Platzhalter-Wörter.
 
 STIL:
 - Distanziert-professionell, wie ein externer Gutachter

--- a/prompts/de/roadmap_12m.md
+++ b/prompts/de/roadmap_12m.md
@@ -39,15 +39,9 @@ ZIEL: 12-Monats-Roadmap als strategische Entscheidungskette (nicht Tool-Umsetzun
 SPRACHSHIFT v6.0 — ENTSCHEIDUNGEN STATT IMPLEMENTIERUNGEN:
 =============================================================================
 
-VERBOTENE FORMULIERUNGEN → ERSETZUNGEN:
-❌ "Einführung / Implementierung"  → ✅ "Festlegung / Definition / Abgrenzung"
-❌ "Tool ausrollen"                → ✅ "Standards etablieren"
-❌ "System integrieren"            → ✅ "Verantwortlichkeiten klären"
-❌ "Workflow automatisieren"       → ✅ "Entscheidungsrahmen schaffen"
-❌ "Digitalisierung vorantreiben"  → ✅ "Prioritäten setzen"
-
-Die Roadmap zeigt WELCHE ENTSCHEIDUNGEN zu treffen sind,
-nicht WELCHE TOOLS einzuführen sind.
+SPRACHSHIFT (verbindlich):
+Roadmap als Entscheidungskette formulieren, nicht als Implementierungsplan.
+Formulierungen beziehen sich auf Rahmen, Grenzen, Kriterien – nicht auf Produktnamen oder Rollout-Schritte.
 
 LESBARKEIT (v6.1 NEU):
 - Maximal EIN abstrakter Gedanke pro Absatz

--- a/prompts/de/roadmap_90d.md
+++ b/prompts/de/roadmap_90d.md
@@ -140,14 +140,9 @@ SPRACHSHIFT v6.0 — ENTSCHEIDUNGEN STATT IMPLEMENTIERUNGEN:
 Die Roadmap ist KEINE To-do-Liste für Tool-Auswahl und -Nutzung.
 Die Roadmap ist eine Abfolge von bewussten Entscheidungen.
 
-VERBOTENE FORMULIERUNGEN → ERSETZUNGEN:
-❌ "Einführung eines KI-Tools"     → ✅ "Festlegung, welche Aufgaben automatisiert werden"
-❌ "Tool implementieren"           → ✅ "Grenzen des KI-Einsatzes definieren"
-❌ "KI-System einrichten"          → ✅ "Entscheidungsrahmen für KI-Nutzung schaffen"
-❌ "Automatisierung aufsetzen"     → ✅ "Kriterien für Automatisierung festlegen"
-❌ "Workflow digitalisieren"       → ✅ "Abgrenzung zwischen manuell und automatisiert"
-❌ "Software ausrollen"            → ✅ "Standards für den Einsatz etablieren"
-❌ "Integration durchführen"       → ✅ "Schnittstellen-Verantwortlichkeiten klären"
+SPRACHSHIFT (verbindlich):
+Roadmap als Entscheidungskette formulieren, nicht als Implementierungsplan.
+Formulierungen beziehen sich auf Rahmen, Grenzen, Kriterien – nicht auf Produktnamen oder Rollout-Schritte.
 
 TONALITÄT:
 - Entscheidungsorientiert, nicht technisch

--- a/prompts/de/roadmap_90d_decision.md
+++ b/prompts/de/roadmap_90d_decision.md
@@ -79,40 +79,31 @@ INHALTLICHE GRUNDLAGE:
 Verdichte die bestehenden Roadmap-Inhalte. Erfinde nichts Neues.
 Fokus: Was muss entschieden werden, nicht was gemacht werden könnte.
 
-STRUKTUR (exakt einhalten):
+STRUKTUR (exakt einhalten, HTML ONLY):
 
-<div class="roadmap-decision">
-  <p><strong>90-Tage-Umsetzungs-Roadmap – Entscheidungsfassung</strong></p>
+Outer: div.roadmap-decision
 
-  <p><strong>Phase 1 (0–30 Tage): Fundament</strong></p>
-  <ul>
-    <li><strong>Ziel:</strong> [1 Satz, messbar]</li>
-    <li><strong>Umsetzung:</strong> [Max. 2-3 konkrete Schritte]</li>
-    <li><strong>Erfolgskriterium:</strong> [1 klares, prüfbares Kriterium]</li>
-    <li><strong>Stop-Regel:</strong> [Wann wird Phase abgebrochen/pausiert]</li>
-  </ul>
+Titel: p > strong "90-Tage-Umsetzungs-Roadmap – Entscheidungsfassung"
 
-  <p><strong>Phase 2 (31–60 Tage): Pilotierung</strong></p>
-  <ul>
-    <li><strong>Ziel:</strong> [1 Satz, messbar]</li>
-    <li><strong>Umsetzung:</strong> [Max. 2-3 konkrete Schritte]</li>
-    <li><strong>Erfolgskriterium:</strong> [1 klares, prüfbares Kriterium]</li>
-    <li><strong>Stop-Regel:</strong> [Wann wird Phase abgebrochen/pausiert]</li>
-  </ul>
+Dann 3 Phasen-Blöcke:
+- Phase 1 (0–30 Tage): Fundament
+- Phase 2 (31–60 Tage): Pilotierung
+- Phase 3 (61–90 Tage): Entscheidung
 
-  <p><strong>Phase 3 (61–90 Tage): Entscheidung</strong></p>
-  <ul>
-    <li><strong>Ziel:</strong> [1 Satz, messbar]</li>
-    <li><strong>Umsetzung:</strong> [Max. 2-3 konkrete Schritte]</li>
-    <li><strong>Erfolgskriterium:</strong> [1 klares, prüfbares Kriterium]</li>
-    <li><strong>Stop-Regel:</strong> [Wann wird Erweiterung nicht empfohlen]</li>
-  </ul>
-</div>
+Pro Phase:
+- p > strong mit Phasenname
+- ul mit exakt 4 li in dieser Reihenfolge:
+  - Ziel: ein messbarer Satz
+  - Umsetzung: zwei bis drei konkrete Schritte
+  - Erfolgskriterium: ein klares, prüfbares Kriterium
+  - Stop-Regel: wann wird Phase abgebrochen oder pausiert
 
-STOP-REGELN (Beispiele zur Orientierung):
-- "Kein messbarer Zeitgewinn nach 14 Tagen → vereinfachen oder stoppen"
-- "Qualitätsprobleme >20% → zurück zu manueller Prüfung"
-- "Keine Akzeptanz im Alltag → Pilotierung abbrechen"
+Jede Zeile nach dem Label ist ein vollständiger, konkreter Satz. Keine Platzhalter, keine Template-Marker.
+
+STOP-REGELN (Orientierung für konkrete Formulierungen):
+- Bei fehlendem messbarem Zeitgewinn nach zwei Wochen: vereinfachen oder stoppen
+- Bei Qualitätsproblemen über zwanzig Prozent: zurück zu manueller Prüfung
+- Bei fehlender Akzeptanz im Alltag: Pilotierung abbrechen
 
 STIL:
 - Distanziert-professionell

--- a/scripts/prompt_audit_523a.py
+++ b/scripts/prompt_audit_523a.py
@@ -1,0 +1,505 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+FIX-523A: Prompt Hygiene Audit Script
+
+Audits all prompt files for potential issues:
+1. Code fences (``` or ~~~)
+2. Explicit chat phrases
+3. Explicit forbidden token lists (blacklists naming forbidden words)
+4. Placeholder bait ([1 Satz], {variable}, {{token}} in examples)
+5. HTML entity artifacts (&uuml; etc.) and typographic quotes („")
+6. Unresolved/missing template variables
+
+Usage:
+    python scripts/prompt_audit_523a.py [--strict] [--output-json artifacts/prompt_audit_523a.json]
+
+Exit codes:
+    0 - No violations (or --strict not specified)
+    1 - Violations found in strict mode
+"""
+
+import argparse
+import json
+import logging
+import os
+import re
+import sys
+from dataclasses import dataclass, field, asdict
+from pathlib import Path
+from typing import Dict, List, Optional, Set
+
+logging.basicConfig(level=logging.INFO, format='[%(levelname)s] %(message)s')
+log = logging.getLogger(__name__)
+
+# =============================================================================
+# CONFIGURATION
+# =============================================================================
+
+# Directories to scan for prompt files
+PROMPT_DIRS = [
+    "prompts/de",
+    "prompts/en",
+]
+
+# File patterns to audit
+PROMPT_PATTERNS = ["*.md", "*.txt"]
+
+# Allowed template variables (Jinja2 style)
+ALLOWED_VARS = {
+    # Core fields
+    "BRANCHE", "branche", "BRANCHE_LABEL", "BRANCH_CORE_LABEL", "BRANCH_CONTEXT_LABEL",
+    "UNTERNEHMENSGROESSE", "unternehmensgroesse", "UNTERNEHMENSGROESSE_LABEL",
+    "COMPANY_SIZE", "company_size",
+    "BUNDESLAND", "bundesland", "BUNDESLAND_LABEL",
+    "hauptleistung", "HAUPTLEISTUNG", "HAUPTUMSATZTREIBER", "OFFERING_LABEL",
+    # Goldnuggets
+    "ZEITERSPARNIS_PRIORITAET", "ZEITERSPARNIS_PRIORITAET_SAFE",
+    "KI_PROJEKTE", "KI_PROJEKTE_SAFE", "ki_projekte",
+    "KI_GUARDRAILS", "ki_guardrails",
+    "VISION_3_JAHRE", "VISION_3_JAHRE_SAFE", "vision_3_jahre",
+    # Scores
+    "score_security", "score_governance", "score_maturity", "score_readiness",
+    "score_innovation", "score_data_readiness", "score_process_automation",
+    # Dates and meta
+    "TODAY", "heute_iso", "DATE_30D", "report_date", "report_year",
+    "next_year", "next_year_short",
+    # Other common vars
+    "JAHRESUMSATZ_LABEL", "INVESTITIONSBUDGET",
+    "IT_INFRASTRUKTUR_LABEL", "PROZESSE_PAPIERLOS_LABEL",
+    "AUTOMATISIERUNGSGRAD_LABEL", "INTERNE_KI_KOMPETENZEN_LABEL",
+    "ROADMAP_VORHANDEN_LABEL", "GOVERNANCE_RICHTLINIEN_LABEL",
+    "CHANGE_MANAGEMENT_LABEL", "INTERESSE_FOERDERUNG_LABEL",
+    "MARKTPOSITION_LABEL", "BENCHMARK_WETTBEWERB_LABEL",
+    "SELBSTSTAENDIG_LABEL", "ZIELGRUPPEN_LABELS",
+    "KI_ZIELE_LABELS", "KI_HEMMNISSE_LABELS",
+    "ANWENDUNGSFAELLE_LABELS", "DATENQUELLEN_LABELS",
+    "VORHANDENE_TOOLS_LABELS", "REGULIERTE_BRANCHE_LABELS",
+    "TRAININGS_INTERESSEN_LABELS",
+}
+
+# Chat phrases that should not appear in prompts
+CHAT_PHRASES = [
+    r"\bwie kann ich (?:dir|Ihnen) helfen\b",
+    r"\bgern(?:e)? geschehen\b",
+    r"\bnatürlich(?:,| )(?:hier|gerne)\b",
+    r"\bhier (?:sind|ist|haben Sie)\b",
+    r"\bbitte beschreib(?:e|en)\b",
+    r"\bfrag(?:e|en Sie) (?:mich|uns)\b",
+    r"\bkann ich (?:dir|Ihnen) (?:noch|weiter)\b",
+    r"\blass(?:en Sie)? mich wissen\b",
+    r"\bstehe(?:n Sie)? (?:gerne |)zur Verfügung\b",
+    r"\bwenn Sie (?:noch |weitere )?Fragen haben\b",
+    r"\bzögern Sie nicht\b",
+    r"\bich helfe (?:dir|Ihnen) gerne\b",
+]
+
+# Forbidden token blacklist patterns (explicit naming of forbidden words)
+BLACKLIST_PATTERNS = [
+    r"(?:HARD |STRICT )?BLACKLIST[:\s]",
+    r"VERBOTENE?\s+(?:WÖRTER|BEGRIFFE|TOKEN)[:\s]",
+    r"FORBIDDEN\s+(?:WORDS|TOKENS|TERMS)[:\s]",
+    r"(?:NICHT|NEVER)\s+(?:VERWENDEN|USE)[:\s].*(?:Rollout|Stack|Skalierung|Stakeholder|Dashboard|Pipeline|Module)",
+]
+
+# HTML entity patterns that should not appear
+ENTITY_PATTERNS = [
+    r"&uuml;", r"&ouml;", r"&auml;",
+    r"&Uuml;", r"&Ouml;", r"&Auml;",
+    r"&szlig;", r"&amp;(?:uuml|ouml|auml|Uuml|Ouml|Auml|szlig);",
+]
+
+# Typographic quote patterns
+TYPO_QUOTE_PATTERNS = [
+    r"„", r""", r""",  # German quotes
+    r"'", r"'",  # Smart single quotes
+]
+
+
+# =============================================================================
+# DATA CLASSES
+# =============================================================================
+
+@dataclass
+class Violation:
+    """Represents a single audit violation."""
+    category: str
+    line_number: int
+    line_content: str
+    description: str
+
+
+@dataclass
+class FileAuditResult:
+    """Audit result for a single file."""
+    file_path: str
+    violations: List[Violation] = field(default_factory=list)
+    code_fence_count: int = 0
+    chat_phrase_count: int = 0
+    blacklist_count: int = 0
+    placeholder_bait_count: int = 0
+    entity_artifact_count: int = 0
+    typo_quote_count: int = 0
+    unresolved_vars: List[str] = field(default_factory=list)
+
+    @property
+    def total_violations(self) -> int:
+        return len(self.violations)
+
+    @property
+    def is_clean(self) -> bool:
+        return self.total_violations == 0
+
+
+@dataclass
+class AuditSummary:
+    """Summary of the entire audit."""
+    total_files: int = 0
+    clean_files: int = 0
+    files_with_violations: int = 0
+    total_violations: int = 0
+    violations_by_category: Dict[str, int] = field(default_factory=dict)
+    file_results: List[FileAuditResult] = field(default_factory=list)
+
+
+# =============================================================================
+# AUDIT FUNCTIONS
+# =============================================================================
+
+def audit_file(file_path: Path) -> FileAuditResult:
+    """
+    Audit a single prompt file for violations.
+
+    Args:
+        file_path: Path to the prompt file
+
+    Returns:
+        FileAuditResult with all found violations
+    """
+    result = FileAuditResult(file_path=str(file_path))
+
+    try:
+        content = file_path.read_text(encoding='utf-8')
+    except Exception as e:
+        result.violations.append(Violation(
+            category="READ_ERROR",
+            line_number=0,
+            line_content="",
+            description=f"Failed to read file: {e}"
+        ))
+        return result
+
+    lines = content.split('\n')
+
+    for line_num, line in enumerate(lines, start=1):
+        # Skip HTML comments (they're not rendered to LLM)
+        if line.strip().startswith('<!--') or line.strip().startswith('-->'):
+            continue
+        # Check if we're in an HTML comment block
+        # (simplified check - doesn't handle all edge cases)
+
+        # 1. Code fences
+        if re.search(r'^```|^~~~', line.strip()):
+            result.code_fence_count += 1
+            result.violations.append(Violation(
+                category="CODE_FENCE",
+                line_number=line_num,
+                line_content=line[:100],
+                description="Code fence found - may prime LLM to output code blocks"
+            ))
+
+        # 2. Chat phrases
+        for pattern in CHAT_PHRASES:
+            if re.search(pattern, line, re.IGNORECASE):
+                result.chat_phrase_count += 1
+                result.violations.append(Violation(
+                    category="CHAT_PHRASE",
+                    line_number=line_num,
+                    line_content=line[:100],
+                    description=f"Chat phrase pattern found: {pattern}"
+                ))
+                break  # Only count once per line
+
+        # 3. Explicit forbidden token blacklists
+        for pattern in BLACKLIST_PATTERNS:
+            if re.search(pattern, line, re.IGNORECASE):
+                result.blacklist_count += 1
+                result.violations.append(Violation(
+                    category="EXPLICIT_BLACKLIST",
+                    line_number=line_num,
+                    line_content=line[:100],
+                    description="Explicit blacklist naming forbidden words - may prime those words"
+                ))
+                break
+
+        # 4. Placeholder bait (but not in HTML comments)
+        placeholder_patterns = [
+            r'\[1 Satz\]', r'\[Max\. \d', r'\[Bezug zu',
+            r'\{variable\}', r'\{\{token\}\}',
+            r'\[konkret', r'\[hier ', r'\[ein ',
+        ]
+        for pattern in placeholder_patterns:
+            if re.search(pattern, line, re.IGNORECASE):
+                # Skip if in HTML comment
+                if '<!--' in line or '-->' in line:
+                    continue
+                result.placeholder_bait_count += 1
+                result.violations.append(Violation(
+                    category="PLACEHOLDER_BAIT",
+                    line_number=line_num,
+                    line_content=line[:100],
+                    description=f"Placeholder pattern in non-comment: {pattern}"
+                ))
+                break
+
+        # 5. HTML entity artifacts
+        for pattern in ENTITY_PATTERNS:
+            if re.search(pattern, line):
+                result.entity_artifact_count += 1
+                result.violations.append(Violation(
+                    category="HTML_ENTITY",
+                    line_number=line_num,
+                    line_content=line[:100],
+                    description=f"HTML entity artifact: {pattern}"
+                ))
+                break
+
+        # 6. Typographic quotes
+        for pattern in TYPO_QUOTE_PATTERNS:
+            if pattern in line:
+                # Skip in HTML comments
+                if '<!--' in line or '-->' in line:
+                    continue
+                result.typo_quote_count += 1
+                result.violations.append(Violation(
+                    category="TYPO_QUOTE",
+                    line_number=line_num,
+                    line_content=line[:100],
+                    description=f"Typographic quote found: {pattern}"
+                ))
+                break
+
+    # 7. Check for unresolved template variables
+    all_vars = set(re.findall(r'\{\{(\w+)\}\}', content))
+    unresolved = all_vars - ALLOWED_VARS
+    if unresolved:
+        result.unresolved_vars = list(unresolved)
+        # Don't add as violations - just informational
+
+    return result
+
+
+def run_audit(prompt_dirs: List[str], strict: bool = False) -> AuditSummary:
+    """
+    Run the full audit across all prompt directories.
+
+    Args:
+        prompt_dirs: List of directories to scan
+        strict: If True, code_fence in examples (not output sections) is not a violation
+
+    Returns:
+        AuditSummary with all results
+    """
+    summary = AuditSummary()
+
+    for prompt_dir in prompt_dirs:
+        dir_path = Path(prompt_dir)
+        if not dir_path.exists():
+            log.warning(f"Prompt directory not found: {prompt_dir}")
+            continue
+
+        for pattern in PROMPT_PATTERNS:
+            for file_path in dir_path.glob(pattern):
+                result = audit_file(file_path)
+                summary.file_results.append(result)
+                summary.total_files += 1
+
+                if result.is_clean:
+                    summary.clean_files += 1
+                else:
+                    summary.files_with_violations += 1
+                    summary.total_violations += result.total_violations
+
+                    # Count by category
+                    for v in result.violations:
+                        summary.violations_by_category[v.category] = \
+                            summary.violations_by_category.get(v.category, 0) + 1
+
+    return summary
+
+
+def generate_markdown_report(summary: AuditSummary) -> str:
+    """Generate a Markdown report from the audit summary."""
+    lines = [
+        "# FIX-523A Prompt Audit Report",
+        "",
+        "## Summary",
+        "",
+        f"- **Total files scanned:** {summary.total_files}",
+        f"- **Clean files:** {summary.clean_files}",
+        f"- **Files with violations:** {summary.files_with_violations}",
+        f"- **Total violations:** {summary.total_violations}",
+        "",
+    ]
+
+    if summary.violations_by_category:
+        lines.append("### Violations by Category")
+        lines.append("")
+        for cat, count in sorted(summary.violations_by_category.items()):
+            lines.append(f"- **{cat}:** {count}")
+        lines.append("")
+
+    if summary.files_with_violations > 0:
+        lines.append("## Files with Violations")
+        lines.append("")
+
+        for result in summary.file_results:
+            if not result.is_clean:
+                lines.append(f"### {result.file_path}")
+                lines.append("")
+                lines.append(f"**Violations:** {result.total_violations}")
+                lines.append("")
+
+                for v in result.violations:
+                    lines.append(f"- **Line {v.line_number}** [{v.category}]: {v.description}")
+                    lines.append(f"  ```")
+                    lines.append(f"  {v.line_content}")
+                    lines.append(f"  ```")
+                lines.append("")
+
+                if result.unresolved_vars:
+                    lines.append(f"**Unresolved variables:** {', '.join(result.unresolved_vars)}")
+                    lines.append("")
+
+    lines.append("## Fix Hints")
+    lines.append("")
+    lines.append("- **CODE_FENCE:** Remove code fences from prompt output examples; describe structure in prose")
+    lines.append("- **CHAT_PHRASE:** Remove conversational language from prompts")
+    lines.append("- **EXPLICIT_BLACKLIST:** Replace explicit forbidden-word lists with general rules")
+    lines.append("- **PLACEHOLDER_BAIT:** Replace [placeholder] patterns with concrete descriptions")
+    lines.append("- **HTML_ENTITY:** Replace &uuml; etc. with actual UTF-8 characters (ü)")
+    lines.append("- **TYPO_QUOTE:** Replace „ " " with ASCII quotes (\")")
+    lines.append("")
+
+    return "\n".join(lines)
+
+
+def generate_json_report(summary: AuditSummary) -> dict:
+    """Generate a JSON-serializable report from the audit summary."""
+    return {
+        "summary": {
+            "total_files": summary.total_files,
+            "clean_files": summary.clean_files,
+            "files_with_violations": summary.files_with_violations,
+            "total_violations": summary.total_violations,
+            "violations_by_category": summary.violations_by_category,
+        },
+        "files": [
+            {
+                "path": r.file_path,
+                "violations": [asdict(v) for v in r.violations],
+                "counts": {
+                    "code_fence": r.code_fence_count,
+                    "chat_phrase": r.chat_phrase_count,
+                    "blacklist": r.blacklist_count,
+                    "placeholder_bait": r.placeholder_bait_count,
+                    "entity_artifact": r.entity_artifact_count,
+                    "typo_quote": r.typo_quote_count,
+                },
+                "unresolved_vars": r.unresolved_vars,
+            }
+            for r in summary.file_results
+        ]
+    }
+
+
+# =============================================================================
+# MAIN
+# =============================================================================
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="FIX-523A: Prompt Hygiene Audit"
+    )
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="Exit with code 1 if any violations found"
+    )
+    parser.add_argument(
+        "--output-json",
+        type=str,
+        default="artifacts/prompt_audit_523a.json",
+        help="Path to output JSON report"
+    )
+    parser.add_argument(
+        "--output-md",
+        type=str,
+        default="docs/PROMPT_AUDIT_523A.md",
+        help="Path to output Markdown report"
+    )
+    parser.add_argument(
+        "--json-only",
+        action="store_true",
+        help="Output JSON summary to stdout only (for preflight checks)"
+    )
+    args = parser.parse_args()
+
+    log.info("[FIX-523A] Starting prompt hygiene audit...")
+
+    # Run audit
+    summary = run_audit(PROMPT_DIRS, strict=args.strict)
+
+    # JSON-only mode for preflight checks
+    if args.json_only:
+        compact_summary = {
+            "total_files": summary.total_files,
+            "total_violations": summary.total_violations,
+            "by_type": summary.violations_by_category,
+            "status": "FAIL" if summary.total_violations > 0 else "PASS"
+        }
+        print(json.dumps(compact_summary))
+        sys.exit(1 if summary.total_violations > 0 else 0)
+
+    # Generate reports
+    md_report = generate_markdown_report(summary)
+    json_report = generate_json_report(summary)
+
+    # Write reports
+    Path(args.output_md).parent.mkdir(parents=True, exist_ok=True)
+    Path(args.output_md).write_text(md_report, encoding='utf-8')
+    log.info(f"[FIX-523A] Markdown report written to: {args.output_md}")
+
+    Path(args.output_json).parent.mkdir(parents=True, exist_ok=True)
+    Path(args.output_json).write_text(
+        json.dumps(json_report, indent=2, ensure_ascii=False),
+        encoding='utf-8'
+    )
+    log.info(f"[FIX-523A] JSON report written to: {args.output_json}")
+
+    # Print summary
+    print("\n" + "=" * 60)
+    print("FIX-523A PROMPT AUDIT SUMMARY")
+    print("=" * 60)
+    print(f"Total files:          {summary.total_files}")
+    print(f"Clean files:          {summary.clean_files}")
+    print(f"Files with issues:    {summary.files_with_violations}")
+    print(f"Total violations:     {summary.total_violations}")
+    print("=" * 60)
+
+    if summary.violations_by_category:
+        print("\nViolations by category:")
+        for cat, count in sorted(summary.violations_by_category.items()):
+            print(f"  {cat}: {count}")
+
+    # Exit code
+    if args.strict and summary.total_violations > 0:
+        log.error(f"[FIX-523A] STRICT MODE: {summary.total_violations} violations found - FAIL")
+        sys.exit(1)
+    else:
+        log.info("[FIX-523A] Audit complete")
+        sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run_release_e2e_check.py
+++ b/scripts/run_release_e2e_check.py
@@ -276,6 +276,79 @@ def submit_profile_to_api(profile_data: Dict, base_url: str) -> Dict[str, Any]:
 
 
 # =============================================================================
+# FIX-523A: PROMPT HYGIENE PREFLIGHT CHECK
+# =============================================================================
+
+def run_prompt_hygiene_preflight() -> tuple[bool, str]:
+    """
+    FIX-523A: Run prompt audit as preflight check before E2E tests.
+
+    Returns:
+        Tuple of (passed, message)
+    """
+    log.info("-" * 78)
+    log.info("FIX-523A: PROMPT HYGIENE PREFLIGHT CHECK")
+    log.info("-" * 78)
+
+    try:
+        # Import the audit module
+        audit_script = PROJECT_ROOT / "scripts" / "prompt_audit_523a.py"
+        if not audit_script.exists():
+            return True, "Audit script not found, skipping preflight"
+
+        # Run audit
+        import subprocess
+        result = subprocess.run(
+            [sys.executable, str(audit_script), "--json-only"],
+            capture_output=True,
+            text=True,
+            cwd=str(PROJECT_ROOT),
+            timeout=60,
+        )
+
+        # Check for critical violations in output
+        if result.returncode != 0:
+            # Parse JSON output to count violations
+            try:
+                output_lines = result.stdout.strip().split('\n')
+                for line in output_lines:
+                    if line.startswith('{'):
+                        data = json.loads(line)
+                        total = data.get("total_violations", 0)
+                        critical_types = ["CODE_FENCE", "CHAT_PHRASE", "EXPLICIT_BLACKLIST"]
+                        critical_count = sum(
+                            data.get("by_type", {}).get(t, 0)
+                            for t in critical_types
+                        )
+                        if critical_count > 0:
+                            msg = f"FAIL: {critical_count} critical violations (CODE_FENCE/CHAT_PHRASE/BLACKLIST)"
+                            log.error(f"[FIX-523A] {msg}")
+                            return False, msg
+                        else:
+                            msg = f"PASS: {total} violations (none critical)"
+                            log.info(f"[FIX-523A] {msg}")
+                            return True, msg
+            except json.JSONDecodeError:
+                pass
+
+            msg = f"WARN: Audit returned exit code {result.returncode}"
+            log.warning(f"[FIX-523A] {msg}")
+            return True, msg  # Non-critical, continue
+
+        log.info("[FIX-523A] PASS: No critical prompt violations")
+        return True, "PASS: No critical prompt violations"
+
+    except subprocess.TimeoutExpired:
+        msg = "WARN: Audit timed out, skipping"
+        log.warning(f"[FIX-523A] {msg}")
+        return True, msg
+    except Exception as e:
+        msg = f"WARN: Audit error: {str(e)[:100]}"
+        log.warning(f"[FIX-523A] {msg}")
+        return True, msg  # Non-critical error, continue
+
+
+# =============================================================================
 # VALIDATION LOGIC
 # =============================================================================
 
@@ -390,6 +463,7 @@ def validate_profile(
 def run_e2e_tests(
     base_url: Optional[str] = None,
     mock_mode: bool = True,
+    skip_prompt_preflight: bool = False,
 ) -> E2ETestSuite:
     """
     Run E2E tests for all gold profiles.
@@ -397,6 +471,7 @@ def run_e2e_tests(
     Args:
         base_url: API base URL (required for live mode)
         mock_mode: If True, use mock responses instead of live API
+        skip_prompt_preflight: If True, skip prompt hygiene preflight check
 
     Returns:
         E2ETestSuite with all results
@@ -411,6 +486,18 @@ def run_e2e_tests(
     if base_url:
         log.info(f"Base URL: {base_url}")
     log.info("")
+
+    # FIX-523A: Run prompt hygiene preflight check
+    if not skip_prompt_preflight:
+        preflight_passed, preflight_msg = run_prompt_hygiene_preflight()
+        if not preflight_passed:
+            # Create a synthetic failed result for the preflight
+            preflight_result = ProfileTestResult(profile_id="prompt_hygiene_preflight")
+            preflight_result.add_fail(preflight_msg)
+            preflight_result.finalize()
+            suite.add_result(preflight_result)
+            # Continue with tests but suite will show FAIL
+        log.info("")
 
     for profile_config in GOLD_PROFILES:
         profile_id = str(profile_config["id"])
@@ -510,6 +597,11 @@ def main():
         action="store_true",
         help="Use live API mode",
     )
+    parser.add_argument(
+        "--skip-prompt-preflight",
+        action="store_true",
+        help="FIX-523A: Skip prompt hygiene preflight check",
+    )
     args = parser.parse_args()
 
     mock_mode = not args.live
@@ -517,6 +609,7 @@ def main():
     suite = run_e2e_tests(
         base_url=args.base_url,
         mock_mode=mock_mode,
+        skip_prompt_preflight=args.skip_prompt_preflight,
     )
 
     # Exit code based on result

--- a/services/html_contract.py
+++ b/services/html_contract.py
@@ -778,6 +778,81 @@ def strip_code_fences_final(html: str) -> str:
     return result
 
 
+def normalize_typos_and_entities(html: str) -> str:
+    """
+    FIX-523A: Normalize HTML entities and typographic quotes.
+
+    This function normalizes:
+    1. HTML entities: &nbsp; → space, &uuml; → ü, &ouml; → ö, etc.
+    2. Typographic quotes: „" → " (straight double quotes)
+    3. Typographic single quotes: '' → ' (straight single quotes)
+
+    Args:
+        html: Raw HTML string
+
+    Returns:
+        Normalized HTML string
+
+    Note:
+        Call this BEFORE final validation to ensure clean output.
+    """
+    if not html:
+        return html
+
+    result = html
+
+    # 1. Common HTML entities → Unicode
+    entity_map = {
+        "&nbsp;": " ",
+        "&amp;": "&",
+        "&lt;": "<",
+        "&gt;": ">",
+        "&quot;": '"',
+        "&apos;": "'",
+        # German umlauts
+        "&auml;": "ä",
+        "&ouml;": "ö",
+        "&uuml;": "ü",
+        "&Auml;": "Ä",
+        "&Ouml;": "Ö",
+        "&Uuml;": "Ü",
+        "&szlig;": "ß",
+        # Common punctuation
+        "&ndash;": "–",
+        "&mdash;": "—",
+        "&hellip;": "…",
+        "&euro;": "€",
+        "&copy;": "©",
+        "&reg;": "®",
+        "&trade;": "™",
+    }
+
+    for entity, char in entity_map.items():
+        result = result.replace(entity, char)
+
+    # 2. Typographic double quotes → straight
+    # German opening „ (U+201E) and closing " (U+201C)
+    result = result.replace("„", '"')
+    result = result.replace(""", '"')
+    result = result.replace(""", '"')  # U+201D closing quote
+
+    # 3. Typographic single quotes → straight
+    result = result.replace("'", "'")  # U+2018 left single
+    result = result.replace("'", "'")  # U+2019 right single
+    result = result.replace("‚", "'")  # U+201A single low-9
+
+    # 4. Numeric HTML entities (common ones)
+    # &#160; = non-breaking space
+    result = re.sub(r'&#160;', ' ', result)
+    # &#8211; = en-dash
+    result = re.sub(r'&#8211;', '–', result)
+    # &#8212; = em-dash
+    result = re.sub(r'&#8212;', '—', result)
+
+    log.debug("[FIX-523A][HTML-CONTRACT] normalize_typos_and_entities applied")
+    return result
+
+
 def validate_quick_wins_rendered(html: str) -> bool:
     """
     Check if QuickWins section is properly rendered.


### PR DESCRIPTION
… typo/entity normalizer

FIX-523A Prompt Hygiene implementation:

TASK 1: Prompt audit script
- Add scripts/prompt_audit_523a.py with 6 check categories: CODE_FENCE, CHAT_PHRASE, EXPLICIT_BLACKLIST, PLACEHOLDER_BAIT, HTML_ENTITY, TYPO_QUOTE
- Add --json-only flag for preflight integration
- Generate docs/PROMPT_AUDIT_523A.md report

TASK 2: De-prime high-impact prompts
- executive_decision.md: Replace HTML code block with prose description
- roadmap_90d_decision.md: Replace STRUKTUR block with prose
- roadmap_90d.md: Replace VERBOTENE FORMULIERUNGEN block with SPRACHSHIFT prose
- roadmap_12m.md: Replace VERBOTENE FORMULIERUNGEN block with SPRACHSHIFT prose

TASK 3: Typo/entity normalizer
- Add normalize_typos_and_entities() to services/html_contract.py
- Handles HTML entities (&uuml; → ü) and typographic quotes („ → ")

TASK 4: Preflight integration
- Add prompt hygiene preflight check to run_release_e2e_check.py
- Add --skip-prompt-preflight CLI flag
- Fails on critical violations (CODE_FENCE, CHAT_PHRASE, BLACKLIST)