### PR TITLE
feat: Integrate Report Healer into report generation pipeline

### DIFF
--- a/gpt_analyze.py
+++ b/gpt_analyze.py
@@ -15848,8 +15848,9 @@ NUR HTML ausgeben. Keine Erklärungen, keine Markdown-Fences."""
                     "sections_failed": error_gate.sections_failed,
                 }
 
-            # Get predictive output if available
-            predictive_output = sections.get("_predictive_output")
+            # Get predictive output if available (must be dict or None for type safety)
+            _predictive_raw = sections.get("_predictive_output")
+            predictive_output: Optional[Dict[str, Any]] = _predictive_raw if isinstance(_predictive_raw, dict) else None
 
             # Get segment stats if available
             segment_stats = None

--- a/gpt_analyze.py
+++ b/gpt_analyze.py
@@ -117,6 +117,7 @@ from field_registry import fields  # added by Patch03
 from models import Analysis, Briefing, Report, User
 from services.report_renderer import render
 from services.text_healing import heal_all_text_blocks, heal_text_block
+from services.report_healer import heal_report_html  # FIX-A-G: Report healing pipeline
 from services.pdf_client import render_pdf_from_html, build_footer_template
 from services.icon_system import (
     replace_emojis_with_icons,
@@ -15747,6 +15748,65 @@ NUR HTML ausgeben. Keine Erklärungen, keine Markdown-Fences."""
             raise  # Re-raise hard gate failures
         except Exception as e:
             log.warning(f"[{run_id}] [LEAK-KILL] Scan failed: {e} - continuing without leak validation")
