### PR TITLE
fix: Size-aware truncation guard prevents Team/KMU SECTION_TOO_SHORT …

### DIFF
--- a/config/size_profiles.py
+++ b/config/size_profiles.py
@@ -68,9 +68,21 @@ SIZE_PROFILES: Dict[str, Dict[str, Any]] = {
             "EXECUTIVE_SUMMARY_HTML": 2000,
             "QUICK_WINS_HTML": 1500,
             "ROADMAP_90D_HTML": 1200,
+            "ROADMAP_12M_HTML": 8000,
             "RECOMMENDATIONS_HTML": 1500,
             "RISKS_HTML": 1200,
+            "GAMECHANGER_HTML": 1500,
+            "FOERDERPOTENZIAL_HTML": 1000,
+            "ORG_CHANGE_HTML": 1200,
             "BUSINESS_CASE_HTML": 2500,
+            "PILOT_PLAN_HTML": 1200,
+            "DATA_READINESS_HTML": 1200,
+            "STRATEGIE_GOVERNANCE_HTML": 1200,
+            "UNTERNEHMENSPROFIL_MARKT_HTML": 1500,
+            "MONETARISIERUNG_HTML": 1200,
+            "KI_SKILLPLAN_HTML": 1200,
+            "TOOLS_EMPFEHLUNGEN_HTML": 1200,
+            "TECHNOLOGIE_PROZESSE_HTML": 2000,
             "_default": 1000,
         },
 
@@ -133,9 +145,21 @@ SIZE_PROFILES: Dict[str, Dict[str, Any]] = {
             "EXECUTIVE_SUMMARY_HTML": 3000,
             "QUICK_WINS_HTML": 2000,
             "ROADMAP_90D_HTML": 1800,
+            "ROADMAP_12M_HTML": 12000,
             "RECOMMENDATIONS_HTML": 2500,
             "RISKS_HTML": 1800,
+            "GAMECHANGER_HTML": 10000,
+            "FOERDERPOTENZIAL_HTML": 2000,
+            "ORG_CHANGE_HTML": 1800,
             "BUSINESS_CASE_HTML": 4000,
+            "PILOT_PLAN_HTML": 1800,
+            "DATA_READINESS_HTML": 1800,
+            "STRATEGIE_GOVERNANCE_HTML": 3000,
+            "UNTERNEHMENSPROFIL_MARKT_HTML": 2500,
+            "MONETARISIERUNG_HTML": 1800,
+            "KI_SKILLPLAN_HTML": 1800,
+            "TOOLS_EMPFEHLUNGEN_HTML": 3000,
+            "TECHNOLOGIE_PROZESSE_HTML": 3000,
             "_default": 1500,
         },
 
@@ -192,9 +216,21 @@ SIZE_PROFILES: Dict[str, Dict[str, Any]] = {
             "EXECUTIVE_SUMMARY_HTML": 4000,
             "QUICK_WINS_HTML": 2500,
             "ROADMAP_90D_HTML": 2500,
+            "ROADMAP_12M_HTML": 14000,
             "RECOMMENDATIONS_HTML": 3500,
             "RISKS_HTML": 2500,
+            "GAMECHANGER_HTML": 12000,
+            "FOERDERPOTENZIAL_HTML": 10000,
+            "ORG_CHANGE_HTML": 2000,
             "BUSINESS_CASE_HTML": 5000,
+            "PILOT_PLAN_HTML": 2000,
+            "DATA_READINESS_HTML": 2000,
+            "STRATEGIE_GOVERNANCE_HTML": 3500,
+            "UNTERNEHMENSPROFIL_MARKT_HTML": 3000,
+            "MONETARISIERUNG_HTML": 2000,
+            "KI_SKILLPLAN_HTML": 2000,
+            "TOOLS_EMPFEHLUNGEN_HTML": 3500,
+            "TECHNOLOGIE_PROZESSE_HTML": 3000,
             "_default": 2000,
         },
 
@@ -288,8 +324,96 @@ def get_segment_for_size(size_value: str) -> str:
     return str(profile["segment"])
 
 
+def get_section_budget(segment: str, html_key: str) -> int:
+    """
+    Get the character budget for a section in a given segment.
+
+    Args:
+        segment: 'solo', 'team', or 'kmu'
+        html_key: Canonical HTML key (e.g., 'GAMECHANGER_HTML')
+
+    Returns:
+        Character budget for the section. Falls back to _default, then 2000.
+    """
+    profile = SIZE_PROFILES.get(segment, SIZE_PROFILES["solo"])
+    budgets = profile.get("section_budgets", {})
+    return int(budgets.get(html_key, budgets.get("_default", 2000)))
+
+
+def get_min_words(segment: str, logical_name: str) -> int:
+    """
+    Get the minimum word count for a section in a given segment.
+
+    Args:
+        segment: 'solo', 'team', or 'kmu'
+        logical_name: Logical section name (e.g., 'gamechanger')
+
+    Returns:
+        Minimum word count. Defaults to 50 if not specified.
+    """
+    profile = SIZE_PROFILES.get(segment, SIZE_PROFILES["solo"])
+    min_words = profile.get("min_words", {})
+    return int(min_words.get(logical_name, 50))
+
+
+def sanity_check_profiles() -> list[str]:
+    """
+    Startup sanity check: verify that section_budgets can accommodate min_words.
+
+    Rule: budget_chars >= min_words * 7 (average ~7 chars per German word incl. HTML)
+    This is a conservative estimate; actual HTML overhead varies.
+
+    Returns:
+        List of warning messages. Empty list means all checks passed.
+    """
+    warnings: list[str] = []
+    chars_per_word = 7  # Conservative estimate for German text with HTML markup
+
+    # Import canonical mapping for name resolution
+    try:
+        from services.section_keys import CANONICAL_MAP
+    except ImportError:
+        log.warning("[SIZE-PROFILES] Cannot import section_keys for sanity check")
+        return warnings
+
+    for seg_name, profile in SIZE_PROFILES.items():
+        min_words_map = profile.get("min_words", {})
+        budgets = profile.get("section_budgets", {})
+        default_budget = budgets.get("_default", 2000)
+
+        for logical_name, min_w in min_words_map.items():
+            html_key = CANONICAL_MAP.get(logical_name, logical_name.upper() + "_HTML")
+            budget = budgets.get(html_key, default_budget)
+            min_chars_needed = min_w * chars_per_word
+
+            if budget < min_chars_needed:
+                msg = (
+                    f"[{seg_name}] {html_key}: budget={budget} chars < "
+                    f"min_words({min_w}) * {chars_per_word} = {min_chars_needed} chars"
+                )
+                warnings.append(msg)
+                log.warning("[SIZE-PROFILES][SANITY] %s", msg)
+
+    return warnings
+
+
+# =============================================================================
+# MODULE INITIALIZATION
+# =============================================================================
+
 log.info(
     "[SIZE-PROFILES] Loaded %d profiles: %s",
     len(SIZE_PROFILES),
     list(SIZE_PROFILES.keys()),
 )
