### PR TITLE
fix: RC1/RC2/RC3 — Team/KMU release blockers from Railway log analysis

### DIFF
--- a/gpt_analyze.py
+++ b/gpt_analyze.py
@@ -13479,10 +13479,15 @@ Gib NUR das angeforderte HTML-Fragment aus - keine Fragen, keine Hilfsangebote, 
     log.info("=" * 80)
 
     # === PLATIN+++ v5.4.3: COMPACT REPORT MODE for streamlined reports ===
-    # Derive company_size from answers
+    # Derive company_size from answers — use canonical segment (solo/team/kmu)
     size_raw = (answers.get("unternehmensgroesse") or "solo").lower()
-    size_map = {"solo": "solo", "klein": "klein", "kmu": "kmu"}
-    company_size = size_map.get(size_raw, "klein")
+    # FIX-RC1: Normalize to canonical segment (never use "klein" internally)
+    if "solo" in size_raw or "freiberuf" in size_raw or "einzelunt" in size_raw:
+        company_size = "solo"
+    elif "kmu" in size_raw or "11" in size_raw or "mittel" in size_raw:
+        company_size = "kmu"
+    else:
+        company_size = "team"  # "klein", "kleines team", etc. → "team"
 
     # Read ENV variable PLATIN_APPENDIX_MODE
     # - "all"  = compact mode for solo+klein (≤25 pages), full for kmu (~43 pages)