+
+    # =========================================================================
+    # FIX-A-G: REPORT HEALER - Sanitize and heal sections before rendering
+    # Runs AFTER all LLM content generation, BEFORE template rendering
+    # Fixes: A=template phrases, B=persona language, C=redundancy, D=ROI rules,
+    #        E=incomplete sentences, F=payback consistency, G=segment budget
+    # =========================================================================
+    try:
+        # Map company_size to healer segment (klein → team)
+        healer_segment_map = {"solo": "solo", "klein": "team", "team": "team", "kmu": "kmu"}
+        healer_segment = healer_segment_map.get(persona, "team")  # type: ignore[arg-type]
+
+        # Get canonical payback months for consistency check (Fix F)
+        canonical_payback = answers.get("PAYBACK_MONTHS")
+        if canonical_payback and isinstance(canonical_payback, (int, float)):
+            canonical_payback = float(canonical_payback)
+        else:
+            canonical_payback = None
+
+        log.info(f"[{run_id}] [HEALER] Running report_healer: segment={healer_segment}, payback={canonical_payback}")
+
+        healing_result = heal_report_html(
+            sections=sections,
+            segment=healer_segment,  # type: ignore[arg-type]
+            canonical_payback_months=canonical_payback,
+        )
+
+        # Replace sections with healed version
+        sections = healing_result.sections
+
+        # Log healing stats
+        log.info(
+            f"[{run_id}] [HEALER] ✅ Completed: total_fixes={healing_result.total_fixes} "
+            f"(A={healing_result.template_phrases_removed}, B={healing_result.persona_replacements}, "
+            f"C={healing_result.redundancy_stats.blocks_removed if healing_result.redundancy_stats else 0}, "
+            f"D={healing_result.roi_violations_fixed}, E={healing_result.fragments_trimmed}, "
+            f"F={healing_result.payback_fixes}, G={healing_result.sections_budget_trimmed})"
+        )
+
+        # Store healing stats for metadata/debugging
+        sections["_healer_stats"] = {
+            "total_fixes": healing_result.total_fixes,
+            "template_phrases_removed": healing_result.template_phrases_removed,
+            "persona_replacements": healing_result.persona_replacements,
+            "redundancy_blocks_removed": healing_result.redundancy_stats.blocks_removed if healing_result.redundancy_stats else 0,
+            "roi_violations_fixed": healing_result.roi_violations_fixed,
+            "fragments_trimmed": healing_result.fragments_trimmed,
+            "payback_fixes": healing_result.payback_fixes,
+            "sections_budget_trimmed": healing_result.sections_budget_trimmed,
+            "segment": healer_segment,
+        }
+
+    except ImportError:
+        log.debug(f"[{run_id}] [HEALER] report_healer not available")
+    except Exception as e:
+        log.warning(f"[{run_id}] [HEALER] ⚠️ Report healing failed: {e} - continuing without healing")
+    # =========================================================================
+    # END FIX-A-G: REPORT HEALER
+    # =========================================================================
 
     result = render(
         br,

--- a/gpt_analyze.py
+++ b/gpt_analyze.py
@@ -15756,9 +15756,13 @@ NUR HTML ausgeben. Keine Erklärungen, keine Markdown-Fences."""
     #        E=incomplete sentences, F=payback consistency, G=segment budget
     # =========================================================================
     try:
+        import json as _json_healer
+        from typing import cast, Literal as _Literal
+
         # Map company_size to healer segment (klein → team)
         healer_segment_map = {"solo": "solo", "klein": "team", "team": "team", "kmu": "kmu"}
-        healer_segment = healer_segment_map.get(persona, "team")  # type: ignore[arg-type]
+        healer_segment_raw = healer_segment_map.get(persona, "team")
+        healer_segment = cast(_Literal["solo", "team", "kmu"], healer_segment_raw)
 
         # Get canonical payback months for consistency check (Fix F)
         canonical_payback = answers.get("PAYBACK_MONTHS")
@@ -15771,7 +15775,7 @@ NUR HTML ausgeben. Keine Erklärungen, keine Markdown-Fences."""
 
         healing_result = heal_report_html(
             sections=sections,
-            segment=healer_segment,  # type: ignore[arg-type]
+            segment=healer_segment,
             canonical_payback_months=canonical_payback,
         )
 
@@ -15787,8 +15791,8 @@ NUR HTML ausgeben. Keine Erklärungen, keine Markdown-Fences."""
             f"F={healing_result.payback_fixes}, G={healing_result.sections_budget_trimmed})"
         )
 
-        # Store healing stats for metadata/debugging
-        sections["_healer_stats"] = {
+        # Store healing stats for metadata/debugging (as JSON string for Dict[str, str] compatibility)
+        sections["_healer_stats"] = _json_healer.dumps({
             "total_fixes": healing_result.total_fixes,
             "template_phrases_removed": healing_result.template_phrases_removed,
             "persona_replacements": healing_result.persona_replacements,
@@ -15798,7 +15802,7 @@ NUR HTML ausgeben. Keine Erklärungen, keine Markdown-Fences."""
             "payback_fixes": healing_result.payback_fixes,
             "sections_budget_trimmed": healing_result.sections_budget_trimmed,
             "segment": healer_segment,
-        }
+        })
 
     except ImportError:
         log.debug(f"[{run_id}] [HEALER] report_healer not available")