+
+# Run sanity check at import time
+_sanity_warnings = sanity_check_profiles()
+if _sanity_warnings:
+    log.warning(
+        "[SIZE-PROFILES] Sanity check found %d issues:\n  %s",
+        len(_sanity_warnings),
+        "\n  ".join(_sanity_warnings),
+    )
+else:
+    log.info("[SIZE-PROFILES] Sanity check passed: all budgets accommodate min_words")

--- a/gpt_analyze.py
+++ b/gpt_analyze.py
@@ -12550,15 +12550,33 @@ ERWEITERUNGSANFORDERUNGEN:
             sections["hero"] = ""
             sections["HERO_HTML"] = ""
 
-    # ========== GLOBAL AGGRESSIVE TRUNCATION (v10.0 + FIX-506 TASK 5) ==========
+    # ========== GLOBAL SIZE-AWARE TRUNCATION (v10.0 + FIX-515 + FIX-TEAM-KMU) ==========
     # Apply to ALL major content sections FIRST
+    # FIX-TEAM-KMU: Now budget-based and min-words-safe per segment
     truncation_targets = [
         "RISKS_HTML", "GAMECHANGER_HTML", "FOERDERPOTENZIAL_HTML", "RECOMMENDATIONS_HTML",
         "ORG_CHANGE_HTML", "BUSINESS_CASE_HTML", "PILOT_PLAN_HTML", "ROADMAP_12M_HTML",
         "DATA_READINESS_HTML", "STRATEGIE_GOVERNANCE_HTML", "UNTERNEHMENSPROFIL_MARKT_HTML",
         "MONETARISIERUNG_HTML", "KI_SKILLPLAN_HTML", "QUICK_WINS_HTML"
     ]
-    log.info("[GLOBAL-TRUNCATION] Starting aggressive truncation for %d sections", len(truncation_targets))
+
+    # FIX-TEAM-KMU: Derive segment for budget-based truncation
+    try:
+        from config.size_profiles import get_section_budget, get_min_words, get_segment_for_size
+        from services.section_keys import logical_name as _sk_logical_name, html_word_count as _sk_word_count
+        _trunc_size_raw = answers.get("unternehmensgroesse", "1")
+        _trunc_segment = get_segment_for_size(str(_trunc_size_raw))
+        log.info(
+            "[GLOBAL-TRUNCATION] Size-aware truncation: segment=%s size_raw=%s targets=%d",
+            _trunc_segment, _trunc_size_raw, len(truncation_targets),
+        )
+    except Exception as _trunc_import_err:
+        log.warning("[GLOBAL-TRUNCATION] Size-aware import failed (%s), using solo defaults", _trunc_import_err)
+        _trunc_segment = "solo"
+        get_section_budget = None  # type: ignore[assignment]
+        get_min_words = None  # type: ignore[assignment]
+        _sk_logical_name = None  # type: ignore[assignment]
+        _sk_word_count = None  # type: ignore[assignment]
 
     # FIX-506 TASK 5: Import cleanup function for post-truncation artifacts
     try:
@@ -12568,53 +12586,178 @@ ERWEITERUNGSANFORDERUNGEN:
         _cleanup_available = False
         log.warning("[GLOBAL-TRUNCATION] cleanup_truncation_artifacts not available")
 
+    import re as _re_trunc
+
     for key in truncation_targets:
         html = sections.get(key, "")
         if html and len(html) > 200:
             try:
                 original_len = len(html)
+
+                # FIX-TEAM-KMU: Get budget and min_words for this section
+                if get_section_budget is not None:
+                    _budget = get_section_budget(_trunc_segment, key)
+                else:
+                    _budget = int(original_len * 0.5)  # Legacy: 50% cap fallback
+
+                if get_min_words is not None and _sk_logical_name is not None:
+                    _logical = _sk_logical_name(key)
+                    _min_w = get_min_words(_trunc_segment, _logical)
+                else:
+                    _min_w = 600  # Legacy safe default
+
+                # Skip truncation if section is already within budget
+                if original_len <= _budget:
+                    log.debug(
+                        "[GLOBAL-TRUNCATION] %s within budget (%d <= %d), skipping",
+                        key, original_len, _budget,
+                    )
+                    continue
+
                 truncated = _aggressive_text_truncation(html)
 
-                # FIX-506 TASK 5: Clean up truncation artifacts to prevent TEMPLATE_PHRASE hits
+                # FIX-506 TASK 5: Clean up truncation artifacts
                 if _cleanup_available:
                     truncated = cleanup_truncation_artifacts(truncated)
 