@@ -16115,6 +16120,8 @@ NUR HTML ausgeben. Keine Erklärungen, keine Markdown-Fences."""
             "score_details": score_wrap.get("details", {}),
             "research_last_updated": sections["research_last_updated"],
             "sections": serializable_sections,  # Store sections for summary gate
+            "unternehmensgroesse": answers.get("unternehmensgroesse", ""),  # FIX-RC1: Pass for WP4 guard
+            "company_size": sections.get("COMPANY_SIZE", "team"),  # FIX-RC1: Canonical segment
         }
     )
 
@@ -16746,15 +16753,10 @@ def run_briefing_pipeline(db: Session, briefing_id: int, email: Optional[str] = 
         # WP4: Auto-compact guard for oversized Team/KMU reports
         try:
             from services.solo_compact_engine import check_and_apply_compact_guard
-            _wp4_size = (meta.get("unternehmensgroesse", "") or "").lower()
-            if "solo" in _wp4_size or "freiberuf" in _wp4_size:
-                _wp4_persona = "solo"
-            elif "kmu" in _wp4_size or "11" in _wp4_size:
-                _wp4_persona = "kmu"
-            else:
-                _wp4_persona = "team"
+            # FIX-RC1: Use canonical company_size from meta (populated from sections)
+            _wp4_persona = meta.get("company_size", "team")
             html, _wp4_sections, compact_result = check_and_apply_compact_guard(
-                html, {}, company_size=_wp4_persona
+                html, meta.get("sections", {}), company_size=_wp4_persona
             )
             if compact_result.compacted:
                 log.info(

--- a/scripts/report_qa_scan.py
+++ b/scripts/report_qa_scan.py
@@ -127,6 +127,26 @@ DEFAULT_RULES: List[Rule] = [
         where='text',
         pattern=r"\b(?:how\s+can\s+I\s+help|as\s+an\s+AI|I(?:'m| am)\s+an?\s+AI)\b",
     ),
+    # --- RC3: Empty-input LLM fallback (confirmed blocker in Report #561) ---
+    Rule(
+        id='PLACEHOLDER_EMPTY_INPUT_FALLBACK',
+        description='LLM-Fallback: Chatbot meldet fehlende Eingabe statt Report-Content',
+        severity='error',
+        where='text',
+        pattern=r'\bIch\s+habe\s+keine\s+(?:Frage|Aufgabe|Information(?:en)?|Angaben)\b'
+                r'|\bkeine\s+Frage\s+oder\s+Aufgabe\s+von\s+Ihnen\b'
+                r'|\bwobei\s+kann\s+ich\s+(?:dir|Ihnen)\s+helfen\b',
+    ),
+    # --- RC3: Prompt-/Input-Checklist leak (confirmed in Report #561 PDF) ---
+    Rule(
+        id='LEAK_INPUT_CHECKLIST',
+        description='Prompt-Leak: Input-Checklist-Begriff im Fliesstext (Datenlage/Tool-Uebersicht)',
+        severity='warning',
+        where='text',
+        # "Datenlage" and "Tool-Übersicht" are pipeline input terms that shouldn't
+        # appear verbatim in rendered reports. "Branche und Ziel" excluded (too broad).
+        pattern=r'\b(?:Input-Checkliste|Datenlage|Tool-Übersicht)\b',
+    ),
     # --- Du-form (informal address) ---
     Rule(
         id='DU_FORM_PRONOUNS',

--- a/services/report_healer.py
+++ b/services/report_healer.py
@@ -3374,6 +3374,25 @@ def heal_final_html(
     except Exception as e:
         log.warning("[HEALER-POST] WP1 business case empty value sanitizer error: %s", e)
 
+    # FIX-RC3: Remove LLM empty-input fallback phrases (all segments)
+    try:
+        _rc3_patterns: List[Tuple[str, str]] = [
+            # Chatbot "no input" fallbacks — must never appear in report
+            (r'(?:Ich habe keine (?:Frage|Aufgabe|Informationen?|Angaben)[^.]*\.)', ''),
+            (r'(?:keine Frage oder Aufgabe von Ihnen[^.]*\.)', ''),
+            (r'(?:[Ww]obei (?:soll|kann) ich (?:dir|Ihnen) helfen[^.]*[.?])', ''),
+            # "Datenlage" as standalone input-checklist leak
+            (r'<li[^>]*>\s*Datenlage\s*</li>', ''),
+        ]
+        for pat, repl in _rc3_patterns:
+            _rc3_matches = re.findall(pat, result, flags=re.IGNORECASE)
+            if _rc3_matches:
+                result = re.sub(pat, repl, result, flags=re.IGNORECASE)
+                fixes_applied += len(_rc3_matches)
+                log.info("[HEALER-POST] [FIX-RC3] Removed %d LLM fallback phrase(s)", len(_rc3_matches))
+    except Exception as e:
+        log.warning("[HEALER-POST] FIX-RC3 error: %s", e)
+
     # TASK D: ROI as qualitative ranges for SOLO (P1 optional)
     if segment_lower == "solo":
         try:

--- a/services/solo_compact_engine.py
+++ b/services/solo_compact_engine.py
@@ -719,7 +719,7 @@ def check_and_apply_compact_guard(
     result.reason = "; ".join(reasons)
     log.warning("[WP4-GUARD] Auto-compact triggered: %s", result.reason)
 
-    # Drop low-priority sections
+    # Step 1: Drop low-priority sections from sections dict
     updated_sections = dict(sections)
     for section_key in TEAM_KMU_LOW_PRIORITY_SECTIONS:
         if section_key in updated_sections:
@@ -729,17 +729,42 @@ def check_and_apply_compact_guard(
                 updated_sections[section_key] = ""
                 log.info("[WP4-GUARD] Dropped low-priority section: %s", section_key)
 
-    # Re-estimate after dropping sections
-    # For the HTML string, remove dropped section content
+    # Step 2: Remove dropped sections from rendered HTML
+    # FIX-RC2: Use <section> block matching instead of non-existent <!-- markers -->
     compacted_html = html
     for dropped_key in result.sections_dropped:
-        # Try to find and remove the section content in the rendered HTML
-        # This is a conservative approach - remove clearly marked sections
+        # Try CSS class-based pattern: <section class="report-section vendor-audit-section ...">...</section>
+        css_slug = dropped_key.replace("_HTML", "").replace("_", "-").lower()
         section_pattern = re.compile(
-            rf'<!-- BEGIN {dropped_key} -->.*?<!-- END {dropped_key} -->',
-            re.DOTALL | re.IGNORECASE
+            rf'<section[^>]*class="[^"]*{re.escape(css_slug)}[^"]*"[^>]*>.*?</section>',
+            re.DOTALL | re.IGNORECASE,
         )
-        compacted_html = section_pattern.sub('', compacted_html)
+        new_html = section_pattern.sub('', compacted_html)
+        if len(new_html) < len(compacted_html):
+            compacted_html = new_html
+            log.info("[WP4-GUARD] Removed section block via CSS class: %s", css_slug)
+
+    # Step 3: If still too large, trim excessively long text blocks (hard budget)
+    _target_kb = MAX_PAGES_BY_SIZE.get(size_lower, 45) * 3.5  # ~3.5KB per page estimate
+    if len(compacted_html.encode("utf-8")) / 1024 > _target_kb * 1.5:
+        # Aggressively shorten very long <li> and <p> blocks (> 800 chars)
+        def _trim_long_block(m: re.Match[str]) -> str:
+            tag = m.group(1)
+            content = m.group(2)
+            close = m.group(3)
+            if len(content) > 800:
+                # Cut at sentence boundary near 600 chars
+                cut = content[:600]
+                last_period = cut.rfind(".")
+                if last_period > 300:
+                    return f"<{tag}>{content[:last_period + 1]}</{close}>"
+            return m.group(0)
+        compacted_html = re.sub(
+            r'<((?:li|p)[^>]*)>(.*?)</(\1|li|p)>',
+            _trim_long_block,
+            compacted_html,
+            flags=re.DOTALL,
+        )
 
     result.compacted = True
     result.final_size_kb = len(compacted_html.encode("utf-8")) / 1024


### PR DESCRIPTION
RC1 — company_size normalization (root cause of 62-page Team reports):
- gpt_analyze.py:13484: Replace broken size_map {"klein":"klein"} with canonical segment derivation (solo/team/kmu). "klein" → "team".
- This fixes COMPACT_REPORT_MODE=False for team (was False because "klein" not in ["solo","team"]), enabling template section hiding.
- Add unternehmensgroesse + company_size to meta dict for WP4 guard.
- WP4 guard now uses meta["company_size"] instead of re-deriving.

RC2 — Compact Engine actually drops sections now:
- solo_compact_engine.py: Replace non-existent <!-- BEGIN/END -->
  markers with CSS class-based section removal (vendor-audit-section etc.)
- Add hard-budget text trimming for <li>/<p> blocks >800 chars when report still exceeds 1.5x target KB after section drops.
- WP4 now passes meta["sections"] instead of empty {} dict.

RC3 — LLM fallback phrase sanitizer:
- report_healer.py: Add FIX-RC3 step in heal_final_html() that removes "Ich habe keine Frage/Aufgabe" and "wobei kann ich helfen" fallback phrases, plus "Datenlage" as <li> input-checklist leak.

QA Scanner — two new rules from confirmed Report #561 blockers:
- PLACEHOLDER_EMPTY_INPUT_FALLBACK (error): LLM empty-input fallback
- LEAK_INPUT_CHECKLIST (warning): "Datenlage"/"Tool-Übersicht" leaks

Tests: 69 passed (46 QA scanner + 23 release readiness)

https://claude.ai/code/session_01Hvu6uNjVh6o7NDBCaJQaTm