--- a/tests/test_report_healer_integration.py
+++ b/tests/test_report_healer_integration.py
@@ -1,0 +1,290 @@
+# -*- coding: utf-8 -*-
+"""
+Integration tests for Report Healer in the Report Pipeline.
+
+FIX-A-G: Verifies that the healer is correctly integrated and
+sanitizes sections before HTML rendering.
+"""
+from __future__ import annotations
+
+import pytest
+from typing import Dict, Literal
+
+
+class TestReportHealerIntegration:
+    """Integration tests for report healer in the pipeline."""
+
+    def test_healer_removes_prompt_artifacts(self) -> None:
+        """Healer should remove prompt artifacts from sections."""
+        from services.report_healer import heal_report_html
+
+        sections = {
+            "EXECUTIVE_SUMMARY_HTML": """
+                <div class="heading heading-h1">Wie kann ich Ihnen heute helfen?</div>
+                <p>Dies ist die Executive Summary.</p>
+            """,
+            "QUICK_WINS_HTML": """
+                <p>Wobei kann ich dir helfen?</p>
+                <p>Quick Win 1: Automatisierung einführen.</p>
+            """,
+        }
+
+        result = heal_report_html(sections, "solo")
+
+        # Prompt artifacts should be removed
+        assert "Wie kann ich" not in result.sections.get("EXECUTIVE_SUMMARY_HTML", "")
+        assert "Wobei kann ich" not in result.sections.get("QUICK_WINS_HTML", "")
+        # Real content should remain
+        assert "Executive Summary" in result.sections.get("EXECUTIVE_SUMMARY_HTML", "")
+        assert "Automatisierung" in result.sections.get("QUICK_WINS_HTML", "")
+        assert result.template_phrases_removed > 0
+
+    def test_healer_normalizes_payback_decimal(self) -> None:
+        """Healer should normalize 3.5 Monate → 3,5 Monate."""
+        from services.report_healer import heal_report_html
+
+        sections = {
+            "BUSINESS_CASE_HTML": """
+                <p>Die Amortisationszeit beträgt 3.5 Monate.</p>
+                <p>ROI wird nach 2.5 Wochen sichtbar.</p>
+            """,
+        }
+
+        result = heal_report_html(sections, "team")
+
+        bc_html = result.sections.get("BUSINESS_CASE_HTML", "")
+        # German decimal format should be used
+        assert "3,5 Monate" in bc_html
+        assert "2,5 Wochen" in bc_html
+        # English decimal should be removed
+        assert "3.5 Monate" not in bc_html
+        assert "2.5 Wochen" not in bc_html
+
+    def test_healer_solo_persona_simplifies_terms(self) -> None:
+        """Healer should replace enterprise terms for solo segment."""
+        from services.report_healer import heal_report_html
+
+        sections = {
+            "RECOMMENDATIONS_HTML": """
+                <p>Die KI-Architektur sollte auf einem modernen Stack aufbauen.</p>
+                <p>Governance und Compliance sind wichtige Stakeholder-Themen.</p>
+            """,
+        }
+
+        result = heal_report_html(sections, "solo")
+
+        rec_html = result.sections.get("RECOMMENDATIONS_HTML", "")
+        # Solo-friendly terms should be used
+        assert "Aufbau" in rec_html  # Architektur → Aufbau
+        assert "Tool-Set" in rec_html or "Werkzeugkasten" in rec_html  # Stack → Tool-Set
+        assert "Beteiligte" in rec_html  # Stakeholder → Beteiligte
+        assert result.persona_replacements > 0
+
+    def test_healer_removes_placeholder_brackets(self) -> None:
+        """Healer should remove [Platzhalter] and similar patterns."""
+        from services.report_healer import heal_report_html
+
+        sections = {
+            "ROADMAP_90D_HTML": """
+                <p>[Platzhalter für Kundenname]</p>
+                <p>Monat 1: Pilotphase starten.</p>
+                <p>[hier einfügen: Details]</p>
+            """,
+        }
+
+        result = heal_report_html(sections, "team")
+
+        roadmap_html = result.sections.get("ROADMAP_90D_HTML", "")
+        # Placeholders should be removed
+        assert "[Platzhalter" not in roadmap_html
+        assert "[hier einfügen" not in roadmap_html
+        # Real content should remain
+        assert "Pilotphase" in roadmap_html
+
+    def test_healer_removes_jinja_tokens(self) -> None:
+        """Healer should remove unreplaced {{ }} and {% %} tokens."""
+        from services.report_healer import heal_report_html
+
+        sections = {
+            "RISKS_HTML": """
+                <p>Risiko 1: {{ risk_description }}</p>
+                <p>{% if show_mitigation %}Mitigation hier{% endif %}</p>
+                <p>Konkretes Risiko: Datenschutzverletzung.</p>
+            """,
+        }
+
+        result = heal_report_html(sections, "kmu")
+
+        risks_html = result.sections.get("RISKS_HTML", "")
+        # Template tokens should be removed
+        assert "{{" not in risks_html
+        assert "{%" not in risks_html
+        # Real content should remain
+        assert "Datenschutzverletzung" in risks_html
+
+    def test_healer_removes_duplicate_progress_100(self) -> None:
+        """Healer should keep only first Payback Progress 100%."""
+        from services.report_healer import heal_report_html
+
+        sections = {
+            "BUSINESS_CASE_HTML": """
+                <p>Progress: 100% erreicht.</p>
+                <p>Weitere Details zum Business Case.</p>
+            """,
+            "EXECUTIVE_SUMMARY_HTML": """
+                <p>Progress: 100% erreicht.</p>
+                <p>Die Zusammenfassung der Ergebnisse.</p>
+            """,
+        }
+
+        result = heal_report_html(sections, "team")
+
+        # First occurrence in BUSINESS_CASE should remain
+        bc_html = result.sections.get("BUSINESS_CASE_HTML", "")
+        assert "Progress" in bc_html or "100%" in bc_html
+
+        # Second occurrence in EXECUTIVE_SUMMARY should be removed
+        # (depending on section order, one should remain, one should be gone)
+        total_progress_count = (
+            result.sections.get("BUSINESS_CASE_HTML", "").count("Progress: 100%") +
+            result.sections.get("EXECUTIVE_SUMMARY_HTML", "").count("Progress: 100%")
+        )
+        # Should have at most 1 occurrence across all sections
+        assert total_progress_count <= 1
+
+    def test_healer_segment_mapping(self) -> None:
+        """Test that all segment values are handled correctly."""
+        from services.report_healer import heal_report_html
+
+        sections = {"TEST_HTML": "<p>Test content</p>"}
+
+        for segment in ["solo", "team", "kmu"]:
+            result = heal_report_html(sections, segment)  # type: ignore[arg-type]
+            assert result.sections.get("_healer_segment") == segment
+
+    def test_healer_idempotent_in_pipeline(self) -> None:
+        """Running healer twice should produce same result."""
+        from services.report_healer import heal_report_html
+
+        sections = {
+            "EXECUTIVE_SUMMARY_HTML": """
+                <p>Wie kann ich dir helfen?</p>
+                <p>Die Architektur basiert auf einem modernen Stack.</p>
+                <p>Payback: 3.5 Monate.</p>
+            """,
+        }
+
+        # First pass
+        result1 = heal_report_html(sections, "solo")
+
+        # Second pass
+        result2 = heal_report_html(result1.sections, "solo")
+
+        # Results should be identical
+        assert result1.sections.get("EXECUTIVE_SUMMARY_HTML") == result2.sections.get("EXECUTIVE_SUMMARY_HTML")
+        # Second pass should have 0 fixes (already healed)
+        assert result2.total_fixes == 0
+
+    def test_healer_preserves_valid_content(self) -> None:
+        """Healer should not modify valid content."""
+        from services.report_healer import heal_report_html
+
+        valid_content = """
+            <div class="executive-summary">
+                <h2>Executive Summary</h2>
+                <p>Ihr Unternehmen kann durch den Einsatz von KI erhebliche
+                Effizienzgewinne erzielen. Die Amortisationszeit beträgt
+                ca. 3,5 Monate bei einem ROI von 120%.</p>
+                <ul>
+                    <li>Prozessautomatisierung</li>
+                    <li>Datenanalyse</li>
+                    <li>Kundenkommunikation</li>
+                </ul>
+            </div>
+        """
+
+        sections = {"EXECUTIVE_SUMMARY_HTML": valid_content}
+
+        result = heal_report_html(sections, "kmu")
+
+        # Content structure should be preserved
+        assert "<h2>Executive Summary</h2>" in result.sections.get("EXECUTIVE_SUMMARY_HTML", "")
+        assert "Effizienzgewinne" in result.sections.get("EXECUTIVE_SUMMARY_HTML", "")
+        assert "<li>Prozessautomatisierung</li>" in result.sections.get("EXECUTIVE_SUMMARY_HTML", "")
+
+    def test_healer_canonical_payback_normalization(self) -> None:
+        """Healer should normalize to canonical payback value."""
+        from services.report_healer import heal_report_html
+
+        sections = {
+            "BUSINESS_CASE_HTML": """
+                <p>Payback: 4 Monate</p>
+                <p>Amortisation: 5 Monate</p>
+            """,
+        }
+
+        # Normalize to canonical value of 3.5 months
+        result = heal_report_html(sections, "team", canonical_payback_months=3.5)
+
+        bc_html = result.sections.get("BUSINESS_CASE_HTML", "")
+        # All payback values should be normalized to canonical
+        assert "3,5 Monate" in bc_html
+        assert result.payback_fixes > 0
+
+
+class TestHealerSegmentInPipeline:
+    """Test segment mapping in the pipeline context."""
+
+    def test_persona_to_segment_mapping(self) -> None:
+        """Test that persona values map correctly to healer segments."""
+        # This tests the mapping logic used in gpt_analyze.py
+        healer_segment_map = {"solo": "solo", "klein": "team", "team": "team", "kmu": "kmu"}
+
+        assert healer_segment_map.get("solo") == "solo"
+        assert healer_segment_map.get("klein") == "team"  # klein → team
+        assert healer_segment_map.get("team") == "team"
+        assert healer_segment_map.get("kmu") == "kmu"
+        assert healer_segment_map.get("unknown", "team") == "team"  # default
+
+    def test_unternehmensgroesse_to_persona_mapping(self) -> None:
+        """Test that unternehmensgroesse values map correctly to persona."""
+        # This tests the logic in gpt_analyze.py around line 14528-14535
+        def get_persona(size_raw: str) -> Literal["solo", "team", "kmu"]:
+            size = (size_raw or "").lower()
+            if "solo" in size or "freiberuf" in size or "einzelunt" in size:
+                return "solo"
+            elif "kmu" in size or "11" in size:
+                return "kmu"
+            else:
+                return "team"
+
+        # Solo variants
+        assert get_persona("solo") == "solo"
+        assert get_persona("Solo-Selbständig") == "solo"
+        assert get_persona("Freiberufler") == "solo"
+        assert get_persona("Einzelunternehmer") == "solo"
+
+        # KMU variants
+        assert get_persona("KMU") == "kmu"
+        assert get_persona("11-50 Mitarbeiter") == "kmu"
+
+        # Team (default)
+        assert get_persona("klein") == "team"
+        assert get_persona("2-10 Mitarbeiter") == "team"
+        assert get_persona("") == "team"
+
+
+class TestHealerImportInPipeline:
+    """Test that healer import works correctly."""
+
+    def test_healer_import_available(self) -> None:
+        """Healer should be importable."""
+        from services.report_healer import heal_report_html, HealingResult
+        assert callable(heal_report_html)
+        assert HealingResult is not None
+
+    def test_healer_patterns_loaded(self) -> None:
+        """Healer patterns should be loaded."""
+        from services.report_healer import BOILERPLATE_PATTERNS, PAYBACK_PATTERNS_DE
+        assert len(BOILERPLATE_PATTERNS) >= 20  # Should have comprehensive patterns
+        assert len(PAYBACK_PATTERNS_DE) >= 5  # Should have payback patterns


### PR DESCRIPTION
- Add heal_report_html call before render() in analyze_briefing
- Maps persona (solo/team/kmu) to healer segment
- Passes canonical PAYBACK_MONTHS for Fix F normalization
- Logs healing stats for debugging and stores in _healer_stats
- Add 14 integration tests covering:
  - Prompt artifact removal
  - Payback decimal normalization (3.5 → 3,5)
  - Solo persona term simplification
  - Placeholder bracket removal
  - Jinja token cleanup
  - Duplicate Progress 100% removal
  - Segment mapping validation
  - Idempotent behavior
  - Valid content preservation

Call graph: LLM → sections → (Healer) → render() → HTML → PDF

All 41 tests passing (27 unit + 14 integration)