### PR TITLE
feat: Extend QA scanner with Team/KMU-specific rules and truncation d…

### DIFF
--- a/scripts/report_qa_scan.py
+++ b/scripts/report_qa_scan.py
@@ -10,7 +10,13 @@ Checks:
 - Leakage phrases (prompt echoes, template phrases)
 - Du-forms (informal address in formal reports)
 - Placeholders (TODO, Lorem ipsum, unrendered {{...}})
-- Segment-specific rules (Solo: no Governance/Enterprise terms)
+- Truncation artifacts (ellipsis 'daue…', 'Le…', incomplete sentences)
+- Un-localized English BC labels ('Payback Progress', 'Time Savings')
+- Excessive n.v. values (indicates BC calculation failure)
+- Segment-specific rules:
+  - Solo: no Governance/Enterprise terms
+  - Team: no Solo-specific terms, Team-adequate complexity
+  - KMU: no Solo terms, KMU-adequate governance depth
 
 Exit codes:
 - 0: no violations (or warnings-only when --fail-on=error)
@@ -148,6 +154,45 @@ DEFAULT_RULES: List[Rule] = [
         where='raw',
         pattern=r'(\{\{[^}]+\}\}|\{%\s*[^%]+%\})',
     ),
+    # --- Truncation artifacts (survive content_quality_enforcer) ---
+    Rule(
+        id='TRUNCATION_ELLIPSIS',
+        description='Trunkierungs-Artefakt: abgeschnittenes Wort mit Ellipse',
+        severity='error',
+        where='text',
+        # Words ending with … or ... that indicate LLM/post-processing truncation
+        # Exclude legitimate "..." at sentence end (3+ chars before dots)
+        pattern=r'\b[A-Za-zÄÖÜäöüß]{1,4}[…]',
+        flags=0,
+    ),
+    Rule(
+        id='INCOMPLETE_SENTENCE_FRAGMENT',
+        description='Unvollstaendiger Satz: Konjunktion/Artikel am Satzende ohne Fortsetzung',
+        severity='warning',
+        where='text',
+        # A conjunction/article immediately followed by a period — indicates truncation
+        pattern=r'\b(?:jedoch|darüber hinaus|allerdings|zudem|sowie|eines|einer|einem)\s*\.',
+    ),
+    # --- Un-localized English BC labels (should have been translated by healer) ---
+    Rule(
+        id='ENGLISH_BC_LABEL',
+        description='Nicht lokalisiertes englisches Business-Case-Label',
+        severity='error',
+        where='text',
+        pattern=r'\b(?:Payback\s+Progress|Time\s+Savings\s+(?:Hours|\(Hours\))|Monthly\s+Savings|Net\s+Present\s+Value)\b',
+    ),
+    # --- Excessive "n.v." indicating BC calculation failure ---
+    Rule(
+        id='NV_PLACEHOLDER_CLUSTER',
+        description='Gehaeufte n.v.-Platzhalter (>3): Business-Case-Berechnung vermutlich fehlgeschlagen',
+        severity='warning',
+        where='text',
+        # Matches 4th+ occurrence of "n. v." / "n.v." in text — the scan_content
+        # loop handles first 3 as benign, 4th+ triggers this rule via post-scan check.
+        # This pattern matches every single "n. v." / "n.v." occurrence;
+        # the _check_nv_cluster post-scan step evaluates the count.
+        pattern=r'n\.[\s\xa0]?v\.',
+    ),
 ]
 
 # Segment-specific rules
@@ -168,8 +213,46 @@ SEGMENT_RULES: Dict[str, List[Rule]] = {
             pattern=r'\b(?:Stakeholder|Audit[-\s]?Trail|Matrixorganisation)\b',
         ),
     ],
