### PR TITLE
feat(FIX-526): STRICT Grade-A (warnings_total=0) implementation

### DIFF
--- a/services/content_quality_enforcer.py
+++ b/services/content_quality_enforcer.py
@@ -70,10 +70,16 @@ SOLO_TERM_REPLACEMENTS = [
 
     # Deployment/Rollout terms
     (r'\bDeployment\b', 'Einrichtung', 'Deployment→Einrichtung'),
-    (r'\bRollout\b', 'Einführung', 'Rollout→Einführung'),
-    (r'\bRoll-out\b', 'Einführung', 'Roll-out→Einführung'),
+    # FIX-526: Rollout → REMOVE entirely (not replace) per user feedback
+    (r'\bRollout\b', '', 'FIX-526: Rollout→ENTFERNEN'),
+    (r'\bRoll-out\b', '', 'FIX-526: Roll-out→ENTFERNEN'),
+    (r'\bRollouts\b', '', 'FIX-526: Rollouts→ENTFERNEN'),
     (r'\bImplementierung\b', 'Umsetzung', 'Implementierung→Umsetzung'),
     (r'\bIntegration\b', 'Einbindung', 'Integration→Einbindung'),
+
+    # FIX-526: Baukasten → Vorlagenpaket (forbidden for solo per user feedback)
+    (r'\bBaukästen\b', 'Vorlagenpakete', 'FIX-526: Baukästen→Vorlagenpakete'),
+    (r'\bBaukasten\b', 'Vorlagenpaket', 'FIX-526: Baukasten→Vorlagenpaket'),
 
     # Scaling terms
     (r'\bSkalierung\b', 'Ausbau', 'Skalierung→Ausbau'),
@@ -341,6 +347,7 @@ def apply_solo_language_normalizer(sections: dict, company_size: str) -> dict:
     sections_touched = 0
 
     # Sections to process - Fix-Batch C3: Expanded list to cover all content sections
+    # FIX-526: Added NEXT_ACTIONS_HTML, PILOT_PLAN_HTML
     check_sections = [
         "EXECUTIVE_SUMMARY_HTML", "EXECUTIVE_DECISION_HTML", "RECOMMENDATIONS_HTML",
         "QUICK_WINS_HTML", "QUICK_WINS_HTML_LEFT", "QUICK_WINS_HTML_RIGHT",
@@ -353,6 +360,7 @@ def apply_solo_language_normalizer(sections: dict, company_size: str) -> dict:
         "BRANCH_DEEP_DIVE_HTML", "TOP_3_MASSNAHMEN_HTML", "MONETARISIERUNG_HTML",
         "TEMPLATES_START_HTML", "KICKOFF_VORLAGE_HTML", "PROMPT_FRAMEWORK_HTML",
         "TECHNOLOGIE_PROZESSE_HTML", "WETTBEWERB_BENCHMARK_HTML", "UNTERNEHMENSPROFIL_MARKT_HTML",
+        "NEXT_ACTIONS_HTML", "PILOT_PLAN_HTML",
     ]
 
     for section_key in check_sections:
@@ -370,6 +378,9 @@ def apply_solo_language_normalizer(sections: dict, company_size: str) -> dict:
                 section_replacements += matches
 
         if section_replacements > 0:
+            # FIX-526: Clean up double-spaces from removals (e.g., "Rollout" → "")
+            modified_content = re.sub(r'\s{2,}', ' ', modified_content)
+            modified_content = re.sub(r'\s+([.,;:!?])', r'\1', modified_content)  # Fix space before punctuation
             sections[section_key] = modified_content
             sections_touched += 1
             total_replacements += section_replacements
@@ -390,6 +401,78 @@ def apply_solo_language_normalizer(sections: dict, company_size: str) -> dict:
             raise RuntimeError(f"[FIX-52x][SOLO-LEAK] forbidden terms remain after rewrite: {still}")
 
     return sections
+
+
+def apply_solo_language_to_briefing(briefing: dict, company_size: str) -> dict:
+    """
+    FIX-526 P2: Early-stage SOLO scrubbing for user free-text fields.
+
+    Applies SOLO_TERM_REPLACEMENTS to user-provided briefing fields BEFORE
+    they are used in prompts. This prevents forbidden terms from being
+    "baked into" the LLM context.
+
+    Target fields:
+    - vision_3_jahre
+    - hauptleistung
+    - strategische_ziele
+    - ki_vision
+    - herausforderungen
+    - stärken
+    - etc.
+
+    Args:
+        briefing: Dict with user-provided briefing data
+        company_size: Company size ("solo", "team", "kmu")
+
+    Returns:
+        Sanitized briefing dict
+    """
+    if not company_size or company_size.lower() != "solo":
+        return briefing
+
+    if not briefing:
+        return briefing
+
+    # Fields to scrub early
+    early_scrub_fields = [
+        "vision_3_jahre", "hauptleistung", "strategische_ziele",
+        "ki_vision", "herausforderungen", "stärken", "schwächen",
+        "zielgruppe", "wettbewerber", "usp", "geschäftsmodell",
+        "ki_erfahrung", "bisherige_ki_nutzung", "freitext_notizen",
+        "branche_beschreibung", "angebot_beschreibung",
+    ]
+
+    total_replacements = 0
+    result = dict(briefing)
+
+    for field in early_scrub_fields:
+        value = result.get(field)
+        if not value or not isinstance(value, str):
+            continue
+
+        modified = value
+        field_replacements = 0
+
+        for pattern, replacement, desc in SOLO_TERM_REPLACEMENTS:
+            matches = len(re.findall(pattern, modified, re.IGNORECASE))
+            if matches > 0:
+                modified = re.sub(pattern, replacement, modified, flags=re.IGNORECASE)
+                field_replacements += matches
+
+        if field_replacements > 0:
+            # Clean up double-spaces from removals
+            modified = re.sub(r'\s{2,}', ' ', modified)
+            modified = re.sub(r'\s+([.,;:!?])', r'\1', modified)
+            result[field] = modified
+            total_replacements += field_replacements
+
+    if total_replacements > 0:
+        log.info(
+            "[FIX-526][SOLO-BRIEFING] early_scrub: %d replacements in briefing fields",
+            total_replacements
+        )
+
+    return result
 
 
 # =============================================================================

--- a/services/report_validator.py
+++ b/services/report_validator.py
@@ -760,11 +760,79 @@ class ReportValidator:
     SMART_MODE_ENABLED = True  # Enable warning de-duplication and bundling
     MAX_WARNINGS_PER_CATEGORY = 3  # Max warnings shown per category before bundling
 
+    # FIX-526: Shadow/Raw section keys that should be excluded when HTML version exists
+    # These are lowercase/raw keys that duplicate the canonical *_HTML versions
+    SHADOW_KEY_TO_HTML_MAP: Dict[str, str] = {
+        "quick_wins": "QUICK_WINS_HTML",
+        "business_case": "BUSINESS_CASE_HTML",
+        "risks": "RISKS_HTML",
+        "executive_summary": "EXECUTIVE_SUMMARY_HTML",
+        "recommendations": "RECOMMENDATIONS_HTML",
+        "roadmap_90d": "ROADMAP_90D_HTML",
+        "roadmap_12m": "ROADMAP_12M_HTML",
+        "gamechanger": "GAMECHANGER_HTML",
+        "tools_empfehlungen": "TOOLS_EMPFEHLUNGEN_HTML",
+        "next_actions": "NEXT_ACTIONS_HTML",
+        "ki_stack_summary": "KI_STACK_SUMMARY_HTML",
+        "pilot_plan": "PILOT_PLAN_HTML",
+    }
+
     def __init__(self, sections: Dict[str, Any], meta: Dict[str, Any]) -> None:
         self.sections = sections or {}
         self.meta = meta or {}
         self.errors: List[ValidationError] = []
         self.company_size: str = self.meta.get("unternehmensgroesse", "unbekannt")
+        # FIX-526: Build canonical view excluding shadow sections
+        self._canonical_sections: Optional[Dict[str, Any]] = None
+        self._excluded_shadow_keys: Optional[set] = None
+
+    def _build_canonical_view(self) -> Tuple[Dict[str, Any], set]:
+        """
+        FIX-526: Build canonical view of sections for validation.
+
+        When both a shadow/raw key (e.g., 'risks') and its HTML version
+        (e.g., 'RISKS_HTML') exist, only the HTML version is canonical.
+
+        This prevents false-positive REDUNDANCY_DETECTED and SECTION_TOO_SHORT
+        warnings for shadow/raw duplicates.
+
+        Returns:
+            Tuple of (canonical_sections_dict, excluded_shadow_keys_set)
+        """
+        canonical = {}
+        excluded = set()
+
+        for key, value in self.sections.items():
+            # Check if this is a shadow key with existing HTML version
+            html_key = self.SHADOW_KEY_TO_HTML_MAP.get(key)
+            if html_key and html_key in self.sections:
+                # HTML version exists → exclude this shadow key
+                excluded.add(key)
+                continue
+            canonical[key] = value
+
+        if excluded:
+            log.info(
+                "[VALIDATOR][FIX-526] canonical_keys=%d excluded_shadow=%s",
+                len(canonical),
+                sorted(excluded)
+            )
+
+        return canonical, excluded
+
+    @property
+    def canonical_sections(self) -> Dict[str, Any]:
+        """FIX-526: Get canonical sections view (excludes shadow/raw duplicates)."""
+        if self._canonical_sections is None:
+            self._canonical_sections, self._excluded_shadow_keys = self._build_canonical_view()
+        return self._canonical_sections
+
+    @property
+    def excluded_shadow_keys(self) -> set:
+        """FIX-526: Get set of excluded shadow keys."""
+        if self._excluded_shadow_keys is None:
+            self._canonical_sections, self._excluded_shadow_keys = self._build_canonical_view()
+        return self._excluded_shadow_keys
 
     # ------------------------------------------------------------------
     # SPRINT G14-C: Smart Mode - Warning De-Duplication & Bundling
@@ -1130,7 +1198,8 @@ class ReportValidator:
                 )
 
     def _check_template_phrases(self) -> None:
-        for section_name, content in self.sections.items():
+        # FIX-526: Use canonical_sections to avoid duplicate warnings for shadow keys
+        for section_name, content in self.canonical_sections.items():
             if not isinstance(content, str):
                 continue
             for phrase in self.TEMPLATE_PHRASES:
@@ -1262,7 +1331,8 @@ class ReportValidator:
         if not forbidden_terms:
             return
 
-        for section_name, content in self.sections.items():
+        # FIX-526: Use canonical_sections to avoid duplicate warnings for shadow keys
+        for section_name, content in self.canonical_sections.items():
             if not isinstance(content, str):
                 continue
             for term in forbidden_terms:
@@ -1746,7 +1816,8 @@ class ReportValidator:
         # Collect all sentences from all sections
         sentence_occurrences: Dict[str, List[str]] = {}  # normalized → list of sections
 
-        for section_name, content in self.sections.items():
+        # FIX-526: Use canonical_sections to avoid false-positive redundancy from shadow keys
+        for section_name, content in self.canonical_sections.items():
             if not isinstance(content, str) or not content:
                 continue
 

--- a/services/zero_leak_engine.py
+++ b/services/zero_leak_engine.py
@@ -219,11 +219,43 @@ def _strip_prompt_echo_prefix(text: str, phrases: List[str]) -> tuple:
     return text, removed
 
 
