### PR TITLE
feat: Add post-render QA scan script with CI integration

### DIFF
--- a/.github/workflows/report-smoke.yml
+++ b/.github/workflows/report-smoke.yml
@@ -235,6 +235,52 @@ jobs:
           name: reports-${{ github.run_number }}
           path: ${{ env.ARTIFACTS_DIR }}/
 
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: QA Scan Report Artifacts
+        id: qa-scan
+        if: always()
+        run: |
+          echo "::group::QA Scan - Post-Render Artifact Validation"
+          QA_PASSED=true
+
+          # Scan each segment's PDF/HTML artifacts
+          for segment in solo team kmu; do
+            pdf=$(ls ${{ env.ARTIFACTS_DIR }}/*${segment}*.pdf 2>/dev/null | head -1)
+            html_file=$(ls ${{ env.ARTIFACTS_DIR }}/*${segment}*.html 2>/dev/null | head -1)
+            target="${pdf:-$html_file}"
+
+            if [ -n "$target" ] && [ -f "$target" ]; then
+              echo "--- Scanning $segment: $target ---"
+              python scripts/report_qa_scan.py "$target" \
+                --segment "$segment" \
+                --junit "${{ env.ARTIFACTS_DIR }}/qa_scan_${segment}.xml" \
+                --json > "${{ env.ARTIFACTS_DIR }}/qa_scan_${segment}.json" 2>&1 && SCAN_EXIT=0 || SCAN_EXIT=$?
+
+              if [ "$SCAN_EXIT" -eq 2 ]; then
+                echo "::warning ::QA scan found errors in $segment report"
+                QA_PASSED=false
+              elif [ "$SCAN_EXIT" -eq 0 ]; then
+                echo "::notice ::QA scan passed for $segment"
+              else
+                echo "::warning ::QA scan runtime error for $segment (exit=$SCAN_EXIT)"
+              fi
+            else
+              echo "::notice ::No $segment artifact found to scan"
+            fi
+          done
+
+          echo "::endgroup::"
+
+          if [ "$QA_PASSED" = "true" ]; then
+            echo "qa_scan=passed" >> $GITHUB_OUTPUT
+          else
+            echo "qa_scan=failed" >> $GITHUB_OUTPUT
+          fi
+
       - name: Validate Solo-Compact gates
         id: solo-gates
         run: |
@@ -288,6 +334,7 @@ jobs:
             echo "|------|--------|"
             echo "| Solo Leak Count = 0 | ${{ steps.solo-gates.outputs.solo_gates == 'passed' && '✅ Passed' || '❌ Failed' }} |"
             echo "| Solo Report Generated | ${{ needs.generate-reports.outputs.solo_status == 'success' && '✅ Passed' || '❌ Failed' }} |"
+            echo "| QA Scan (post-render) | ${{ steps.qa-scan.outputs.qa_scan == 'passed' && '✅ Passed' || '⚠️ Issues' }} |"
             echo ""
           } >> $GITHUB_STEP_SUMMARY
 

--- a/scripts/report_qa_scan.py
+++ b/scripts/report_qa_scan.py
@@ -1,0 +1,476 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Report QA Scan (HTML/PDF) — CI-friendly post-render scanner.
+
+Scans rendered report artifacts (HTML and/or PDF) for common blockers
+that may have survived the pipeline healing/validation steps.
+
+Checks:
+- Empty currency/percentage artifacts ('€.', 'bei %')
+- Leakage phrases (prompt echoes, template phrases)
+- Du-forms (informal address in formal reports)
+- Placeholders (TODO, Lorem ipsum, unrendered {{...}})
+- Segment-specific rules (Solo: no Governance/Enterprise terms)
+
+Exit codes:
+- 0: no violations (or warnings-only when --fail-on=error)
+- 2: violations found (CI should fail)
+- 1: runtime error
+
+Usage:
+  python scripts/report_qa_scan.py dist/report.html
+  python scripts/report_qa_scan.py dist/report.pdf
+  python scripts/report_qa_scan.py dist/ --json
+  python scripts/report_qa_scan.py dist/ --segment solo --fail-on error
+  python scripts/report_qa_scan.py artifacts/ --junit artifacts/qa_scan.xml
+
+Optional outputs:
+  --json        print machine-readable JSON report to stdout
+  --junit PATH  write a small JUnit XML file (useful for CI artifacts)
+
+Notes:
+- PDF text extraction uses PyMuPDF (fitz) if available, otherwise pypdf/pdfminer.
+- HTML text extraction uses BeautifulSoup if available, otherwise a simple tag-stripper.
+- Complements (not replaces) the in-pipeline validators in services/.
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import html as html_lib
+import json
+import os
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional, Sequence, Tuple
+
+
+# ---------------------------------------------------------------------------
+# Rules
+# ---------------------------------------------------------------------------
+
+@dataclass(frozen=True)
+class Rule:
+    id: str
+    description: str
+    severity: str  # 'error' | 'warning'
+    # where: 'text' = extracted human text; 'raw' = raw file content (HTML only)
+    where: str
+    pattern: str
+    flags: int = re.IGNORECASE | re.MULTILINE
+
+    def compile(self) -> "re.Pattern[str]":
+        return re.compile(self.pattern, self.flags)
+
+
+# Core blockers — focused on post-render artifacts
+DEFAULT_RULES: List[Rule] = [
+    # --- WP1 blocker patterns (empty business case values) ---
+    Rule(
+        id='CURRENCY_EURO_DOT',
+        description='Leerer Euro-Wert: Punkt direkt nach € ohne Zahl (Template-Artefakt)',
+        severity='error',
+        where='text',
+        # Match "€." but NOT "6.000 €." (valid sentence ending after a value).
+        # Key: no digit within 3 chars before the €. Catches ": €." and standalone "€."
+        pattern=r'(?<!\d)(?<!\d[ \xa0])€\s*\.',
+    ),
+    Rule(
+        id='PERCENT_PLACEHOLDER_BEI',
+        description='Leerer Prozent-Platzhalter: "bei %" ohne Zahl davor',
+        severity='error',
+        where='text',
+        pattern=r'bei\s+%(?=\s|[)\].,;:!?]|$)',
+    ),
+    Rule(
+        id='COLON_PERCENT_EMPTY',
+        description='Leerer Prozent-Wert nach Doppelpunkt: ": %"',
+        severity='error',
+        where='text',
+        pattern=r':\s+%(?=\s|[)\].,;:!?]|$)',
+    ),
+    # --- Prompt/template leak patterns ---
+    Rule(
+        id='LEAK_PLATZHALTER',
+        description="Template-Leak: 'Platzhalter' im Fliesstext",
+        severity='error',
+        where='text',
+        pattern=r'\bPlatzhalter\b',
+    ),
+    Rule(
+        id='LEAK_BITTE_NENNE',
+        description="Prompt-Leak: 'Bitte nenne/nennen kurz ...'",
+        severity='error',
+        where='text',
+        pattern=r'\bbitte\s+nenn(?:e|en)\s+kurz\b',
+    ),
+    Rule(
+        id='LEAK_ASSISTANT_DE',
+        description="KI-Assistenz-Leak: 'wie kann ich dir/Ihnen helfen', 'als KI-Assistent'",
+        severity='error',
+        where='text',
+        pattern=r'\b(?:wie\s+kann\s+ich\s+(?:dir|Ihnen|ihnen)\s+helfen|als\s+KI[- ]?Assistent|ich\s+bin\s+ein\s+KI)\b',
+    ),
+    Rule(
+        id='LEAK_ASSISTANT_EN',
+        description="AI assistant leak: 'how can I help', 'as an AI'",
+        severity='error',
+        where='text',
+        pattern=r"\b(?:how\s+can\s+I\s+help|as\s+an\s+AI|I(?:'m| am)\s+an?\s+AI)\b",
+    ),
+    # --- Du-form (informal address) ---
+    Rule(
+        id='DU_FORM_PRONOUNS',
+        description="Du-Ansprache gefunden (du/dein/dich/dir) — Report soll Sie-Form verwenden",
+        severity='warning',
+        where='text',
+        # Strict word-boundary: exclude "durch", "Produkt", "Industrie", "Verdunstung", etc.
+        # Only match standalone du/dein/dich/dir NOT preceded/followed by letters
+        # Use negative lookbehind/lookahead for German letters including umlauts
+        pattern=r'(?<![A-Za-zÄÖÜäöüß])(?:du|dich|dir|dein(?:e[mnrs]?)?)(?![A-Za-zÄÖÜäöüß-])',
+        flags=0,  # case-sensitive: only lowercase "du" etc.
+    ),
+    # --- Placeholder/TODO markers ---
+    Rule(
+        id='PLACEHOLDER_TODO',
+        description='Platzhalter-Text: TODO/TBD/Lorem ipsum',
+        severity='error',
+        where='text',
+        pattern=r'\b(?:TODO|TBD|Lorem\s+ipsum)\b',
+    ),
+    Rule(
+        id='PLACEHOLDER_JINJA',
+        description='Ungerenderter Template-Marker: {{ ... }} oder {% ... %}',
+        severity='error',
+        where='raw',
+        pattern=r'(\{\{[^}]+\}\}|\{%\s*[^%]+%\})',
+    ),
+]
+
+# Segment-specific rules
+SEGMENT_RULES: Dict[str, List[Rule]] = {
+    'solo': [
+        Rule(
+            id='SOLO_GOVERNANCE',
+            description="SOLO: 'Governance' sollte als 'Spielregeln' erscheinen",
+            severity='error',
+            where='text',
+            pattern=r'\bGovernance\b',
+        ),
+        Rule(
+            id='SOLO_ENTERPRISE_TERMS',
+            description='SOLO: Enterprise-Begriff (Stakeholder/Audit-Trail/Matrixorganisation)',
+            severity='warning',
+            where='text',
+            pattern=r'\b(?:Stakeholder|Audit[-\s]?Trail|Matrixorganisation)\b',
+        ),
+    ],
+    'team': [],
+    'kmu': [],
+}
+
+
+# ---------------------------------------------------------------------------
+# Findings model
+# ---------------------------------------------------------------------------
+
+@dataclass
+class Finding:
+    file: str
+    file_type: str  # 'html' | 'pdf' | 'txt'
+    rule_id: str
+    severity: str
+    description: str
+    match: str
+    snippet: str
+    position: int
+
+
+# ---------------------------------------------------------------------------
+# Text extraction
+# ---------------------------------------------------------------------------
+
+def _extract_text_from_html(raw: str) -> str:
+    """Extract visible text from HTML, stripping tags/scripts/styles."""
+    try:
+        from bs4 import BeautifulSoup
+        soup = BeautifulSoup(raw, 'html.parser')
+        # Remove script and style elements
+        for tag in soup(['script', 'style']):
+            tag.decompose()
+        text = soup.get_text(' ')
+    except Exception:
+        # Fallback: crude tag stripping
+        text = re.sub(r'<script\b[^>]*>.*?</script>', ' ', raw, flags=re.IGNORECASE | re.DOTALL)
+        text = re.sub(r'<style\b[^>]*>.*?</style>', ' ', text, flags=re.IGNORECASE | re.DOTALL)
+        text = re.sub(r'<[^>]+>', ' ', text)
+    text = html_lib.unescape(text)
+    text = re.sub(r'[ \t\r\f\v]+', ' ', text)
+    text = re.sub(r'\n{2,}', '\n', text)
+    return text.strip()
+
+
+def _extract_text_from_pdf(path: Path) -> str:
+    """Extract text from PDF using best available library."""
+    # Try PyMuPDF first (fast + robust)
+    try:
+        import fitz
+        doc = fitz.open(str(path))
+        parts: List[str] = []
+        for page in doc:
+            parts.append(page.get_text('text'))
+        doc.close()
+        return '\n'.join(parts)
+    except Exception:
+        pass
+
+    # Fallback: pypdf
+    for mod in ('pypdf', 'PyPDF2'):
+        try:
+            pdf_mod = __import__(mod)
+            reader = pdf_mod.PdfReader(str(path))
+            parts = []
+            for p in reader.pages:
+                parts.append(p.extract_text() or '')
+            return '\n'.join(parts)
+        except Exception:
+            continue
+
+    # Fallback: pdfminer.six
+    try:
+        from pdfminer.high_level import extract_text
+        return extract_text(str(path)) or ''
+    except Exception as exc:
+        raise RuntimeError(f'Could not extract text from PDF {path}: {exc}') from exc
+
+
+def _read_file(path: Path) -> Tuple[str, str, str]:
+    """Returns (file_type, raw_content, extracted_text)."""
+    suffix = path.suffix.lower()
+    if suffix in ('.html', '.htm'):
+        raw = path.read_text(encoding='utf-8', errors='replace')
+        return ('html', raw, _extract_text_from_html(raw))
+    if suffix == '.pdf':
+        extracted = _extract_text_from_pdf(path)
+        return ('pdf', '', extracted)
+    raw = path.read_text(encoding='utf-8', errors='replace')
+    return ('txt', raw, raw)
+
+
+# ---------------------------------------------------------------------------
+# Scanning
+# ---------------------------------------------------------------------------
+
+def _snippet(text: str, start: int, end: int, radius: int = 60) -> str:
+    """Extract a context snippet around a match."""
+    a = max(0, start - radius)
+    b = min(len(text), end + radius)
+    sn = text[a:b].replace('\n', ' ').strip()
+    return re.sub(r'\s{2,}', ' ', sn)
+
+
+def scan_content(
+    *,
+    file_path: Path,
+    file_type: str,
+    raw: str,
+    text: str,
+    rules: Sequence[Rule],
+    max_findings_per_rule: int = 50,
+) -> List[Finding]:
+    """Scan content against all rules and return findings."""
+    findings: List[Finding] = []
+    for rule in rules:
+        haystack = text if rule.where == 'text' else raw
+        if not haystack:
+            continue
+        rx = rule.compile()
+        count = 0
+        for m in rx.finditer(haystack):
+            s, e = m.span()
+            findings.append(
+                Finding(
+                    file=str(file_path),
+                    file_type=file_type,
+                    rule_id=rule.id,
+                    severity=rule.severity,
+                    description=rule.description,
+                    match=(m.group(0) or '')[:200],
+                    snippet=_snippet(haystack, s, e),
+                    position=s,
+                )
+            )
+            count += 1
+            if count >= max_findings_per_rule:
+                break
+    return findings
+
+
+def iter_target_files(paths: Sequence[Path]) -> Iterable[Path]:
+    """Yield scannable files from paths (files or directories)."""
+    exts = {'.pdf', '.html', '.htm', '.txt'}
+    for p in paths:
+        if p.is_dir():
+            for root, _, files in os.walk(p):
+                for fn in sorted(files):
+                    fp = Path(root) / fn
+                    if fp.suffix.lower() in exts:
+                        yield fp
+        else:
+            yield p
+
+
+def build_rules(segment: Optional[str]) -> List[Rule]:
+    """Build the rule set, optionally adding segment-specific rules."""
+    rules = list(DEFAULT_RULES)
+    if segment:
+        rules.extend(SEGMENT_RULES.get(segment.strip().lower(), []))
+    return rules
+
+
+# ---------------------------------------------------------------------------
+# Output helpers
+# ---------------------------------------------------------------------------
+
+def print_human(findings: List[Finding]) -> None:
+    """Print human-readable findings to stdout."""
+    if not findings:
+        print('\u2705 QA-SCAN: Keine Verstoesse gefunden.')
+        return
+
+    total_errors = sum(1 for f in findings if f.severity == 'error')
+    total_warnings = sum(1 for f in findings if f.severity == 'warning')
+    print(f'\u274c QA-SCAN: Verstoesse gefunden \u2014 errors={total_errors}, warnings={total_warnings}')
+
+    by_file: Dict[str, List[Finding]] = {}
+    for f in findings:
+        by_file.setdefault(f.file, []).append(f)
+
+    for file, items in sorted(by_file.items()):
+        print(f'\n{file}')
+        for it in sorted(items, key=lambda x: (x.severity != 'error', x.rule_id, x.position)):
+            sev = 'ERROR' if it.severity == 'error' else 'WARN '
+            print(f'  [{sev}] {it.rule_id}: {it.description}')
+            print(f'         match: {it.match!r}')
+            print(f'       snippet: {it.snippet!r}')
+
+
+def write_junit(path: Path, findings: List[Finding]) -> None:
+    """Write findings as JUnit XML for CI artifact upload."""
+    import xml.etree.ElementTree as ET
+
+    by_file: Dict[str, List[Finding]] = {}
+    for f in findings:
+        by_file.setdefault(f.file, []).append(f)
+
+    testsuite = ET.Element(
+        'testsuite',
+        attrib={
+            'name': 'report_qa_scan',
+            'tests': str(len(by_file) if by_file else 1),
+            'failures': str(sum(1 for f in findings if f.severity == 'error')),
+        },
+    )
+
+    if not by_file:
+        tc = ET.SubElement(testsuite, 'testcase', attrib={'name': 'no_findings'})
+        ET.SubElement(tc, 'system-out').text = 'No findings'
+    else:
+        for file, items in sorted(by_file.items()):
+            tc = ET.SubElement(testsuite, 'testcase', attrib={'name': file})
+            errors = [x for x in items if x.severity == 'error']
+            if errors:
+                msg_lines = [f'{e.rule_id}: {e.match} | {e.snippet}' for e in errors[:25]]
+                failure = ET.SubElement(tc, 'failure', attrib={'message': f'{len(errors)} error(s) found'})
+                failure.text = '\n'.join(msg_lines)
+            warnings = [x for x in items if x.severity == 'warning']
+            if warnings:
+                out_lines = [f'[WARN] {w.rule_id}: {w.match} | {w.snippet}' for w in warnings[:50]]
+                ET.SubElement(tc, 'system-out').text = '\n'.join(out_lines)
+
+    tree = ET.ElementTree(testsuite)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tree.write(str(path), encoding='utf-8', xml_declaration=True)
+
+
+def findings_to_json(findings: List[Finding]) -> Dict[str, object]:
+    """Convert findings to JSON-serializable dict."""
+    return {
+        'schema': 'report_qa_scan.v1',
+        'passed': sum(1 for f in findings if f.severity == 'error') == 0,
+        'summary': {
+            'total': len(findings),
+            'errors': sum(1 for f in findings if f.severity == 'error'),
+            'warnings': sum(1 for f in findings if f.severity == 'warning'),
+        },
+        'findings': [dataclasses.asdict(f) for f in findings],
+    }
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    ap = argparse.ArgumentParser(
+        description='CI-friendly QA scan for rendered report HTML/PDF artifacts.'
+    )
+    ap.add_argument('paths', nargs='+', help='File(s) or directory(ies) to scan')
+    ap.add_argument('--segment', choices=['solo', 'team', 'kmu'], default=None,
+                    help='Size segment (adds segment-specific checks)')
+    ap.add_argument('--json', action='store_true', help='Print JSON report to stdout')
+    ap.add_argument('--junit', default=None, help='Write JUnit XML to given path')
+    ap.add_argument('--fail-on', choices=['error', 'warning'], default='error',
+                    help='Exit code 2 on errors only (default) or also on warnings')
+    ap.add_argument('--max-findings-per-rule', type=int, default=50,
+                    help='Max findings per rule per file (default: 50)')
+    args = ap.parse_args(argv)
+
+    try:
+        paths = [Path(p) for p in args.paths]
+        rules = build_rules(args.segment)
+
+        findings: List[Finding] = []
+        scanned = 0
+        for fp in iter_target_files(paths):
+            if not fp.exists():
+                continue
+            file_type, raw, text = _read_file(fp)
+            findings.extend(
+                scan_content(
+                    file_path=fp,
+                    file_type=file_type,
+                    raw=raw,
+                    text=text,
+                    rules=rules,
+                    max_findings_per_rule=args.max_findings_per_rule,
+                )
+            )
+            scanned += 1
+
+        if scanned == 0:
+            print('QA-SCAN: Keine scanbaren Dateien gefunden.', file=sys.stderr)
+            return 1
+
+        if args.json:
+            print(json.dumps(findings_to_json(findings), ensure_ascii=False, indent=2))
+        else:
+            print_human(findings)
+
+        if args.junit:
+            write_junit(Path(args.junit), findings)
+
+        if args.fail_on == 'warning':
+            return 2 if findings else 0
+        return 2 if any(f.severity == 'error' for f in findings) else 0
+
+    except Exception as exc:
+        print(f'QA-SCAN runtime error: {exc}', file=sys.stderr)
+        return 1
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/tests/test_report_qa_scan.py
+++ b/tests/test_report_qa_scan.py
@@ -1,0 +1,303 @@
+# -*- coding: utf-8 -*-
+"""Tests for scripts/report_qa_scan.py."""
+import os
+import sys
+import json
+import tempfile
+from pathlib import Path
+
+import pytest
+
+# Ensure scripts/ is importable
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+
+from report_qa_scan import (
+    Rule,
+    Finding,
+    scan_content,
+    build_rules,
+    _extract_text_from_html,
+    findings_to_json,
+    main,
+)
+
+
+# ---------------------------------------------------------------------------
+# Rule / scan_content unit tests
+# ---------------------------------------------------------------------------
+
+class TestCurrencyEuroDot:
+    """CURRENCY_EURO_DOT: detect empty '€.' artifacts."""
+
+    def test_detects_euro_dot(self):
+        rules = [r for r in build_rules(None) if r.id == "CURRENCY_EURO_DOT"]
+        findings = scan_content(
+            file_path=Path("test.html"), file_type="html", raw="", text="Kosten: €.",
+            rules=rules,
+        )
+        assert len(findings) >= 1
+
+    def test_ignores_valid_euro(self):
+        rules = [r for r in build_rules(None) if r.id == "CURRENCY_EURO_DOT"]
+        findings = scan_content(
+            file_path=Path("test.html"), file_type="html", raw="", text="Kosten: 6.000 €.",
+            rules=rules,
+        )
+        # "6.000 €." has a digit before the space-euro, so our negative lookbehind fires
+        # This is actually a sentence ending after a valid euro value — should NOT match
+        assert len(findings) == 0
+
+
+class TestPercentPlaceholder:
+    """PERCENT_PLACEHOLDER_BEI: detect 'bei %' without a number."""
+
+    def test_detects_bei_percent(self):
+        rules = [r for r in build_rules(None) if r.id == "PERCENT_PLACEHOLDER_BEI"]
+        findings = scan_content(
+            file_path=Path("t.html"), file_type="html", raw="", text="Der ROI liegt bei %.",
+            rules=rules,
+        )
+        assert len(findings) >= 1
+
+    def test_ignores_valid_percent(self):
+        rules = [r for r in build_rules(None) if r.id == "PERCENT_PLACEHOLDER_BEI"]
+        findings = scan_content(
+            file_path=Path("t.html"), file_type="html", raw="", text="ROI bei 200 %",
+            rules=rules,
+        )
+        assert len(findings) == 0
+
+
+class TestColonPercent:
+    """COLON_PERCENT_EMPTY: detect ': %' without a number."""
+
+    def test_detects_colon_percent(self):
+        rules = [r for r in build_rules(None) if r.id == "COLON_PERCENT_EMPTY"]
+        findings = scan_content(
+            file_path=Path("t.html"), file_type="html", raw="", text="ROI: %.",
+            rules=rules,
+        )
+        assert len(findings) >= 1
+
+
+class TestDuForm:
+    """DU_FORM_PRONOUNS: detect informal 'du' but not false positives."""
+
+    def test_detects_standalone_du(self):
+        rules = [r for r in build_rules(None) if r.id == "DU_FORM_PRONOUNS"]
+        findings = scan_content(
+            file_path=Path("t.html"), file_type="html", raw="",
+            text="Wenn du die Software einsetzt, steigt deine Effizienz.",
+            rules=rules,
+        )
+        assert len(findings) >= 2  # "du" + "deine"
+
+    def test_ignores_durch(self):
+        """'durch' must NOT trigger Du-form detection."""
+        rules = [r for r in build_rules(None) if r.id == "DU_FORM_PRONOUNS"]
+        findings = scan_content(
+            file_path=Path("t.html"), file_type="html", raw="",
+            text="durch Automatisierung steigt die Produktivitaet",
+            rules=rules,
+        )
+        assert len(findings) == 0
+
+    def test_ignores_produkt(self):
+        """'Produkt' must NOT trigger Du-form detection."""
+        rules = [r for r in build_rules(None) if r.id == "DU_FORM_PRONOUNS"]
+        findings = scan_content(
+            file_path=Path("t.html"), file_type="html", raw="",
+            text="Das Produkt wurde industriell gefertigt. Industrie 4.0 ist relevant.",
+            rules=rules,
+        )
+        assert len(findings) == 0
+
+    def test_ignores_uppercase_Du(self):
+        """Uppercase 'Du' (polite form in some contexts) should NOT match (case-sensitive)."""
+        rules = [r for r in build_rules(None) if r.id == "DU_FORM_PRONOUNS"]
+        findings = scan_content(
+            file_path=Path("t.html"), file_type="html", raw="",
+            text="Wenn Du das Tool nutzt",
+            rules=rules,
+        )
+        # Our regex is case-sensitive (flags=0), so uppercase "Du" should not match
+        assert len(findings) == 0
+
+
+class TestLeakDetection:
+    """Leak phrase detection rules."""
+
+    def test_detects_platzhalter(self):
+        rules = [r for r in build_rules(None) if r.id == "LEAK_PLATZHALTER"]
+        findings = scan_content(
+            file_path=Path("t.html"), file_type="html", raw="",
+            text="Dies ist ein Platzhalter fuer spaeteren Inhalt.",
+            rules=rules,
+        )
+        assert len(findings) == 1
+
+    def test_detects_assistant_de(self):
+        rules = [r for r in build_rules(None) if r.id == "LEAK_ASSISTANT_DE"]
+        findings = scan_content(
+            file_path=Path("t.html"), file_type="html", raw="",
+            text="wie kann ich dir helfen bei der Implementierung?",
+            rules=rules,
+        )
+        assert len(findings) == 1
+
+    def test_detects_assistant_en(self):
+        rules = [r for r in build_rules(None) if r.id == "LEAK_ASSISTANT_EN"]
+        findings = scan_content(
+            file_path=Path("t.html"), file_type="html", raw="",
+            text="As an AI assistant, I can help you.",
+            rules=rules,
+        )
+        assert len(findings) >= 1
+
+
+class TestJinjaPlaceholder:
+    """PLACEHOLDER_JINJA: detect unrendered {{ }} in raw HTML."""
+
+    def test_detects_jinja(self):
+        rules = [r for r in build_rules(None) if r.id == "PLACEHOLDER_JINJA"]
+        findings = scan_content(
+            file_path=Path("t.html"), file_type="html",
+            raw="<p>{{CAPEX_REALISTISCH_EUR}} Euro</p>",
+            text="Euro",
+            rules=rules,
+        )
+        assert len(findings) == 1
+
+    def test_no_jinja_in_clean_html(self):
+        rules = [r for r in build_rules(None) if r.id == "PLACEHOLDER_JINJA"]
+        findings = scan_content(
+            file_path=Path("t.html"), file_type="html",
+            raw="<p>6.000 Euro</p>",
+            text="6.000 Euro",
+            rules=rules,
+        )
+        assert len(findings) == 0
+
+
+class TestSoloSegmentRules:
+    """Solo-specific rules."""
+
+    def test_solo_governance_detected(self):
+        rules = build_rules("solo")
+        solo_rules = [r for r in rules if r.id == "SOLO_GOVERNANCE"]
+        findings = scan_content(
+            file_path=Path("t.html"), file_type="html", raw="",
+            text="Die Governance-Struktur sollte etabliert werden.",
+            rules=solo_rules,
+        )
+        assert len(findings) == 1
+
+    def test_solo_governance_not_in_team(self):
+        rules = build_rules("team")
+        governance_rules = [r for r in rules if r.id == "SOLO_GOVERNANCE"]
+        assert len(governance_rules) == 0  # Not a team rule
+
+
+# ---------------------------------------------------------------------------
+# HTML extraction tests
+# ---------------------------------------------------------------------------
+
+class TestHTMLExtraction:
+    """HTML text extraction strips tags/styles correctly."""
+
+    def test_strips_style_content(self):
+        html = '<style>.foo { width: 100%; }</style><p>Visible text</p>'
+        text = _extract_text_from_html(html)
+        assert "100%" not in text
+        assert "Visible text" in text
+
+    def test_strips_script_content(self):
+        html = '<script>var x = "100%";</script><p>Only this</p>'
+        text = _extract_text_from_html(html)
+        assert "Only this" in text
+        assert "var x" not in text
+
+    def test_unescapes_entities(self):
+        html = '<p>6.000&nbsp;&euro;</p>'
+        text = _extract_text_from_html(html)
+        assert "\u20ac" in text  # euro sign
+
+
+# ---------------------------------------------------------------------------
+# JSON output tests
+# ---------------------------------------------------------------------------
+
+class TestJSONOutput:
+    """JSON output format."""
+
+    def test_empty_findings(self):
+        result = findings_to_json([])
+        assert result["passed"] is True
+        assert result["summary"]["errors"] == 0
+
+    def test_with_errors(self):
+        f = Finding(
+            file="test.html", file_type="html", rule_id="X",
+            severity="error", description="d", match="m",
+            snippet="s", position=0,
+        )
+        result = findings_to_json([f])
+        assert result["passed"] is False
+        assert result["summary"]["errors"] == 1
+
+
+# ---------------------------------------------------------------------------
+# CLI integration tests
+# ---------------------------------------------------------------------------
+
+class TestCLI:
+    """CLI main() integration."""
+
+    def test_clean_file_exits_0(self, tmp_path: Path):
+        f = tmp_path / "clean.html"
+        f.write_text("<html><body><p>Sauberer Report mit 6.000 Euro.</p></body></html>")
+        exit_code = main([str(f)])
+        assert exit_code == 0
+
+    def test_dirty_file_exits_2(self, tmp_path: Path):
+        f = tmp_path / "dirty.html"
+        f.write_text("<html><body><p>Kosten: €. Der ROI liegt bei %.</p></body></html>")
+        exit_code = main([str(f)])
+        assert exit_code == 2
+
+    def test_json_output(self, tmp_path: Path, capsys):
+        f = tmp_path / "test.html"
+        f.write_text("<html><body><p>Sauberer Text</p></body></html>")
+        exit_code = main([str(f), "--json"])
+        assert exit_code == 0
+        out = capsys.readouterr().out
+        data = json.loads(out)
+        assert data["passed"] is True
+
+    def test_junit_output(self, tmp_path: Path):
+        f = tmp_path / "test.html"
+        f.write_text("<html><body><p>Platzhalter im Text</p></body></html>")
+        junit_path = tmp_path / "results.xml"
+        exit_code = main([str(f), "--junit", str(junit_path)])
+        assert exit_code == 2
+        assert junit_path.exists()
+        content = junit_path.read_text()
+        assert "LEAK_PLATZHALTER" in content
+
+    def test_segment_solo(self, tmp_path: Path):
+        f = tmp_path / "solo.html"
+        f.write_text("<html><body><p>Die Governance sollte geaendert werden.</p></body></html>")
+        exit_code = main([str(f), "--segment", "solo"])
+        assert exit_code == 2  # SOLO_GOVERNANCE triggers error
+
+    def test_directory_scan(self, tmp_path: Path):
+        (tmp_path / "a.html").write_text("<p>OK</p>")
+        (tmp_path / "b.html").write_text("<p>TODO here</p>")
+        exit_code = main([str(tmp_path)])
+        assert exit_code == 2  # b.html has TODO
+
+    def test_no_files_exits_1(self, tmp_path: Path):
+        empty_dir = tmp_path / "empty"
+        empty_dir.mkdir()
+        exit_code = main([str(empty_dir)])
+        assert exit_code == 1  # No scannable files


### PR DESCRIPTION
- Add scripts/report_qa_scan.py: regex-based quality scanner for rendered report artifacts (HTML/PDF) detecting empty placeholders, template leaks, Du-form pronouns, and segment-specific issues
- Optimizations vs. original: removed false-positive LEAK_INPUT_CHECKLIST rule, made Du-form case-sensitive (warning not error), improved CURRENCY_EURO_DOT regex to not match valid "6.000 €." sentence endings
- Add tests/test_report_qa_scan.py: 28 tests covering all rules, HTML extraction, JSON/JUnit output, and CLI integration
- Integrate QA scan into .github/workflows/report-smoke.yml validate-gates job

https://claude.ai/code/session_01Hvu6uNjVh6o7NDBCaJQaTm