-    'team': [],
-    'kmu': [],
+    'team': [
+        Rule(
+            id='TEAM_SOLO_LANGUAGE',
+            description='TEAM: Solo-spezifische Sprache erkannt (Einzelunternehmer/Freelancer/Solopreneur)',
+            severity='warning',
+            where='text',
+            pattern=r'\b(?:Einzelunternehmer(?:in)?|Freelancer(?:in)?|Solopreneur(?:in)?|Solo-Selbstst[äa]ndige[rn]?|Ihre\s+Agilit[äa]t\s+als\s+Einzelperson)\b',
+        ),
+        Rule(
+            id='TEAM_PAYBACK_PROGRESS_RAW',
+            description='TEAM: Un-lokalisiertes "Payback Progress" Label (sollte deutsch sein)',
+            severity='error',
+            where='text',
+            pattern=r'Payback\s+Progress\s*:?\s*\d+\s*%',
+        ),
+    ],
+    'kmu': [
+        Rule(
+            id='KMU_SOLO_LANGUAGE',
+            description='KMU: Solo-spezifische Sprache erkannt (Einzelunternehmer/Freelancer/Solopreneur)',
+            severity='warning',
+            where='text',
+            pattern=r'\b(?:Einzelunternehmer(?:in)?|Freelancer(?:in)?|Solopreneur(?:in)?|Solo-Selbstst[äa]ndige[rn]?|Ihre\s+Agilit[äa]t\s+als\s+Einzelperson)\b',
+        ),
+        Rule(
+            id='KMU_PAYBACK_PROGRESS_RAW',
+            description='KMU: Un-lokalisiertes "Payback Progress" Label (sollte deutsch sein)',
+            severity='error',
+            where='text',
+            pattern=r'Payback\s+Progress\s*:?\s*\d+\s*%',
+        ),
+        Rule(
+            id='KMU_GOVERNANCE_DEPTH',
+            description='KMU: "Spielregeln" statt "Governance" — KMU benoetigt Enterprise-Terminologie',
+            severity='warning',
+            where='text',
+            # Inverse of Solo rule: KMU should use Governance, not Solo-simplified "Spielregeln"
+            pattern=r'\bSpielregeln\b',
+        ),
+    ],
 }
 
 
@@ -272,6 +355,9 @@ def _snippet(text: str, start: int, end: int, radius: int = 60) -> str:
     return re.sub(r'\s{2,}', ' ', sn)
 
 
