### PR TITLE
fix(R2): 6 showstopper fixes for testuser release (Report-566)

### DIFF
--- a/gpt_analyze.py
+++ b/gpt_analyze.py
@@ -12979,6 +12979,38 @@ Gib den erweiterten HTML-Inhalt aus (mindestens {_heal_target_words} Wörter):
             if _old in _risks_final:
                 _risks_final = _risks_final.replace(_old, _new)
                 log.info("[FIX-2.4] Replaced '%s' with '%s' in RISKS_HTML", _old, _new)
+
+        # FIX-R2-5: Also handle HTML-wrapped score placeholders
+        # e.g., <strong>nicht angegeben</strong> or <td>nicht angegeben</td>
+        _score_label_map = {
+            "Governance": _score_gov,
+            "Sicherheit": _score_sec,
+            "Security": _score_sec,
+        }
+        for _label, _score_val in _score_label_map.items():
+            for _placeholder in ["nicht angegeben", "nicht erhoben", "n/a", "N/A"]:
+                # Pattern: "Governance-Score: <strong>nicht angegeben</strong>"
+                _risks_final = _risks_final.replace(
+                    f"{_label}-Score: <strong>{_placeholder}</strong>",
+                    f"{_label}-Score: <strong>{_score_val}/100</strong>"
+                )
+                # Pattern: <strong>Governance-Score: nicht angegeben</strong>
+                _risks_final = _risks_final.replace(
+                    f"<strong>{_label}-Score: {_placeholder}</strong>",
+                    f"<strong>{_label}-Score: {_score_val}/100</strong>"
+                )
+                # Pattern: standalone "nicht angegeben" after label in a <td>
+                _risks_final = _risks_final.replace(
+                    f"{_label}-Score</td><td>{_placeholder}",
+                    f"{_label}-Score</td><td>{_score_val}/100"
+                )
+                # Also handle "Sicherheits-Score" with extra s
+                if _label == "Sicherheit":
+                    _risks_final = _risks_final.replace(
+                        f"Sicherheits-Score: <strong>{_placeholder}</strong>",
+                        f"Sicherheits-Score: <strong>{_score_val}/100</strong>"
+                    )
+
         sections["RISKS_HTML"] = _risks_final
         sections["risks"] = _risks_final
 
@@ -13092,6 +13124,52 @@ Gib den erweiterten HTML-Inhalt aus (mindestens {_heal_target_words} Wörter):
     else:
         log.warning("[CI-DESIGN] Förderpotenzial HTML empty or too short")
     sections["foerderpotenzial"] = foerderpotenzial_html
