### PR TITLE
fix(FIX-629): remove redundant re-import causing UnboundLocalError fo…

### DIFF
--- a/gpt_analyze.py
+++ b/gpt_analyze.py
@@ -15007,8 +15007,11 @@ Gib NUR das angeforderte HTML-Fragment aus - keine Fragen, keine Hilfsangebote, 
             else:
                 log.warning(f"[{run_id}] ⚠️ N4.3: DoD FAILED - conflicts={n43_report.governance_conflicts}, issues={len(n43_report.issues)}")
                 # PLATIN+++ FIX 5.2: Trigger additional healing pass on DoD failure
+                # FIX-629: Do NOT re-import process_n43_governance here – a local
+                # `from … import` makes Python treat the name as local for the
+                # ENTIRE function, causing UnboundLocalError at the earlier
+                # reference on line ~14979.  The module-level import is sufficient.
                 try:
-                    from services.n43_integration import process_n43_governance
                     sections, _n43_retry_report = process_n43_governance(
                         sections=sections,
                         briefing=answers,


### PR DESCRIPTION
…r process_n43_governance

The `from services.n43_integration import process_n43_governance` at line 15011 inside the function body caused Python to treat `process_n43_governance` as a local variable for the entire function scope. This made the earlier reference at line 14979 (`if N43_GOVERNANCE_AVAILABLE and process_n43_governance:`) fail with UnboundLocalError before the local assignment happened.

Fix: Remove the redundant re-import; the module-level import is sufficient.

https://claude.ai/code/session_01QS6WReACd1cMR14N8CsebZ