-                # FIX-514 CHANGE 1: Truncation guard for ROADMAP_12M_HTML
-                # Never let truncation drop word count below minimum (600 for solo)
-                if key == "ROADMAP_12M_HTML":
-                    import re as _re_trunc
-                    stripped_text = _re_trunc.sub(r'<[^>]+>', '', truncated)
-                    word_count = len(stripped_text.split())
-                    min_words = 600  # solo minimum (strictest threshold)
-                    if word_count < min_words:
-                        log.warning(
-                            "[FIX-514][TRUNCATION-GUARD] Reverted truncation for %s "
-                            "(would_drop_below_min_words: %d < %d)",
-                            key, word_count, min_words
-                        )
-                        continue  # Skip this key, keep original
-
-                # FIX-515 TASK 1: Cap truncation at max 50% cut to prevent extreme shrinking
-                # FIX-52x: Instead of reverting, cap at 50% (keep at least half)
-                trunc_pct = (1 - len(truncated) / original_len) * 100 if original_len > 0 else 0
-                if trunc_pct > 50:
-                    # Cap to 50% of original instead of reverting
-                    min_len = int(original_len * 0.5)
-                    truncated = html[:min_len]
+                # FIX-TEAM-KMU: Budget-based cap (replaces blind 50% cap)
+                # If truncation cut too aggressively, cap at budget instead of 50%
+                if len(truncated) < _budget and original_len > _budget:
+                    # Truncation went below budget - cap at budget
+                    truncated = html[:_budget]
                     log.info(
-                        "[FIX-52x][TRUNC] capped_to_half section=%s before=%d target=%d effective=%d",
-                        key, original_len, len(truncated), min_len
+                        "[FIX-TEAM-KMU][TRUNC] budget_cap section=%s budget=%d before=%d after=%d",
+                        key, _budget, original_len, len(truncated),
                     )
+
+                # FIX-TEAM-KMU: Min-words guard (replaces ROADMAP_12M-only guard)
+                # Never let truncation drop word count below the section's min_words
+                stripped_text = _re_trunc.sub(r'<[^>]+>', '', truncated)
+                word_count = len(stripped_text.split())
+                if word_count < _min_w:
+                    log.warning(
+                        "[FIX-TEAM-KMU][TRUNC-GUARD] Reverted truncation for %s "
+                        "(words=%d < min_words=%d, segment=%s)",
+                        key, word_count, _min_w, _trunc_segment,
+                    )
+                    continue  # Keep original content
 
                 sections[key] = truncated
                 delta = len(truncated) - original_len
                 if delta != 0:
+                    trunc_pct = (1 - len(truncated) / original_len) * 100 if original_len > 0 else 0
                     log.info(
-                        "[FIX-515][TRUNC] section=%s before=%d after=%d delta=%d pct=%.0f%%",
-                        key, original_len, len(truncated), delta, trunc_pct
+                        "[FIX-515][TRUNC] section=%s before=%d after=%d delta=%d pct=%.0f%% "
+                        "budget=%d min_words=%d segment=%s",
+                        key, original_len, len(truncated), delta, trunc_pct,
+                        _budget, _min_w, _trunc_segment,
                     )
             except Exception as e:
                 log.warning(f"[GLOBAL-TRUNCATION] {key} failed: {e}")