+# =============================================================================
+# FIX-526 P3: DETERMINISTIC PRESCRUB PHRASES
+# =============================================================================
+# These phrases are deterministically scrubbed BEFORE the critical scan.
+# They are template/prompt leaks that should be cleaned without triggering FAIL-CLOSED.
+# This prevents unnecessary regeneration cycles for recoverable template artifacts.
+DETERMINISTIC_PRESCRUB_PHRASES: List[str] = [
+    # Template prompt echoes
+    "bitte beschreibe kurz",
+    "bitte beschreiben sie kurz",
+    "Bitte beschreibe kurz",
+    "Bitte beschreiben Sie kurz",
+    "bitte beschreib kurz",
+    # Context requests that slip through
+    "beschreibe kurz dein anliegen",
+    "beschreiben sie kurz ihr anliegen",
+    # Template markers
+    "Beispiel-Workflow",
+    "Beispiel-Ablauf",
+    "Platzhalter",
+    # Chat introduction artifacts
+    "Hier ist",
+    "Natürlich,",
+    "Natürlich!",
+    "Selbstverständlich,",
+    "Selbstverständlich!",
+    "Gerne!",
+    "Gerne,",
+]
+
+
 # Fix-Batch A3: EXECUTIVE_CRITICAL_PHRASES
 # =============================================================================
 # These phrases are CRITICAL (fail-closed) ONLY when found in EXECUTIVE_SECTIONS.
 # They are chat/assistant artifacts that should NEVER appear in executive summaries.
 # In other sections, they remain BENIGN (clean-and-keep).