+_NV_CLUSTER_THRESHOLD = 3  # 1-3 "n.v." is normal; 4+ indicates BC failure
+
+
 def scan_content(
     *,
     file_path: Path,
@@ -287,6 +373,28 @@ def scan_content(
         haystack = text if rule.where == 'text' else raw
         if not haystack:
             continue
+
+        # NV_PLACEHOLDER_CLUSTER: only emit findings if count exceeds threshold
+        if rule.id == 'NV_PLACEHOLDER_CLUSTER':
+            rx = rule.compile()
+            matches = list(rx.finditer(haystack))
+            if len(matches) > _NV_CLUSTER_THRESHOLD:
+                # Report a single aggregated finding
+                first = matches[0]
+                findings.append(
+                    Finding(
+                        file=str(file_path),
+                        file_type=file_type,
+                        rule_id=rule.id,
+                        severity=rule.severity,
+                        description=f'{rule.description} ({len(matches)}x gefunden)',
+                        match=f'n.v. x{len(matches)}',
+                        snippet=_snippet(haystack, first.start(), first.end()),
+                        position=first.start(),
+                    )
+                )
+            continue
+
         rx = rule.compile()
         count = 0
         for m in rx.finditer(haystack):

--- a/tests/test_report_qa_scan.py
+++ b/tests/test_report_qa_scan.py
@@ -17,6 +17,7 @@ from report_qa_scan import (
     scan_content,
     build_rules,
     _extract_text_from_html,
+    _NV_CLUSTER_THRESHOLD,
     findings_to_json,
     main,
 )
@@ -301,3 +302,205 @@ class TestCLI:
         empty_dir.mkdir()
         exit_code = main([str(empty_dir)])
         assert exit_code == 1  # No scannable files
+
+
+# ---------------------------------------------------------------------------
+# NEW: Truncation artifact tests
+# ---------------------------------------------------------------------------
+
+class TestTruncationEllipsis:
+    """TRUNCATION_ELLIPSIS: detect truncated words like 'daue…', 'Le…'."""
+
+    def test_detects_truncated_word(self):
+        rules = [r for r in build_rules(None) if r.id == "TRUNCATION_ELLIPSIS"]
+        findings = scan_content(
+            file_path=Path("t.html"), file_type="html", raw="",
+            text="Die Implementierung daue\u2026 und weitere Schritte folgen.",
+            rules=rules,
+        )
+        assert len(findings) >= 1
+
+    def test_detects_short_truncation(self):
+        rules = [r for r in build_rules(None) if r.id == "TRUNCATION_ELLIPSIS"]
+        findings = scan_content(
+            file_path=Path("t.html"), file_type="html", raw="",
+            text="Le\u2026 Weitere Informationen.",
+            rules=rules,
+        )
+        assert len(findings) >= 1
+
+    def test_ignores_normal_text(self):
+        rules = [r for r in build_rules(None) if r.id == "TRUNCATION_ELLIPSIS"]
+        findings = scan_content(
+            file_path=Path("t.html"), file_type="html", raw="",
+            text="Die vollstaendige Implementierung laeuft planmaessig.",
+            rules=rules,
+        )
+        assert len(findings) == 0
+
+
+class TestIncompleteSentence:
+    """INCOMPLETE_SENTENCE_FRAGMENT: detect truncated sentence endings."""
+
+    def test_detects_fragment(self):
+        rules = [r for r in build_rules(None) if r.id == "INCOMPLETE_SENTENCE_FRAGMENT"]
+        findings = scan_content(
+            file_path=Path("t.html"), file_type="html", raw="",
+            text="Die Implementierung ist wichtig jedoch. Weitere Schritte sind noetig.",
+            rules=rules,
+        )
+        assert len(findings) >= 1
+
+    def test_ignores_proper_sentence(self):
+        """Proper sentences with complete clauses should not trigger."""
+        rules = [r for r in build_rules(None) if r.id == "INCOMPLETE_SENTENCE_FRAGMENT"]
+        findings = scan_content(
+            file_path=Path("t.html"), file_type="html", raw="",
+            text="Die Implementierung laeuft planmaessig und erfolgreich.",
+            rules=rules,
+        )
+        assert len(findings) == 0
+
+
+class TestEnglishBCLabel:
+    """ENGLISH_BC_LABEL: detect un-localized English business case labels."""
+
+    def test_detects_payback_progress(self):
+        rules = [r for r in build_rules(None) if r.id == "ENGLISH_BC_LABEL"]
+        findings = scan_content(
+            file_path=Path("t.html"), file_type="html", raw="",
+            text="Payback Progress: 78% within 12 months.",
+            rules=rules,
+        )
+        assert len(findings) >= 1
+
+    def test_detects_time_savings(self):
+        rules = [r for r in build_rules(None) if r.id == "ENGLISH_BC_LABEL"]
+        findings = scan_content(
+            file_path=Path("t.html"), file_type="html", raw="",
+            text="Time Savings Hours: 120 pro Monat.",
+            rules=rules,
+        )
+        assert len(findings) >= 1
+
+    def test_ignores_german_labels(self):
+        rules = [r for r in build_rules(None) if r.id == "ENGLISH_BC_LABEL"]
+        findings = scan_content(
+            file_path=Path("t.html"), file_type="html", raw="",
+            text="Amortisations-Fortschritt: 78 innerhalb von 12 Monaten.",
+            rules=rules,
+        )
+        assert len(findings) == 0
+
+
+class TestNVCluster:
+    """NV_PLACEHOLDER_CLUSTER: detect excessive n.v. placeholders."""
+
+    def test_few_nv_are_ok(self):
+        rules = [r for r in build_rules(None) if r.id == "NV_PLACEHOLDER_CLUSTER"]
+        text = "CAPEX: n.\u202fv. OPEX: n.\u202fv. ROI: n.\u202fv."
+        findings = scan_content(
+            file_path=Path("t.html"), file_type="html", raw="", text=text,
+            rules=rules,
+        )
+        assert len(findings) == 0  # 3 is within threshold
+
+    def test_many_nv_triggers_warning(self):
+        rules = [r for r in build_rules(None) if r.id == "NV_PLACEHOLDER_CLUSTER"]
+        # Exceed the threshold (default 3)
+        nv_items = " ".join(["n.\u202fv." for _ in range(_NV_CLUSTER_THRESHOLD + 2)])
+        text = f"CAPEX: {nv_items} ROI: n.\u202fv."
+        findings = scan_content(
+            file_path=Path("t.html"), file_type="html", raw="", text=text,
+            rules=rules,
+        )
+        assert len(findings) == 1
+        assert "x" in findings[0].match  # Aggregated count
+
+
+# ---------------------------------------------------------------------------
+# NEW: Team segment tests
+# ---------------------------------------------------------------------------
+
+class TestTeamSegmentRules:
+    """Team-specific segment rules."""
+
+    def test_team_detects_solo_language(self):
+        rules = build_rules("team")
+        solo_lang_rules = [r for r in rules if r.id == "TEAM_SOLO_LANGUAGE"]
+        findings = scan_content(
+            file_path=Path("t.html"), file_type="html", raw="",
+            text="Als Einzelunternehmer profitieren Sie von der Automatisierung.",
+            rules=solo_lang_rules,
+        )
+        assert len(findings) >= 1
+
+    def test_team_ignores_team_language(self):
+        rules = build_rules("team")
+        solo_lang_rules = [r for r in rules if r.id == "TEAM_SOLO_LANGUAGE"]
+        findings = scan_content(
+            file_path=Path("t.html"), file_type="html", raw="",
+            text="Ihr Team profitiert von der Automatisierung.",
+            rules=solo_lang_rules,
+        )
+        assert len(findings) == 0
+
+    def test_team_payback_progress_english(self):
+        rules = build_rules("team")
+        pp_rules = [r for r in rules if r.id == "TEAM_PAYBACK_PROGRESS_RAW"]
+        findings = scan_content(
+            file_path=Path("t.html"), file_type="html", raw="",
+            text="Payback Progress: 78%",
+            rules=pp_rules,
+        )
+        assert len(findings) >= 1
+
+    def test_team_rules_not_in_solo(self):
+        rules = build_rules("solo")
+        team_rules = [r for r in rules if r.id.startswith("TEAM_")]
+        assert len(team_rules) == 0
+
+
+# ---------------------------------------------------------------------------
+# NEW: KMU segment tests
+# ---------------------------------------------------------------------------
+
+class TestKMUSegmentRules:
+    """KMU-specific segment rules."""
+
+    def test_kmu_detects_solo_language(self):
+        rules = build_rules("kmu")
+        solo_lang_rules = [r for r in rules if r.id == "KMU_SOLO_LANGUAGE"]
+        findings = scan_content(
+            file_path=Path("t.html"), file_type="html", raw="",
+            text="Der Freelancer sollte die KI-Tools evaluieren.",
+            rules=solo_lang_rules,
+        )
+        assert len(findings) >= 1
+
+    def test_kmu_detects_spielregeln(self):
+        """KMU should use 'Governance', not Solo-simplified 'Spielregeln'."""
+        rules = build_rules("kmu")
+        gov_rules = [r for r in rules if r.id == "KMU_GOVERNANCE_DEPTH"]
+        findings = scan_content(
+            file_path=Path("t.html"), file_type="html", raw="",
+            text="Die Spielregeln fuer KI sollten definiert werden.",
+            rules=gov_rules,
+        )
+        assert len(findings) >= 1
+
+    def test_kmu_governance_is_ok(self):
+        """'Governance' in KMU should NOT trigger KMU_GOVERNANCE_DEPTH."""
+        rules = build_rules("kmu")
+        gov_rules = [r for r in rules if r.id == "KMU_GOVERNANCE_DEPTH"]
+        findings = scan_content(
+            file_path=Path("t.html"), file_type="html", raw="",
+            text="Die KI-Governance sollte etabliert werden.",
+            rules=gov_rules,
+        )
+        assert len(findings) == 0
+
+    def test_kmu_rules_not_in_solo(self):
+        rules = build_rules("solo")
+        kmu_rules = [r for r in rules if r.id.startswith("KMU_")]
+        assert len(kmu_rules) == 0


### PR DESCRIPTION
…etection

New rules added to report_qa_scan.py:
- TRUNCATION_ELLIPSIS: Detects word-level truncation artifacts (daue…, Le…)
- INCOMPLETE_SENTENCE_FRAGMENT: Flags sentences ending on conjunction/article
- ENGLISH_BC_LABEL: Catches un-localized "Payback Progress", "Time Savings"
- NV_PLACEHOLDER_CLUSTER: Warns when >3 n.v. placeholders indicate BC failure

Team segment rules:
- TEAM_SOLO_LANGUAGE: Flags Solo-specific terms (Einzelunternehmer, Freelancer)
- TEAM_PAYBACK_PROGRESS_RAW: Catches un-localized Payback Progress labels

KMU segment rules:
- KMU_SOLO_LANGUAGE: Same Solo-term detection for KMU context
- KMU_PAYBACK_PROGRESS_RAW: Same Payback Progress detection
- KMU_GOVERNANCE_DEPTH: Flags "Spielregeln" (Solo-simplified) — KMU needs proper "Governance" terminology

Tests: 46 passed (28 existing + 18 new)

https://claude.ai/code/session_01Hvu6uNjVh6o7NDBCaJQaTm