+
+    # ========== POST-TRIM HEALING LOOP (FIX-TEAM-KMU WP-D) ==========
+    # After truncation, check if any critical section dropped below min_words.
+    # If so, re-expand those sections (max 2 iterations).
+    try:
+        _heal_critical_sections = ["gamechanger", "roadmap_12m", "executive_summary", "tools_empfehlungen"]
+        _heal_max_iterations = 2
+
+        for _heal_iter in range(_heal_max_iterations):
+            _heal_needed = []
+
+            for _heal_logical in _heal_critical_sections:
+                if get_min_words is not None and _sk_logical_name is not None and _sk_word_count is not None:
+                    from services.section_keys import canonical_key as _sk_canonical_key
+                    _heal_html_key = _sk_canonical_key(_heal_logical)
+                    _heal_content = sections.get(_heal_html_key, "")
+                    if not _heal_content or not isinstance(_heal_content, str):
+                        continue
+                    _heal_wc = _sk_word_count(_heal_content)
+                    _heal_min = get_min_words(_trunc_segment, _heal_logical)
+                    if _heal_wc < _heal_min:
+                        _heal_needed.append((_heal_logical, _heal_html_key, _heal_wc, _heal_min))
+
+            if not _heal_needed:
+                if _heal_iter == 0:
+                    log.info("[POST-TRIM-HEAL] All critical sections above min_words, no healing needed")
+                break
+
+            log.info(
+                "[POST-TRIM-HEAL] Iteration %d: %d sections need healing: %s",
+                _heal_iter + 1,
+                len(_heal_needed),
+                [(n, wc, mw) for n, _, wc, mw in _heal_needed],
+            )
+
+            for _heal_logical, _heal_html_key, _heal_wc, _heal_min in _heal_needed:
+                _heal_target_words = _heal_min + 50  # Buffer above minimum
+                _heal_existing = sections.get(_heal_html_key, "")
+                try:
+                    _heal_expand_prompt = f"""
+Der folgende Inhalt ist zu kurz und muss erweitert werden.
+Ziel-Wortanzahl: mindestens {_heal_target_words} Wörter (aktuell: {_heal_wc}).
+
+REGELN FÜR ERWEITERUNG:
+- Behalte ALLE bestehenden Informationen und Strukturen
+- Füge MEHR Details, Beispiele und Erklärungen hinzu
+- Vertiefe jeden Punkt mit konkreten Maßnahmen
+- Verwende die gleiche HTML-Struktur
+- KEINE Assistenten-Sprache, KEINE Fragen an den Leser
+
+Bestehender Inhalt zum Erweitern:
+{_heal_existing}
+
+Gib den erweiterten HTML-Inhalt aus (mindestens {_heal_target_words} Wörter):
+"""
+                    _heal_expanded = _call_llm_for_section(
+                        section_key=f"{_heal_logical}_post_trim_heal_{_heal_iter}",
+                        prompt=_heal_expand_prompt,
+                        system_prompt="Du bist ein Senior-KI-Berater. Erweitere den Inhalt mit mehr Details. Nur valides HTML.",
+                        temperature=llm["temperature"],
+                        max_tokens=llm["max_tokens"] + 500,
+                        model=llm["model"],
+                    ) or ""
+
+                    _heal_expanded = _clean_html(_heal_expanded)
+                    if _needs_repair(_heal_expanded):
+                        _heal_expanded = _repair_html(_heal_logical, _heal_expanded)
+
+                    _heal_expanded_wc = _sk_word_count(_heal_expanded)
+                    if _heal_expanded_wc >= _heal_min:
+                        # Budget-safe: cap at budget if needed
+                        if get_section_budget is not None:
+                            _heal_budget = get_section_budget(_trunc_segment, _heal_html_key)
+                            if len(_heal_expanded) > _heal_budget:
+                                _heal_expanded = _heal_expanded[:_heal_budget]
+                                # Re-check words after budget cap
+                                _heal_recapped_wc = _sk_word_count(_heal_expanded)
+                                if _heal_recapped_wc < _heal_min:
+                                    log.warning(
+                                        "[POST-TRIM-HEAL] Budget cap dropped %s below min_words "
+                                        "(%d < %d), keeping expanded version",
+                                        _heal_html_key, _heal_recapped_wc, _heal_min,
+                                    )
+                                    # Don't apply budget cap in this case
+                                    _heal_expanded = sections.get(_heal_html_key, _heal_expanded)
+
+                        sections[_heal_html_key] = _heal_expanded
+                        # Also update shadow key if it exists
+                        if _heal_logical in sections:
+                            sections[_heal_logical] = _heal_expanded
+                        log.info(
+                            "[POST-TRIM-HEAL] Healed %s: %d -> %d words (min=%d, iter=%d)",
+                            _heal_html_key, _heal_wc, _heal_expanded_wc, _heal_min, _heal_iter + 1,
+                        )
+                    else:
+                        log.warning(
+                            "[POST-TRIM-HEAL] Expansion insufficient for %s: %d words (need %d)",
+                            _heal_html_key, _heal_expanded_wc, _heal_min,
+                        )
+                except Exception as _heal_err:
+                    log.warning("[POST-TRIM-HEAL] Failed to heal %s: %s", _heal_html_key, _heal_err)
+
+    except Exception as _heal_loop_err:
+        log.warning("[POST-TRIM-HEAL] Healing loop failed: %s", _heal_loop_err)
 
     # ========== SAFE RISKS FORMATTING ==========
     risks_html = sections.get("RISKS_HTML", "")

--- a/gpt_analyze.py
+++ b/gpt_analyze.py
@@ -12564,7 +12564,7 @@ ERWEITERUNGSANFORDERUNGEN:
     try:
         from config.size_profiles import get_section_budget, get_min_words, get_segment_for_size
         from services.section_keys import logical_name as _sk_logical_name, html_word_count as _sk_word_count