+# FIX-526: "bitte beschreibe kurz" moved to DETERMINISTIC_PRESCRUB_PHRASES (scrub before fail-closed)
 EXECUTIVE_CRITICAL_PHRASES: List[str] = [
     # KI-Assistenz Identifikation
     "ich bin ein KI-Assistent",
@@ -241,9 +273,7 @@ EXECUTIVE_CRITICAL_PHRASES: List[str] = [
     "wobei kann ich helfen",
     "wobei ich dir helfen",
     "wobei ich Ihnen helfen",
-    # Meta-Kommentare
-    "bitte beschreibe kurz",
-    "bitte beschreiben sie kurz",
+    # Meta-Kommentare (FIX-526: "bitte beschreibe kurz" moved to prescrub)
     "ich sehe keine konkrete frage",
     "ich sehe keine konkrete aufgabe",
     "ich sehe keine frage",
@@ -350,7 +380,32 @@ def apply_blacklist_classified(text: str, section_name: str = "") -> BlacklistRe
 
     critical_hits: List[str] = []
     benign_hits: List[str] = []
+    prescrub_count: int = 0
     cleaned = text
+
+    # FIX-526 P3: Deterministic prescrub - remove template phrases BEFORE critical scan
+    # This prevents FAIL-CLOSED for recoverable template artifacts
+    for phrase in DETERMINISTIC_PRESCRUB_PHRASES:
+        pattern = re.compile(re.escape(phrase), re.IGNORECASE)
+        matches = pattern.findall(cleaned)
+        if matches:
+            cleaned = pattern.sub("", cleaned)
+            prescrub_count += len(matches)
+            log.debug(
+                '[zero-leak-prescrub] phrase="%s" hits=%d section=%s (no fail-closed)',
+                phrase[:30],
+                len(matches),
+                section_name or "unknown"
+            )
+
+    if prescrub_count > 0:
+        # Clean up double spaces from removals
+        cleaned = re.sub(r'\s{2,}', ' ', cleaned)
+        log.info(
+            "[FIX-526][PRESCRUB] Removed %d template phrases from %s (no fail-closed triggered)",
+            prescrub_count,
+            section_name or "unknown"
+        )
 
     # Check CRITICAL string patterns first
     for phrase in CRITICAL_LEAK_PATTERNS:

--- a/tests/test_fix497_quality_gates.py
+++ b/tests/test_fix497_quality_gates.py
@@ -115,15 +115,17 @@ class TestSoloTermReplacements:
         assert 'Bausteine' in result['EXECUTIVE_SUMMARY_HTML']
         assert 'Module' not in result['EXECUTIVE_SUMMARY_HTML']
 
-    def test_rollout_replacement(self):
-        """Test Rollout -> Einführung replacement."""
+    def test_rollout_removal(self):
+        """Test Rollout is REMOVED (FIX-526: not replaced, removed entirely)."""
         from services.content_quality_enforcer import apply_solo_language_normalizer
 
         sections = {'EXECUTIVE_SUMMARY_HTML': 'Der Rollout erfolgt schrittweise.'}
         result = apply_solo_language_normalizer(sections, 'solo')
 
-        assert 'Einführung' in result['EXECUTIVE_SUMMARY_HTML']
+        # FIX-526: Rollout is removed entirely, not replaced with Einführung
         assert 'Rollout' not in result['EXECUTIVE_SUMMARY_HTML']
+        # Should not have double spaces after removal
+        assert '  ' not in result['EXECUTIVE_SUMMARY_HTML']
 
     def test_skalierung_replacement(self):
         """Test Skalierung -> Ausbau replacement."""

--- a/tests/test_fix504_kpi_lock_solo_scale.py
+++ b/tests/test_fix504_kpi_lock_solo_scale.py
@@ -200,15 +200,17 @@ class TestTask3SoloTermReplacements:
         result = apply_solo_language_normalizer(sections.copy(), "")
         assert "Skalierung" in result["EXECUTIVE_SUMMARY_HTML"]
 
-    def test_rollout_replacement(self):
-        """Test 'Rollout' -> 'Einführung'."""
+    def test_rollout_removal(self):
+        """Test 'Rollout' is REMOVED (FIX-526: not replaced, removed entirely)."""
         from services.content_quality_enforcer import apply_solo_language_normalizer
 
         sections = {"ROADMAP_90D_HTML": "Der Rollout startet in Q1."}
         result = apply_solo_language_normalizer(sections, "solo")
 
-        assert "Einführung" in result["ROADMAP_90D_HTML"]
+        # FIX-526: Rollout is removed entirely, not replaced with Einführung
         assert "Rollout" not in result["ROADMAP_90D_HTML"]
+        # Should not have double spaces after removal
+        assert "  " not in result["ROADMAP_90D_HTML"]
 
 
 class TestTask4QuickWinsFullWidthLayout:
@@ -411,7 +413,9 @@ class TestIntegration:
         # FIX-509-A: Now uses "Mandate" instead of "Mandanten"
         assert "Mandate" in content
         assert "Baustein" in content or "Technikpaket" in content
-        assert "Einführung" in content
+        # FIX-526: Rollout is REMOVED (not replaced with Einführung)
+        # No double spaces after removal
+        assert "  " not in content
 
 
 class TestEdgeCases:

--- a/tests/test_fix526_strict_grade_a.py
+++ b/tests/test_fix526_strict_grade_a.py
@@ -1,0 +1,266 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+FIX-526 Tests: STRICT Grade-A (warnings_total=0)
+
+Tests for:
+P1: Validator canonical_view (excludes shadow sections)
+P2: SOLO-Language scrubbing (Baukasten, Rollout removal)
+P3: Template/Prompt leaks deterministic prescrub
+P4: ROI filter for recommendations
+"""
+
+import unittest
+import re
+
+
+class TestP1ValidatorCanonicalView(unittest.TestCase):
+    """Test P1: Validator uses canonical_view to avoid shadow section warnings."""
+
+    def test_canonical_view_excludes_shadow_sections(self):
+        """Test that shadow sections are excluded when HTML version exists."""
+        from services.report_validator import ReportValidator
+
+        sections = {
+            "risks": "<p>Short risks content</p>",
+            "RISKS_HTML": "<section class='risks'><h2>Risks</h2><p>This is the canonical risks content with enough words to pass validation. " * 10 + "</p></section>",
+            "quick_wins": "<p>Short quick wins</p>",
+            "QUICK_WINS_HTML": "<section class='quick-wins'><h2>Quick Wins</h2><p>Canonical quick wins with sufficient content. " * 10 + "</p></section>",
+        }
+
+        validator = ReportValidator(sections, {"unternehmensgroesse": "solo"})
+
+        # Check canonical_sections excludes shadow keys
+        canonical = validator.canonical_sections
+        self.assertNotIn("risks", canonical)
+        self.assertNotIn("quick_wins", canonical)
+        self.assertIn("RISKS_HTML", canonical)
+        self.assertIn("QUICK_WINS_HTML", canonical)
+
+    def test_canonical_view_includes_keys_without_html_version(self):
+        """Test that keys without HTML versions are included."""
+        from services.report_validator import ReportValidator
+
+        sections = {
+            "roadmap_90d": "<p>Roadmap content</p>",
+            "custom_section": "<p>Custom content</p>",
+        }
+
+        validator = ReportValidator(sections, {"unternehmensgroesse": "team"})
+        canonical = validator.canonical_sections
+
+        self.assertIn("roadmap_90d", canonical)
+        self.assertIn("custom_section", canonical)
+
+    def test_excluded_shadow_keys_logged(self):
+        """Test that excluded shadow keys are tracked."""
+        from services.report_validator import ReportValidator
+
+        sections = {
+            "business_case": "<p>Short BC</p>",
+            "BUSINESS_CASE_HTML": "<section><h2>Business Case</h2>" + "<p>Content</p>" * 50 + "</section>",
+        }
+
+        validator = ReportValidator(sections, {"unternehmensgroesse": "kmu"})
+
+        excluded = validator.excluded_shadow_keys
+        self.assertIn("business_case", excluded)
+
+
+class TestP2SoloLanguageScrubbing(unittest.TestCase):
+    """Test P2: SOLO-Language scrubbing extensions."""
+
+    def test_baukasten_replaced_with_vorlagenpaket(self):
+        """Test that Baukasten is replaced with Vorlagenpaket for solo."""
+        from services.content_quality_enforcer import apply_solo_language_normalizer
+
+        sections = {
+            "RECOMMENDATIONS_HTML": "<p>Nutzen Sie den KI-Baukasten für Ihre Arbeit.</p>"
+        }
+
+        result = apply_solo_language_normalizer(sections, "solo")
+        self.assertNotIn("Baukasten", result["RECOMMENDATIONS_HTML"])
+        self.assertIn("Vorlagenpaket", result["RECOMMENDATIONS_HTML"])
+
+    def test_rollout_removed_not_replaced(self):
+        """Test that Rollout is REMOVED (not replaced) per user feedback."""
+        from services.content_quality_enforcer import apply_solo_language_normalizer
+
+        sections = {
+            "ROADMAP_90D_HTML": "<p>Nach dem Rollout der KI-Lösung folgt die nächste Phase.</p>"
+        }
+
+        result = apply_solo_language_normalizer(sections, "solo")
+        # Rollout should be removed entirely
+        self.assertNotIn("Rollout", result["ROADMAP_90D_HTML"])
+        # Should NOT contain "Einführung" as replacement (it's removed, not replaced)
+        # But the sentence should still make sense
+        html = result["ROADMAP_90D_HTML"]
+        # Clean up double spaces
+        self.assertNotIn("  ", html)  # No double spaces
+
+    def test_double_spaces_cleaned_after_removal(self):
+        """Test that double spaces are cleaned up after term removal."""
+        from services.content_quality_enforcer import apply_solo_language_normalizer
+
+        sections = {
+            "EXECUTIVE_SUMMARY_HTML": "<p>Der Rollout beginnt im Januar.</p>"
+        }
+
+        result = apply_solo_language_normalizer(sections, "solo")
+        # Should not have double spaces
+        self.assertNotIn("  ", result["EXECUTIVE_SUMMARY_HTML"])
+
+    def test_solo_scrubbing_not_applied_for_team(self):
+        """Test that solo scrubbing is not applied for team size."""
+        from services.content_quality_enforcer import apply_solo_language_normalizer
+
+        sections = {
+            "RECOMMENDATIONS_HTML": "<p>Der Baukasten bietet viele Möglichkeiten.</p>"
+        }
+
+        result = apply_solo_language_normalizer(sections, "team")
+        # Should remain unchanged
+        self.assertIn("Baukasten", result["RECOMMENDATIONS_HTML"])
+
+
+class TestP2EarlyStageScrubbing(unittest.TestCase):
+    """Test P2: Early-stage scrubbing for briefing fields."""
+
+    def test_early_scrub_applies_to_briefing_fields(self):
+        """Test that early scrub applies to user briefing fields."""
+        from services.content_quality_enforcer import apply_solo_language_to_briefing
+
+        briefing = {
+            "hauptleistung": "KI-Plattform für Stakeholder-Management",
+            "vision_3_jahre": "Skalierung auf 100+ Kunden mit Audit-Trail",
+            "strategische_ziele": "Rollout einer Engine-basierten Lösung",
+        }
+
+        result = apply_solo_language_to_briefing(briefing, "solo")
+
+        # Check terms were replaced
+        self.assertNotIn("Plattform", result["hauptleistung"])
+        self.assertNotIn("Stakeholder", result["hauptleistung"])
+        self.assertNotIn("Skalierung", result["vision_3_jahre"])
+        self.assertNotIn("Audit-Trail", result["vision_3_jahre"])
+        self.assertNotIn("Rollout", result["strategische_ziele"])
+        self.assertNotIn("Engine", result["strategische_ziele"])
+
+    def test_early_scrub_not_applied_for_non_solo(self):
+        """Test that early scrub is not applied for non-solo."""
+        from services.content_quality_enforcer import apply_solo_language_to_briefing
+
+        briefing = {
+            "hauptleistung": "KI-Plattform für Stakeholder",
+        }
+
+        result = apply_solo_language_to_briefing(briefing, "kmu")
+        self.assertIn("Plattform", result["hauptleistung"])
+        self.assertIn("Stakeholder", result["hauptleistung"])
+
+
+class TestP3DeterministicPrescrub(unittest.TestCase):
+    """Test P3: Deterministic prescrub before fail-closed."""
+
+    def test_prescrub_list_exists(self):
+        """Test that DETERMINISTIC_PRESCRUB_PHRASES list exists."""
+        from services.zero_leak_engine import DETERMINISTIC_PRESCRUB_PHRASES
+
+        self.assertIsInstance(DETERMINISTIC_PRESCRUB_PHRASES, list)
+        self.assertTrue(len(DETERMINISTIC_PRESCRUB_PHRASES) > 0)
+
+    def test_prescrub_includes_bitte_beschreibe(self):
+        """Test that prescrub includes 'bitte beschreibe kurz' variants."""
+        from services.zero_leak_engine import DETERMINISTIC_PRESCRUB_PHRASES
+
+        phrases_lower = [p.lower() for p in DETERMINISTIC_PRESCRUB_PHRASES]
+        self.assertIn("bitte beschreibe kurz", phrases_lower)
+        self.assertIn("bitte beschreiben sie kurz", phrases_lower)
+
+    def test_prescrub_includes_template_markers(self):
+        """Test that prescrub includes template markers."""
+        from services.zero_leak_engine import DETERMINISTIC_PRESCRUB_PHRASES
+
+        # Should include Platzhalter and Beispiel-Workflow
+        self.assertIn("Platzhalter", DETERMINISTIC_PRESCRUB_PHRASES)
+        self.assertIn("Beispiel-Workflow", DETERMINISTIC_PRESCRUB_PHRASES)
+
+    def test_executive_critical_no_longer_has_bitte_beschreibe(self):
+        """Test that EXECUTIVE_CRITICAL_PHRASES no longer has 'bitte beschreibe'."""
+        from services.zero_leak_engine import EXECUTIVE_CRITICAL_PHRASES
+
+        phrases_lower = [p.lower() for p in EXECUTIVE_CRITICAL_PHRASES]
+        # These should be moved to prescrub, not in critical
+        self.assertNotIn("bitte beschreibe kurz", phrases_lower)
+        self.assertNotIn("bitte beschreiben sie kurz", phrases_lower)
+
+    def test_check_blacklist_prescrubs_without_fail_closed(self):
+        """Test that prescrub phrases don't cause fail-closed."""
+        from services.zero_leak_engine import apply_blacklist_classified
+
+        text = "<p>Bitte beschreibe kurz dein Anliegen. Dies ist ein Test.</p>"
+        result = apply_blacklist_classified(text, section_name="EXECUTIVE_SUMMARY_HTML")
+
+        # Should be cleaned
+        self.assertNotIn("Bitte beschreibe kurz", result.cleaned_text)
+        # Should NOT be in critical hits (prescrub bypasses critical)
+        critical_lower = [h.lower() for h in result.critical_hits]
+        self.assertNotIn("bitte beschreibe kurz", critical_lower)
+
+
+class TestP4RoiFilter(unittest.TestCase):
+    """Test P4: ROI filter for recommendations."""
+
+    def test_roi_filter_removes_from_recommendations(self):
+        """Test that ROI percentages are removed from RECOMMENDATIONS_HTML."""
+        from services.content_quality_enforcer import apply_roi_filter
+
+        sections = {
+            "RECOMMENDATIONS_HTML": "<p>Diese Maßnahme bietet einen ROI von 284%. Sehr profitabel.</p>",
+            "BUSINESS_CASE_HTML": "<p>ROI: 284% über 12 Monate.</p>",  # Should be preserved
+        }
+
+        result = apply_roi_filter(sections)
+
+        # ROI should be removed from recommendations
+        self.assertNotIn("284%", result["RECOMMENDATIONS_HTML"])
+        self.assertIn("Business Case", result["RECOMMENDATIONS_HTML"])  # Reference added
+
+        # ROI should be preserved in business case
+        self.assertIn("284%", result["BUSINESS_CASE_HTML"])
+
+    def test_roi_filter_preserves_business_case(self):
+        """Test that ROI is preserved in business case sections."""
+        from services.content_quality_enforcer import apply_roi_filter
+
+        sections = {
+            "BUSINESS_CASE_HTML": "<p>Erwarteter ROI: 150% im ersten Jahr.</p>",
+        }
+
+        result = apply_roi_filter(sections)
+        self.assertIn("150%", result["BUSINESS_CASE_HTML"])
+
+
+class TestShadowKeyMap(unittest.TestCase):
+    """Test the shadow key mapping is comprehensive."""
+
+    def test_shadow_key_map_covers_common_sections(self):
+        """Test that SHADOW_KEY_TO_HTML_MAP covers common sections."""
+        from services.report_validator import ReportValidator
+
+        expected_mappings = {
+            "quick_wins": "QUICK_WINS_HTML",
+            "business_case": "BUSINESS_CASE_HTML",
+            "risks": "RISKS_HTML",
+            "executive_summary": "EXECUTIVE_SUMMARY_HTML",
+            "recommendations": "RECOMMENDATIONS_HTML",
+        }
+
+        for shadow, html in expected_mappings.items():
+            self.assertIn(shadow, ReportValidator.SHADOW_KEY_TO_HTML_MAP)
+            self.assertEqual(ReportValidator.SHADOW_KEY_TO_HTML_MAP[shadow], html)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
P1: Validator canonical_view (excludes shadow/raw duplicates)
- Add SHADOW_KEY_TO_HTML_MAP for shadow key detection
- Add canonical_sections property to exclude duplicates
- Update _check_size_specific_issues, _check_template_phrases, _check_redundancy to use canonical_sections
- Prevents false-positive REDUNDANCY_DETECTED and SECTION_TOO_SHORT

P2: SOLO-Language scrubbing extensions
- Add Baukasten → Vorlagenpaket replacement
- Change Rollout → REMOVE (not replace) per user feedback
- Add double-space cleanup after removals
- Add apply_solo_language_to_briefing() for early-stage scrubbing
- Add NEXT_ACTIONS_HTML and PILOT_PLAN_HTML to check_sections

P3: Template/Prompt leaks deterministic prescrub
- Add DETERMINISTIC_PRESCRUB_PHRASES list
- Prescrub "bitte beschreibe kurz" and template markers
- Prescrub happens BEFORE critical scan (no fail-closed trigger)
- Remove "bitte beschreibe kurz" from EXECUTIVE_CRITICAL_PHRASES

P4: ROI-Prohibited + Contract-Warnings
- Existing ROI filter already handles RECOMMENDATIONS_HTML
- Contract warnings from MISSING_HEADING/UNCLOSED_TAG are edge cases

Tests: 17 new tests in test_fix526_strict_grade_a.py