### PR TITLE
feat(FIX-527): Report facts single-source-of-truth + Platzhalter markers

### DIFF
--- a/services/content_quality_enforcer.py
+++ b/services/content_quality_enforcer.py
@@ -2756,6 +2756,26 @@ def apply_all_quality_enforcers(sections: dict, hauptleistung: str = "", bundesl
     if company_size:
         sections = apply_solo_terms_final(sections, company_size)
 
+    # =========================================================================
+    # FIX-527: Report Facts Integration
+    # =========================================================================
+
+    # 23. FIX-527: Collect open inputs (markers) and generate OPEN_INPUTS_HTML
+    try:
+        from services.report_facts import collect_open_inputs, validate_no_platzhalter_text
+        open_inputs, open_inputs_html = collect_open_inputs(sections)
+        if open_inputs_html:
+            sections["OPEN_INPUTS_HTML"] = open_inputs_html
+            sections["_OPEN_INPUTS_COUNT"] = len(open_inputs)
+
+        # 24. FIX-527: Validate no "Platzhalter" text in report
+        platzhalter_ok, platzhalter_violations = validate_no_platzhalter_text(sections)
+        sections["_PLATZHALTER_AUDIT_PASS"] = platzhalter_ok
+        if not platzhalter_ok:
+            log.warning("[FIX-527] Platzhalter text found: %s", platzhalter_violations)
+    except ImportError:
+        log.debug("[FIX-527] report_facts module not available, skipping")
+
     log.info("[QUALITY-ENFORCER] Pipeline complete (FIX-52x final polish applied)")
     return sections
 

--- a/services/report_facts.py
+++ b/services/report_facts.py
@@ -1,0 +1,380 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+FIX-527: Report Facts - Single Source of Truth for Canonical Values
+
+This module provides centralized, immutable canonical values for reports.
+All templates and section generators MUST use these values to ensure consistency.
+
+Usage:
+    from services.report_facts import ReportFacts
+
+    facts = ReportFacts.from_briefing(briefing, sections)
+    payback = facts.payback_months  # Always consistent
+"""
+
+import logging
+import re
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional, Tuple
+
+log = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class ReportFacts:
+    """
+    Immutable container for canonical report values.
+
+    All values are frozen after creation to prevent accidental modification.
+    Use from_briefing() to create an instance from briefing/sections data.
+    """
+    payback_months: float
+    roi_12m: float
+    capex_eur: float
+    opex_monthly_eur: float
+    savings_monthly_eur: float
+    company_size: str
+    hauptleistung: str
+
+    # Formatted versions for templates
+    @property
+    def payback_months_de(self) -> str:
+        """German formatted payback (e.g., '11' or '3,5')."""
+        if self.payback_months == int(self.payback_months):
+            return str(int(self.payback_months))
+        return f"{self.payback_months:.1f}".replace(".", ",")
+
+    @property
+    def payback_display_de(self) -> str:
+        """Full display string (e.g., '11 Monate')."""
+        return f"{self.payback_months_de} Monate"
+
+    @property
+    def payback_approx_de(self) -> str:
+        """Approximate display (e.g., '~11 Monate')."""
+        return f"~{self.payback_months_de} Monate"
+
+    @classmethod
+    def from_briefing(
+        cls,
+        briefing: Dict[str, Any],
+        sections: Optional[Dict[str, Any]] = None
+    ) -> "ReportFacts":
+        """
+        Create ReportFacts from briefing and sections data.
+
+        Priority: sections > briefing > defaults
+        """
+        sections = sections or {}
+
+        # Payback: prefer sections (calculated) over briefing (input)
+        payback_raw = (
+            sections.get("PAYBACK_MONTHS") or
+            briefing.get("PAYBACK_MONTHS") or
+            11  # Default per user requirement
+        )
+        try:
+            payback = float(str(payback_raw).replace(",", "."))
+        except (ValueError, TypeError):
+            payback = 11.0
+
+        # ROI
+        roi_raw = sections.get("ROI_12M") or briefing.get("ROI_12M") or 0
+        try:
+            roi = float(str(roi_raw).replace(",", ".").replace("%", ""))
+        except (ValueError, TypeError):
+            roi = 0.0
+
+        # Financial values
+        capex = float(sections.get("CAPEX_REALISTISCH_EUR") or briefing.get("CAPEX_REALISTISCH_EUR") or 0)
+        opex = float(sections.get("OPEX_REALISTISCH_EUR") or briefing.get("OPEX_REALISTISCH_EUR") or 0)
+        savings = float(sections.get("EINSPARUNG_MONAT_EUR") or briefing.get("EINSPARUNG_MONAT_EUR") or 0)
+
+        # Company size
+        size_raw = briefing.get("unternehmensgroesse") or briefing.get("company_size") or "solo"
+        size = str(size_raw).lower()
+        if "solo" in size or "1" == size or "freiberuf" in size:
+            company_size = "solo"
+        elif "team" in size or "klein" in size or size in ("2", "3", "4", "5"):
+            company_size = "team"
+        else:
+            company_size = "kmu"
+
+        # Hauptleistung
+        hauptleistung = briefing.get("hauptleistung") or ""
+
+        return cls(
+            payback_months=payback,
+            roi_12m=roi,
+            capex_eur=capex,
+            opex_monthly_eur=opex,
+            savings_monthly_eur=savings,
+            company_size=company_size,
+            hauptleistung=hauptleistung,
+        )
+
+
+# =============================================================================
+# PAYBACK AUDIT - Validates consistency across all sections
+# =============================================================================
+
+# Allowed payback string patterns (canonical value substituted)
+def _get_allowed_payback_patterns(canonical: float) -> List[str]:
+    """Generate list of allowed payback string patterns for the canonical value."""
+    # Format canonical
+    if canonical == int(canonical):
+        canonical_str = str(int(canonical))
+    else:
+        canonical_str = f"{canonical:.1f}".replace(".", ",")
+
+    # Integer version for whole numbers
+    canonical_int = str(int(round(canonical)))
+
+    patterns = [
+        f"{canonical_str} Monate",
+        f"{canonical_str} Monaten",
+        f"~{canonical_str} Monate",
+        f"~{canonical_str} Monaten",
+        f"ca. {canonical_str} Monate",
+        f"etwa {canonical_str} Monate",
+        f"Payback: {canonical_str}",
+        f"Payback {canonical_str}",
+        f"Amortisation: {canonical_str}",
+        f"Amortisation {canonical_str}",
+    ]
+
+    # Also allow integer version if close
+    if canonical_int != canonical_str:
+        patterns.extend([
+            f"{canonical_int} Monate",
+            f"{canonical_int} Monaten",
+            f"~{canonical_int} Monate",
+            f"ca. {canonical_int} Monate",
+        ])
+
+    return patterns
+
+
+# Pattern to find any payback mention
+PAYBACK_DETECTION_PATTERN = re.compile(
+    r'(?:Payback|Amortisation|Amortisierung|payback)[:\s]+(?:von\s+)?'
+    r'(\d+(?:[.,]\d+)?)\s*(?:Monate?|months?|Monaten)',
+    re.IGNORECASE
+)
+
+
+def audit_payback_consistency(
+    sections: Dict[str, Any],
+    facts: ReportFacts,
+    tolerance_percent: float = 20.0
+) -> Tuple[bool, List[str]]:
+    """
+    FIX-527: Audit all sections for payback consistency.
+
+    Scans all HTML sections for payback mentions and validates they match
+    the canonical value within tolerance.
+
+    Args:
+        sections: Dict with all report sections
+        facts: ReportFacts with canonical payback_months
+        tolerance_percent: Allowed deviation percentage (default 20%)
+
+    Returns:
+        Tuple of (passed, list_of_violations)
+        - passed: True if all payback mentions are consistent
+        - violations: List of violation descriptions
+    """
+    canonical = facts.payback_months
+    violations: List[str] = []
+    matches_found = 0
+
+    # Sections to audit (all HTML sections)
+    audit_sections = [k for k in sections.keys() if k.endswith("_HTML") or k.endswith("_html")]
+
+    for section_key in audit_sections:
+        content = sections.get(section_key)
+        if not content or not isinstance(content, str):
+            continue
+
+        # Find all payback mentions
+        for match in PAYBACK_DETECTION_PATTERN.finditer(content):
+            value_str = match.group(1)
+            matches_found += 1
+
+            try:
+                found_value = float(value_str.replace(",", "."))
+            except ValueError:
+                continue
+
+            # Check if within tolerance
+            if canonical > 0:
+                deviation = abs(found_value - canonical) / canonical * 100
+            else:
+                deviation = 100 if found_value != 0 else 0
+
+            if deviation > tolerance_percent:
+                violations.append(
+                    f"[{section_key}] Found '{match.group(0)}' (value={found_value:.1f}) "
+                    f"differs from canonical {canonical:.1f} by {deviation:.0f}%"
+                )
+
+    passed = len(violations) == 0
+
+    if passed:
+        log.info(
+            "[FIX-527][PAYBACK-AUDIT] PASS: canonical=%.1f found=%d matches, 0 violations",
+            canonical, matches_found
+        )
+    else:
+        log.warning(
+            "[FIX-527][PAYBACK-AUDIT] FAIL: canonical=%.1f violations=%d: %s",
+            canonical, len(violations), violations[:3]
+        )
+
+    return passed, violations
+
+
+# =============================================================================
+# PLACEHOLDER MARKER SYSTEM
+# =============================================================================
+
+# Marker syntax: ⟦INPUT:<key>|<label>|<hint>⟧
+MARKER_PATTERN = re.compile(
+    r'⟦INPUT:([^|⟧]+)\|([^|⟧]+)\|([^⟧]*)⟧'
+)
+
+# Alternative ASCII-safe marker: [[INPUT:<key>|<label>|<hint>]]
+MARKER_PATTERN_ASCII = re.compile(
+    r'\[\[INPUT:([^\|\]]+)\|([^\|\]]+)\|([^\]]*)\]\]'
+)
+
+
+@dataclass
+class OpenInput:
+    """Represents a single open input marker."""
+    key: str
+    label: str
+    hint: str
+    section_id: str
+
+
+def collect_open_inputs(sections: Dict[str, Any]) -> Tuple[List[OpenInput], str]:
+    """
+    FIX-527: Collect all open input markers from sections.
+
+    Scans all HTML sections for ⟦INPUT:...⟧ markers and collects them.
+    Generates OPEN_INPUTS_HTML table section.
+
+    Args:
+        sections: Dict with all report sections
+
+    Returns:
+        Tuple of (list_of_OpenInput, open_inputs_html)
+    """
+    open_inputs: List[OpenInput] = []
+
+    # Scan all HTML sections
+    for section_key, content in sections.items():
+        if not content or not isinstance(content, str):
+            continue
+        if not (section_key.endswith("_HTML") or section_key.endswith("_html")):
+            continue
+
+        # Try both marker patterns
+        for pattern in [MARKER_PATTERN, MARKER_PATTERN_ASCII]:
+            for match in pattern.finditer(content):
+                open_inputs.append(OpenInput(
+                    key=match.group(1).strip(),
+                    label=match.group(2).strip(),
+                    hint=match.group(3).strip() if match.group(3) else "",
+                    section_id=section_key,
+                ))
+
+    # Generate HTML table
+    if not open_inputs:
+        html = ""
+    else:
+        rows = []
+        for inp in open_inputs:
+            rows.append(f"""
+            <tr>
+                <td><code>⟦{inp.key}⟧</code></td>
+                <td>{inp.label}</td>
+                <td>{inp.hint or "—"}</td>
+                <td>{inp.section_id.replace("_HTML", "").replace("_", " ").title()}</td>
+            </tr>
+            """)
+
+        html = f"""
+        <section class="open-inputs" id="open-inputs">
+            <h2>Offene Inputs</h2>
+            <p>Die folgenden Informationen werden noch benötigt, um den Report zu vervollständigen:</p>
+            <table class="open-inputs-table">
+                <thead>
+                    <tr>
+                        <th>Marker</th>
+                        <th>Was fehlt?</th>
+                        <th>Hinweis</th>
+                        <th>Sektion</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {"".join(rows)}
+                </tbody>
+            </table>
+        </section>
+        """
+
+    log.info("[FIX-527][OPEN-INPUTS] Collected %d open input markers", len(open_inputs))
+
+    return open_inputs, html
+
+
+def validate_no_platzhalter_text(sections: Dict[str, Any]) -> Tuple[bool, List[str]]:
+    """
+    FIX-527: Validate that "Platzhalter" word does not appear in report text.
+
+    The word "Platzhalter" should never appear in the final report.
+    Only markers (⟦INPUT:...⟧) are allowed.
+
+    Args:
+        sections: Dict with all report sections
+
+    Returns:
+        Tuple of (passed, list_of_violations)
+    """
+    violations: List[str] = []
+
+    # Pattern to find "Platzhalter" as word (not in marker syntax)
+    platzhalter_pattern = re.compile(r'\bPlatzhalter\b', re.IGNORECASE)
+
+    for section_key, content in sections.items():
+        if not content or not isinstance(content, str):
+            continue
+        if not (section_key.endswith("_HTML") or section_key.endswith("_html")):
+            continue
+
+        # Skip OPEN_INPUTS section (allowed there if user wants)
+        if "OPEN_INPUTS" in section_key.upper():
+            continue
+
+        matches = platzhalter_pattern.findall(content)
+        if matches:
+            violations.append(f"[{section_key}] Found 'Platzhalter' {len(matches)}x")
+
+    passed = len(violations) == 0
+
+    if passed:
+        log.info("[FIX-527][PLATZHALTER-AUDIT] PASS: No 'Platzhalter' text found")
+    else:
+        log.warning("[FIX-527][PLATZHALTER-AUDIT] FAIL: %s", violations)
+
+    return passed, violations
+
+
+# =============================================================================
+# INITIALIZATION
+# =============================================================================
+
+log.info("[FIX-527] report_facts module loaded: ReportFacts, audit_payback_consistency, collect_open_inputs")

--- a/tests/test_fix527_report_facts.py
+++ b/tests/test_fix527_report_facts.py
@@ -1,0 +1,319 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+FIX-527 Tests: Report Facts - Single Source of Truth
+
+Tests for:
+- ReportFacts canonical value container
+- Payback audit consistency
+- Open inputs marker collection
+- Platzhalter text validation
+"""
+
+import unittest
+
+
+class TestReportFacts(unittest.TestCase):
+    """Test ReportFacts dataclass and factory methods."""
+
+    def test_from_briefing_basic(self):
+        """Test basic ReportFacts creation from briefing."""
+        from services.report_facts import ReportFacts
+
+        briefing = {
+            "PAYBACK_MONTHS": 11,
+            "ROI_12M": 150,
+            "unternehmensgroesse": "solo",
+            "hauptleistung": "KI-Beratung",
+        }
+
+        facts = ReportFacts.from_briefing(briefing)
+
+        self.assertEqual(facts.payback_months, 11.0)
+        self.assertEqual(facts.roi_12m, 150.0)
+        self.assertEqual(facts.company_size, "solo")
+        self.assertEqual(facts.hauptleistung, "KI-Beratung")
+
+    def test_payback_months_de_integer(self):
+        """Test German formatting for integer payback."""
+        from services.report_facts import ReportFacts
+
+        facts = ReportFacts(
+            payback_months=11.0,
+            roi_12m=100.0,
+            capex_eur=5000.0,
+            opex_monthly_eur=200.0,
+            savings_monthly_eur=1000.0,
+            company_size="solo",
+            hauptleistung="Test",
+        )
+
+        self.assertEqual(facts.payback_months_de, "11")
+        self.assertEqual(facts.payback_display_de, "11 Monate")
+
+    def test_payback_months_de_decimal(self):
+        """Test German formatting for decimal payback."""
+        from services.report_facts import ReportFacts
+
+        facts = ReportFacts(
+            payback_months=3.5,
+            roi_12m=100.0,
+            capex_eur=5000.0,
+            opex_monthly_eur=200.0,
+            savings_monthly_eur=1000.0,
+            company_size="solo",
+            hauptleistung="Test",
+        )
+
+        self.assertEqual(facts.payback_months_de, "3,5")
+        self.assertEqual(facts.payback_display_de, "3,5 Monate")
+        self.assertEqual(facts.payback_approx_de, "~3,5 Monate")
+
+    def test_company_size_normalization(self):
+        """Test company size is normalized correctly."""
+        from services.report_facts import ReportFacts
+
+        # Solo variants
+        for size in ["solo", "Solo", "1", "freiberufler", "FREIBERUFLICH"]:
+            facts = ReportFacts.from_briefing({"unternehmensgroesse": size})
+            self.assertEqual(facts.company_size, "solo", f"Failed for: {size}")
+
+        # Team variants
+        for size in ["team", "Team", "kleinunternehmen", "2"]:
+            facts = ReportFacts.from_briefing({"unternehmensgroesse": size})
+            self.assertEqual(facts.company_size, "team", f"Failed for: {size}")
+
+        # KMU (default)
+        for size in ["kmu", "KMU", "mittelstand", "50"]:
+            facts = ReportFacts.from_briefing({"unternehmensgroesse": size})
+            self.assertEqual(facts.company_size, "kmu", f"Failed for: {size}")
+
+    def test_sections_override_briefing(self):
+        """Test that sections values take priority over briefing."""
+        from services.report_facts import ReportFacts
+
+        briefing = {"PAYBACK_MONTHS": 5}
+        sections = {"PAYBACK_MONTHS": 11}
+
+        facts = ReportFacts.from_briefing(briefing, sections)
+
+        self.assertEqual(facts.payback_months, 11.0)
+
+
+class TestPaybackAudit(unittest.TestCase):
+    """Test payback consistency audit."""
+
+    def test_audit_passes_with_consistent_values(self):
+        """Test audit passes when all values match canonical."""
+        from services.report_facts import ReportFacts, audit_payback_consistency
+
+        facts = ReportFacts(
+            payback_months=11.0,
+            roi_12m=100.0,
+            capex_eur=5000.0,
+            opex_monthly_eur=200.0,
+            savings_monthly_eur=1000.0,
+            company_size="solo",
+            hauptleistung="Test",
+        )
+
+        sections = {
+            "EXECUTIVE_SUMMARY_HTML": "<p>Mit einem Payback von 11 Monaten ist das Projekt wirtschaftlich.</p>",
+            "BUSINESS_CASE_HTML": "<p>Die Amortisation: 11 Monate.</p>",
+        }
+
+        passed, violations = audit_payback_consistency(sections, facts)
+
+        self.assertTrue(passed)
+        self.assertEqual(len(violations), 0)
+
+    def test_audit_fails_with_inconsistent_values(self):
+        """Test audit fails when values differ significantly."""
+        from services.report_facts import ReportFacts, audit_payback_consistency
+
+        facts = ReportFacts(
+            payback_months=11.0,
+            roi_12m=100.0,
+            capex_eur=5000.0,
+            opex_monthly_eur=200.0,
+            savings_monthly_eur=1000.0,
+            company_size="solo",
+            hauptleistung="Test",
+        )
+
+        sections = {
+            "EXECUTIVE_SUMMARY_HTML": "<p>Mit einem Payback von 3,5 Monaten ist das Projekt wirtschaftlich.</p>",
+        }
+
+        passed, violations = audit_payback_consistency(sections, facts)
+
+        self.assertFalse(passed)
+        self.assertEqual(len(violations), 1)
+        self.assertIn("3,5", violations[0])
+
+    def test_audit_tolerates_minor_differences(self):
+        """Test audit allows values within 20% tolerance."""
+        from services.report_facts import ReportFacts, audit_payback_consistency
+
+        facts = ReportFacts(
+            payback_months=10.0,
+            roi_12m=100.0,
+            capex_eur=5000.0,
+            opex_monthly_eur=200.0,
+            savings_monthly_eur=1000.0,
+            company_size="solo",
+            hauptleistung="Test",
+        )
+
+        sections = {
+            # 11 is within 20% of 10
+            "EXECUTIVE_SUMMARY_HTML": "<p>Payback 11 Monate.</p>",
+        }
+
+        passed, violations = audit_payback_consistency(sections, facts)
+
+        self.assertTrue(passed)
+
+
+class TestOpenInputsCollection(unittest.TestCase):
+    """Test open inputs marker collection."""
+
+    def test_collect_unicode_markers(self):
+        """Test collection of Unicode markers ⟦INPUT:...⟧."""
+        from services.report_facts import collect_open_inputs
+
+        sections = {
+            "EXECUTIVE_SUMMARY_HTML": (
+                "<p>Die ⟦INPUT:umsatz_ziel|Umsatzziel 2025|Bitte aus Finanzplanung⟧ "
+                "werden analysiert.</p>"
+            ),
+        }
+
+        inputs, html = collect_open_inputs(sections)
+
+        self.assertEqual(len(inputs), 1)
+        self.assertEqual(inputs[0].key, "umsatz_ziel")
+        self.assertEqual(inputs[0].label, "Umsatzziel 2025")
+        self.assertEqual(inputs[0].hint, "Bitte aus Finanzplanung")
+        self.assertIn("Offene Inputs", html)
+
+    def test_collect_ascii_markers(self):
+        """Test collection of ASCII markers [[INPUT:...]]."""
+        from services.report_facts import collect_open_inputs
+
+        sections = {
+            "ROADMAP_HTML": (
+                "<p>Phase 1: [[INPUT:timeline|Zeitrahmen|Aus Projektplan]] festlegen.</p>"
+            ),
+        }
+
+        inputs, html = collect_open_inputs(sections)
+
+        self.assertEqual(len(inputs), 1)
+        self.assertEqual(inputs[0].key, "timeline")
+        self.assertEqual(inputs[0].label, "Zeitrahmen")
+
+    def test_empty_when_no_markers(self):
+        """Test returns empty when no markers found."""
+        from services.report_facts import collect_open_inputs
+
+        sections = {
+            "EXECUTIVE_SUMMARY_HTML": "<p>Normaler Text ohne Marker.</p>",
+        }
+
+        inputs, html = collect_open_inputs(sections)
+
+        self.assertEqual(len(inputs), 0)
+        self.assertEqual(html, "")
+
+
+class TestPlatzhalterValidation(unittest.TestCase):
+    """Test Platzhalter text validation."""
+
+    def test_passes_when_no_platzhalter(self):
+        """Test validation passes when no Platzhalter text found."""
+        from services.report_facts import validate_no_platzhalter_text
+
+        sections = {
+            "EXECUTIVE_SUMMARY_HTML": "<p>Normaler Text ohne verbotene Wörter.</p>",
+            "RECOMMENDATIONS_HTML": "<p>Empfehlungen hier.</p>",
+        }
+
+        passed, violations = validate_no_platzhalter_text(sections)
+
+        self.assertTrue(passed)
+        self.assertEqual(len(violations), 0)
+
+    def test_fails_when_platzhalter_found(self):
+        """Test validation fails when Platzhalter text found."""
+        from services.report_facts import validate_no_platzhalter_text
+
+        sections = {
+            "EXECUTIVE_SUMMARY_HTML": "<p>Dieser Platzhalter muss ersetzt werden.</p>",
+        }
+
+        passed, violations = validate_no_platzhalter_text(sections)
+
+        self.assertFalse(passed)
+        self.assertEqual(len(violations), 1)
+
+    def test_allows_platzhalter_in_open_inputs(self):
+        """Test Platzhalter is allowed in OPEN_INPUTS section."""
+        from services.report_facts import validate_no_platzhalter_text
+
+        sections = {
+            "OPEN_INPUTS_HTML": "<h2>Offene Platzhalter</h2>",  # Allowed here
+            "EXECUTIVE_SUMMARY_HTML": "<p>Normaler Text.</p>",
+        }
+
+        passed, violations = validate_no_platzhalter_text(sections)
+
+        self.assertTrue(passed)
+
+
+class TestIntegration(unittest.TestCase):
+    """Integration tests for report_facts module."""
+
+    def test_full_workflow(self):
+        """Test full workflow: create facts, audit, collect inputs."""
+        from services.report_facts import (
+            ReportFacts,
+            audit_payback_consistency,
+            collect_open_inputs,
+            validate_no_platzhalter_text,
+        )
+
+        briefing = {
+            "PAYBACK_MONTHS": 11,
+            "unternehmensgroesse": "solo",
+            "hauptleistung": "KI-Beratung",
+        }
+
+        sections = {
+            "PAYBACK_MONTHS": 11,
+            "EXECUTIVE_SUMMARY_HTML": (
+                "<p>Mit einem Payback von 11 Monaten rechnet sich die Investition. "
+                "Die ⟦INPUT:roi_details|ROI-Details|Aus Controlling⟧ werden nachgereicht.</p>"
+            ),
+        }
+
+        # Create facts
+        facts = ReportFacts.from_briefing(briefing, sections)
+        self.assertEqual(facts.payback_months, 11.0)
+        self.assertEqual(facts.company_size, "solo")
+
+        # Audit payback
+        payback_ok, payback_violations = audit_payback_consistency(sections, facts)
+        self.assertTrue(payback_ok)
+
+        # Collect inputs
+        inputs, open_html = collect_open_inputs(sections)
+        self.assertEqual(len(inputs), 1)
+
+        # Validate no Platzhalter
+        platzhalter_ok, _ = validate_no_platzhalter_text(sections)
+        self.assertTrue(platzhalter_ok)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
- Add ReportFacts dataclass for canonical payback/ROI/financial values
- Implement audit_payback_consistency() with 20% tolerance check
- Add open input marker system: ⟦INPUT:<key>|<label>|<hint>⟧
- Implement collect_open_inputs() for "Offene Inputs" page generation
- Add validate_no_platzhalter_text() to detect raw placeholder text
- Integrate report_facts audit into content_quality_enforcer pipeline
- Company-size normalization (solo/team/kmu) with German formatting
- 15 new tests covering all FIX-527 functionality