### PR TITLE
feat: P1 Sprint fixes - Final-Check, Quick Wins gate, SOLO labels, RO…

### DIFF
--- a/services/quickwins_renderer.py
+++ b/services/quickwins_renderer.py
@@ -403,6 +403,135 @@ def get_quickwin_enrichment(title: str, icon: str = "") -> dict:
     return QUICKWIN_ENRICHMENT_MAP["default"]
 
 
+# =============================================================================
+# TASK B (P0): Quick Wins Completeness Gate
+# =============================================================================
+# Ensures all Quick Wins have non-empty problem/wirkung/umsetzung fields.
+# Uses deterministic heuristics to fill missing fields from available context.
+
+# Default fallback texts for empty fields based on title keywords
+QUICKWIN_FIELD_FALLBACKS = {
+    "problem": {
+        "automatisierung": "Manuelle Prozesse binden Zeit und erhöhen Fehlerquoten.",
+        "effizienz": "Ineffiziente Abläufe verursachen vermeidbare Kosten.",
+        "kommunikation": "Inkonsistente Kommunikation mindert Professionalität.",
+        "content": "Content-Erstellung ist zeitintensiv und ressourcenbindend.",
+        "daten": "Datensilos verhindern fundierte Entscheidungen.",
+        "kund": "Langsame Reaktionszeiten beeinträchtigen Kundenzufriedenheit.",
+        "service": "Support-Anfragen überlasten das Team.",
+        "default": "Aktueller Prozess ist zeitintensiv und fehleranfällig.",
+    },
+    "wirkung": {
+        "automatisierung": "Automatisierte Abläufe reduzieren Zeitaufwand um 50-70%.",
+        "effizienz": "Effizientere Prozesse steigern Durchsatz messbar.",
+        "kommunikation": "Konsistente, professionelle Kommunikation stärkt Markenwahrnehmung.",
+        "content": "Schnellere Content-Erstellung bei gleichbleibender Qualität.",
+        "daten": "Bessere Datenverfügbarkeit ermöglicht schnellere Entscheidungen.",
+        "kund": "Kürzere Reaktionszeiten erhöhen Kundenbindung.",
+        "service": "Entlastung des Support-Teams bei Routineanfragen.",
+        "default": "Spürbare Zeit- und Kostenersparnis bei höherer Qualität.",
+    },
+    "umsetzung": {
+        "automatisierung": "Schrittweise Automatisierung der häufigsten Abläufe starten.",
+        "effizienz": "Pilotprojekt mit höchstem Optimierungspotenzial beginnen.",
+        "kommunikation": "Templates und Vorlagen für häufige Kommunikationsfälle erstellen.",
+        "content": "KI-Unterstützung für Content-Workflows einrichten.",
+        "daten": "Datenquellen verknüpfen und Dashboard aufsetzen.",
+        "kund": "Chatbot oder Selbstservice-Portal für Standardanfragen implementieren.",
+        "service": "FAQ-basierte Automatisierung für häufige Fragen einführen.",
+        "default": "Pilotprojekt mit kleinem Scope starten, dann skalieren.",
+    },
+}
+
+
+def _get_field_fallback(field: str, title: str, hinweis: str = "") -> str:
+    """
+    Get deterministic fallback text for a missing Quick Win field.
+
+    Args:
+        field: Field name (problem, wirkung, umsetzung)
+        title: Quick Win title for keyword matching
+        hinweis: Optional hint text that might contain useful info
+
+    Returns:
+        Fallback text for the field
+    """
+    if field not in QUICKWIN_FIELD_FALLBACKS:
+        return ""
+
+    field_fallbacks = QUICKWIN_FIELD_FALLBACKS[field]
+    combined = f"{title} {hinweis}".lower()
+
+    # Try to match a keyword
+    for keyword, text in field_fallbacks.items():
+        if keyword != "default" and keyword in combined:
+            return text
+
+    return field_fallbacks.get("default", "")
+
+
+def enforce_quickwins_complete(quickwins: list) -> list:
+    """
+    TASK B (P0): Ensure all Quick Wins have complete problem/wirkung/umsetzung fields.
+
+    For each Quick Win:
+    1. Check if problem, wirkung, umsetzung are non-empty
+    2. If empty, use deterministic heuristics to fill from title/hinweis
+    3. Log completeness actions for debugging
+
+    Args:
+        quickwins: List of Quick Win dicts with fields:
+            - title, icon, problem, wirkung, umsetzung, hinweis
+
+    Returns:
+        List of Quick Wins with all fields completed (non-empty)
+
+    Example:
+        >>> qw = [{"title": "Automatisierung", "problem": "", "wirkung": "", "umsetzung": ""}]
+        >>> result = enforce_quickwins_complete(qw)
+        >>> all(result[0][f] for f in ["problem", "wirkung", "umsetzung"])
+        True
+    """
+    if not quickwins or not isinstance(quickwins, list):
+        return quickwins
+
+    completed = []
+    completions_made = 0
+
+    for i, qw in enumerate(quickwins):
+        if not isinstance(qw, dict):
+            completed.append(qw)
+            continue
+
+        qw_copy = dict(qw)  # Don't mutate original
+        title = str(qw_copy.get("title", "")).strip()
+        hinweis = str(qw_copy.get("hinweis", "")).strip()
+
+        # Check and fill each required field
+        for field in ["problem", "wirkung", "umsetzung"]:
+            current_value = str(qw_copy.get(field, "")).strip()
+
+            if not current_value:
+                # Field is empty - fill with deterministic fallback
+                fallback = _get_field_fallback(field, title, hinweis)
+                qw_copy[field] = fallback
+                completions_made += 1
+                log.debug(
+                    "[QUICKWINS-COMPLETE] QW#%d '%s': filled empty %s with fallback",
+                    i + 1, title[:30], field
+                )
+
+        completed.append(qw_copy)
+
+    if completions_made > 0:
+        log.info(
+            "[QUICKWINS-COMPLETE] Filled %d empty fields across %d Quick Wins",
+            completions_made, len(quickwins)
+        )
+
+    return completed
+
+
 def enrich_quickwin_card(html: str) -> str:
     """
     FIX-506: Enrich a single Quick Win card with Nutzen and Aufwand sublines.
@@ -551,6 +680,9 @@ def render_quickwins_premium_json(raw_json: str, template_mode: str = "FULL") ->
         if not isinstance(data, list) or len(data) == 0:
             return None
 
+        # TASK B (P0): Apply completeness gate - fill empty fields with deterministic fallbacks
+        data = enforce_quickwins_complete(data)
+
         # Build premium cards
         cards_html = []
         total_words = 0
@@ -571,26 +703,39 @@ def render_quickwins_premium_json(raw_json: str, template_mode: str = "FULL") ->
             card_words = len(card_text.split())
             total_words += card_words
 
-            # Build rich card HTML
+            # TASK B: Build field blocks only if they have content (skip empty)
+            problem_block = ""
+            if problem:
+                problem_block = f'''
+        <div class="quick-win-problem" style="margin-bottom:10px;padding:10px;background:#fef2f2;border-radius:8px;border-left:3px solid #ef4444;">
+            <strong style="color:#dc2626;font-size:11px;text-transform:uppercase;letter-spacing:0.5px;">Problem:</strong>
+            <p style="margin:4px 0 0 0;">{problem}</p>
+        </div>'''
+
+            wirkung_block = ""
+            if wirkung:
+                wirkung_block = f'''
+        <div class="quick-win-wirkung" style="margin-bottom:10px;padding:10px;background:#f0fdf4;border-radius:8px;border-left:3px solid #22c55e;">
+            <strong style="color:#16a34a;font-size:11px;text-transform:uppercase;letter-spacing:0.5px;">Wirkung:</strong>
+            <p style="margin:4px 0 0 0;">{wirkung}</p>
+        </div>'''
+
+            umsetzung_block = ""
+            if umsetzung:
+                umsetzung_block = f'''
+        <div class="quick-win-umsetzung" style="margin-bottom:10px;padding:10px;background:#eff6ff;border-radius:8px;border-left:3px solid #3b82f6;">
+            <strong style="color:#2563eb;font-size:11px;text-transform:uppercase;letter-spacing:0.5px;">Umsetzung:</strong>
+            <p style="margin:4px 0 0 0;">{umsetzung}</p>
+        </div>'''
+
+            # TASK B: Build card HTML with conditional blocks (skip empty ones)
             card_html = f'''
 <div class="quick-win quick-win-card-premium" data-qw-json-rendered="true" data-qw-premium="true" style="background:#ffffff;border:1px solid #e5e7eb;border-radius:12px;padding:16px;margin-bottom:16px;break-inside:avoid;page-break-inside:avoid;">
     <div class="quick-win-header" style="display:flex;align-items:center;gap:12px;margin-bottom:12px;">
         <span class="quick-win-icon" style="font-size:24px;flex-shrink:0;">{icon}</span>
         <h4 class="quick-win-title" style="margin:0;font-size:14px;font-weight:600;color:#1e293b;line-height:1.3;">{title}</h4>
     </div>
-    <div class="quick-win-body" style="font-size:12px;line-height:1.5;color:#475569;">
-        <div class="quick-win-problem" style="margin-bottom:10px;padding:10px;background:#fef2f2;border-radius:8px;border-left:3px solid #ef4444;">
-            <strong style="color:#dc2626;font-size:11px;text-transform:uppercase;letter-spacing:0.5px;">Problem:</strong>
-            <p style="margin:4px 0 0 0;">{problem}</p>
-        </div>
-        <div class="quick-win-wirkung" style="margin-bottom:10px;padding:10px;background:#f0fdf4;border-radius:8px;border-left:3px solid #22c55e;">
-            <strong style="color:#16a34a;font-size:11px;text-transform:uppercase;letter-spacing:0.5px;">Wirkung:</strong>
-            <p style="margin:4px 0 0 0;">{wirkung}</p>
-        </div>
-        <div class="quick-win-umsetzung" style="margin-bottom:10px;padding:10px;background:#eff6ff;border-radius:8px;border-left:3px solid #3b82f6;">
-            <strong style="color:#2563eb;font-size:11px;text-transform:uppercase;letter-spacing:0.5px;">Umsetzung:</strong>
-            <p style="margin:4px 0 0 0;">{umsetzung}</p>
-        </div>
+    <div class="quick-win-body" style="font-size:12px;line-height:1.5;color:#475569;">{problem_block}{wirkung_block}{umsetzung_block}
         <div class="quick-win-hinweis" style="font-size:11px;color:#6b7280;font-style:italic;padding-top:8px;border-top:1px solid #e5e7eb;">
             💡 {hinweis}
         </div>

--- a/services/report_healer.py
+++ b/services/report_healer.py
@@ -977,6 +977,108 @@ BUSINESS_CASE_LABEL_LOCALIZATION_DE: Dict[str, str] = {
 }
 
 
+# =============================================================================
+# TASK D (P1 optional): ROI as Ranges/Qualitative for SOLO
+# =============================================================================
+# For SOLO segment, convert exact ROI % values to qualitative ranges
+# to avoid overly precise numbers that may seem unrealistic.
+
+# ROI value ranges and their qualitative descriptions (German)
+ROI_QUALITATIVE_RANGES_DE = [
+    (300, "sehr hoch (über 300%)"),
+    (200, "hoch (200-300%)"),
+    (150, "gut (150-200%)"),
+    (100, "solide (100-150%)"),
+    (50, "moderat (50-100%)"),
+    (0, "gering (unter 50%)"),
+]
+
+
+def format_roi_span(roi_value: float, lang: str = "de") -> str:
+    """
+    TASK D: Convert exact ROI % to qualitative range/span.
+
+    For SOLO segment, replaces exact ROI numbers with ranges
+    to make the numbers more approachable and realistic.
+
+    Args:
+        roi_value: ROI as percentage (e.g., 200.0 for 200%)
+        lang: Language code (currently only 'de' supported)
+
+    Returns:
+        Qualitative ROI description like "hoch (200-300%)"
+
+    Examples:
+        >>> format_roi_span(250.0)
+        'hoch (200-300%)'
+        >>> format_roi_span(75.0)
+        'moderat (50-100%)'
+    """
+    if lang != "de":
+        # For non-German, return the numeric value for now
+        return f"{roi_value:.0f}%"
+
+    for threshold, description in ROI_QUALITATIVE_RANGES_DE:
+        if roi_value >= threshold:
+            return description
+
+    return "gering (unter 50%)"
+
+
+def sanitize_roi_for_solo(html: str) -> Tuple[str, int]:
+    """
+    TASK D: Convert exact ROI % values to qualitative ranges in SOLO HTML.
+
+    Finds patterns like "ROI: 250%" or "ROI von 200%" and replaces
+    with qualitative descriptions for SOLO.
+
+    Args:
+        html: HTML content to process
+
+    Returns:
+        Tuple of (processed_html, replacements_count)
+
+    Example patterns matched:
+        - "ROI: 200%"
+        - "ROI von 150%"
+        - "200% ROI"
+        - "ROI 12M: 180%"
+    """
+    if not html:
+        return html, 0
+
+    result = html
+    replacement_count = 0
+
+    # Pattern for ROI followed by percentage
+    roi_patterns = [
+        # "ROI: 200%" or "ROI von 200%" or "ROI 200%"
+        (r'ROI[\s:]*(?:von\s+)?(\d+(?:[.,]\d+)?)\s*%', r'ROI: {qual}'),
+        # "200% ROI" - percentage before ROI
+        (r'(\d+(?:[.,]\d+)?)\s*%\s*ROI', r'{qual} ROI'),
+        # "ROI 12M: 200%" - with 12M suffix
+        (r'ROI\s*(?:12M|12\s*M)[\s:]*(\d+(?:[.,]\d+)?)\s*%', r'ROI 12M: {qual}'),
+    ]
+
+    for pattern, replacement_template in roi_patterns:
+        matches = list(re.finditer(pattern, result, re.IGNORECASE))
+        for match in reversed(matches):  # Process in reverse to maintain positions
+            try:
+                roi_str = match.group(1).replace(',', '.')
+                roi_val = float(roi_str)
+                qual = format_roi_span(roi_val)
+                replacement = replacement_template.format(qual=qual)
+                result = result[:match.start()] + replacement + result[match.end():]
+                replacement_count += 1
+            except (ValueError, IndexError):
+                continue
+
+    if replacement_count > 0:
+        log.info("[TASK-D] SOLO ROI: Converted %d exact ROI values to qualitative ranges", replacement_count)
+
+    return result, replacement_count
+
+
 def enforce_persona_language(
     html: str,
     segment: Literal["solo", "team", "kmu"]
@@ -2356,6 +2458,14 @@ def heal_final_html(
             fixes_applied += label_fixes
         except Exception as e:
             log.warning("[HEALER-POST] Label localization error: %s", e)
+
+    # TASK D: ROI as qualitative ranges for SOLO (P1 optional)
+    if segment_lower == "solo":
+        try:
+            result, roi_fixes = sanitize_roi_for_solo(result)
+            fixes_applied += roi_fixes
+        except Exception as e:
+            log.warning("[HEALER-POST] TASK-D ROI sanitization error: %s", e)
 
     # Remove duplicate "Progress 100%" (keep first) - legacy pattern
     try:

--- a/services/report_renderer.py
+++ b/services/report_renderer.py
@@ -21,7 +21,7 @@ from services.html_minifier import optimize_html_for_pdf, strip_unused_sections
 from services.report_validator import GENERIC_LLM_LEAK_PHRASES, remove_leak_phrases_from_html
 from services.html_sanitizer import sanitize_en_locale_tokens
 from services.lang_utils import normalize_lang
-from services.i18n import ui as ui_factory
+from services.i18n import ui as ui_factory, ui_for_segment
 from services.locale_rewriter import apply_locale_v2
 from services.debug_503d import build_debug_503d_attachments, build_debug_503d_summary, is_debug_render_enabled
 
@@ -658,9 +658,16 @@ def render(briefing_obj: Any,
 
     # =========================================================================
     # Multilingual v1 Step 4: Inject ui() into template context
+    # TASK C: Use segment-aware ui_for_segment() for SOLO label localization
     # =========================================================================
-    ctx["ui"] = ui_factory(lang)
+    segment = sections.get("COMPANY_SIZE", "team")
+    # Normalize segment to canonical form (SOLO, TEAM, KMU)
+    segment_map = {"solo": "SOLO", "team": "TEAM", "klein": "TEAM", "kmu": "KMU"}
+    segment_canonical = segment_map.get(str(segment).lower(), "TEAM")
+    ctx["ui"] = ui_for_segment(lang, segment=segment_canonical)
     ctx["report_lang"] = lang
+    ctx["report_segment"] = segment_canonical
+    log.debug("[RENDER] Using segment-aware labels: segment=%s, lang=%s", segment_canonical, lang)
 
     # Log what we're rendering (for debugging)
     log.info(f"🎨 Rendering report {run_id} with {len(sections)} sections (lang={lang})")

--- a/templates/pdf_template.html
+++ b/templates/pdf_template.html
@@ -6640,7 +6640,7 @@
                             {% set gov_level = 'excellent' if gov_score >= 80 else 'good' if gov_score >= 65 else 'medium' if gov_score >= 50 else 'low' %}
                             {% set gov_color = '#22c55e' if gov_level == 'excellent' else '#84cc16' if gov_level == 'good' else '#eab308' if gov_level == 'medium' else '#ef4444' %}
                             <div class="dimension-card-modern" data-level="{{ gov_level }}" style="background: white; border: 1px solid #e2e8f0; border-radius: 12px; padding: 1.25rem; text-align: center; box-shadow: 0 2px 4px rgba(0,0,0,0.04);">
-                                <div class="dimension-label" style="font-size: 8pt; text-transform: uppercase; letter-spacing: 0.08em; color: #64748b; margin-bottom: 8px; font-weight: 600;">Governance</div>
+                                <div class="dimension-label" style="font-size: 8pt; text-transform: uppercase; letter-spacing: 0.08em; color: #64748b; margin-bottom: 8px; font-weight: 600;">{{ ui("governance_label", "Governance") }}</div>
                                 <div class="dimension-score" style="font-size: 28px; font-weight: 700; line-height: 1; margin-bottom: 8px; color: {{ gov_color }};">{{ gov_score }}</div>
                                 <div class="dimension-bar" style="height: 6px; background: #e2e8f0; border-radius: 3px; overflow: hidden;">
                                     <div class="dimension-bar-fill" style="width: {{ gov_score }}%; height: 100%; border-radius: 3px; background: {{ gov_color }};"></div>
@@ -6780,22 +6780,20 @@
                     </div>
 
                     <!-- FINAL CHECK with prominent actions - v5.4.4 Visual Upgrade -->
+                    <!-- TASK A FIX: Using p.final-check-item instead of flex spans for WeasyPrint word-wrap compatibility -->
                     {% if FINAL_CHECK_INTRO or FINAL_CHECK_DECISIONS %}
-                    <div style="background: linear-gradient(135deg, #2563eb 0%, #1e40af 100%); color: white; padding: 24px; border-radius: 16px; margin-bottom: 24px; box-shadow: 0 8px 24px rgba(37, 99, 235, 0.3);">
+                    <div class="final-check-box" style="background: linear-gradient(135deg, #2563eb 0%, #1e40af 100%); color: white; padding: 24px; border-radius: 16px; margin-bottom: 24px; box-shadow: 0 8px 24px rgba(37, 99, 235, 0.3);">
                         <div style="display: flex; align-items: center; gap: 12px; margin-bottom: 16px;">
                             <span style="font-size: 28px; line-height: 1;">🚀</span>
                             <h3 style="font-size: 22px; font-weight: 700; margin: 0; letter-spacing: -0.02em;">Final-Check</h3>
                         </div>
                         {% if FINAL_CHECK_INTRO %}
-                        <p style="margin: 0 0 20px 0; font-size: 15px; line-height: 1.6; opacity: 0.95;">{{ FINAL_CHECK_INTRO }}</p>
+                        <p style="margin: 0 0 20px 0; font-size: 15px; line-height: 1.6; opacity: 0.95; word-wrap: break-word; overflow-wrap: break-word;">{{ FINAL_CHECK_INTRO }}</p>
                         {% endif %}
                         {% if FINAL_CHECK_DECISIONS %}
-                        <div style="display: flex; flex-direction: column; gap: 12px;">
+                        <div class="final-check-list" style="display: flex; flex-direction: column; gap: 12px;">
                             {% for decision in FINAL_CHECK_DECISIONS %}
-                            <div style="display: flex; align-items: flex-start; gap: 12px; background: rgba(255, 255, 255, 0.15); padding: 14px 18px; border-radius: 10px; border-left: 4px solid rgba(255, 255, 255, 0.4); backdrop-filter: blur(10px);">
-                                <span style="font-size: 18px; font-weight: 700; color: rgba(255, 255, 255, 0.9); min-width: 24px;">•</span>
-                                <span style="font-size: 15px; line-height: 1.5; color: rgba(255, 255, 255, 0.95);">{{ decision }}</span>
-                            </div>
+                            <p class="final-check-item" style="display: block; background: rgba(255, 255, 255, 0.15); padding: 14px 18px; border-radius: 10px; border-left: 4px solid rgba(255, 255, 255, 0.4); margin: 0; font-size: 15px; line-height: 1.5; color: rgba(255, 255, 255, 0.95); word-wrap: break-word; overflow-wrap: break-word; white-space: normal;">• {{ decision }}</p>
                             {% endfor %}
                         </div>
                         {% endif %}
@@ -7731,7 +7729,7 @@
                 <section class="section chapter">
                     <div class="section-header">
                         <div class="section-title">
-                            <span class="section-kicker">Governance</span>
+                            <span class="section-kicker">{{ ui("governance_section_kicker", "Governance") }}</span>
                             <br/>
                             <h2>AI Mini-Policy</h2>
                         </div>

--- a/tests/test_p1_sprint_fixes.py
+++ b/tests/test_p1_sprint_fixes.py
@@ -1,0 +1,388 @@
+# -*- coding: utf-8 -*-
+"""
+Tests for P1 Sprint Fixes:
+- TASK A: Final-Check Rendering (p.final-check-item)
+- TASK B: Quick Wins Completeness Gate (enforce_quickwins_complete)
+- TASK C: SOLO Labels Source-of-Truth (segment-aware template labels)
+"""
+import pytest
+import re
+
+
+# =============================================================================
+# TASK A: Final-Check Rendering Tests
+# =============================================================================
+
+class TestFinalCheckRendering:
+    """Tests for Final-Check Box rendering changes."""
+
+    def test_template_has_final_check_item_class(self):
+        """Verify template uses p.final-check-item instead of ul/li."""
+        from pathlib import Path
+
+        template_path = Path(__file__).parent.parent / "templates" / "pdf_template.html"
+        with open(template_path, "r", encoding="utf-8") as f:
+            content = f.read()
+
+        # Find the Final-Check section (greedy to capture the whole block)
+        final_check_start = content.find('<!-- FINAL CHECK')
+        assert final_check_start != -1, "Final-Check section not found in template"
+
+        # Find the end of the Final-Check block (next major section or 500 chars)
+        final_check_end = content.find('<!-- TOP-3 MUSS', final_check_start)
+        if final_check_end == -1:
+            final_check_end = final_check_start + 3000  # fallback
+
+        final_check_html = content[final_check_start:final_check_end]
+
+        # Should have p.final-check-item
+        assert 'class="final-check-item"' in final_check_html, \
+            f"Expected p.final-check-item class in Final-Check section. Found: {final_check_html[:500]}..."
+
+        # Should NOT have ul/li for FINAL_CHECK_DECISIONS
+        # Check that there's no <ul> before the {% endfor %} for decisions
+        decisions_block = re.search(r'FINAL_CHECK_DECISIONS.*?endfor', final_check_html, re.DOTALL)
+        if decisions_block:
+            assert '<ul' not in decisions_block.group(0), \
+                "Final-Check decisions should not use ul element"
+
+    def test_final_check_has_word_wrap_css(self):
+        """Verify Final-Check has word-wrap CSS for WeasyPrint compatibility."""
+        from pathlib import Path
+
+        template_path = Path(__file__).parent.parent / "templates" / "pdf_template.html"
+        with open(template_path, "r", encoding="utf-8") as f:
+            content = f.read()
+
+        # Find the Final-Check section
+        final_check_match = re.search(
+            r'class="final-check-item"[^>]*style="[^"]*',
+            content
+        )
+
+        assert final_check_match, "final-check-item with style not found"
+        style = final_check_match.group(0)
+
+        # Should have word-wrap
+        assert 'word-wrap' in style or 'overflow-wrap' in style, \
+            "Expected word-wrap or overflow-wrap in final-check-item style"
+
+
+# =============================================================================
+# TASK B: Quick Wins Completeness Gate Tests
+# =============================================================================
+
+class TestQuickWinsCompletenessGate:
+    """Tests for enforce_quickwins_complete function."""
+
+    def test_enforce_fills_empty_problem(self):
+        """Test that empty problem field is filled with fallback."""
+        from services.quickwins_renderer import enforce_quickwins_complete
+
+        quickwins = [
+            {"title": "Automatisierung der Rechnungsstellung", "problem": "", "wirkung": "Test", "umsetzung": "Test"}
+        ]
+
+        result = enforce_quickwins_complete(quickwins)
+
+        assert result[0]["problem"], "Expected problem field to be filled"
+        assert "Manuelle" in result[0]["problem"] or "automatisier" in result[0]["problem"].lower()
+
+    def test_enforce_fills_empty_wirkung(self):
+        """Test that empty wirkung field is filled with fallback."""
+        from services.quickwins_renderer import enforce_quickwins_complete
+
+        quickwins = [
+            {"title": "Effizienzsteigerung", "problem": "Test", "wirkung": "", "umsetzung": "Test"}
+        ]
+
+        result = enforce_quickwins_complete(quickwins)
+
+        assert result[0]["wirkung"], "Expected wirkung field to be filled"
+
+    def test_enforce_fills_empty_umsetzung(self):
+        """Test that empty umsetzung field is filled with fallback."""
+        from services.quickwins_renderer import enforce_quickwins_complete
+
+        quickwins = [
+            {"title": "Kundenservice Chatbot", "problem": "Test", "wirkung": "Test", "umsetzung": ""}
+        ]
+
+        result = enforce_quickwins_complete(quickwins)
+
+        assert result[0]["umsetzung"], "Expected umsetzung field to be filled"
+        # Should match customer-related fallback
+        assert "Chatbot" in result[0]["umsetzung"] or "Selbstservice" in result[0]["umsetzung"] or "Pilotprojekt" in result[0]["umsetzung"]
+
+    def test_enforce_fills_all_empty_fields(self):
+        """Test that all empty fields are filled."""
+        from services.quickwins_renderer import enforce_quickwins_complete
+
+        quickwins = [
+            {"title": "Content-Erstellung mit KI", "problem": "", "wirkung": "", "umsetzung": "", "hinweis": "siehe BC"}
+        ]
+
+        result = enforce_quickwins_complete(quickwins)
+
+        assert result[0]["problem"], "Expected problem field to be filled"
+        assert result[0]["wirkung"], "Expected wirkung field to be filled"
+        assert result[0]["umsetzung"], "Expected umsetzung field to be filled"
+
+    def test_enforce_preserves_non_empty_fields(self):
+        """Test that non-empty fields are preserved."""
+        from services.quickwins_renderer import enforce_quickwins_complete
+
+        original_problem = "Manueller Prozess dauert zu lange"
+        original_wirkung = "50% Zeitersparnis"
+        quickwins = [
+            {"title": "Test", "problem": original_problem, "wirkung": original_wirkung, "umsetzung": ""}
+        ]
+
+        result = enforce_quickwins_complete(quickwins)
+
+        assert result[0]["problem"] == original_problem, "Non-empty problem should be preserved"
+        assert result[0]["wirkung"] == original_wirkung, "Non-empty wirkung should be preserved"
+
+    def test_enforce_handles_empty_list(self):
+        """Test that empty list returns empty list."""
+        from services.quickwins_renderer import enforce_quickwins_complete
+
+        result = enforce_quickwins_complete([])
+        assert result == []
+
+    def test_enforce_handles_none(self):
+        """Test that None input returns None."""
+        from services.quickwins_renderer import enforce_quickwins_complete
+
+        result = enforce_quickwins_complete(None)
+        assert result is None
+
+    def test_render_skips_empty_blocks(self):
+        """Test that render_quickwins_premium_json skips truly empty blocks."""
+        from services.quickwins_renderer import render_quickwins_premium_json
+        import json
+
+        # Create JSON where enforce would fill the fields
+        quickwins_json = json.dumps([
+            {"title": "Test Quick Win", "icon": "🎯", "problem": "", "wirkung": "", "umsetzung": "", "hinweis": "Test"}
+        ])
+
+        html = render_quickwins_premium_json(quickwins_json)
+
+        assert html is not None, "Expected HTML output"
+        # After enforce, fields should be filled, so blocks should be present
+        assert "Problem:" in html or "quick-win-problem" in html
+
+
+# =============================================================================
+# TASK C: SOLO Labels Source-of-Truth Tests
+# =============================================================================
+
+class TestSoloLabelsSourceOfTruth:
+    """Tests for segment-aware labels in template rendering."""
+
+    def test_template_uses_ui_for_governance_label(self):
+        """Verify template uses ui() for Governance dimension label."""
+        from pathlib import Path
+
+        template_path = Path(__file__).parent.parent / "templates" / "pdf_template.html"
+        with open(template_path, "r", encoding="utf-8") as f:
+            content = f.read()
+
+        # Should use ui("governance_label", ...) for dimension label
+        assert 'ui("governance_label"' in content, \
+            "Expected template to use ui('governance_label') for dimension label"
+
+    def test_template_uses_ui_for_governance_section_kicker(self):
+        """Verify template uses ui() for Governance section kicker."""
+        from pathlib import Path
+
+        template_path = Path(__file__).parent.parent / "templates" / "pdf_template.html"
+        with open(template_path, "r", encoding="utf-8") as f:
+            content = f.read()
+
+        # Should use ui("governance_section_kicker", ...) for section kicker
+        assert 'ui("governance_section_kicker"' in content, \
+            "Expected template to use ui('governance_section_kicker') for section kicker"
+
+    def test_report_renderer_uses_segment_aware_ui(self):
+        """Verify report_renderer uses ui_for_segment."""
+        from pathlib import Path
+
+        renderer_path = Path(__file__).parent.parent / "services" / "report_renderer.py"
+        with open(renderer_path, "r", encoding="utf-8") as f:
+            content = f.read()
+
+        # Should import ui_for_segment
+        assert "ui_for_segment" in content, \
+            "Expected report_renderer to import ui_for_segment"
+
+        # Should use segment-aware ui
+        assert 'ui_for_segment(lang, segment=' in content, \
+            "Expected report_renderer to call ui_for_segment with segment"
+
+    def test_i18n_solo_governance_returns_spielregeln(self):
+        """Test that SOLO segment returns 'Spielregeln' for governance."""
+        from services.i18n import get_label_for_segment
+
+        result = get_label_for_segment("governance_label", "de", segment="SOLO")
+        assert result == "Spielregeln", f"Expected 'Spielregeln' for SOLO governance, got '{result}'"
+
+    def test_i18n_team_governance_returns_governance(self):
+        """Test that TEAM segment returns 'Governance' for governance."""
+        from services.i18n import get_label_for_segment
+
+        # TEAM should fall back to standard (no _team suffix exists)
+        result = get_label_for_segment("governance_label", "de", segment="TEAM")
+        # Should return the fallback "Governance" or the standard label
+        assert "Governance" in result or result == "governance_label"
+
+
+# =============================================================================
+# Integration Tests
+# =============================================================================
+
+class TestP1SprintIntegration:
+    """Integration tests for P1 Sprint fixes."""
+
+    def test_quickwins_completeness_in_premium_render(self):
+        """Test that premium renderer applies completeness gate."""
+        from services.quickwins_renderer import render_quickwins_premium_json
+        import json
+
+        # Input with empty fields
+        quickwins_json = json.dumps([
+            {
+                "title": "Automatisierung",
+                "icon": "🤖",
+                "problem": "",
+                "wirkung": "",
+                "umsetzung": "",
+                "hinweis": "siehe Business Case"
+            }
+        ])
+
+        html = render_quickwins_premium_json(quickwins_json)
+
+        assert html is not None
+        # Should have content in the blocks (filled by enforce)
+        assert "Problem:" in html
+        assert "Wirkung:" in html
+        assert "Umsetzung:" in html
+
+    def test_solo_segment_normalization_in_renderer(self):
+        """Test that segment is normalized correctly."""
+        # segment_map = {"solo": "SOLO", "team": "TEAM", "klein": "TEAM", "kmu": "KMU"}
+        segment_map = {"solo": "SOLO", "team": "TEAM", "klein": "TEAM", "kmu": "KMU"}
+
+        assert segment_map.get("solo") == "SOLO"
+        assert segment_map.get("klein") == "TEAM"
+        assert segment_map.get("kmu") == "KMU"
+        assert segment_map.get("unknown", "TEAM") == "TEAM"
+
+
+# =============================================================================
+# TASK D: ROI as Ranges/Qualitative Tests
+# =============================================================================
+
+class TestRoiQualitativeRanges:
+    """Tests for ROI as qualitative ranges for SOLO."""
+
+    def test_format_roi_span_very_high(self):
+        """Test format_roi_span for very high ROI."""
+        from services.report_healer import format_roi_span
+
+        result = format_roi_span(350.0)
+        assert "sehr hoch" in result
+        assert "300%" in result
+
+    def test_format_roi_span_high(self):
+        """Test format_roi_span for high ROI."""
+        from services.report_healer import format_roi_span
+
+        result = format_roi_span(250.0)
+        assert "hoch" in result
+        assert "200-300%" in result
+
+    def test_format_roi_span_good(self):
+        """Test format_roi_span for good ROI."""
+        from services.report_healer import format_roi_span
+
+        result = format_roi_span(175.0)
+        assert "gut" in result
+        assert "150-200%" in result
+
+    def test_format_roi_span_solid(self):
+        """Test format_roi_span for solid ROI."""
+        from services.report_healer import format_roi_span
+
+        result = format_roi_span(120.0)
+        assert "solide" in result
+        assert "100-150%" in result
+
+    def test_format_roi_span_moderate(self):
+        """Test format_roi_span for moderate ROI."""
+        from services.report_healer import format_roi_span
+
+        result = format_roi_span(75.0)
+        assert "moderat" in result
+        assert "50-100%" in result
+
+    def test_format_roi_span_low(self):
+        """Test format_roi_span for low ROI."""
+        from services.report_healer import format_roi_span
+
+        result = format_roi_span(30.0)
+        assert "gering" in result
+        assert "unter 50%" in result
+
+    def test_sanitize_roi_for_solo_replaces_roi_colon(self):
+        """Test sanitize_roi_for_solo replaces 'ROI: 200%' pattern."""
+        from services.report_healer import sanitize_roi_for_solo
+
+        html = "<p>Der ROI: 250% ist sehr gut.</p>"
+        result, count = sanitize_roi_for_solo(html)
+
+        assert count == 1
+        assert "hoch (200-300%)" in result
+        assert "250%" not in result
+
+    def test_sanitize_roi_for_solo_replaces_roi_von(self):
+        """Test sanitize_roi_for_solo replaces 'ROI von 150%' pattern."""
+        from services.report_healer import sanitize_roi_for_solo
+
+        html = "<p>Mit einem ROI von 175% lohnt sich die Investition.</p>"
+        result, count = sanitize_roi_for_solo(html)
+
+        assert count == 1
+        assert "gut (150-200%)" in result
+        assert "175%" not in result
+
+    def test_heal_final_html_applies_roi_sanitization_for_solo(self):
+        """Test heal_final_html applies ROI sanitization for SOLO."""
+        from services.report_healer import heal_final_html
+
+        html = """<html>
+        <body>
+            <p>Der ROI: 200% zeigt gute Rentabilität.</p>
+            <p>Payback: 6 Monate</p>
+        </body>
+        </html>"""
+
+        result = heal_final_html(html, segment="SOLO")
+
+        # Should have qualitative range
+        assert "200%" not in result or "hoch" in result
+        # Payback should be preserved
+        assert "6" in result
+
+    def test_heal_final_html_preserves_roi_for_team(self):
+        """Test heal_final_html preserves exact ROI for TEAM."""
+        from services.report_healer import heal_final_html
+
+        html = "<p>Der ROI: 200% ist sehr gut.</p>"
+
+        result = heal_final_html(html, segment="TEAM")
+
+        # TEAM should preserve exact ROI
+        assert "200%" in result


### PR DESCRIPTION
…I ranges

Implements all tasks from the P1 Sprint briefing:

**TASK A (P0): Final-Check Rendering Fix**
- Changed Final-Check decisions from flex spans to `<p class="final-check-item">`
- Added word-wrap: break-word for WeasyPrint compatibility
- Prevents word-by-word text wrapping in PDF renderer

**TASK B (P0): Quick Wins Completeness Gate**
- Added `enforce_quickwins_complete()` function to quickwins_renderer.py
- Fills empty problem/wirkung/umsetzung fields with deterministic fallbacks
- Uses keyword matching for context-appropriate fallback text
- Modified `render_quickwins_premium_json()` to use completeness gate
- Only renders blocks that have content (skips empty)

**TASK C (P1): SOLO Labels Source-of-Truth**
- Updated report_renderer.py to use `ui_for_segment()` for segment-aware labels
- Template now uses `ui("governance_label")` instead of hardcoded "Governance"
- Template now uses `ui("governance_section_kicker")` for section kicker
- SOLO segment automatically gets "Spielregeln" instead of "Governance"

**TASK D (P1 optional): ROI as Ranges/Qualitative**
- Added `format_roi_span()` function to convert exact ROI % to qualitative ranges
- Added `sanitize_roi_for_solo()` to replace ROI patterns in HTML
- Integrated into heal_final_html() for SOLO segment
- Qualitative ranges: sehr hoch (>300%), hoch (200-300%), gut (150-200%), etc.

All 179 tests pass (27 new + 152 existing).

https://claude.ai/code/session_018pVrc45wCkYbzjQ9Thibwt