+
+    # =========================================================================
+    # FIX-R2-6A: Resolve Bundesland codes to full labels in Förder + Risk HTML
+    # Problem: LLM renders "In be existieren..." instead of "In Berlin existieren..."
+    # =========================================================================
+    _bl_raw = str(briefing.get("bundesland", "") or "").strip().lower()
+    _bl_label = BUNDESLAND_MAPPING.get(_bl_raw, "")
+    if _bl_raw and _bl_label and len(_bl_raw) == 2:
+        for _bl_key in ["FOERDERPOTENZIAL_HTML", "foerderpotenzial", "RISKS_HTML", "risks"]:
+            _bl_html = sections.get(_bl_key, "")
+            if _bl_html and isinstance(_bl_html, str):
+                _bl_changed = False
+                # "In be existieren" → "In Berlin existieren"
+                for _bl_pattern in [f"In {_bl_raw} ", f"in {_bl_raw} ", f"Im {_bl_raw} ", f"im {_bl_raw} "]:
+                    if _bl_pattern in _bl_html:
+                        _bl_html = _bl_html.replace(_bl_pattern, _bl_pattern[:3].replace(_bl_raw, _bl_label))
+                        _bl_changed = True
+                # "In  existieren" (completely empty bundesland)
+                _bl_html = re.sub(r'In\s+existieren\s+Förderprogramme', f'In {_bl_label} existieren Förderprogramme', _bl_html)
+                # Replace raw code in strong tags: <strong>be</strong> → <strong>Berlin</strong>
+                _bl_html = _bl_html.replace(f"<strong>{_bl_raw}</strong>", f"<strong>{_bl_label}</strong>")
+                _bl_html = _bl_html.replace(f"<strong>{_bl_raw.upper()}</strong>", f"<strong>{_bl_label}</strong>")
+                if _bl_changed or sections.get(_bl_key) != _bl_html:
+                    sections[_bl_key] = _bl_html
+                    log.info("[FIX-R2-6A] Resolved bundesland '%s' → '%s' in %s", _bl_raw, _bl_label, _bl_key)
+
+    # =========================================================================
+    # FIX-R2-6B: Filter discontinued Förderprogramme (go-digital, Digital Jetzt)
+    # These programs are no longer available; replace with discontinuation notice
+    # =========================================================================
+    _FOERDER_BLACKLIST = ["go-digital", "go_digital", "digital jetzt", "digital_jetzt"]
+    for _fp_key in ["FOERDERPOTENZIAL_HTML", "foerderpotenzial"]:
+        _fp_html = sections.get(_fp_key, "")
+        if _fp_html and isinstance(_fp_html, str):
+            for _discontinued in _FOERDER_BLACKLIST:
+                if _discontinued.lower() in _fp_html.lower():
+                    # Add discontinuation notice instead of removing entirely
+                    _fp_html = re.sub(
+                        rf'({re.escape(_discontinued)}(?:\s*\([^)]*\))?)',
+                        r'\1 (Programm eingestellt)',
+                        _fp_html,
+                        flags=re.IGNORECASE,
+                        count=1,
+                    )
+                    log.info("[FIX-R2-6B] Marked '%s' as discontinued in %s", _discontinued, _fp_key)
+            sections[_fp_key] = _fp_html
 
     # ========== SAFE RECOMMENDATIONS FORMATTING (v9.0 - Maßnahme 5) ==========
     recommendations_html = sections.get("RECOMMENDATIONS_HTML", "")
@@ -15301,6 +15379,24 @@ Gib NUR das angeforderte HTML-Fragment aus - keine Fragen, keine Hilfsangebote, 
     except Exception as e:
         log.warning(f"[{run_id}] [QUALITY-ENFORCER-RENDER] Failed: {e}")
 
+    # =========================================================================
+    # FIX-R2-3: QUICK-WINS RECONCILIATION
+    # QUICK_WINS_HTML may have been shortened by enforcer passes, losing the
+    # premium-rendered PROBLEM/WIRKUNG/UMSETZUNG blocks.  QUICK_WINS_HTML_LEFT
+    # preserves the original premium render.  If LEFT is significantly richer,
+    # prefer it for the final template.
+    # =========================================================================
+    _qw_left = sections.get("QUICK_WINS_HTML_LEFT", "") or ""
+    _qw_main = sections.get("QUICK_WINS_HTML", "") or ""
+    if (isinstance(_qw_left, str) and isinstance(_qw_main, str)
+            and len(_qw_left) > len(_qw_main) + 500
+            and 'data-qw-json-rendered="true"' in _qw_left):
+        log.info(
+            "[FIX-R2-3] QUICK_WINS_HTML_LEFT is richer (%d chars) than QUICK_WINS_HTML (%d chars) — using LEFT version",
+            len(_qw_left), len(_qw_main),
+        )
+        sections["QUICK_WINS_HTML"] = _qw_left
+        sections["quick_wins"] = _qw_left
 
     # =========================================================================
     # FIX-528: PIPELINE SANITIZATION (decode HTML entities + complete sentences)

--- a/prompts/de/executive_decision.md
+++ b/prompts/de/executive_decision.md
@@ -99,3 +99,5 @@ STIL:
 
 GUARDRAIL (zwingend):
 Keine Assistenz-/Dialog-Sprache, keine Fragen, keine Imperative, keine Meta-Kommentare. Ausschließlich neutrale Berichtssprache.
