### PR TITLE
fix: Hook HAUPTLEISTUNG_UNDERUSE fix into pipeline BEFORE validation

### DIFF
--- a/gpt_analyze.py
+++ b/gpt_analyze.py
@@ -14763,6 +14763,33 @@ Gib NUR das angeforderte HTML-Fragment aus - keine Fragen, keine Hilfsangebote, 
         log.warning(f"[{run_id}] [QUALITY-ENFORCER-RENDER] Failed: {e}")
 
     # =========================================================================
+    # HAUPTLEISTUNG_UNDERUSE FIX: Robust failsafe AFTER Quality Enforcer
+    # Ensures minimum hauptleistung occurrences BEFORE final validation
+    # =========================================================================
+    try:
+        from services.report_healer import (
+            ensure_hauptleistung_in_recommendations,
+            ensure_hauptleistung_in_exec_summary,
+        )
+        hl_value = hauptleistung_render or answers.get("hauptleistung", "")
+        if hl_value and len(hl_value.strip()) >= 6:
+            # Fix Recommendations (minimum 2 for CRITICAL threshold)
+            sections, rec_inj = ensure_hauptleistung_in_recommendations(
+                sections, hauptleistung=hl_value, min_mentions=2
+            )
+            if rec_inj > 0:
+                log.info(f"[{run_id}] [HAUPTLEISTUNG-FIX] Injected hauptleistung into RECOMMENDATIONS_HTML")
+
+            # Fix Executive Summary (minimum 3 for CRITICAL threshold)
+            sections, exec_inj = ensure_hauptleistung_in_exec_summary(
+                sections, hauptleistung=hl_value, min_mentions=3
+            )
+            if exec_inj > 0:
+                log.info(f"[{run_id}] [HAUPTLEISTUNG-FIX] Injected hauptleistung into EXEC_SUMMARY_HTML")
+    except Exception as e:
+        log.warning(f"[{run_id}] [HAUPTLEISTUNG-FIX] Failed: {e}")
+
+    # =========================================================================
     # FIX-528: PIPELINE SANITIZATION (decode HTML entities + complete sentences)
     # Applied after quality enforcer, before final validation
     # =========================================================================

--- a/services/report_healer.py
+++ b/services/report_healer.py
@@ -62,6 +62,7 @@ __all__ = [
     "sanitize_quickwin_empty_fields",
     "sanitize_input_checklist",
     "ensure_hauptleistung_in_recommendations",
+    "ensure_hauptleistung_in_exec_summary",
     "format_roi_span",
     "sanitize_roi_for_solo",
     "QualityGateResult",


### PR DESCRIPTION
The previous fix ran too late (at line 15776, after validation at 14788). Now the robust hauptleistung injection runs:
- AFTER Quality Enforcer (line 14760)
- BEFORE Final Validation (line 14788)

Pipeline position:
[14760] apply_all_quality_enforcers()
[14764] HAUPTLEISTUNG_UNDERUSE FIX  ← NEW POSITION [14788] validate_and_heal() ← Validator now sees injected content

Changes:
- gpt_analyze.py: Added ensure_hauptleistung_in_recommendations/exec_summary calls between Quality Enforcer and validation
- services/report_healer.py: Added ensure_hauptleistung_in_exec_summary to exports

All 76 tests pass.

https://claude.ai/code/session_018pVrc45wCkYbzjQ9Thibwt