### PR TITLE
fix: Use German decimal format (3,5) for payback values in reports

### DIFF
--- a/gpt_analyze.py
+++ b/gpt_analyze.py
@@ -117,7 +117,7 @@ from field_registry import fields  # added by Patch03
 from models import Analysis, Briefing, Report, User
 from services.report_renderer import render
 from services.text_healing import heal_all_text_blocks, heal_text_block
-from services.report_healer import heal_report_html, heal_final_html  # FIX-A-G: Report healing pipeline
+from services.report_healer import heal_report_html, heal_final_html, format_payback_de  # FIX-A-G: Report healing pipeline
 from services.pdf_client import render_pdf_from_html, build_footer_template
 from services.icon_system import (
     replace_emojis_with_icons,
@@ -14213,7 +14213,7 @@ Gib NUR das angeforderte HTML-Fragment aus - keine Fragen, keine Hilfsangebote, 
             '{CAPEX_REALISTISCH_EUR}': str(int(bc.get('CAPEX_REALISTISCH_EUR', 6000))),
             '{OPEX_REALISTISCH_EUR}': str(int(bc.get('OPEX_REALISTISCH_EUR', 120))),
             '{EINSPARUNG_MONAT_EUR}': str(int(bc.get('EINSPARUNG_MONAT_EUR', 4500))),
-            '{PAYBACK_MONTHS}': str(round(bc.get('PAYBACK_MONTHS', 2.9), 1)),
+            '{PAYBACK_MONTHS}': format_payback_de(bc.get('PAYBACK_MONTHS', 2.9)),  # German decimal: "3,5"
             '{ROI_12M}': f"{bc.get('ROI_12M', 0):.1f}",  # ROI_12M ist bereits in % (z.B. 200.0)
             '{ROI_12M_EUR}': str(int(bc.get('ROI_12M_EUR', 0))),
             '{ROI_12M_LOW}': f"{sections.get('ROI_12M_LOW', 0):.1f}",
@@ -14222,15 +14222,15 @@ Gib NUR das angeforderte HTML-Fragment aus - keine Fragen, keine Hilfsangebote, 
             '{EINSPARUNG_MONAT_EUR_HIGH}': str(int(sections.get('EINSPARUNG_MONAT_EUR_HIGH', 0))),
             '{OPEX_REALISTISCH_EUR_LOW}': str(int(sections.get('OPEX_REALISTISCH_EUR_LOW', 0))),
             '{OPEX_REALISTISCH_EUR_HIGH}': str(int(sections.get('OPEX_REALISTISCH_EUR_HIGH', 0))),
-            '{PAYBACK_MONTHS_PESSIMISTIC}': str(round(sections.get('PAYBACK_MONTHS_PESSIMISTIC', 0), 1)),
-            '{PAYBACK_MONTHS_OPTIMISTIC}': str(round(sections.get('PAYBACK_MONTHS_OPTIMISTIC', 0), 1)),
+            '{PAYBACK_MONTHS_PESSIMISTIC}': format_payback_de(sections.get('PAYBACK_MONTHS_PESSIMISTIC', 0)),  # German decimal
+            '{PAYBACK_MONTHS_OPTIMISTIC}': format_payback_de(sections.get('PAYBACK_MONTHS_OPTIMISTIC', 0)),  # German decimal
             '{COMPANY_SIZE}': sections.get('COMPANY_SIZE', 'team'),  # Use mapped value from sections
             '{qw_hours_total}': str(qw_hours),
             # Double-brace patterns (Jinja2-style that GPT may use)
             '{{CAPEX_REALISTISCH_EUR}}': str(int(bc.get('CAPEX_REALISTISCH_EUR', 6000))),
             '{{OPEX_REALISTISCH_EUR}}': str(int(bc.get('OPEX_REALISTISCH_EUR', 120))),
             '{{EINSPARUNG_MONAT_EUR}}': str(int(bc.get('EINSPARUNG_MONAT_EUR', 4500))),
-            '{{PAYBACK_MONTHS}}': str(round(bc.get('PAYBACK_MONTHS', 2.9), 1)),
+            '{{PAYBACK_MONTHS}}': format_payback_de(bc.get('PAYBACK_MONTHS', 2.9)),  # German decimal: "3,5"
             '{{ROI_12M}}': f"{bc.get('ROI_12M', 0):.1f}",  # ROI_12M ist bereits in % (z.B. 200.0)
             '{{ROI_12M_LOW}}': f"{sections.get('ROI_12M_LOW', 0):.1f}",
             '{{ROI_12M_HIGH}}': f"{sections.get('ROI_12M_HIGH', 0):.1f}",
@@ -14238,8 +14238,8 @@ Gib NUR das angeforderte HTML-Fragment aus - keine Fragen, keine Hilfsangebote, 
             '{{EINSPARUNG_MONAT_EUR_HIGH}}': str(int(sections.get('EINSPARUNG_MONAT_EUR_HIGH', 0))),
             '{{OPEX_REALISTISCH_EUR_LOW}}': str(int(sections.get('OPEX_REALISTISCH_EUR_LOW', 0))),
             '{{OPEX_REALISTISCH_EUR_HIGH}}': str(int(sections.get('OPEX_REALISTISCH_EUR_HIGH', 0))),
-            '{{PAYBACK_MONTHS_PESSIMISTIC}}': str(round(sections.get('PAYBACK_MONTHS_PESSIMISTIC', 0), 1)),
-            '{{PAYBACK_MONTHS_OPTIMISTIC}}': str(round(sections.get('PAYBACK_MONTHS_OPTIMISTIC', 0), 1)),
+            '{{PAYBACK_MONTHS_PESSIMISTIC}}': format_payback_de(sections.get('PAYBACK_MONTHS_PESSIMISTIC', 0)),  # German decimal
+            '{{PAYBACK_MONTHS_OPTIMISTIC}}': format_payback_de(sections.get('PAYBACK_MONTHS_OPTIMISTIC', 0)),  # German decimal
             '{{qw_hours_total}}': str(qw_hours),
             '{{ qw_hours_total }}': str(qw_hours),
         }