-        _trunc_size_raw = answers.get("unternehmensgroesse", "1")
+        _trunc_size_raw = briefing.get("unternehmensgroesse", briefing.get("UNTERNEHMENSGROESSE", "1"))
         _trunc_segment = get_segment_for_size(str(_trunc_size_raw))
         log.info(
             "[GLOBAL-TRUNCATION] Size-aware truncation: segment=%s size_raw=%s targets=%d",
@@ -12573,10 +12573,10 @@ ERWEITERUNGSANFORDERUNGEN:
     except Exception as _trunc_import_err:
         log.warning("[GLOBAL-TRUNCATION] Size-aware import failed (%s), using solo defaults", _trunc_import_err)
         _trunc_segment = "solo"
-        get_section_budget = None  # type: ignore[assignment]
-        get_min_words = None  # type: ignore[assignment]
-        _sk_logical_name = None  # type: ignore[assignment]
-        _sk_word_count = None  # type: ignore[assignment]
+        get_section_budget = None
+        get_min_words = None
+        _sk_logical_name = None
+        _sk_word_count = None
 
     # FIX-506 TASK 5: Import cleanup function for post-truncation artifacts
     try:
@@ -12709,13 +12709,14 @@ Bestehender Inhalt zum Erweitern:
 
 Gib den erweiterten HTML-Inhalt aus (mindestens {_heal_target_words} Wörter):
 """
+                    _heal_llm = _llm_params_for(_heal_logical)
                     _heal_expanded = _call_llm_for_section(
                         section_key=f"{_heal_logical}_post_trim_heal_{_heal_iter}",
                         prompt=_heal_expand_prompt,
                         system_prompt="Du bist ein Senior-KI-Berater. Erweitere den Inhalt mit mehr Details. Nur valides HTML.",
-                        temperature=llm["temperature"],
-                        max_tokens=llm["max_tokens"] + 500,
-                        model=llm["model"],
+                        temperature=_heal_llm["temperature"],
+                        max_tokens=_heal_llm["max_tokens"] + 500,
+                        model=_heal_llm["model"],
                     ) or ""
 
                     _heal_expanded = _clean_html(_heal_expanded)

--- a/services/section_keys.py
+++ b/services/section_keys.py
@@ -1,0 +1,163 @@
+# -*- coding: utf-8 -*-
+"""
+Section Key Canonical Mapping
+==============================
+
+Single source of truth for mapping logical section names to their canonical
+*_HTML keys in the sections dict. Used by validator, truncation, and healing.
+
+Every content section has:
+- A logical name (e.g., "gamechanger")
+- A canonical key (e.g., "GAMECHANGER_HTML") — the rendered/expanded version
+
+The validator, truncation engine, and healing loop all use canonical_key()
+to resolve the correct key for content operations.
+
+Version: 1.0.0 (FIX-TEAM-KMU)
+"""
+from __future__ import annotations
+
+import logging
+import re
+from typing import Any, Dict, Optional
+
+log = logging.getLogger(__name__)
+
+
+# =============================================================================
+# CANONICAL MAP: logical name → HTML section key
+# =============================================================================
+
+CANONICAL_MAP: Dict[str, str] = {
+    "executive_summary": "EXECUTIVE_SUMMARY_HTML",
+    "quick_wins": "QUICK_WINS_HTML",
+    "business_case": "BUSINESS_CASE_HTML",
+    "roadmap_90d": "ROADMAP_90D_HTML",
+    "roadmap_12m": "ROADMAP_12M_HTML",
+    "risks": "RISKS_HTML",
+    "recommendations": "RECOMMENDATIONS_HTML",
+    "gamechanger": "GAMECHANGER_HTML",
+    "tools_empfehlungen": "TOOLS_EMPFEHLUNGEN_HTML",
+    "foerderpotenzial": "FOERDERPOTENZIAL_HTML",
+    "org_change": "ORG_CHANGE_HTML",
+    "pilot_plan": "PILOT_PLAN_HTML",
+    "data_readiness": "DATA_READINESS_HTML",
+    "strategie_governance": "STRATEGIE_GOVERNANCE_HTML",
+    "unternehmensprofil_markt": "UNTERNEHMENSPROFIL_MARKT_HTML",
+    "monetarisierung": "MONETARISIERUNG_HTML",
+    "ki_skillplan": "KI_SKILLPLAN_HTML",
+    "transparency_box": "TRANSPARENCY_BOX_HTML",
+    "technologie_prozesse": "TECHNOLOGIE_PROZESSE_HTML",
+    "next_actions": "NEXT_ACTIONS_HTML",
+    "ki_stack_summary": "KI_STACK_SUMMARY_HTML",
+}
+
+# Reverse mapping: HTML key → logical name
+_REVERSE_MAP: Dict[str, str] = {v: k for k, v in CANONICAL_MAP.items()}
+
+
+# =============================================================================
+# FUNCTIONS
+# =============================================================================
+
+def canonical_key(logical_name: str) -> str:
+    """
+    Get the canonical *_HTML key for a logical section name.
+
+    Returns the *_HTML variant if mapped, otherwise returns the input unchanged.
+
+    Examples:
+        >>> canonical_key("gamechanger")
+        'GAMECHANGER_HTML'
+        >>> canonical_key("GAMECHANGER_HTML")
+        'GAMECHANGER_HTML'
+    """
+    if logical_name in CANONICAL_MAP:
+        return CANONICAL_MAP[logical_name]
+    # Already a canonical key
+    if logical_name in _REVERSE_MAP:
+        return logical_name
+    return logical_name
+
+
+def logical_name(html_key: str) -> str:
+    """
+    Get the logical name for a canonical *_HTML key.
+
+    Returns the lowercase logical name if mapped, otherwise returns the input unchanged.
+
+    Examples:
+        >>> logical_name("GAMECHANGER_HTML")
+        'gamechanger'
+        >>> logical_name("gamechanger")
+        'gamechanger'
+    """
+    if html_key in _REVERSE_MAP:
+        return _REVERSE_MAP[html_key]
+    if html_key in CANONICAL_MAP:
+        return html_key
+    return html_key
+
+
+def resolve_key(sections: Dict[str, Any], name: str) -> Optional[str]:
+    """
+    Resolve which key actually exists in the sections dict.
+
+    Tries canonical *_HTML key first, then logical name.
+    Returns the actual key found, or None if neither exists.
+    """
+    # Try canonical key first
+    html_key = CANONICAL_MAP.get(name)
+    if html_key and html_key in sections:
+        return html_key
+
+    # Try name as-is (could be either logical or HTML)
+    if name in sections:
+        return name
+
+    # Try reverse mapping (if given an HTML key, try the logical name)
+    logical = _REVERSE_MAP.get(name)
+    if logical and logical in sections:
+        return logical
+
+    return None
+
+
+def get_canonical_value(
+    sections: Dict[str, Any],
+    name: str,
+    default: Any = None,
+) -> Any:
+    """
+    Get a section's content by trying canonical key first, then logical name.
+
+    Args:
+        sections: The sections dict
+        name: Logical name or HTML key
+        default: Default value if not found
+
+    Returns:
+        The section content, preferring the canonical *_HTML version.
+    """
+    key = resolve_key(sections, name)
+    if key is not None:
+        return sections[key]
+    return default
+
+
+def html_word_count(html_content: str) -> int:
+    """
+    Count words in HTML content after stripping tags.
+
+    Utility used by truncation guard and healing loop.
+    """
+    if not html_content:
+        return 0
+    text = re.sub(r'<[^>]+>', '', html_content).strip()
+    return len(text.split()) if text else 0
+
+
+log.info(
+    "[SECTION-KEYS] Loaded %d canonical mappings",
+    len(CANONICAL_MAP),
+)

--- a/tests/test_fix514_truncation_scrub.py
+++ b/tests/test_fix514_truncation_scrub.py
@@ -60,11 +60,11 @@ class TestFix514TruncationGuard:
 
         assert word_count >= min_words, "Should be above threshold"
 
-    def test_truncation_guard_source_has_fix514_log(self):
-        """gpt_analyze.py must contain [FIX-514][TRUNCATION-GUARD] log line."""
+    def test_truncation_guard_source_has_trunc_guard_log(self):
+        """gpt_analyze.py must contain truncation guard log line (FIX-514 or FIX-TEAM-KMU)."""
         from pathlib import Path
         source = Path("gpt_analyze.py").read_text()
-        assert "[FIX-514][TRUNCATION-GUARD]" in source
+        assert "[FIX-TEAM-KMU][TRUNC-GUARD]" in source or "[FIX-514][TRUNCATION-GUARD]" in source
 
 
 class TestFix514ForbiddenTokenScrub:

--- a/tests/test_solo_final_pass.py
+++ b/tests/test_solo_final_pass.py
@@ -1208,5 +1208,303 @@ class TestValidatorShadowKeyFix:
         assert validator._normalize_size_key() == "solo"
 
 
+# =============================================================================
+# TEST: WP-A – Section Keys Canonical Mapping
+# =============================================================================
+
+class TestSectionKeys:
+    """Tests for services/section_keys.py canonical key infrastructure."""
+
+    def test_canonical_key_from_logical(self):
+        """canonical_key maps logical name to *_HTML key."""
+        from services.section_keys import canonical_key
+        assert canonical_key("gamechanger") == "GAMECHANGER_HTML"
+        assert canonical_key("executive_summary") == "EXECUTIVE_SUMMARY_HTML"
+        assert canonical_key("roadmap_12m") == "ROADMAP_12M_HTML"
+
+    def test_canonical_key_identity_for_html(self):
+        """canonical_key returns HTML key unchanged if already canonical."""
+        from services.section_keys import canonical_key
+        assert canonical_key("GAMECHANGER_HTML") == "GAMECHANGER_HTML"
+
+    def test_canonical_key_unknown(self):
+        """canonical_key returns input unchanged for unknown names."""
+        from services.section_keys import canonical_key
+        assert canonical_key("unknown_section") == "unknown_section"
+
+    def test_logical_name_from_html(self):
+        """logical_name maps *_HTML key back to logical name."""
+        from services.section_keys import logical_name
+        assert logical_name("GAMECHANGER_HTML") == "gamechanger"
+        assert logical_name("RISKS_HTML") == "risks"
+
+    def test_logical_name_identity_for_logical(self):
+        """logical_name returns logical name unchanged if already logical."""
+        from services.section_keys import logical_name
+        assert logical_name("gamechanger") == "gamechanger"
+
+    def test_resolve_key_prefers_canonical(self):
+        """resolve_key returns HTML key when both exist."""
+        from services.section_keys import resolve_key
+        sections = {
+            "gamechanger": "short shadow",
+            "GAMECHANGER_HTML": "<p>Full expanded content</p>",
+        }
+        assert resolve_key(sections, "gamechanger") == "GAMECHANGER_HTML"
+
+    def test_resolve_key_falls_back_to_logical(self):
+        """resolve_key falls back to logical name if HTML key absent."""
+        from services.section_keys import resolve_key
+        sections = {"gamechanger": "shadow content only"}
+        assert resolve_key(sections, "gamechanger") == "gamechanger"
+
+    def test_resolve_key_from_html_name(self):
+        """resolve_key works when given an HTML key directly."""
+        from services.section_keys import resolve_key
+        sections = {"GAMECHANGER_HTML": "<p>Content</p>"}
+        assert resolve_key(sections, "GAMECHANGER_HTML") == "GAMECHANGER_HTML"
+
+    def test_resolve_key_returns_none_if_missing(self):
+        """resolve_key returns None when section doesn't exist."""
+        from services.section_keys import resolve_key
+        assert resolve_key({}, "gamechanger") is None
+
+    def test_get_canonical_value(self):
+        """get_canonical_value returns HTML content over shadow."""
+        from services.section_keys import get_canonical_value
+        sections = {
+            "gamechanger": "short",
+            "GAMECHANGER_HTML": "<p>Expanded</p>",
+        }
+        assert get_canonical_value(sections, "gamechanger") == "<p>Expanded</p>"
+
+    def test_get_canonical_value_default(self):
+        """get_canonical_value returns default when missing."""
+        from services.section_keys import get_canonical_value
+        assert get_canonical_value({}, "gamechanger", default="N/A") == "N/A"
+
+    def test_html_word_count(self):
+        """html_word_count strips tags and counts words."""
+        from services.section_keys import html_word_count
+        assert html_word_count("<p>Eins zwei <strong>drei</strong> vier.</p>") == 4
+        assert html_word_count("") == 0
+        assert html_word_count("<div></div>") == 0
+
+    def test_all_truncation_targets_have_mapping(self):
+        """Every truncation target key has a reverse mapping to a logical name."""
+        from services.section_keys import _REVERSE_MAP
+        truncation_targets = [
+            "RISKS_HTML", "GAMECHANGER_HTML", "FOERDERPOTENZIAL_HTML",
+            "RECOMMENDATIONS_HTML", "ORG_CHANGE_HTML", "BUSINESS_CASE_HTML",
+            "PILOT_PLAN_HTML", "ROADMAP_12M_HTML", "DATA_READINESS_HTML",
+            "STRATEGIE_GOVERNANCE_HTML", "UNTERNEHMENSPROFIL_MARKT_HTML",
+            "MONETARISIERUNG_HTML", "KI_SKILLPLAN_HTML", "QUICK_WINS_HTML",
+        ]
+        for key in truncation_targets:
+            assert key in _REVERSE_MAP, f"{key} missing from CANONICAL_MAP reverse"
+
+
+# =============================================================================
+# TEST: WP-B – Size Profiles Sanity Check
+# =============================================================================
+
+class TestSizeProfilesSanity:
+    """Tests for config/size_profiles.py sanity check and helpers."""
+
+    def test_sanity_check_passes(self):
+        """All profiles pass the budget >= min_words * 7 check."""
+        from config.size_profiles import sanity_check_profiles
+        warnings = sanity_check_profiles()
+        assert len(warnings) == 0, f"Sanity check failures: {warnings}"
+
+    def test_get_section_budget(self):
+        """get_section_budget returns correct budget per segment."""
+        from config.size_profiles import get_section_budget
+        # Solo has smaller budgets
+        solo_gc = get_section_budget("solo", "GAMECHANGER_HTML")
+        team_gc = get_section_budget("team", "GAMECHANGER_HTML")
+        kmu_gc = get_section_budget("kmu", "GAMECHANGER_HTML")
+        assert solo_gc < team_gc <= kmu_gc
+
+    def test_get_section_budget_default(self):
+        """get_section_budget returns _default for unknown keys."""
+        from config.size_profiles import get_section_budget
+        budget = get_section_budget("solo", "UNKNOWN_SECTION_HTML")
+        assert budget == 1000  # solo _default
+
+    def test_get_min_words(self):
+        """get_min_words returns correct min per segment."""
+        from config.size_profiles import get_min_words
+        solo_gc = get_min_words("solo", "gamechanger")
+        team_gc = get_min_words("team", "gamechanger")
+        assert solo_gc < team_gc  # Solo: 100, Team: 750
+
+    def test_get_min_words_default(self):
+        """get_min_words returns 50 for unknown sections."""
+        from config.size_profiles import get_min_words
+        assert get_min_words("solo", "unknown_section") == 50
+
+    def test_all_truncation_targets_have_budget(self):
+        """Every truncation target has an explicit budget in all profiles."""
+        from config.size_profiles import SIZE_PROFILES
+        truncation_targets = [
+            "RISKS_HTML", "GAMECHANGER_HTML", "FOERDERPOTENZIAL_HTML",
+            "RECOMMENDATIONS_HTML", "ORG_CHANGE_HTML", "BUSINESS_CASE_HTML",
+            "ROADMAP_12M_HTML", "STRATEGIE_GOVERNANCE_HTML",
+            "UNTERNEHMENSPROFIL_MARKT_HTML", "KI_SKILLPLAN_HTML", "QUICK_WINS_HTML",
+        ]
+        for seg_name, profile in SIZE_PROFILES.items():
+            budgets = profile["section_budgets"]
+            for key in truncation_targets:
+                assert key in budgets, (
+                    f"{seg_name} profile missing budget for {key}"
+                )
+
+    def test_budget_accommodates_min_words(self):
+        """For every section with min_words, budget >= min_words * 7."""
+        from config.size_profiles import SIZE_PROFILES
+        from services.section_keys import CANONICAL_MAP
+        for seg_name, profile in SIZE_PROFILES.items():
+            min_words_map = profile.get("min_words", {})
+            budgets = profile.get("section_budgets", {})
+            default_budget = budgets.get("_default", 2000)
+            for logical_name, min_w in min_words_map.items():
+                html_key = CANONICAL_MAP.get(logical_name, logical_name.upper() + "_HTML")
+                budget = budgets.get(html_key, default_budget)
+                assert budget >= min_w * 7, (
+                    f"{seg_name}/{html_key}: budget={budget} < min_words({min_w}) * 7 = {min_w * 7}"
+                )
+
+
+# =============================================================================
+# TEST: WP-C – Size-Aware Truncation Guard
+# =============================================================================
+
+class TestTruncationGuard:
+    """Tests that the truncation logic respects min_words per segment."""
+
+    def test_solo_gamechanger_low_min_words(self):
+        """Solo gamechanger has low min_words (100), so truncation is more aggressive."""
+        from config.size_profiles import get_min_words
+        assert get_min_words("solo", "gamechanger") == 100
+
+    def test_team_gamechanger_high_min_words(self):
+        """Team gamechanger has high min_words (750), so truncation is guarded."""
+        from config.size_profiles import get_min_words
+        assert get_min_words("team", "gamechanger") == 750
+
+    def test_kmu_gamechanger_high_min_words(self):
+        """KMU gamechanger has high min_words (750), so truncation is guarded."""
+        from config.size_profiles import get_min_words
+        assert get_min_words("kmu", "gamechanger") == 750
+
+    def test_team_budget_larger_than_solo(self):
+        """Team has larger section budgets than solo."""
+        from config.size_profiles import get_section_budget
+        for key in ["GAMECHANGER_HTML", "ROADMAP_12M_HTML", "RISKS_HTML"]:
+            solo = get_section_budget("solo", key)
+            team = get_section_budget("team", key)
+            assert team > solo, f"{key}: team budget ({team}) should exceed solo ({solo})"
+
+    def test_kmu_budget_larger_than_team(self):
+        """KMU has larger (or equal) section budgets than team."""
+        from config.size_profiles import get_section_budget
+        for key in ["GAMECHANGER_HTML", "ROADMAP_12M_HTML", "RISKS_HTML"]:
+            team = get_section_budget("team", key)
+            kmu = get_section_budget("kmu", key)
+            assert kmu >= team, f"{key}: kmu budget ({kmu}) should be >= team ({team})"
+
+    def test_truncation_would_not_drop_below_min_words(self):
+        """Simulates the min-words guard logic from the TRUNC block."""
+        from config.size_profiles import get_min_words
+        from services.section_keys import logical_name, html_word_count
+
+        # Simulate: GAMECHANGER_HTML with 800 words for team segment
+        content = "<p>" + " ".join(f"Wort{i}" for i in range(800)) + "</p>"
+        html_key = "GAMECHANGER_HTML"
+        segment = "team"
+
+        _logical = logical_name(html_key)
+        _min_w = get_min_words(segment, _logical)
+        wc = html_word_count(content)
+
+        # Content has 800 words, team min is 750 → should NOT be reverted
+        assert wc >= _min_w, f"800 words should be >= {_min_w}"
+
+    def test_truncation_guard_reverts_when_too_short(self):
+        """Simulates the min-words guard reverting when content drops below min."""
+        from config.size_profiles import get_min_words
+        from services.section_keys import logical_name, html_word_count
+
+        # Simulate: after truncation, only 400 words left for team gamechanger
+        truncated = "<p>" + " ".join(f"Wort{i}" for i in range(400)) + "</p>"
+        html_key = "GAMECHANGER_HTML"
+        segment = "team"
+
+        _logical = logical_name(html_key)
+        _min_w = get_min_words(segment, _logical)
+        wc = html_word_count(truncated)
+
+        # 400 words < team min of 750 → should be reverted
+        assert wc < _min_w, f"400 words should be < {_min_w} (team min)"
+
+
+# =============================================================================
+# TEST: WP-D – Post-Trim Healing Verification
+# =============================================================================
+
+class TestPostTrimHealingConfig:
+    """Tests that post-trim healing infrastructure is correctly configured."""
+
+    def test_heal_critical_sections_have_min_words(self):
+        """All critical sections for healing have min_words defined in all profiles."""
+        from config.size_profiles import SIZE_PROFILES
+        heal_critical = ["gamechanger", "roadmap_12m", "executive_summary", "tools_empfehlungen"]
+        for seg_name, profile in SIZE_PROFILES.items():
+            min_words_map = profile.get("min_words", {})
+            for section in heal_critical:
+                assert section in min_words_map, (
+                    f"{seg_name} missing min_words for heal-critical section '{section}'"
+                )
+
+    def test_heal_critical_sections_have_canonical_keys(self):
+        """All critical sections for healing have canonical key mappings."""
+        from services.section_keys import CANONICAL_MAP
+        heal_critical = ["gamechanger", "roadmap_12m", "executive_summary", "tools_empfehlungen"]
+        for section in heal_critical:
+            assert section in CANONICAL_MAP, f"'{section}' missing from CANONICAL_MAP"
+
+    def test_heal_critical_sections_in_expand_eligible(self):
+        """Critical sections should be in EXPAND_ELIGIBLE_SECTIONS for 2-pass expand."""
+        # This verifies the sections used in post-trim heal are also expandable
+        from services.section_keys import CANONICAL_MAP
+        heal_critical = ["gamechanger", "roadmap_12m", "executive_summary", "tools_empfehlungen"]
+        # tools_empfehlungen may not be in EXPAND_ELIGIBLE (that's OK, healing is separate)
+        expandable = ["gamechanger", "roadmap_12m", "executive_summary"]
+        try:
+            # Try importing from gpt_analyze (may not work in test env)
+            import importlib
+            mod = importlib.import_module("gpt_analyze")
+            expand_eligible = getattr(mod, "EXPAND_ELIGIBLE_SECTIONS", None)
+            if expand_eligible:
+                for section in expandable:
+                    assert section in expand_eligible, (
+                        f"'{section}' should be in EXPAND_ELIGIBLE_SECTIONS"
+                    )
+        except (ImportError, Exception):
+            # gpt_analyze may not be importable in test environment
+            pass
+
+    def test_segment_derivation_consistency(self):
+        """get_segment_for_size is consistent with validator _normalize_size_key."""
+        from config.size_profiles import get_segment_for_size
+        # Test the same values the validator receives
+        assert get_segment_for_size("1") == "solo"
+        assert get_segment_for_size("2-10") == "team"
+        assert get_segment_for_size("2\u201310") == "team"  # En-dash
+        assert get_segment_for_size("11-100") == "kmu"
+        assert get_segment_for_size("11\u2013100") == "kmu"  # En-dash
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v", "--tb=short"])


### PR DESCRIPTION
…aborts

Root cause: FIX-515 TRUNC aggressively halved HTML content after 2-pass expand, causing expanded sections (e.g., gamechanger: 1103→453 words) to fall below MinWords thresholds, triggering CRITICAL SECTION_TOO_SHORT.

WP-A: Create services/section_keys.py with canonical key mapping
- CANONICAL_MAP, canonical_key(), logical_name(), resolve_key()
- get_canonical_value() with HTML-key preference and shadow fallback
- html_word_count() utility for truncation/healing

WP-B: Extend config/size_profiles.py
- Complete section_budgets for all truncation targets (all 3 segments)
- get_section_budget() and get_min_words() helpers
- Startup sanity check: budget >= min_words * 7

WP-C: Replace blind 50% truncation cap with budget-based, min-words-safe
- Derive segment from answers["unternehmensgroesse"] before truncation
- Skip truncation if section is within budget
- Cap at budget (not 50%) when truncation is too aggressive
- Min-words guard: revert truncation for ANY section that would drop below its size-specific min_words (replaces ROADMAP_12M-only guard)

WP-D: Post-trim healing loop
- After truncation, check critical sections (gamechanger, roadmap_12m, executive_summary, tools_empfehlungen) against min_words
- Re-expand via LLM if below threshold (max 2 iterations)
- Budget-safe: cap re-expanded content at section budget

Tests: 31 new tests (127 total in test_solo_final_pass.py)
- TestSectionKeys: 13 tests (canonical mapping, resolve, word count)
- TestSizeProfilesSanity: 7 tests (budgets, min_words, sanity check)
- TestTruncationGuard: 7 tests (min_words guard logic per segment)
- TestPostTrimHealingConfig: 4 tests (heal config, canonical keys)

https://claude.ai/code/session_01H7cZZ6yvLRwHjZkAHGAtJg