### PR TITLE
feat: Testuser-ready report fixes (Tasks 1-4)

### DIFF
--- a/services/report_healer.py
+++ b/services/report_healer.py
@@ -40,9 +40,15 @@ __all__ = [
     "apply_segment_budget",
     "parse_payback_months",
     "format_payback_de",
+    "localize_business_case_labels_de",
+    "run_quality_gate",
+    "QualityGateResult",
+    "ReportQualityError",
     "HealingResult",
     "BOILERPLATE_PATTERNS",
     "PAYBACK_PATTERNS_DE",
+    "SOLO_BLACKLIST_TERMS",
+    "BUSINESS_CASE_LABEL_LOCALIZATION_DE",
     "BoilerplatePattern",
     "PaybackPattern",
 ]
@@ -256,8 +262,33 @@ class BoilerplatePattern:
 # Registry of known boilerplate/prompt artifacts (BOILERPLATE_PATTERNS_DE)
 BOILERPLATE_PATTERNS: List[BoilerplatePattern] = [
     # -------------------------------------------------------------------------
-    # A) Prompt-/Chat-Blöcke
+    # A) Prompt-/Chat-Blöcke (TASK 1: Robust prompt artifact removal)
     # -------------------------------------------------------------------------
+    # A1) "Wobei soll/kann ich dich unterstützen?" + <ol>/<ul> block (with <strong>)
+    BoilerplatePattern(
+        pattern=r'(?is)<p[^>]*>\s*<strong>\s*Wobei\s+(?:kann|soll)\s+ich\s+(?:dir|dich|Sie|Ihnen)[^<]*(?:unterstützen|helfen)[^<]*</strong>\s*</p>\s*<(?:ol|ul)[^>]*>.*?</(?:ol|ul)>',
+        action="drop",
+        description="PROMPT_WOBEI_STRONG_BLOCK: 'Wobei soll ich dich unterstützen?' with <strong> + list"
+    ),
+    # A2) Same but without <strong> tags
+    BoilerplatePattern(
+        pattern=r'(?is)<p[^>]*>\s*Wobei\s+(?:kann|soll)\s+ich\s+(?:dir|dich|Sie|Ihnen)[^<]*(?:unterstützen|helfen)[^<]*\??\s*</p>\s*<(?:ol|ul)[^>]*>.*?</(?:ol|ul)>',
+        action="drop",
+        description="PROMPT_WOBEI_PLAIN_BLOCK: 'Wobei soll ich...' without <strong> + list"
+    ),
+    # A3) Fallback: Just the question text + following list (no <p> wrapper)
+    BoilerplatePattern(
+        pattern=r'(?is)Wobei\s+(?:kann|soll)\s+ich\s+(?:dir|dich|Sie|Ihnen)\s+.*?(?:unterstützen|helfen)\s*\??\s*(?:</(?:p|strong)>)?\s*<(?:ol|ul)[^>]*>.*?</(?:ol|ul)>',
+        action="drop",
+        description="PROMPT_WOBEI_FALLBACK_BLOCK: 'Wobei soll/kann ich...' fallback with list"
+    ),
+    # A4) Question text alone (no list) - catch any remaining instances
+    BoilerplatePattern(
+        pattern=r'(?i)<p[^>]*>\s*(?:<strong>)?\s*Wobei\s+(?:kann|soll)\s+ich\s+(?:dir|dich|Sie|Ihnen)\s+[^<]*(?:unterstützen|helfen)[^<]*\??\s*(?:</strong>)?\s*</p>',
+        action="drop",
+        description="PROMPT_WOBEI_QUESTION_ONLY: Standalone question paragraph"
+    ),
+    # A5) Original patterns for "Wie/Wobei kann ich helfen"
     BoilerplatePattern(
         pattern=r'(?is)<div[^>]*class="heading[^"]*heading-h1"[^>]*>.*?(?:Wie|Wobei)\s+kann\s+ich.*?</div>',
         action="drop",
@@ -521,12 +552,119 @@ SOLO_TERM_REPLACEMENTS: Dict[str, str] = {
     "Change Management": "Veränderungsprozess",
 }
 
+# Extended SOLO term replacements (TASK 2: Comprehensive mapping)
+SOLO_TERM_REPLACEMENTS_EXTENDED: Dict[str, str] = {
+    # Additional mappings from TASK 2 specification
+    "Governance": "Spielregeln",
+    "governance": "spielregeln",
+    "Executive": "Inhaber:in",
+    "executive": "Inhaber:in",
+    "Audit": "Prüfung",
+    "audit": "prüfung",
+    "Audits": "Prüfungen",
+    "Rollout": "Einführung",
+    "rollout": "einführung",
+    "Layer": "Ebene",
+    "layer": "ebene",
+    "Layers": "Ebenen",
+    "Enterprise": "größere Unternehmen",
+    "enterprise": "größere Unternehmen",
+    "Blueprint": "Vorlage",
+    "blueprint": "Vorlage",
+    "Blueprints": "Vorlagen",
+    "Framework": "Vorgehensrahmen",
+    "framework": "Vorgehensrahmen",
+    "Frameworks": "Vorgehensrahmen",
+    "KPI-Dashboard": "Kennzahlen-Übersicht",
+    "kpi-dashboard": "Kennzahlen-Übersicht",
+    "Operating Model": "Arbeitsmodell",
+    "operating model": "Arbeitsmodell",
+    "Compliance": "Regelkonformität",
+    "compliance": "Regelkonformität",
+    # Additional enterprise terms
+    "Konzern": "größeres Unternehmen",
+    "konzern": "größeres Unternehmen",
+    "Konzerne": "größere Unternehmen",
+}
+
+# SOLO Blacklist Terms (TASK 2: Hard blacklist for SOLO segment)
+SOLO_BLACKLIST_TERMS: List[str] = [
+    "Governance",
+    "Executive",
+    "Audit",
+    "Rollout",
+    "Layer",
+    "Enterprise",
+    "Blueprint",
+    "KPI-Dashboard",
+    "Operating Model",
+    "Compliance",
+    "Stakeholder",
+    "Architektur",
+    "Framework",
+    "Pipeline",
+    "Deployment",
+    "Konzern",
+]
+
+# Fallback replacements for blacklist terms that slip through
+SOLO_BLACKLIST_FALLBACKS: Dict[str, str] = {
+    "Governance": "Leitplanken",
+    "Executive": "Leitung",
+    "Audit": "Check",
+    "Rollout": "Einführung",
+    "Layer": "Ebene",
+    "Enterprise": "",  # Remove entirely
+    "Blueprint": "Plan",
+    "KPI-Dashboard": "Kennzahlen-Übersicht",
+    "Operating Model": "Arbeitsweise",
+    "Compliance": "Vorgaben",
+    "Stakeholder": "Beteiligte",
+    "Architektur": "Aufbau",
+    "Framework": "Methode",
+    "Pipeline": "Ablauf",
+    "Deployment": "Bereitstellung",
+    "Konzern": "",  # Remove entirely
+}
+
 # Patterns to remove entirely for SOLO (too complex)
 SOLO_REMOVE_PATTERNS: List[str] = [
     r"(?:unternehmensweite|organisationsweite)\s+(?:Governance|Compliance|Audit)",
     r"(?:Enterprise|Multi-Team)\s+(?:Architektur|Rollout|Deployment)",
     r"(?:Skalierung|Scaling)\s+(?:auf|für)\s+(?:mehrere|viele)\s+(?:Teams|Abteilungen)",
 ]
+
+# =============================================================================
+# TASK 3: Business-Case Label Localization (English → German)
+# =============================================================================
+
+BUSINESS_CASE_LABEL_LOCALIZATION_DE: Dict[str, str] = {
+    # Primary labels
+    "Payback Progress": "Amortisations-Fortschritt",
+    "payback progress": "Amortisations-Fortschritt",
+    "Payback progress": "Amortisations-Fortschritt",
+    "Time Savings Hours": "Zeitersparnis (Std.)",
+    "Time Savings (Hours)": "Zeitersparnis (Stunden)",
+    "time savings hours": "Zeitersparnis (Std.)",
+    "Time Savings/Month": "Zeitersparnis/Monat",
+    "Time Savings (hrs)": "Zeitersparnis (Std.)",
+    "Monthly Savings": "Monatliche Einsparung",
+    "monthly savings": "monatliche Einsparung",
+    "Monthly Savings (€)": "Monatliche Ersparnis (€)",
+    "Annual Savings": "Jährliche Einsparung",
+    "annual savings": "jährliche Einsparung",
+    # Secondary labels
+    "Payback Period": "Amortisationszeitraum",
+    "payback period": "Amortisationszeitraum",
+    "ROI Details": "ROI-Details",
+    "ROI Comparison": "ROI-Vergleich",
+    "Expected Trend": "Erwarteter Verlauf",
+    "12-Month Trend": "12-Monats-Trend",
+    # Contextual savings
+    "Cost Savings": "Kosteneinsparung",
+    "cost savings": "Kosteneinsparung",
+    "Savings": "Einsparung",
+}
 
 
 def enforce_persona_language(
@@ -536,7 +674,8 @@ def enforce_persona_language(
     """
     Fix B: Enforce persona-appropriate language.
 
-    For SOLO: Replace enterprise terms with simpler alternatives.
+    For SOLO: Replace enterprise terms with simpler alternatives,
+              then enforce blacklist with fallback replacements.
     For TEAM/KMU: Keep B2B standard tone.
 
     Args:
@@ -555,7 +694,7 @@ def enforce_persona_language(
     result = html
     replacement_count = 0
 
-    # Apply term replacements (case-insensitive, preserve case of first letter)
+    # Step 1: Apply primary term replacements (case-insensitive, preserve case)
     for enterprise_term, simple_term in SOLO_TERM_REPLACEMENTS.items():
         pattern = re.compile(re.escape(enterprise_term), re.IGNORECASE)
         matches = pattern.findall(result)
@@ -570,7 +709,24 @@ def enforce_persona_language(
 
             result = pattern.sub(replace_preserve_case, result)
 
-    # Remove overly complex patterns for SOLO
+    # Step 2: Apply extended term replacements (TASK 2)
+    for enterprise_term, simple_term in SOLO_TERM_REPLACEMENTS_EXTENDED.items():
+        pattern = re.compile(re.escape(enterprise_term), re.IGNORECASE)
+        matches = pattern.findall(result)
+        if matches:
+            replacement_count += len(matches)
+
+            def replace_preserve_case_ext(m: re.Match) -> str:
+                original = m.group(0)
+                if not simple_term:  # Empty replacement means remove
+                    return ""
+                if original[0].isupper():
+                    return simple_term[0].upper() + simple_term[1:]
+                return simple_term.lower()
+
+            result = pattern.sub(replace_preserve_case_ext, result)
+
+    # Step 3: Remove overly complex patterns for SOLO
     for remove_pattern in SOLO_REMOVE_PATTERNS:
         try:
             pattern = re.compile(remove_pattern, re.IGNORECASE)
@@ -581,10 +737,104 @@ def enforce_persona_language(
         except re.error:
             pass
 
+    # Step 4: SOLO Blacklist Guard (TASK 2) - catch any remaining blacklist terms
+    result, blacklist_fixes = _enforce_solo_blacklist(result)
+    replacement_count += blacklist_fixes
+
     if replacement_count > 0:
         log.info("[FIX-B] SOLO persona: %d term replacements applied", replacement_count)
 
     return result, replacement_count
+
+
+def _enforce_solo_blacklist(html: str) -> Tuple[str, int]:
+    """
+    TASK 2: Enforce SOLO blacklist - replace any remaining blacklist terms.
+
+    Runs AFTER the primary replacements as a safety net.
+
+    Args:
+        html: HTML content to check
+
+    Returns:
+        Tuple of (cleaned_html, fixes_applied)
+    """
+    if not html:
+        return html, 0
+
+    result = html
+    fixes_applied = 0
+
+    for term in SOLO_BLACKLIST_TERMS:
+        # Case-insensitive search for the term
+        pattern = re.compile(r'\b' + re.escape(term) + r'\b', re.IGNORECASE)
+        matches = pattern.findall(result)
+
+        if matches:
+            # Get fallback replacement
+            fallback = SOLO_BLACKLIST_FALLBACKS.get(term, "")
+
+            for match in matches:
+                if fallback:
+                    # Replace with fallback, preserving case
+                    if match[0].isupper():
+                        replacement = fallback[0].upper() + fallback[1:] if fallback else ""
+                    else:
+                        replacement = fallback.lower() if fallback else ""
+                else:
+                    replacement = ""
+
+                result = pattern.sub(replacement, result, count=1)
+                fixes_applied += 1
+                log.debug(
+                    "[FIX-B-BLACKLIST] Replaced SOLO blacklist term '%s' with '%s'",
+                    match, replacement
+                )
+
+    # Clean up any double spaces or empty patterns left behind
+    result = re.sub(r'\s{2,}', ' ', result)
+    result = re.sub(r'<p>\s*</p>', '', result)
+
+    if fixes_applied > 0:
+        log.info("[FIX-B-BLACKLIST] Applied %d SOLO blacklist fixes", fixes_applied)
+
+    return result, fixes_applied
+
+
+def localize_business_case_labels_de(html: str) -> Tuple[str, int]:
+    """
+    TASK 3: Localize business-case labels from English to German.
+
+    Replaces English labels like "Payback Progress", "Time Savings Hours",
+    "Monthly Savings" with German equivalents.
+
+    Args:
+        html: HTML content to process
+
+    Returns:
+        Tuple of (localized_html, replacements_made)
+    """
+    if not html:
+        return html, 0
+
+    result = html
+    replacements_made = 0
+
+    # Apply label localizations (exact match, case-sensitive for proper labels)
+    for en_label, de_label in BUSINESS_CASE_LABEL_LOCALIZATION_DE.items():
+        if en_label in result:
+            count = result.count(en_label)
+            result = result.replace(en_label, de_label)
+            replacements_made += count
+            log.debug(
+                "[LOCALIZE-BC] Replaced '%s' → '%s' (%d times)",
+                en_label, de_label, count
+            )
+
+    if replacements_made > 0:
+        log.info("[LOCALIZE-BC] Localized %d business-case labels to German", replacements_made)
+
+    return result, replacements_made
 
 
 # =============================================================================
@@ -1510,6 +1760,8 @@ def heal_final_html(
     segment: Literal["solo", "team", "kmu"] = "team",
     *,
     canonical_payback_months: Optional[Union[float, Decimal, str]] = None,
+    localize_labels: bool = True,
+    run_quality_check: bool = False,
 ) -> str:
     """
     POST-RENDER safety net: Heal the final rendered HTML string.
@@ -1517,15 +1769,19 @@ def heal_final_html(
     This is a CONSERVATIVE healing pass that runs AFTER template rendering.
     It catches artifacts that were generated during rendering (e.g., from lists).
 
-    Only applies safe fixes that won't break HTML structure:
-    - Fix A: Template/prompt artifacts removal
+    Applies safe fixes that won't break HTML structure:
+    - Fix A: Template/prompt artifacts removal (including Wobei soll/kann ich blocks)
+    - Fix B: SOLO blacklist enforcement (for SOLO segment)
     - Fix F: Payback decimal normalization (3.5 → 3,5)
+    - TASK 3: Business-case label localization (English → German)
     - Consecutive duplicate removal (conservative)
 
     Args:
         html: Final rendered HTML string
-        segment: Target segment (for logging)
+        segment: Target segment (for segment-specific healing)
         canonical_payback_months: Optional canonical payback value
+        localize_labels: If True, localize English BC labels to German
+        run_quality_check: If True, log quality gate results (no exception)
 
     Returns:
         Healed HTML string
@@ -1539,7 +1795,7 @@ def heal_final_html(
 
     log.info("[HEALER-POST] Starting heal_final_html: len=%d, segment=%s", len(html), segment)
 
-    # Fix A: Remove prompt/template artifacts
+    # Fix A: Remove prompt/template artifacts (TASK 1 - robust patterns)
     try:
         for bp in BOILERPLATE_PATTERNS:
             try:
@@ -1551,10 +1807,19 @@ def heal_final_html(
                         result = pattern.sub("", result)
                     else:  # replace
                         result = pattern.sub(bp.replacement, result)
+                    log.debug("[HEALER-POST] Removed %d matches for: %s", len(matches), bp.description)
             except re.error:
                 pass
     except Exception as e:
         log.warning("[HEALER-POST] Fix A error: %s", e)
+
+    # Fix B: SOLO blacklist enforcement (TASK 2)
+    if segment == "solo":
+        try:
+            result, blacklist_fixes = _enforce_solo_blacklist(result)
+            fixes_applied += blacklist_fixes
+        except Exception as e:
+            log.warning("[HEALER-POST] Fix B (SOLO blacklist) error: %s", e)
 
     # Fix F: Payback decimal normalization (3.5 Monat* → 3,5 Monat*)
     try:
@@ -1568,6 +1833,14 @@ def heal_final_html(
                     fixes_applied += 1
     except Exception as e:
         log.warning("[HEALER-POST] Fix F error: %s", e)
+
+    # TASK 3: Business-case label localization
+    if localize_labels:
+        try:
+            result, label_fixes = localize_business_case_labels_de(result)
+            fixes_applied += label_fixes
+        except Exception as e:
+            log.warning("[HEALER-POST] Label localization error: %s", e)
 
     # Remove duplicate "Progress 100%" (keep first)
     try:
@@ -1585,7 +1858,172 @@ def heal_final_html(
 
     log.info("[HEALER-POST] Completed: fixes_applied=%d, len=%d→%d", fixes_applied, len(html), len(result))
 
+    # TASK 4: Optional quality gate check (logs only, no exception)
+    if run_quality_check:
+        try:
+            qg_result = run_quality_gate(result, segment, strict=False)
+            if not qg_result.passed:
+                log.warning(
+                    "[HEALER-POST] Quality gate violations remaining: %s",
+                    qg_result.to_dict()
+                )
+        except Exception as e:
+            log.warning("[HEALER-POST] Quality gate error: %s", e)
+
     return result
+
+
+# =============================================================================
+# TASK 4: Quality Gate - Final Smoke Checks
+# =============================================================================
+
+@dataclass
+class QualityGateResult:
+    """Result of quality gate checks."""
+    passed: bool = True
+    prompt_leaks: List[str] = field(default_factory=list)
+    english_decimals: List[str] = field(default_factory=list)
+    solo_blacklist_hits: List[str] = field(default_factory=list)
+    business_case_english_labels: List[str] = field(default_factory=list)
+
+    @property
+    def total_violations(self) -> int:
+        """Total number of quality violations."""
+        return (
+            len(self.prompt_leaks) +
+            len(self.english_decimals) +
+            len(self.solo_blacklist_hits) +
+            len(self.business_case_english_labels)
+        )
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert to dict for logging/serialization."""
+        return {
+            "passed": self.passed,
+            "total_violations": self.total_violations,
+            "prompt_leaks": self.prompt_leaks,
+            "english_decimals": self.english_decimals,
+            "solo_blacklist_hits": self.solo_blacklist_hits,
+            "business_case_english_labels": self.business_case_english_labels,
+        }
+
+
+# Patterns for quality gate checks
+_QG_PROMPT_LEAK_PATTERNS: List[Tuple[str, re.Pattern]] = [
+    ("Wobei soll ich", re.compile(r'Wobei\s+soll\s+ich', re.IGNORECASE)),
+    ("Wobei kann ich", re.compile(r'Wobei\s+kann\s+ich', re.IGNORECASE)),
+    ("Wie kann ich dir helfen", re.compile(r'Wie\s+kann\s+ich\s+(?:dir|Ihnen)\s+helfen', re.IGNORECASE)),
+    ("Bitte beschreibe kurz", re.compile(r'Bitte\s+beschreibe?\s+kurz', re.IGNORECASE)),
+]
+
+_QG_ENGLISH_DECIMAL_PATTERN = re.compile(
+    r'\d+\.\d+\s+Monat(?:e|en)?',
+    re.IGNORECASE
+)
+
+_QG_ENGLISH_BC_LABELS: List[str] = [
+    "Payback Progress",
+    "Time Savings Hours",
+    "Time Savings (Hours)",
+    "Monthly Savings",
+    "Annual Savings",
+]
+
+
+def run_quality_gate(
+    html: str,
+    segment: Literal["solo", "team", "kmu"] = "team",
+    *,
+    strict: bool = False,
+    check_bc_labels: bool = True,
+) -> QualityGateResult:
+    """
+    TASK 4: Run quality gate checks on final HTML before PDF generation.
+
+    Checks for:
+    1. Prompt leaks (Wobei soll ich, Wobei kann ich, etc.)
+    2. English decimal format before "Monat(e)" (should be German 3,5 not 3.5)
+    3. SOLO blacklist term violations (only for segment="solo")
+    4. English business-case labels (optional)
+
+    Args:
+        html: Final HTML to check
+        segment: Target segment for segment-specific checks
+        strict: If True, raises ReportQualityError on violations
+        check_bc_labels: If True, also check for English BC labels
+
+    Returns:
+        QualityGateResult with all violations found
+
+    Raises:
+        ReportQualityError: If strict=True and violations found
+    """
+    result = QualityGateResult()
+
+    if not html:
+        return result
+
+    # Check 1: Prompt leaks
+    for name, pattern in _QG_PROMPT_LEAK_PATTERNS:
+        if pattern.search(html):
+            result.prompt_leaks.append(name)
+            result.passed = False
+            log.error("[QUALITY-GATE] Prompt leak detected: '%s'", name)
+
+    # Check 2: English decimal format (3.5 Monate should be 3,5 Monate)
+    english_decimal_matches = _QG_ENGLISH_DECIMAL_PATTERN.findall(html)
+    if english_decimal_matches:
+        result.english_decimals = english_decimal_matches
+        result.passed = False
+        log.error(
+            "[QUALITY-GATE] English decimal format detected: %s",
+            english_decimal_matches
+        )
+
+    # Check 3: SOLO blacklist (only for SOLO segment)
+    if segment == "solo":
+        for term in SOLO_BLACKLIST_TERMS:
+            pattern = re.compile(r'\b' + re.escape(term) + r'\b', re.IGNORECASE)
+            if pattern.search(html):
+                result.solo_blacklist_hits.append(term)
+                result.passed = False
+                log.error("[QUALITY-GATE] SOLO blacklist term detected: '%s'", term)
+
+    # Check 4: English business-case labels (optional)
+    if check_bc_labels:
+        for label in _QG_ENGLISH_BC_LABELS:
+            if label in html:
+                result.business_case_english_labels.append(label)
+                result.passed = False
+                log.error("[QUALITY-GATE] English BC label detected: '%s'", label)
+
+    # Log summary
+    if result.passed:
+        log.info("[QUALITY-GATE] PASSED - No quality violations found")
+    else:
+        log.warning(
+            "[QUALITY-GATE] FAILED - %d violations: prompts=%d, decimals=%d, solo_blacklist=%d, bc_labels=%d",
+            result.total_violations,
+            len(result.prompt_leaks),
+            len(result.english_decimals),
+            len(result.solo_blacklist_hits),
+            len(result.business_case_english_labels)
+        )
+
+    # Strict mode: raise exception on failure
+    if strict and not result.passed:
+        raise ReportQualityError(
+            f"Quality gate failed with {result.total_violations} violations: "
+            f"prompts={result.prompt_leaks}, decimals={result.english_decimals}, "
+            f"solo_blacklist={result.solo_blacklist_hits}, bc_labels={result.business_case_english_labels}"
+        )
+
+    return result
+
+
+class ReportQualityError(Exception):
+    """Raised when report quality gate fails in strict mode."""
+    pass
 
 
 # =============================================================================
@@ -1593,8 +2031,9 @@ def heal_final_html(
 # =============================================================================
 
 log.info(
-    "[HEALER] Report Healer loaded - %d boilerplate patterns, %d payback patterns, %d SOLO term replacements",
+    "[HEALER] Report Healer loaded - %d boilerplate patterns, %d payback patterns, %d SOLO term replacements, %d blacklist terms",
     len(BOILERPLATE_PATTERNS),
     len(PAYBACK_PATTERNS_DE),
-    len(SOLO_TERM_REPLACEMENTS)
+    len(SOLO_TERM_REPLACEMENTS),
+    len(SOLO_BLACKLIST_TERMS)
 )

--- a/tests/test_report_healer.py
+++ b/tests/test_report_healer.py
@@ -835,3 +835,499 @@ class TestHealingResultStats:
             result.sections_budget_trimmed
         )
         assert result.total_fixes == expected_total
+
+
+# =============================================================================
+# TASK 1: Wobei soll/kann ich prompt removal (Testuser-Ready Fixes)
+# =============================================================================
+
+class TestTask1WobeiPromptRemoval:
+    """Tests for TASK 1: Robust removal of 'Wobei soll/kann ich' prompt artifacts."""
+
+    def test_removes_wobei_soll_ich_dich_mit_strong_und_ol(self):
+        """Remove 'Wobei soll ich dich unterstützen?' block with <strong> and <ol>."""
+        from services.report_healer import sanitize_template_phrases
+
+        html = """<div>
+            <p><strong>Wobei soll ich dich unterstützen?</strong></p>
+            <ol>
+                <li>Bei der Analyse deiner Daten</li>
+                <li>Bei der Erstellung von Reports</li>
+                <li>Bei der Optimierung von Prozessen</li>
+            </ol>
+            <p>Echter Inhalt hier.</p>
+        </div>"""
+
+        result, count = sanitize_template_phrases(html)
+
+        assert "Wobei soll ich" not in result
+        assert "unterstützen" not in result
+        assert "Bei der Analyse" not in result
+        assert "Echter Inhalt hier" in result
+        assert count >= 1
+
+    def test_removes_wobei_kann_ich_dir_unterstutzen_mit_ul(self):
+        """Remove 'Wobei kann ich dir unterstützen?' block with <ul>."""
+        from services.report_healer import sanitize_template_phrases
+
+        html = """<section>
+            <p>Wobei kann ich dir unterstützen?</p>
+            <ul>
+                <li>Datenanalyse</li>
+                <li>Prozessoptimierung</li>
+            </ul>
+            <p>Wichtiger Inhalt.</p>
+        </section>"""
+
+        result, count = sanitize_template_phrases(html)
+
+        assert "Wobei kann ich" not in result
+        assert "Datenanalyse" not in result
+        assert "Wichtiger Inhalt" in result
+
+    def test_removes_wobei_soll_ich_ihnen_helfen(self):
+        """Remove 'Wobei soll ich Ihnen helfen?' (formal)."""
+        from services.report_healer import sanitize_template_phrases
+
+        html = """<p><strong>Wobei soll ich Ihnen helfen?</strong></p>
+            <ol><li>Item 1</li></ol>
+            <p>Inhalt.</p>"""
+
+        result, count = sanitize_template_phrases(html)
+
+        assert "Wobei soll ich Ihnen" not in result
+        assert "helfen" not in result or "Inhalt" in result
+
+    def test_removes_standalone_wobei_question(self):
+        """Remove standalone 'Wobei soll ich...' question without list."""
+        from services.report_healer import sanitize_template_phrases
+
+        html = """<p><strong>Wobei soll ich dich unterstützen?</strong></p>
+            <p>Nächster Absatz.</p>"""
+
+        result, count = sanitize_template_phrases(html)
+
+        assert "Wobei soll ich" not in result
+        assert "Nächster Absatz" in result
+
+    def test_heal_final_html_removes_wobei_prompt_leak(self):
+        """heal_final_html should remove Wobei prompt leaks."""
+        from services.report_healer import heal_final_html
+
+        html = """<html>
+            <h1>Report</h1>
+            <p><strong>Wobei soll ich dich unterstützen?</strong></p>
+            <ol>
+                <li>Frage 1</li>
+                <li>Frage 2</li>
+            </ol>
+            <p>Der eigentliche Report-Inhalt beginnt hier.</p>
+        </html>"""
+
+        result = heal_final_html(html, "team")
+
+        assert "Wobei soll ich" not in result
+        assert "Frage 1" not in result
+        assert "Report-Inhalt" in result
+
+
+# =============================================================================
+# TASK 2: SOLO Blacklist Enforcement (Testuser-Ready Fixes)
+# =============================================================================
+
+class TestTask2SoloBlacklistEnforcement:
+    """Tests for TASK 2: SOLO blacklist enforcement with hard replacement."""
+
+    def test_enforce_persona_replaces_governance(self):
+        """SOLO should replace 'Governance' with simple alternative."""
+        from services.report_healer import enforce_persona_language
+
+        html = "<p>Die Governance muss klar definiert sein.</p>"
+        result, count = enforce_persona_language(html, "solo")
+
+        assert "Governance" not in result
+        assert count >= 1
+
+    def test_enforce_persona_replaces_executive(self):
+        """SOLO should replace 'Executive' with simple alternative."""
+        from services.report_healer import enforce_persona_language
+
+        html = "<p>Executive Summary und Executive Board.</p>"
+        result, count = enforce_persona_language(html, "solo")
+
+        assert "Executive" not in result
+        assert count >= 1
+
+    def test_enforce_persona_replaces_all_blacklist_terms(self):
+        """SOLO should replace ALL blacklist terms."""
+        from services.report_healer import enforce_persona_language, SOLO_BLACKLIST_TERMS
+
+        # Create HTML with all blacklist terms
+        terms_html = " ".join([f"<p>{term} im Text.</p>" for term in SOLO_BLACKLIST_TERMS[:5]])
+
+        result, count = enforce_persona_language(terms_html, "solo")
+
+        # Check none of the terms remain
+        for term in SOLO_BLACKLIST_TERMS[:5]:
+            assert term not in result, f"Blacklist term '{term}' should be replaced"
+
+        assert count >= 5
+
+    def test_enforce_persona_preserves_case(self):
+        """Replacements should preserve case (uppercase start)."""
+        from services.report_healer import enforce_persona_language
+
+        html = "<p>Governance und governance.</p>"
+        result, count = enforce_persona_language(html, "solo")
+
+        assert "Governance" not in result
+        assert "governance" not in result
+        assert count >= 2
+
+    def test_no_blacklist_enforcement_for_team(self):
+        """TEAM segment should not have blacklist enforcement."""
+        from services.report_healer import enforce_persona_language
+
+        html = "<p>Governance und Stakeholder bleiben hier.</p>"
+        result, count = enforce_persona_language(html, "team")
+
+        assert "Governance" in result
+        assert "Stakeholder" in result
+        assert count == 0
+
+    def test_no_blacklist_enforcement_for_kmu(self):
+        """KMU segment should not have blacklist enforcement."""
+        from services.report_healer import enforce_persona_language
+
+        html = "<p>Enterprise Framework und Compliance.</p>"
+        result, count = enforce_persona_language(html, "kmu")
+
+        assert "Enterprise" in result
+        assert "Framework" in result
+        assert "Compliance" in result
+        assert count == 0
+
+    def test_heal_report_html_enforces_solo_blacklist(self):
+        """heal_report_html should enforce SOLO blacklist across all sections."""
+        from services.report_healer import heal_report_html
+
+        sections = {
+            "RECOMMENDATIONS_HTML": "<p>Die Governance erfordert ein Framework.</p>",
+            "QUICK_WINS_HTML": "<p>Executive Rollout für Enterprise.</p>",
+        }
+
+        result = heal_report_html(sections, "solo")
+
+        for section_name in ["RECOMMENDATIONS_HTML", "QUICK_WINS_HTML"]:
+            content = result.sections[section_name]
+            assert "Governance" not in content
+            assert "Framework" not in content
+            assert "Executive" not in content
+            assert "Enterprise" not in content
+
+
+# =============================================================================
+# TASK 3: Business-Case Label Localization (Testuser-Ready Fixes)
+# =============================================================================
+
+class TestTask3BusinessCaseLabelLocalization:
+    """Tests for TASK 3: English → German business-case label localization."""
+
+    def test_localize_payback_progress(self):
+        """Localize 'Payback Progress' to German."""
+        from services.report_healer import localize_business_case_labels_de
+
+        html = "<span>Payback Progress: 75%</span>"
+        result, count = localize_business_case_labels_de(html)
+
+        assert "Payback Progress" not in result
+        assert "Amortisations-Fortschritt" in result
+        assert count >= 1
+
+    def test_localize_time_savings_hours(self):
+        """Localize 'Time Savings (Hours)' to German."""
+        from services.report_healer import localize_business_case_labels_de
+
+        html = "<td>Time Savings (Hours)</td><td>40</td>"
+        result, count = localize_business_case_labels_de(html)
+
+        assert "Time Savings (Hours)" not in result
+        assert "Zeitersparnis" in result
+
+    def test_localize_monthly_savings(self):
+        """Localize 'Monthly Savings' to German."""
+        from services.report_healer import localize_business_case_labels_de
+
+        html = "<p>Monthly Savings: €2,400</p>"
+        result, count = localize_business_case_labels_de(html)
+
+        assert "Monthly Savings" not in result
+        assert "Monatliche Einsparung" in result
+
+    def test_localize_all_english_bc_labels(self):
+        """Localize all common English BC labels to German."""
+        from services.report_healer import localize_business_case_labels_de
+
+        html = """<table>
+            <tr><td>Payback Progress</td><td>80%</td></tr>
+            <tr><td>Time Savings (Hours)</td><td>40</td></tr>
+            <tr><td>Monthly Savings</td><td>€2,400</td></tr>
+            <tr><td>Annual Savings</td><td>€28,800</td></tr>
+        </table>"""
+
+        result, count = localize_business_case_labels_de(html)
+
+        assert "Payback Progress" not in result
+        assert "Time Savings" not in result
+        assert "Monthly Savings" not in result
+        assert "Annual Savings" not in result
+        assert count >= 4
+
+    def test_heal_final_html_localizes_bc_labels(self):
+        """heal_final_html should localize BC labels by default."""
+        from services.report_healer import heal_final_html
+
+        html = """<html>
+            <p>Payback Progress: 100%</p>
+            <p>Time Savings Hours: 40</p>
+        </html>"""
+
+        result = heal_final_html(html, "team", localize_labels=True)
+
+        assert "Payback Progress" not in result
+        assert "Amortisations-Fortschritt" in result
+
+    def test_heal_final_html_skip_localization(self):
+        """heal_final_html can skip localization if requested."""
+        from services.report_healer import heal_final_html
+
+        html = "<p>Payback Progress: 100%</p>"
+
+        result = heal_final_html(html, "team", localize_labels=False)
+
+        # Should still have English labels
+        assert "Payback Progress" in result
+
+
+# =============================================================================
+# TASK 4: Quality Gate Smoke-Checks (Testuser-Ready Fixes)
+# =============================================================================
+
+class TestTask4QualityGate:
+    """Tests for TASK 4: Quality gate smoke-checks."""
+
+    def test_quality_gate_detects_wobei_prompt_leak(self):
+        """Quality gate should detect 'Wobei soll ich' prompt leaks."""
+        from services.report_healer import run_quality_gate
+
+        html = "<p>Wobei soll ich dich unterstützen?</p><p>Real content.</p>"
+
+        result = run_quality_gate(html, "team")
+
+        assert not result.passed
+        assert len(result.prompt_leaks) >= 1
+        assert "Wobei soll ich" in result.prompt_leaks
+
+    def test_quality_gate_detects_wobei_kann_ich_leak(self):
+        """Quality gate should detect 'Wobei kann ich' prompt leaks."""
+        from services.report_healer import run_quality_gate
+
+        html = "<p>Wobei kann ich dir helfen?</p>"
+
+        result = run_quality_gate(html, "team")
+
+        assert not result.passed
+        assert len(result.prompt_leaks) >= 1
+
+    def test_quality_gate_detects_english_decimal_format(self):
+        """Quality gate should detect English decimal format (3.5 Monate)."""
+        from services.report_healer import run_quality_gate
+
+        html = "<p>Amortisation in 3.5 Monaten.</p>"
+
+        result = run_quality_gate(html, "team")
+
+        assert not result.passed
+        assert len(result.english_decimals) >= 1
+
+    def test_quality_gate_passes_german_decimal_format(self):
+        """Quality gate should pass German decimal format (3,5 Monate)."""
+        from services.report_healer import run_quality_gate
+
+        html = "<p>Amortisation in 3,5 Monaten.</p>"
+
+        result = run_quality_gate(html, "team")
+
+        # Should pass (no English decimals)
+        assert len(result.english_decimals) == 0
+
+    def test_quality_gate_detects_solo_blacklist_hits(self):
+        """Quality gate should detect SOLO blacklist hits for SOLO segment."""
+        from services.report_healer import run_quality_gate
+
+        html = "<p>Die Governance erfordert ein Framework.</p>"
+
+        result = run_quality_gate(html, "solo")
+
+        assert not result.passed
+        assert len(result.solo_blacklist_hits) >= 2
+        assert "Governance" in result.solo_blacklist_hits
+        assert "Framework" in result.solo_blacklist_hits
+
+    def test_quality_gate_no_solo_blacklist_for_team(self):
+        """Quality gate should NOT check SOLO blacklist for TEAM segment."""
+        from services.report_healer import run_quality_gate
+
+        html = "<p>Die Governance erfordert ein Framework.</p>"
+
+        result = run_quality_gate(html, "team")
+
+        # SOLO blacklist should not apply to TEAM
+        assert len(result.solo_blacklist_hits) == 0
+
+    def test_quality_gate_detects_english_bc_labels(self):
+        """Quality gate should detect English BC labels."""
+        from services.report_healer import run_quality_gate
+
+        html = "<p>Payback Progress: 80%. Monthly Savings: €2400.</p>"
+
+        result = run_quality_gate(html, "team", check_bc_labels=True)
+
+        assert not result.passed
+        assert "Payback Progress" in result.business_case_english_labels
+        assert "Monthly Savings" in result.business_case_english_labels
+
+    def test_quality_gate_passes_clean_html(self):
+        """Quality gate should pass for clean HTML with no violations."""
+        from services.report_healer import run_quality_gate
+
+        html = """<html>
+            <h1>KI-Status Report</h1>
+            <p>Amortisation in 3,5 Monaten.</p>
+            <p>Monatliche Einsparung: €2.400</p>
+        </html>"""
+
+        result = run_quality_gate(html, "team", check_bc_labels=True)
+
+        assert result.passed
+        assert result.total_violations == 0
+
+    def test_quality_gate_strict_mode_raises_exception(self):
+        """Quality gate should raise exception in strict mode."""
+        from services.report_healer import run_quality_gate, ReportQualityError
+
+        html = "<p>Wobei soll ich dich unterstützen?</p>"
+
+        with pytest.raises(ReportQualityError) as exc_info:
+            run_quality_gate(html, "team", strict=True)
+
+        assert "Quality gate failed" in str(exc_info.value)
+
+    def test_quality_gate_result_to_dict(self):
+        """QualityGateResult.to_dict should return proper structure."""
+        from services.report_healer import run_quality_gate
+
+        html = "<p>Wobei soll ich dich unterstützen? Payback Progress: 80%</p>"
+
+        result = run_quality_gate(html, "team")
+        result_dict = result.to_dict()
+
+        assert "passed" in result_dict
+        assert "total_violations" in result_dict
+        assert "prompt_leaks" in result_dict
+        assert result_dict["passed"] is False
+        assert result_dict["total_violations"] >= 1
+
+    def test_integration_heal_final_html_then_quality_gate(self):
+        """After heal_final_html, quality gate should pass."""
+        from services.report_healer import heal_final_html, run_quality_gate
+
+        dirty_html = """<html>
+            <p><strong>Wobei soll ich dich unterstützen?</strong></p>
+            <ol><li>Frage 1</li></ol>
+            <p>Amortisation in 3.5 Monaten.</p>
+            <p>Payback Progress: 100%</p>
+            <p>Echter Inhalt hier.</p>
+        </html>"""
+
+        # First heal
+        healed_html = heal_final_html(dirty_html, "team", localize_labels=True)
+
+        # Then check quality
+        qg_result = run_quality_gate(healed_html, "team", check_bc_labels=True)
+
+        # Should pass after healing
+        assert qg_result.passed, f"Quality gate should pass after healing: {qg_result.to_dict()}"
+        assert "Wobei soll ich" not in healed_html
+        assert "3.5 Monaten" not in healed_html
+        assert "Payback Progress" not in healed_html
+
+
+# =============================================================================
+# Integration Tests: Full Pipeline with All Tasks
+# =============================================================================
+
+class TestFullPipelineIntegration:
+    """Integration tests verifying all tasks work together."""
+
+    def test_full_solo_pipeline_removes_all_violations(self):
+        """Full SOLO pipeline should remove all violations."""
+        from services.report_healer import heal_report_html, heal_final_html, run_quality_gate
+
+        sections = {
+            "EXECUTIVE_SUMMARY_HTML": """
+                <p><strong>Wobei soll ich dich unterstützen?</strong></p>
+                <ol><li>Hilfe 1</li></ol>
+                <p>Die Governance erfordert ein Framework.</p>
+            """,
+            "BUSINESS_CASE_HTML": """
+                <p>Payback Progress: 80%</p>
+                <p>Amortisation in 3.5 Monaten.</p>
+            """,
+        }
+
+        # Step 1: Pre-render healing
+        pre_result = heal_report_html(sections, "solo")
+
+        # Step 2: Simulate render (just concatenate for test)
+        rendered = "\n".join(str(v) for v in pre_result.sections.values() if isinstance(v, str))
+
+        # Step 3: Post-render healing
+        final_html = heal_final_html(rendered, "solo", localize_labels=True)
+
+        # Step 4: Quality gate
+        qg_result = run_quality_gate(final_html, "solo", check_bc_labels=True)
+
+        # Verify all violations removed
+        assert "Wobei soll ich" not in final_html
+        assert "Governance" not in final_html
+        assert "Framework" not in final_html
+        assert "3.5 Monaten" not in final_html
+        assert "Payback Progress" not in final_html
+        assert qg_result.passed, f"Quality gate should pass: {qg_result.to_dict()}"
+
+    def test_payback_remains_german_formatted(self):
+        """Payback should remain in German format (3,5) - regression test."""
+        from services.report_healer import heal_final_html
+
+        html = "<p>Amortisation in 3,5 Monaten.</p>"
+
+        result = heal_final_html(html, "team")
+
+        # Should NOT change German format
+        assert "3,5 Monaten" in result
+        # Should NOT have English format
+        assert "3.5 Monaten" not in result
+
+    def test_payback_english_to_german_conversion(self):
+        """English decimal (3.5) should convert to German (3,5)."""
+        from services.report_healer import heal_final_html
+
+        html = "<p>Amortisation in 3.5 Monaten.</p>"
+
+        result = heal_final_html(html, "team")
+
+        # Should convert to German format
+        assert "3,5 Monaten" in result
+        # Should NOT have English format
+        assert "3.5 Monaten" not in result

--- a/tests/test_report_healer_integration.py
+++ b/tests/test_report_healer_integration.py
@@ -21,7 +21,7 @@ class TestReportHealerIntegration:
         sections = {
             "EXECUTIVE_SUMMARY_HTML": """
                 <div class="heading heading-h1">Wie kann ich Ihnen heute helfen?</div>
-                <p>Dies ist die Executive Summary.</p>
+                <p>Dies ist die Kurzfassung.</p>
             """,
             "QUICK_WINS_HTML": """
                 <p>Wobei kann ich dir helfen?</p>
@@ -34,8 +34,8 @@ class TestReportHealerIntegration:
         # Prompt artifacts should be removed
         assert "Wie kann ich" not in result.sections.get("EXECUTIVE_SUMMARY_HTML", "")
         assert "Wobei kann ich" not in result.sections.get("QUICK_WINS_HTML", "")
-        # Real content should remain
-        assert "Executive Summary" in result.sections.get("EXECUTIVE_SUMMARY_HTML", "")
+        # Real content should remain (note: uses SOLO-friendly terms now)
+        assert "Kurzfassung" in result.sections.get("EXECUTIVE_SUMMARY_HTML", "")
         assert "Automatisierung" in result.sections.get("QUICK_WINS_HTML", "")
         assert result.template_phrases_removed > 0
 


### PR DESCRIPTION
TASK 1: Robust prompt/chat artifact removal (DE)
- Add patterns for "Wobei soll/kann ich dich/dir unterstützen/helfen?"
- Remove entire block including following <ol>/<ul> lists
- Works with and without <strong> tags
- Fallback patterns for various HTML structures

TASK 2: SOLO-Blacklist "hard" enforcement
- Extended SOLO_TERM_REPLACEMENTS with comprehensive mappings
- Add SOLO_BLACKLIST_TERMS for enterprise terms
- Add SOLO_BLACKLIST_FALLBACKS for safety net replacements
- New _enforce_solo_blacklist() function runs after primary replacements
- Replace: Governance→Spielregeln, Executive→Inhaber:in, Audit→Prüfung, Rollout→Einführung, Layer→Ebene, Enterprise→größere Unternehmen, Blueprint→Vorlage, Framework→Vorgehensrahmen, KPI-Dashboard→Kennzahlen-Übersicht, Operating Model→Arbeitsmodell, Compliance→Regelkonformität

TASK 3: Business-Case label localization (EN→DE)
- New localize_business_case_labels_de() function
- Localize: Payback Progress→Amortisations-Fortschritt, Time Savings (Hours)→Zeitersparnis (Stunden), Monthly Savings→Monatliche Einsparung, Annual Savings→Jährliche Einsparung, etc.
- Integrated into heal_final_html() with localize_labels flag

TASK 4: Quality Gate smoke-checks
- New run_quality_gate() function
- Detects: prompt leaks, English decimal format (3.5 vs 3,5), SOLO blacklist violations, English BC labels
- New QualityGateResult dataclass with to_dict() for logging
- New ReportQualityError exception for strict mode
- Optional integration in heal_final_html() via run_quality_check flag

Tests: 111 tests passing (93 unit + 18 integration)