@@ -16662,7 +16662,7 @@ def _fix_exec_placeholders(html_block: str, scores: Dict[str, Any], sections: Di
         "CAPEX_REALISTISCH_EUR": str(int(sections.get("CAPEX_REALISTISCH_EUR", 6000) or 6000)),
         "OPEX_REALISTISCH_EUR": str(int(sections.get("OPEX_REALISTISCH_EUR", 120) or 120)),
         "EINSPARUNG_MONAT_EUR": str(int(sections.get("EINSPARUNG_MONAT_EUR", 4500) or 4500)),
-        "PAYBACK_MONTHS": str(round(float(sections.get("PAYBACK_MONTHS", 2.9) or 2.9), 1)),
+        "PAYBACK_MONTHS": format_payback_de(sections.get("PAYBACK_MONTHS", 2.9)),  # German decimal: "3,5"
         "ROI_12M": f"{float(sections.get('ROI_12M', 0) or 0):.1f}",  # Bereits in % (z.B. 200.0)
         "ROI_12M_LOW": f"{float(sections.get('ROI_12M_LOW', 0) or 0):.1f}",
         "ROI_12M_HIGH": f"{float(sections.get('ROI_12M_HIGH', 0) or 0):.1f}",
@@ -16670,8 +16670,8 @@ def _fix_exec_placeholders(html_block: str, scores: Dict[str, Any], sections: Di
         "EINSPARUNG_MONAT_EUR_HIGH": str(int(sections.get("EINSPARUNG_MONAT_EUR_HIGH", 0) or 0)),
         "OPEX_REALISTISCH_EUR_LOW": str(int(sections.get("OPEX_REALISTISCH_EUR_LOW", 0) or 0)),
         "OPEX_REALISTISCH_EUR_HIGH": str(int(sections.get("OPEX_REALISTISCH_EUR_HIGH", 0) or 0)),
-        "PAYBACK_MONTHS_PESSIMISTIC": str(round(float(sections.get("PAYBACK_MONTHS_PESSIMISTIC", 0) or 0), 1)),
-        "PAYBACK_MONTHS_OPTIMISTIC": str(round(float(sections.get("PAYBACK_MONTHS_OPTIMISTIC", 0) or 0), 1)),
+        "PAYBACK_MONTHS_PESSIMISTIC": format_payback_de(sections.get("PAYBACK_MONTHS_PESSIMISTIC", 0)),  # German decimal
+        "PAYBACK_MONTHS_OPTIMISTIC": format_payback_de(sections.get("PAYBACK_MONTHS_OPTIMISTIC", 0)),  # German decimal
         "qw_hours_total": str(sections.get("qw_hours_total", 36)),
     }
 

--- a/tests/test_report_healer_integration.py
+++ b/tests/test_report_healer_integration.py
@@ -288,3 +288,98 @@ class TestHealerImportInPipeline:
         from services.report_healer import BOILERPLATE_PATTERNS, PAYBACK_PATTERNS_DE
         assert len(BOILERPLATE_PATTERNS) >= 20  # Should have comprehensive patterns
         assert len(PAYBACK_PATTERNS_DE) >= 5  # Should have payback patterns
+
+
+class TestPaybackDecimalRegressionFix:
+    """
+    Regression tests for FIX: Payback 3.5 → 3,5 (German decimal format).
+
+    ROOT CAUSE: str(round(value, 1)) produces "3.5" (English format),
+    but German reports must use "3,5" (comma as decimal separator).
+
+    FIX: Use format_payback_de() instead of str(round(..., 1)).
+    """
+
+    def test_format_payback_de_produces_german_format(self) -> None:
+        """format_payback_de should produce German decimal format."""
+        from services.report_healer import format_payback_de
+
+        # float inputs
+        assert format_payback_de(3.5) == "3,5"
+        assert format_payback_de(2.9) == "2,9"
+        assert format_payback_de(4.0) == "4,0"
+        assert format_payback_de(0.0) == "0,0"
+
+        # int inputs
+        assert format_payback_de(3) == "3,0"
+        assert format_payback_de(0) == "0,0"
+
+        # None returns empty string
+        assert format_payback_de(None) == ""
+
+    def test_no_english_decimal_before_monate_after_heal(self) -> None:
+        """After healing, no English decimal should appear before Monate/Monaten."""
+        import re
+        from services.report_healer import heal_report_html
+
+        # Input with English decimal format
+        sections = {
+            "BUSINESS_CASE_HTML": "<p>Payback: 3.5 Monate</p>",
+            "EXECUTIVE_SUMMARY_HTML": "<p>Amortisation in 2.5 Monaten</p>",
+            "QUICK_WINS_HTML": "<p>ROI nach 4.0 Monate erreicht</p>",
+        }
+
+        result = heal_report_html(sections, "team")
+
+        # Pattern: digit.digit followed by space and Monat(e|en)
+        english_decimal_pattern = re.compile(r'\d+\.\d+\s+Monat(?:e|en)?')
+
+        for key, html in result.sections.items():
+            if key.startswith("_"):
+                continue  # Skip metadata keys
+            match = english_decimal_pattern.search(html)
+            assert match is None, (
+                f"English decimal format found in {key}: {match.group() if match else ''}"
+            )
+
+    def test_no_english_decimal_after_heal_final_html(self) -> None:
+        """heal_final_html should also normalize English decimals."""
+        import re
+        from services.report_healer import heal_final_html
+
+        html = """
+        <html>
+            <p>Payback: 3.5 Monate</p>
+            <p>Die Amortisation erfolgt in 2.9 Monaten.</p>
+            <p>Nach 4.0 Monate ist der ROI erreicht.</p>
+        </html>
+        """
+
+        result = heal_final_html(html, "team")
+
+        # No English decimal before Monate/Monaten
+        english_decimal_pattern = re.compile(r'\d+\.\d+\s+Monat(?:e|en)?')
+        match = english_decimal_pattern.search(result)
+        assert match is None, f"English decimal format found: {match.group() if match else ''}"
+
+        # German format should be present
+        assert "3,5 Monate" in result
+        assert "2,9 Monaten" in result
+
+    def test_canonical_payback_uses_german_format(self) -> None:
+        """Canonical payback normalization should use German format."""
+        from services.report_healer import heal_report_html
+
+        sections = {
+            "BUSINESS_CASE_HTML": "<p>Payback: 6 Monate</p>",
+        }
+
+        # Normalize to canonical value of 3.5 months
+        result = heal_report_html(sections, "team", canonical_payback_months=3.5)
+
+        bc_html = result.sections.get("BUSINESS_CASE_HTML", "")
+
+        # German format should be used
+        assert "3,5 Monate" in bc_html
+        # English format should NOT be present
+        assert "3.5 Monate" not in bc_html


### PR DESCRIPTION
ROOT CAUSE: str(round(value, 1)) produces "3.5" (English decimal format), but German reports must display "3,5" (comma as decimal separator).

Changes:
- Replace str(round(..., 1)) with format_payback_de() for all PAYBACK_ values
- Fix both single-brace {PAYBACK_MONTHS} and double-brace {{PAYBACK_MONTHS}} patterns
- Fix _fix_exec_placeholders() function at line 16665
- Add comprehensive regression tests for German decimal format
- Tests verify no "X.Y Monate(n)" patterns appear in healed output