### PR TITLE
fix: Validator shadow-key blocking + size normalization bug for Team/KMU

### DIFF
--- a/config/size_profiles.py
+++ b/config/size_profiles.py
@@ -140,7 +140,7 @@ SIZE_PROFILES: Dict[str, Dict[str, Any]] = {
         },
 
         "min_words": {
-            "executive_summary": 180,
+            "executive_summary": 140,   # FIX-TEAM-KMU: realistic for LLM output
             "quick_wins": 90,
             "roadmap_90d": 200,
             "roadmap_12m": 600,
@@ -199,7 +199,7 @@ SIZE_PROFILES: Dict[str, Dict[str, Any]] = {
         },
 
         "min_words": {
-            "executive_summary": 200,
+            "executive_summary": 140,   # FIX-TEAM-KMU: realistic for LLM output
             "quick_wins": 120,
             "roadmap_90d": 220,
             "roadmap_12m": 700,

--- a/gpt_analyze.py
+++ b/gpt_analyze.py
@@ -6682,7 +6682,9 @@ LEAK_PHRASES = [
 ]
 
 # Sections eligible for 2-pass expand (per Batch 3 spec)
+# FIX-TEAM-KMU: Added executive_summary to expand-eligible list
 EXPAND_ELIGIBLE_SECTIONS = [
+    "executive_summary",
     "foerderpotenzial",
     "risks",
     "recommendations",
@@ -11094,6 +11096,7 @@ def _generate_content_section(section_name: str, briefing: Dict[str, Any], score
             # HINWEIS: Prompt fordert 900+ Wörter für roadmap_12m, aber wir prüfen
             # konservativ auf 800 Wörter – so verschwinden False Negatives bei Zähldifferenzen.
             platin_min_words = {
+                "executive_summary": 150,     # FIX-TEAM-KMU: Expand if too short
                 "roadmap": 100,               # ~600 Zeichen
                 "roadmap_90d": 100,           # ~600 Zeichen
                 "roadmap_12m": 800,           # PLATIN+: Prompt fordert 900, prüfen auf 800 (Sicherheitsmarge)

--- a/services/report_validator.py
+++ b/services/report_validator.py
@@ -741,7 +741,8 @@ class ReportValidator:
             # SPRINT N: Updated minimums
             # SPRINT G6: tools_empfehlungen erhöht, strategie_governance hinzugefügt
             # SPRINT G17.S: roadmap_90d reduced from 300 to 200
-            "executive_summary": 180,   # SPRINT N requirement
+            # FIX-TEAM-KMU: lowered from 180 → 140 (LLM variance, 2-pass expand at 150)
+            "executive_summary": 140,   # FIX-TEAM-KMU: realistic for LLM output
             "quick_wins": 90,
             "roadmap_90d": 200,         # SPRINT G17.S: reduced from 300
             "roadmap_12m": 600,         # SPRINT N: erhöht von 500
@@ -758,7 +759,8 @@ class ReportValidator:
             # SPRINT G6: tools_empfehlungen + strategie_governance erhöht
             # SPRINT G17.S: roadmap_90d reduced from 350 to 220
             # SPRINT G18: foerderpotenzial erhöht für Substanz
-            "executive_summary": 200,   # SPRINT N requirement
+            # FIX-TEAM-KMU: lowered from 200 → 140 (LLM variance, 2-pass expand at 150)
+            "executive_summary": 140,   # FIX-TEAM-KMU: realistic for LLM output
             "quick_wins": 120,
             "roadmap_90d": 220,         # SPRINT G17.S: reduced from 350
             "roadmap_12m": 700,         # SPRINT N: erhöht von 600
@@ -794,19 +796,24 @@ class ReportValidator:
     # Legacy-Alias für Abwärtskompatibilität
     MIN_SECTION_LENGTH = MIN_SECTION_LENGTH_WORDS
 
+    # FIX-TEAM-KMU: SECTION_KEY_MAP maps logical names to the PREFERRED section key.
+    # For sections that have HTML versions, map to *_HTML keys so min-word checks
+    # validate against the canonical (rendered/expanded) content, not shadow keys.
+    # The _check_empty_or_short_sections() method also has a runtime fallback
+    # via SHADOW_KEY_TO_HTML_MAP for any remaining shadow-key resolutions.
     SECTION_KEY_MAP: Dict[str, str] = {
         "executive_summary": "EXECUTIVE_SUMMARY_HTML",
         "business_case": "BUSINESS_CASE_HTML",
         "quick_wins": "QUICK_WINS_HTML",  # FIX-503B: Use HTML key, not text key
-        "roadmap_90d": "roadmap_90d",
-        "roadmap_12m": "roadmap_12m",
+        "roadmap_90d": "ROADMAP_90D_HTML",          # FIX-TEAM-KMU: was shadow key
+        "roadmap_12m": "ROADMAP_12M_HTML",           # FIX-TEAM-KMU: was shadow key
         "strategie_governance": "strategie_governance",
         "org_change": "org_change",
-        "tools_empfehlungen": "tools_empfehlungen",
+        "tools_empfehlungen": "TOOLS_EMPFEHLUNGEN_HTML",  # FIX-TEAM-KMU: prefer HTML
         "foerderpotenzial": "foerderpotenzial",
-        "risks": "risks",
-        "recommendations": "recommendations",
-        "gamechanger": "gamechanger",
+        "risks": "RISKS_HTML",                       # FIX-TEAM-KMU: was shadow key
+        "recommendations": "RECOMMENDATIONS_HTML",   # FIX-TEAM-KMU: was shadow key
+        "gamechanger": "GAMECHANGER_HTML",            # FIX-TEAM-KMU: was shadow key
         "unternehmensprofil_markt": "unternehmensprofil_markt",
         "transparency_box": "transparency_box",
         "technologie_prozesse": "technologie_prozesse",
@@ -871,6 +878,58 @@ class ReportValidator:
         # FIX-526: Build canonical view excluding shadow sections
         self._canonical_sections: Optional[Dict[str, Any]] = None
         self._excluded_shadow_keys: Optional[set] = None
+        # FIX-TEAM-KMU: Cache normalized size key
+        self._size_key: Optional[str] = None
+
+    def _normalize_size_key(self) -> str:
+        """
+        FIX-TEAM-KMU: Robust company_size → size_key normalization.
+
+        The previous logic used `"1" in size_key` which incorrectly matched
+        "2-10" (contains "1") and "11-100" (contains "1"), routing both to "solo".
+
+        This method uses exact match for "1" and proper range detection.
+        """
+        if self._size_key is not None:
+            return self._size_key
+
+        raw = (self.company_size or "").strip().lower()
+
+        # Normalize dashes for comparison
+        normalized = raw.replace("\u2013", "-").replace("\u2014", "-").replace("\u2212", "-")
+
+        # Check exact matches first (most reliable)
+        if normalized in ("1", "solo"):
+            self._size_key = "solo"
+        elif normalized in ("2-10", "team", "klein", "kleines team"):
+            self._size_key = "team"
+        elif normalized in ("11-100", "kmu", "mittelstand"):
+            self._size_key = "kmu"
+        # Substring fallbacks (order matters: check team/kmu BEFORE solo)
+        elif "team" in normalized or "klein" in normalized:
+            self._size_key = "team"
+        elif "kmu" in normalized or "mittel" in normalized or "11" in normalized:
+            self._size_key = "kmu"
+        elif "solo" in normalized or "freiberuf" in normalized or "einzel" in normalized:
+            self._size_key = "solo"
+        elif normalized == "1":
+            self._size_key = "solo"
+        else:
+            # Default: try to parse numeric
+            import re as _re
+            m = _re.match(r"^(\d+)", normalized)
+            if m:
+                n = int(m.group(1))
+                if n <= 1:
+                    self._size_key = "solo"
+                elif n <= 10:
+                    self._size_key = "team"
+                else:
+                    self._size_key = "kmu"
+            else:
+                self._size_key = "kmu"
+
+        return self._size_key
 
     def _build_canonical_view(self) -> Tuple[Dict[str, Any], set]:
         """
@@ -1194,14 +1253,8 @@ class ReportValidator:
         """
         Ermittelt die size-aware Mindest-Wortanzahl für eine Section.
         """
-        # Normalisiere company_size
-        size_key = self.company_size.lower() if self.company_size else "kmu"
-        if "solo" in size_key or "1" in size_key or "freiberuf" in size_key:
-            size_key = "solo"
-        elif "team" in size_key or "klein" in size_key:
-            size_key = "team"
-        else:
-            size_key = "kmu"
+        # FIX-TEAM-KMU: Use robust normalization
+        size_key = self._normalize_size_key()
 
         # Size-aware Override falls vorhanden
         size_overrides = self.MIN_SECTION_LENGTH_BY_SIZE.get(size_key, {})
@@ -1216,9 +1269,25 @@ class ReportValidator:
         PLATIN+ Validierung: Prüft Sections auf Mindest-WORTZAHL (nicht Zeichen!).
         SIZE-AWARE: Unterschiedliche Mindestlängen je Unternehmensgröße.
         SPRINT N: Critical sections trigger CRITICAL errors, not just warnings.
+
+        FIX-TEAM-KMU: Always prefer canonical HTML keys over shadow keys.
+        When both 'gamechanger' (shadow, short) and 'GAMECHANGER_HTML' (canonical, expanded)
+        exist, validate against the HTML version to avoid false SECTION_TOO_SHORT errors.
         """
         for logical_name in self.MIN_SECTION_LENGTH_WORDS.keys():
             section_key = self.SECTION_KEY_MAP.get(logical_name, logical_name)
+
+            # FIX-TEAM-KMU: Prefer canonical HTML key over shadow key.
+            # If section_key is a shadow key and its HTML version exists, use the HTML version.
+            # Also: if section_key is an HTML key that doesn't exist, fall back to shadow key.
+            html_key = self.SHADOW_KEY_TO_HTML_MAP.get(section_key)
+            if html_key and html_key in self.sections:
+                section_key = html_key
+            elif section_key not in self.sections:
+                # section_key might be an HTML key (from updated SECTION_KEY_MAP) that
+                # doesn't exist in this run. Fall back to the logical (shadow) key.
+                if logical_name in self.sections:
+                    section_key = logical_name
 
             # FIX-503B: Quick Wins fallback logic
             # If QUICK_WINS_HTML not found, try quick_wins text key
@@ -1540,14 +1609,8 @@ class ReportValidator:
         FIX-517C: Uses _term_hit() with word-boundary matching to avoid
         false positives (e.g. "Engine" in "Engineering").
         """
-        # Normalize company_size
-        size_key = self.company_size.lower() if self.company_size else "kmu"
-        if "solo" in size_key or "1" in size_key or "freiberuf" in size_key:
-            size_key = "solo"
-        elif "team" in size_key or "klein" in size_key:
-            size_key = "team"
-        else:
-            size_key = "kmu"
+        # FIX-TEAM-KMU: Use robust normalization
+        size_key = self._normalize_size_key()
 
         forbidden_terms = self.SIZE_FORBIDDEN.get(size_key, [])
         if not forbidden_terms:
@@ -1732,14 +1795,8 @@ class ReportValidator:
         """
         SPRINT G7: Check for persona leaks in AI Act sections.
         """
-        # Normalize company_size
-        size_key = self.company_size.lower() if self.company_size else "kmu"
-        if "solo" in size_key or "1" in size_key or "freiberuf" in size_key:
-            size_key = "solo"
-        elif "team" in size_key or "klein" in size_key:
-            size_key = "team"
-        else:
-            size_key = "kmu"
+        # FIX-TEAM-KMU: Use robust normalization
+        size_key = self._normalize_size_key()
 
         # AI Act sections to check
         ai_act_sections = [
@@ -1869,14 +1926,8 @@ class ReportValidator:
         if not _HAS_TOOLS_ANALYTICS:
             return
 
-        # Normalize company_size
-        size_key = self.company_size.lower() if self.company_size else "kmu"
-        if "solo" in size_key or "1" in size_key or "freiberuf" in size_key:
-            size_key = "solo"
-        elif "team" in size_key or "klein" in size_key:
-            size_key = "team"
-        else:
-            size_key = "kmu"
+        # FIX-TEAM-KMU: Use robust normalization
+        size_key = self._normalize_size_key()
 
         try:
             segment = get_segment_analysis("size_label", size_key)

--- a/tests/test_solo_final_pass.py
+++ b/tests/test_solo_final_pass.py
@@ -1026,5 +1026,187 @@ class TestCrossSizeComparison:
         assert stats["duz_sie"] > 0
 
 
+# =============================================================================
+# WP4: Validator Shadow-Key Regression Tests (FIX-TEAM-KMU)
+# =============================================================================
+
+class TestValidatorShadowKeyFix:
+    """
+    FIX-TEAM-KMU: Validator must NOT block on shadow keys when HTML versions exist.
+
+    Root cause: gamechanger (268 words, shadow) blocked Team/KMU runs even though
+    GAMECHANGER_HTML (1105 words, expanded) was present. The validator checked
+    the shadow key instead of the canonical HTML key.
+    """
+
+    def test_shadow_gamechanger_not_blocking_when_html_exists(self):
+        """gamechanger shadow (short) must not block when GAMECHANGER_HTML (long) exists."""
+        from services.report_validator import ReportValidator
+        # Generate exactly 800 words for GAMECHANGER_HTML (above team min of 750)
+        long_content = " ".join([f"Gamechanger{i}" for i in range(800)])
+        sections = {
+            "gamechanger": "<p>Short shadow content with only a few words.</p>",
+            "GAMECHANGER_HTML": f"<p>{long_content}</p>",
+            "EXECUTIVE_SUMMARY_HTML": "<p>" + ("Executive summary content here. " * 50) + "</p>",
+        }
+        meta = {"unternehmensgroesse": "2-10"}
+        validator = ReportValidator(sections, meta)
+        validator._check_empty_or_short_sections()
+
+        # No CRITICAL SECTION_TOO_SHORT for gamechanger
+        gamechanger_criticals = [
+            e for e in validator.errors
+            if e.category == "SECTION_TOO_SHORT"
+            and "gamechanger" in e.section.lower()
+            and e.severity == "CRITICAL"
+        ]
+        assert len(gamechanger_criticals) == 0, (
+            f"gamechanger shadow key should NOT block when GAMECHANGER_HTML exists. "
+            f"Got: {gamechanger_criticals}"
+        )
+
+    def test_shadow_roadmap_12m_not_blocking_when_html_exists(self):
+        """roadmap_12m shadow (short) must not block when ROADMAP_12M_HTML (long) exists."""
+        from services.report_validator import ReportValidator
+        sections = {
+            "roadmap_12m": "<p>Short roadmap shadow.</p>",
+            "ROADMAP_12M_HTML": "<p>" + ("Detailed 12-month roadmap content. " * 200) + "</p>",
+            "EXECUTIVE_SUMMARY_HTML": "<p>" + ("Executive summary content here. " * 50) + "</p>",
+        }
+        meta = {"unternehmensgroesse": "11-100"}
+        validator = ReportValidator(sections, meta)
+        validator._check_empty_or_short_sections()
+
+        roadmap_criticals = [
+            e for e in validator.errors
+            if e.category == "SECTION_TOO_SHORT"
+            and "roadmap_12m" in e.section.lower()
+            and e.severity == "CRITICAL"
+        ]
+        assert len(roadmap_criticals) == 0, (
+            f"roadmap_12m shadow should NOT block when ROADMAP_12M_HTML exists. "
+            f"Got: {roadmap_criticals}"
+        )
+
+    def test_html_key_validated_when_both_exist(self):
+        """When both shadow and HTML exist, validator uses HTML key for word count."""
+        from services.report_validator import ReportValidator
+        short_text = "<p>Too short.</p>"
+        long_text = "<p>" + ("Long expanded content word. " * 250) + "</p>"
+        sections = {
+            "gamechanger": short_text,
+            "GAMECHANGER_HTML": long_text,
+            "EXECUTIVE_SUMMARY_HTML": "<p>" + ("Summary content. " * 50) + "</p>",
+        }
+        meta = {"unternehmensgroesse": "2-10"}  # team: gamechanger min 750
+        validator = ReportValidator(sections, meta)
+        validator._check_empty_or_short_sections()
+
+        # GAMECHANGER_HTML has ~250 words * 4 = ~1000 words, well above 750
+        gamechanger_errors = [
+            e for e in validator.errors
+            if e.category == "SECTION_TOO_SHORT"
+            and "gamechanger" in e.section.lower()
+        ]
+        assert len(gamechanger_errors) == 0, (
+            f"Should validate against GAMECHANGER_HTML (long), not gamechanger (short). "
+            f"Got: {gamechanger_errors}"
+        )
+
+    def test_fallback_to_shadow_when_no_html_key(self):
+        """When only shadow key exists (no HTML version), still validate it."""
+        from services.report_validator import ReportValidator
+        sections = {
+            "gamechanger": "<p>Short content only in shadow key.</p>",
+            "EXECUTIVE_SUMMARY_HTML": "<p>" + ("Summary. " * 50) + "</p>",
+        }
+        meta = {"unternehmensgroesse": "2-10"}  # team: gamechanger min 750
+        validator = ReportValidator(sections, meta)
+        validator._check_empty_or_short_sections()
+
+        # Should detect gamechanger as too short (only shadow key, no HTML)
+        gamechanger_errors = [
+            e for e in validator.errors
+            if e.category == "SECTION_TOO_SHORT"
+            and "gamechanger" in e.section.lower()
+        ]
+        assert len(gamechanger_errors) > 0, (
+            "When only shadow key exists, it should still be validated"
+        )
+
+    def test_executive_summary_lowered_minimum_team(self):
+        """Team executive_summary minimum should be 140 (lowered from 180)."""
+        from services.report_validator import ReportValidator
+        # Create content with ~145 words (above 140, below old 180)
+        words = " ".join([f"Wort{i}" for i in range(145)])
+        content = f"<p>{words}</p>"
+        sections = {"EXECUTIVE_SUMMARY_HTML": content}
+        meta = {"unternehmensgroesse": "2\u201310"}  # Team (en-dash)
+        validator = ReportValidator(sections, meta)
+        validator._check_empty_or_short_sections()
+
+        exec_errors = [
+            e for e in validator.errors
+            if e.category == "SECTION_TOO_SHORT"
+            and "EXECUTIVE_SUMMARY" in e.section
+        ]
+        assert len(exec_errors) == 0, (
+            f"Executive summary with 145 words should pass for team (min=140). "
+            f"Got: {exec_errors}"
+        )
+
+    def test_executive_summary_lowered_minimum_kmu(self):
+        """KMU executive_summary minimum should be 140 (lowered from 200)."""
+        from services.report_validator import ReportValidator
+        words = " ".join([f"Wort{i}" for i in range(145)])
+        content = f"<p>{words}</p>"
+        sections = {"EXECUTIVE_SUMMARY_HTML": content}
+        meta = {"unternehmensgroesse": "11\u2013100"}  # KMU (en-dash)
+        validator = ReportValidator(sections, meta)
+        validator._check_empty_or_short_sections()
+
+        exec_errors = [
+            e for e in validator.errors
+            if e.category == "SECTION_TOO_SHORT"
+            and "EXECUTIVE_SUMMARY" in e.section
+        ]
+        assert len(exec_errors) == 0, (
+            f"Executive summary with 145 words should pass for KMU (min=140). "
+            f"Got: {exec_errors}"
+        )
+
+    def test_size_normalization_team_not_mapped_to_solo(self):
+        """FIX-TEAM-KMU: '2-10' must NOT map to solo (was broken by '1' in '2-10')."""
+        from services.report_validator import ReportValidator
+        meta = {"unternehmensgroesse": "2-10"}
+        validator = ReportValidator({}, meta)
+        assert validator._normalize_size_key() == "team", (
+            "'2-10' should normalize to 'team', not 'solo'"
+        )
+
+    def test_size_normalization_kmu_not_mapped_to_solo(self):
+        """FIX-TEAM-KMU: '11-100' must NOT map to solo (was broken by '1' in '11-100')."""
+        from services.report_validator import ReportValidator
+        meta = {"unternehmensgroesse": "11-100"}
+        validator = ReportValidator({}, meta)
+        assert validator._normalize_size_key() == "kmu", (
+            "'11-100' should normalize to 'kmu', not 'solo'"
+        )
+
+    def test_size_normalization_endash_team(self):
+        """En-dash variant '2\u201310' maps to team."""
+        from services.report_validator import ReportValidator
+        meta = {"unternehmensgroesse": "2\u201310"}
+        validator = ReportValidator({}, meta)
+        assert validator._normalize_size_key() == "team"
+
+    def test_size_normalization_solo_exact(self):
+        """'1' maps to solo correctly."""
+        from services.report_validator import ReportValidator
+        meta = {"unternehmensgroesse": "1"}
+        validator = ReportValidator({}, meta)
+        assert validator._normalize_size_key() == "solo"
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v", "--tb=short"])


### PR DESCRIPTION
Root cause: Team and KMU report runs aborted at validation because:
1. Validator checked min-word counts on shadow keys (e.g., 'gamechanger' at 268 words) instead of canonical HTML keys ('GAMECHANGER_HTML' at 1105 words after 2-pass expand)
2. Size normalization used `"1" in size_key` which matched "2-10" and "11-100" (both contain "1"), mapping Team/KMU to Solo

Fixes:
- WP1: SECTION_KEY_MAP now maps to *_HTML keys (gamechanger→GAMECHANGER_HTML, roadmap_12m→ROADMAP_12M_HTML, etc). Runtime fallback via SHADOW_KEY_TO_HTML_MAP with graceful degradation to shadow key when HTML version doesn't exist
- WP1: Add _normalize_size_key() method with exact-match priority, replacing broken substring check in all 4 occurrences across the validator
- WP2: Lower executive_summary minimums (team 180→140, KMU 200→140) to match LLM output variance
- WP3: Add executive_summary to EXPAND_ELIGIBLE_SECTIONS and platin_min_words (threshold=150) so 2-pass expand triggers when summary is too short
- WP4: Add 10 regression tests (shadow-key preference, canonical validation, fallback, size normalization for "2-10"/"11-100"/en-dash/"1")

96 tests pass in test_solo_final_pass.py, 315 total across related suites.

https://claude.ai/code/session_01H7cZZ6yvLRwHjZkAHGAtJg