+
+WICHTIG: Antworte NUR mit der inhaltlichen Analyse als HTML. Keine Chat-Floskeln, keine Hilfsangebote, keine Fragen an den Nutzer, keine Begrüßungen, keine Einleitungsfloskeln, keine Eingabeaufforderungen. Beginne direkt mit dem HTML-Inhalt.

--- a/prompts/de/gamechanger_decision.md
+++ b/prompts/de/gamechanger_decision.md
@@ -30,7 +30,7 @@ AUSGABEREGEL (zwingend): Schreibe ausschließlich deklarative Berichtssätze. Ke
 
 STARTFORMAT: Beginne mit einem neutralen Substantivsatz (wie „Der aktuelle Zustand…", „Die empfohlene Vorgehensweise…", „Der strategische Rahmen…").
 
-NICHT ERLAUBT: „wie kann ich helfen", „ich sehe keine frage", „beschreibe dein anliegen", „du hast noch keine frage", „bitte", „frage", „nachricht".
+NICHT ERLAUBT: Hilfsangebote, Gesprächseinstiege, Eingabeaufforderungen, Rückfragen an den Nutzer, Begrüßungsfloskeln, Chat-Formulierungen jeder Art.
 
 WICHTIG: Verwenden Sie keine Anrede, keine Fragen, keine Assistenz- oder Chat-Formulierungen. Keine Meta-Kommentare über fehlende Eingaben. Schreiben Sie ausschließlich in neutraler Berichtssprache.
 
@@ -118,4 +118,6 @@ STRIKTE AUSGABEREGEL (verbindlich):
 - Jeder Absatz muss sofort zitierbar sein, nicht als Template
 
 GUARDRAIL (zwingend):
-Keine Assistenz- oder Chat-Formulierungen (z. B. „wie kann ich helfen", „gerne erkläre ich"). Verwenden Sie ausschließlich Berichtssprache.
+Keine Assistenz- oder Chat-Formulierungen, keine Hilfsangebote, keine Gesprächseinstiege, keine Eingabeaufforderungen. Verwenden Sie ausschließlich Berichtssprache.
+
+WICHTIG: Antworte NUR mit der inhaltlichen Analyse als HTML. Keine Chat-Floskeln, keine Fragen an den Nutzer, keine Begrüßungen, keine Einleitungsfloskeln. Beginne direkt mit dem HTML-Inhalt.

--- a/prompts/de/ki_stack_summary.md
+++ b/prompts/de/ki_stack_summary.md
@@ -30,7 +30,7 @@ AUSGABEREGEL (zwingend): Schreibe ausschließlich deklarative Berichtssätze. Ke
 
 STARTFORMAT: Beginne mit einem neutralen Substantivsatz (wie „Der aktuelle Zustand…", „Die empfohlene Vorgehensweise…", „Der strategische Rahmen…").
 
-NICHT ERLAUBT: „wie kann ich helfen", „ich sehe keine frage", „beschreibe dein anliegen", „du hast noch keine frage", „bitte", „frage", „nachricht".
+NICHT ERLAUBT: Hilfsangebote, Gesprächseinstiege, Eingabeaufforderungen, Rückfragen an den Nutzer, Begrüßungsfloskeln, Chat-Formulierungen jeder Art.
 
 WICHTIG: Verwenden Sie keine Anrede, keine Fragen, keine Assistenz- oder Chat-Formulierungen. Keine Meta-Kommentare über fehlende Eingaben. Schreiben Sie ausschließlich in neutraler Berichtssprache.
 

--- a/prompts/de/top_3_massnahmen.md
+++ b/prompts/de/top_3_massnahmen.md
@@ -38,7 +38,7 @@ MAßNAHME 3: Adressiert Risiken/Guardrails
 VERBOTEN:
 - Generische Phrasen: "Minimal-Stack", "Standard-Workflow", "Review-Regel"
 - Einleitungen wie "Hier sind die Top-3..."
-- Chat-Phrasen wie "Wie kann ich helfen?" oder "Bitte beschreibe..."
+- Chat-Phrasen, Hilfsangebote, Eingabeaufforderungen oder Gesprächseinstiege
 - Überschriften oder Absätze
 - Mehr als 3 Listenelemente
 

--- a/services/business_case_engine_v2.py
+++ b/services/business_case_engine_v2.py
@@ -690,6 +690,45 @@ def inject_canonical_to_sections(
     # After canonical injection, the BC prose HTML may still have empty labels
     _repair_empty_strong_tags(sections, canonical)
 
+    # FIX-R2-1: Final safety net — if BC prose STILL has empty € placeholders,
+    # replace the entire Fließtext block with a canonical template.
+    _bc_html = sections.get("BUSINESS_CASE_HTML", "")
+    if _bc_html and isinstance(_bc_html, str):
+        import re as _re
+        _has_empty = bool(_re.search(r'<strong>\s*€?\s*</strong>', _bc_html)) or \
+                     bool(_re.search(r'rund\s+€[\s.,;)]', _bc_html)) or \
+                     bool(_re.search(r'\(\s*€\s*\)', _bc_html))
+        if _has_empty:
+            _capex = f"{canonical.capex_eur:,.0f}".replace(",", ".")
+            _opex = f"{canonical.opex_month_eur:,.0f}".replace(",", ".")
+            _savings = f"{canonical.monthly_gross:,.0f}".replace(",", ".")
+            _payback = f"{canonical.payback_months:.1f}"
+            _roi = f"{canonical.roi_12m_net:.0f}"
+            _bc_prose = (
+                f'<h3>Investition und laufende Kosten</h3>'
+                f'<p>Die einmaligen Aufwände für Aufbau und Einführung liegen bei rund '
+                f'<strong>{_capex} €</strong>. Hinzu kommen monatliche Betriebskosten von rund '
+                f'<strong>{_opex} €</strong> – hauptsächlich für KI-Nutzung, Infrastruktur, '
+                f'Tools und Lizenzen.</p>'
+                f'<h3>Monatlicher Effekt</h3>'
+                f'<p>Im täglichen Einsatz ist eine realistische Entlastung von rund '
+                f'<strong>{_savings} €</strong> pro Monat erreichbar. Sie entsteht aus '
+                f'Zeitgewinn in Kernprozessen, weniger manuellen Schleifen und '
+                f'konsistenterer Ergebnisqualität.</p>'
+                f'<h3>Amortisation und ROI</h3>'
+                f'<p><strong>Einfache Rechnung:</strong> Investition ({_capex} €) '
+                f'geteilt durch monatliche Einsparung ({_savings} €) ergibt eine '
+                f'Amortisation nach <strong>{_payback} Monaten</strong>. '
+                f'Der ROI nach 12 Monaten liegt bei <strong>{_roi} %</strong>.</p>'
+            )
+            # Replace the prose section but keep any BC table that might follow
+            # Look for the prose block (from first <h3> to the table or end)
+            _table_match = _re.search(r'(<table[\s\S]*)', _bc_html)
+            _table_part = _table_match.group(1) if _table_match else ""
+            sections["BUSINESS_CASE_HTML"] = _bc_prose + _table_part
+            sections["business_case"] = sections["BUSINESS_CASE_HTML"]
+            log.info("[FIX-R2-1] Replaced BC prose with canonical template (empty placeholders detected)")
+
     return updates
 
 
@@ -726,17 +765,49 @@ def _repair_empty_strong_tags(sections: Dict[str, Any], canonical: "BusinessCase
             continue
 
         original = html
-        # Pattern: label text followed by empty <strong></strong>
+        # Pattern: label text followed by empty or partially-empty <strong></strong>
+        # FIX-R2-1: Also match <strong> €</strong>, <strong> %</strong>, <strong> Monaten</strong>
         for keyword, value in field_mapping.items():
+            # Original: empty strong tag
             pattern = re.compile(
                 rf'({re.escape(keyword)}[^<]{{0,30}})<strong>\s*</strong>',
                 re.IGNORECASE
             )
             html = pattern.sub(rf'\1<strong>{value}</strong>', html)
+            # FIX-R2-1: Strong tag with only unit symbol (€, %, Monat/Monaten)
+            pattern_unit = re.compile(
+                rf'({re.escape(keyword)}[^<]{{0,30}})<strong>\s*(?:€|%|Monaten?)\s*</strong>',
+                re.IGNORECASE
+            )
+            html = pattern_unit.sub(rf'\1<strong>{value}</strong>', html)
+
+        # FIX-R2-1: Context-based fallback patterns (no keyword needed)
+        _capex_val = f"{canonical.capex_eur:,.0f} €".replace(",", ".")
+        _opex_val = f"{canonical.opex_month_eur:,.0f} €".replace(",", ".")
+        _savings_val = f"{canonical.monthly_gross:,.0f} €".replace(",", ".")
+        _payback_val = f"{canonical.payback_months:.1f} Monate"
+        _roi_val = f"{canonical.roi_12m_net:.0f} %"
+        _context_patterns = [
+            (r'(einmalig\w*\s+Aufwände[^<]{0,60})<strong>\s*€?\s*</strong>', _capex_val),
+            (r'(Betriebskosten[^<]{0,40})<strong>\s*€?\s*</strong>', _opex_val),
+            (r'(Entlastung[^<]{0,40})<strong>\s*€?\s*</strong>', _savings_val),
+            (r'(Amortisation[^<]{0,40})<strong>\s*\d*\s*Monaten?\s*</strong>', _payback_val),
+            # FIX-R2-1: Parenthesised placeholders like "Investition ( €)"
+            (r'(Investition\s*)\(\s*(?:<strong>)?\s*€?\s*(?:</strong>)?\s*\)', f'({_capex_val})'),
+            (r'(Einsparung\s*)\(\s*(?:<strong>)?\s*€?\s*(?:</strong>)?\s*\)', f'({_savings_val})'),
+        ]
+        for ctx_pattern, ctx_value in _context_patterns:
+            if '<strong>' in ctx_value:
+                html = re.sub(ctx_pattern, rf'\1<strong>{ctx_value}</strong>', html, flags=re.IGNORECASE)
+            else:
+                html = re.sub(ctx_pattern, rf'\1{ctx_value}', html, flags=re.IGNORECASE)
 
         # Also fix standalone "€ " without value (e.g., "€ / Monat")
         html = re.sub(r':\s*€\s*/\s*Monat', f': {canonical.opex_month_eur:,.0f} € / Monat'.replace(",", "."), html)
         html = re.sub(r':\s*€\s*$', f': {canonical.capex_eur:,.0f} €'.replace(",", "."), html, flags=re.MULTILINE)
+        # FIX-R2-1: Fix "rund €" without value
+        html = re.sub(r'rund\s+<strong>\s*€\s*</strong>', f'rund <strong>{_capex_val}</strong>', html)
+        html = re.sub(r'rund\s+€(?=[\s.,;)])', f'rund {_capex_val}', html)
 
         if html != original:
             sections[section_key] = html

--- a/services/content_quality_enforcer.py
+++ b/services/content_quality_enforcer.py
@@ -1145,6 +1145,31 @@ def inject_hauptleistung_recommendations(html: str, hauptleistung: str, current_
     return result
 
 
+def _count_hauptleistung_combined(html: str, hauptleistung: str) -> int:
+    """
+    FIX-R2-4: Count both full-text AND short-form hauptleistung occurrences.
+
+    After FIX-3.1 replaces excess full-text with a short form, the combined
+    count (full + short) is the true density.  The enforcer must use this to
+    avoid re-injecting text that was deliberately shortened.
+    """
+    if not html or not hauptleistung:
+        return 0
+    full_count = len(re.findall(re.escape(hauptleistung), html, re.IGNORECASE))
+    # Derive the same short form that FIX-3.1 uses
+    short = hauptleistung[:60].rsplit(" ", 1)[0] + "..." if len(hauptleistung) > 60 else hauptleistung
+    for sep in [",", ";", ".", " und ", " mit "]:
+        pos = hauptleistung.find(sep)
+        if 15 < pos < 80:
+            short = hauptleistung[:pos]
+            break
+    if short != hauptleistung and len(short) > 10:
+        short_count = len(re.findall(re.escape(short), html, re.IGNORECASE))
+        # Subtract full occurrences that also match short prefix
+        return max(full_count, short_count)
+    return full_count
+
+
 def apply_hauptleistung_enforcer(sections: dict, hauptleistung: str) -> dict:
     """
     Enforced hauptleistung Minimum in Executive Summary und Recommendations.
@@ -1152,11 +1177,18 @@ def apply_hauptleistung_enforcer(sections: dict, hauptleistung: str) -> dict:
     if not hauptleistung or len(hauptleistung) < 3:
         log.warning("[HAUPTLEISTUNG-ENFORCER] No hauptleistung provided, skipping")
         return sections
-    
-    # Executive Summary: Minimum 4x
+
+    # FIX-R2-4: Skip enforcer if FIX-3.1 has already limited repetitions.
+    # Re-injecting after FIX-3.1 causes garbled text ("...UnternehmenBeratung
+    # und Unterstützung...").
+    if sections.get("_fix_3_1_applied"):
+        log.info("[HAUPTLEISTUNG-ENFORCER] Skipped — FIX-3.1 already applied, re-injection would cause garbling")
+        return sections
+
+    # Executive Summary: Minimum 4x (count full + short combined)
     for key in ["EXECUTIVE_SUMMARY_HTML", "executive_summary", "EXEC_SUMMARY_HTML"]:  # v14.23: FINAL_CHECK entfernt (ist Plain Text, nicht HTML)
         if key in sections and sections[key]:
-            current = count_hauptleistung(sections[key], hauptleistung)
+            current = _count_hauptleistung_combined(sections[key], hauptleistung) if len(hauptleistung) > 50 else count_hauptleistung(sections[key], hauptleistung)
             if current < 4:
                 log.info(f"[HAUPTLEISTUNG-ENFORCER] {key}: {current}/4 → enforcing")
                 sections[key] = inject_hauptleistung_executive(
@@ -1164,11 +1196,11 @@ def apply_hauptleistung_enforcer(sections: dict, hauptleistung: str) -> dict:
                 )
                 new_count = count_hauptleistung(sections[key], hauptleistung)
                 log.info(f"[HAUPTLEISTUNG-ENFORCER] {key}: Now {new_count}/4")
-    
+
     # Recommendations: Minimum 3x
     for key in ["RECOMMENDATIONS_HTML", "recommendations"]:
         if key in sections and sections[key]:
-            current = count_hauptleistung(sections[key], hauptleistung)
+            current = _count_hauptleistung_combined(sections[key], hauptleistung) if len(hauptleistung) > 50 else count_hauptleistung(sections[key], hauptleistung)
             if current < 3:
                 log.info(f"[HAUPTLEISTUNG-ENFORCER] {key}: {current}/3 → enforcing")
                 sections[key] = inject_hauptleistung_recommendations(
@@ -1176,7 +1208,7 @@ def apply_hauptleistung_enforcer(sections: dict, hauptleistung: str) -> dict:
                 )
                 new_count = count_hauptleistung(sections[key], hauptleistung)
                 log.info(f"[HAUPTLEISTUNG-ENFORCER] {key}: Now {new_count}/3")
-    
+
     return sections
 
 
@@ -2678,6 +2710,8 @@ def _limit_hauptleistung_repetitions(sections: dict, hauptleistung: str, max_ful
 
     if total_replaced > 0:
         log.info("[FIX-3.1] hauptleistung repetition limited: replaced %d occurrences with short form", total_replaced)
+        # FIX-R2-4: Set flag so the enforcer in subsequent passes won't re-inject
+        sections["_fix_3_1_applied"] = True
 
     return sections
 
@@ -2776,6 +2810,9 @@ def apply_all_quality_enforcers(sections: dict, hauptleistung: str = "", bundesl
 
     # 15. Chat Artefact Filter (Fix-Batch J4) - Remove "Schreib mir", "Frag mich" etc.
     sections = apply_chat_artefact_filter(sections)
+
+    # 15.5 FIX-R2-2: Prompt-Leak Hard-Block (removes entire HTML blocks with prompt leaks)
+    sections = apply_prompt_leak_hard_block(sections)
 
     # 16. FIX-514: Forbidden-Token Scrub (Rollout/Skalierung/Stack in decision+stack sections)
     sections = apply_forbidden_token_scrub(sections)
@@ -3599,6 +3636,97 @@ def apply_chat_artefact_filter(sections: dict) -> dict:
 
     if total_removals > 0:
         log.info(f"[CHAT-ARTEFACT-FILTER] Complete: {total_removals} total artefacts removed")
+
+    return sections
+
+
+# =============================================================================
+# FIX-R2-2: PROMPT-LEAK HARD-BLOCK
+# =============================================================================
+# Problem: LLM sometimes renders the prompt template itself instead of the
+# generated content, showing "Wie kann ich helfen? Bitte beschreibe kurz..."
+# in the final report.  The existing chat-artefact filter (regex patterns)
+# misses multi-sentence prompt leaks.
+#
+# Solution: Detect known prompt-leak phrases and remove the entire
+# containing HTML block (<p>…</p> or <h3>…) to avoid partial remnants.
+# =============================================================================
+
+PROMPT_LEAK_HARD_BLOCK_PHRASES = [
+    "Wie kann ich helfen",
+    "Wie kann ich dir helfen",
+    "Wie kann ich Ihnen helfen",
+    "Bitte beschreibe kurz",
+    "Ihr Ziel (z. B.",
+    "Ihre Daten/Quellen (z. B.",
+    "Ihre Umgebung (Cloud/On-Prem",
+    "Erfolgskriterien (KPIs), Budgetrahmen",
+    "nenne auch Branche und Stakeholder",
+    "Wenn Sie magst",
+    "Wobei kann ich helfen",
+    "beschreibe dein anliegen",
+    "du hast noch keine frage",
+    "ich sehe keine frage",
+]
+
+
+def _remove_html_block_containing(html: str, phrase: str) -> tuple[str, bool]:
+    """Remove the HTML block (<p>…</p>, <li>…</li>, or <div>…</div>) that contains *phrase*."""
+    lower_html = html.lower()
+    lower_phrase = phrase.lower()
+    if lower_phrase not in lower_html:
+        return html, False
+
+    # Try to remove containing <p>…</p>, <li>…</li>, <div>…</div> blocks
+    for tag in ("p", "li", "div"):
+        pattern = re.compile(
+            rf'<{tag}[^>]*>[^<]*(?:<(?!/{tag}>)[^<]*)*{re.escape(phrase)}.*?</{tag}>',
+            re.IGNORECASE | re.DOTALL,
+        )
+        new_html, n = pattern.subn("", html)
+        if n > 0:
+            return new_html, True
+
+    # Fallback: remove the sentence containing the phrase
+    pattern_sent = re.compile(
+        rf'[^.!?]*{re.escape(phrase)}[^.!?]*[.!?]?\s*',
+        re.IGNORECASE,
+    )
+    new_html, n = pattern_sent.subn("", html)
+    return new_html, n > 0
+
+
+def apply_prompt_leak_hard_block(sections: dict) -> dict:
+    """
+    FIX-R2-2: Remove entire HTML blocks that contain prompt-leak phrases.
+
+    These are multi-sentence prompt template leaks that the regex-based
+    chat-artefact filter doesn't catch.
+    """
+    total_removed = 0
+    checked_keys = [
+        k for k in sections
+        if isinstance(sections.get(k), str)
+        and sections[k]
+        and (k.endswith("_HTML") or k.islower())
+        and not k.startswith("_")
+    ]
+
+    for key in checked_keys:
+        html = sections[key]
+        for phrase in PROMPT_LEAK_HARD_BLOCK_PHRASES:
+            html, removed = _remove_html_block_containing(html, phrase)
+            if removed:
+                total_removed += 1
+                log.info("[FIX-R2-2][HARD-BLOCK] Removed block containing '%s' from %s", phrase, key)
+        if total_removed > 0:
+            # Clean up empty paragraphs left behind
+            html = re.sub(r'<p[^>]*>\s*</p>', '', html)
+            html = re.sub(r'\n\s*\n\s*\n', '\n\n', html)
+            sections[key] = html
+
+    if total_removed > 0:
+        log.info("[FIX-R2-2] PROMPT-LEAK HARD-BLOCK: removed %d leak blocks total", total_removed)
 
     return sections
 

--- a/services/funding_parser.py
+++ b/services/funding_parser.py
@@ -7,14 +7,16 @@ from typing import List, Dict, Any
 from ._normalize import _briefing_to_dict
 
 DEFAULT_PROGRAMS: List[Dict[str, Any]] = [
+    # FIX-R2-6B: go-digital removed (Programm eingestellt seit Dez 2024)
+    # Replaced with BAFA Unternehmensberatung as active alternative
     {
-        "name": "go-digital (BMWK)",
+        "name": "BAFA Unternehmensberatung",
         "region": "DE",
-        "target": "Beratungszuschuss für KMU",
-        "amount": "bis 16.500 € (50%)",
+        "target": "Beratungsförderung für KMU",
+        "amount": "bis 3.200 € (50-80%)",
         "deadline": "laufend",
-        "url": "https://www.bmwk.de",
-        "notes": "Module: Digitalisierungsstrategie, IT-Sicherheit, Datenkompetenz",
+        "url": "https://www.bafa.de",
+        "notes": "Beratungsförderung für KMU bis 249 MA; ersetzt go-digital",
     },
     {
         "name": "Berlin – Pro FIT (IBB)",


### PR DESCRIPTION
FIX-R2-1: BC prose empty variables — extend _repair_empty_strong_tags to match <strong> €</strong> and similar partially-filled placeholders. Add canonical BC prose template as final safety net when empty values persist.

FIX-R2-2: Prompt-leak hard-block — add PROMPT_LEAK_HARD_BLOCK_PHRASES to content_quality_enforcer that removes entire HTML blocks containing prompt template leaks ("Wie kann ich helfen", "Bitte beschreibe kurz", etc.). Harden executive_decision.md and gamechanger_decision.md prompts. Remove literal leak phrases from prompt files to prevent LLM echo.

FIX-R2-3: Quick-Win empty fields — reconcile QUICK_WINS_HTML with the richer QUICK_WINS_HTML_LEFT after enforcer passes. The LEFT version preserves the premium-rendered PROBLEM/WIRKUNG/UMSETZUNG blocks that may get lost during quality enforcement.

FIX-R2-4: Hauptleistung-Enforcer vs FIX-3.1 cycle — set _fix_3_1_applied flag when repetition limiter runs; enforcer checks flag and skips in subsequent passes. Also count both full + short form occurrences to avoid false-positive underuse detection after shortening.

FIX-R2-5: Scores "nicht angegeben" — extend score replacement in RISKS_HTML to handle HTML-wrapped variants (<strong>nicht angegeben</strong>, table cell patterns, all label variants).

FIX-R2-6: Bundesland empty + go-digital discontinued — resolve raw bundesland codes (e.g. "be") to full labels ("Berlin") in Förder + Risk sections. Mark discontinued programs (go-digital, Digital Jetzt) with "Programm eingestellt" notice. Replace go-digital in funding_parser.py DEFAULT_PROGRAMS with BAFA Unternehmensberatung.

https://claude.ai/code/session_01QS6WReACd1cMR14N8CsebZ