### PR TITLE
fix(R3): 5 fixes for remaining DoD fails (Report-566 v3 → v4)

### DIFF
--- a/gpt_analyze.py
+++ b/gpt_analyze.py
@@ -7628,14 +7628,14 @@ def _generate_funding_compact(
     """
     if programme is None:
         programme = [
-            {'name': 'go-digital', 'geber': 'BMWK', 'eignung': 'Hoch', 'betrag': '16.500 €', 'komplexitaet': 'Niedrig'},
             {'name': 'BAFA-Beratung', 'geber': 'Bund', 'eignung': 'Hoch', 'betrag': '3.200 €', 'komplexitaet': 'Niedrig'},
+            {'name': 'KMU-innovativ', 'geber': 'BMBF', 'eignung': 'Mittel', 'betrag': 'variabel', 'komplexitaet': 'Mittel'},
         ]
 
     if next_steps is None:
         next_steps = [
             'Projektsteckbrief erstellen (1-2 Seiten)',
-            'Förderfähigkeit mit go-digital prüfen',
+            'Förderfähigkeit mit BAFA-Beratung prüfen',
             'Antrag VOR Projektstart einreichen'
         ]
 
@@ -7785,9 +7785,10 @@ def _generate_funding_compact_from_html(
     land_count = sum(1 for p in programme if p.get('geber') == 'Land')
     if land_count > 2:
         # Regex fand nichts Brauchbares, verwende kuratierte Defaults
+        # FIX-R3-5A: go-digital discontinued — use BAFA + KMU-innovativ
         programme = [
-            {'name': 'go-digital', 'geber': 'BMWK', 'eignung': 'Hoch', 'betrag': '16.500 €', 'komplexitaet': 'Niedrig'},
             {'name': 'BAFA-Beratung', 'geber': 'Bund', 'eignung': 'Hoch', 'betrag': '3.200 €', 'komplexitaet': 'Niedrig'},
+            {'name': 'KMU-innovativ', 'geber': 'BMBF', 'eignung': 'Mittel', 'betrag': 'variabel', 'komplexitaet': 'Mittel'},
         ]
         if bundesland and bundesland != "":
             programme.append({
@@ -7800,9 +7801,10 @@ def _generate_funding_compact_from_html(
 
     # Fallback wenn keine Programme gefunden
     if not programme:
+        # FIX-R3-5A: go-digital discontinued — use BAFA + KMU-innovativ
         programme = [
-            {'name': 'go-digital', 'geber': 'BMWK', 'eignung': 'Hoch', 'betrag': '16.500 €', 'komplexitaet': 'Niedrig'},
             {'name': 'BAFA-Beratung', 'geber': 'Bund', 'eignung': 'Hoch', 'betrag': '3.200 €', 'komplexitaet': 'Niedrig'},
+            {'name': 'KMU-innovativ', 'geber': 'BMBF', 'eignung': 'Mittel', 'betrag': 'variabel', 'komplexitaet': 'Mittel'},
         ]
         if bundesland:
             programme.append({
@@ -7827,7 +7829,7 @@ def _generate_funding_compact_from_html(
 
     next_steps = [
         'Projektsteckbrief erstellen (1-2 Seiten)',
-        'Förderfähigkeit mit go-digital prüfen',
+        'Förderfähigkeit mit BAFA-Beratung prüfen',
         'Beratungsunternehmen auswählen',
         'Antrag einreichen'
     ]
@@ -7873,10 +7875,16 @@ def _generate_hero_page_from_context(
     report_date = datetime.now().strftime("%d.%m.%Y")
 
     # KPI-Werte
+    # FIX-R3-1: Format payback with German decimal (comma, 1 digit) before display
+    _hero_payback_raw = briefing.get("PAYBACK_MONTHS", 4.4)
+    try:
+        _hero_payback_fmt = f"{float(_hero_payback_raw):.1f}".replace(".", ",")
+    except (ValueError, TypeError):
+        _hero_payback_fmt = str(_hero_payback_raw)
     kpi_values = {
         'zeitersparnis': briefing.get("ZEITERSPARNIS_H", 18),
         'roi': briefing.get("ROI_12M", 200),
-        'payback': briefing.get("PAYBACK_MONTHS", 4.4)
+        'payback': _hero_payback_fmt,
     }
 
     # Reifegrad und Potenzial
@@ -8831,7 +8839,7 @@ def _get_fallback_content(section_key: str, briefing: Dict[str, Any], scores: Di
             foerder_focus = "Beratungsförderung, Gründerprogramme und niedrigschwellige Digitalisierungszuschüsse"
             budget_hinweis = "Im Solo-Kontext sind Förderprogramme besonders attraktiv, da sie den Eigenanteil bei Investitionen deutlich reduzieren können"
         elif size_group == "team":
-            foerder_focus = "go-digital, KMU-innovativ und regionale Digitalisierungsprogramme"
+            foerder_focus = "BAFA-Beratungsförderung, KMU-innovativ und regionale Digitalisierungsprogramme"
             budget_hinweis = "Für kleine Teams bieten Förderprogramme die Möglichkeit, ambitioniertere Projekte umzusetzen ohne die Liquidität zu gefährden"
         else:
             foerder_focus = "ZIM, KfW-Digitalisierung und strukturelle KMU-Förderprogramme"
@@ -8915,7 +8923,7 @@ def _get_fallback_content(section_key: str, briefing: Dict[str, Any], scores: Di
       sind wichtig für die nachhaltige Nutzung. Viele Programme fördern explizit den Kompetenzaufbau als Teil von
       Digitalisierungsprojekten.</li>
     <li><strong>Beratungsförderung:</strong> Unterstützung für externe Expertise bei der KI-Strategieentwicklung und
-      Umsetzung kann den Projekterfolg erheblich steigern. Programme wie go-digital oder regionale Beratungsförderung
+      Umsetzung kann den Projekterfolg erheblich steigern. Programme wie BAFA-Unternehmensberatung oder regionale Beratungsförderung
       decken oft einen Großteil der Beratungskosten ab.</li>
     <li><strong>Nachhaltigkeits- und Klimaförderung:</strong> KI-Projekte, die zur Ressourceneffizienz, Energieeinsparung
       oder Reduzierung des ökologischen Fußabdrucks beitragen, können zusätzlich von spezialisierten Förderprogrammen
@@ -9291,7 +9299,7 @@ def _get_fallback_content(section_key: str, briefing: Dict[str, Any], scores: Di
         bis niedrigen dreistelligen Bereich pro Monat.</p>
       <p><strong>Verantwortlich:</strong> {verantwortlich_1}</p>
       <p><strong>Förderchance:</strong> Je nach Bundesland {bundesland} bestehen Zuschussprogramme für
-        digitale Prozessoptimierung. Prüfen Sie go-digital oder regionale Digitalisierungsförderung.</p>
+        digitale Prozessoptimierung. Prüfen Sie BAFA-Beratungsförderung oder regionale Digitalisierungsförderung.</p>
     </li>
 
     <li>
@@ -12186,6 +12194,10 @@ def _generate_content_sections(briefing: Dict[str, Any], scores: Dict[str, Any])
     sections["QUICK_WINS_HTML_RIGHT"] = ""  # Legacy compatibility
     # logischer Inhalt (Validator)
     sections["quick_wins"] = qw_html
+    # FIX-R3-5B: Save pristine copy BEFORE enforcer passes can strip
+    # PROBLEM/WIRKUNG/UMSETZUNG blocks. Key starts with _ so enforcers skip it.
+    if qw_html and 'data-qw-json-rendered="true"' in qw_html:
+        sections["_QUICK_WINS_PRISTINE"] = qw_html
     
     # ========== v14.10: SOFORT-START-SEITE (Gamechanger Feature) ==========
     try:
@@ -13155,7 +13167,10 @@ Gib den erweiterten HTML-Inhalt aus (mindestens {_heal_target_words} Wörter):
     # These programs are no longer available; replace with discontinuation notice
     # =========================================================================
     _FOERDER_BLACKLIST = ["go-digital", "go_digital", "digital jetzt", "digital_jetzt"]
-    for _fp_key in ["FOERDERPOTENZIAL_HTML", "foerderpotenzial"]:
+    # FIX-R3-5A: Extend blacklist scope to ALL text sections that might reference go-digital
+    for _fp_key in ["FOERDERPOTENZIAL_HTML", "foerderpotenzial",
+                     "RECOMMENDATIONS_HTML", "recommendations",
+                     "ROADMAP_90D_HTML", "ROADMAP_12M_HTML"]:
         _fp_html = sections.get(_fp_key, "")
         if _fp_html and isinstance(_fp_html, str):
             for _discontinued in _FOERDER_BLACKLIST:
@@ -15380,23 +15395,40 @@ Gib NUR das angeforderte HTML-Fragment aus - keine Fragen, keine Hilfsangebote, 
         log.warning(f"[{run_id}] [QUALITY-ENFORCER-RENDER] Failed: {e}")
 
     # =========================================================================
-    # FIX-R2-3: QUICK-WINS RECONCILIATION
+    # FIX-R3-5B: QUICK-WINS RECONCILIATION (replaces R2-3)
     # QUICK_WINS_HTML may have been shortened by enforcer passes, losing the
-    # premium-rendered PROBLEM/WIRKUNG/UMSETZUNG blocks.  QUICK_WINS_HTML_LEFT
-    # preserves the original premium render.  If LEFT is significantly richer,
-    # prefer it for the final template.
+    # premium-rendered PROBLEM/WIRKUNG/UMSETZUNG blocks.  _QUICK_WINS_PRISTINE
+    # holds the original premium render saved BEFORE any enforcer pass.
+    # If pristine is significantly richer, restore it for the final template.
     # =========================================================================
-    _qw_left = sections.get("QUICK_WINS_HTML_LEFT", "") or ""
+    _qw_pristine = sections.get("_QUICK_WINS_PRISTINE", "") or ""
     _qw_main = sections.get("QUICK_WINS_HTML", "") or ""
-    if (isinstance(_qw_left, str) and isinstance(_qw_main, str)
-            and len(_qw_left) > len(_qw_main) + 500
-            and 'data-qw-json-rendered="true"' in _qw_left):
+    if (isinstance(_qw_pristine, str) and isinstance(_qw_main, str)
+            and len(_qw_pristine) > len(_qw_main) + 200
+            and 'data-qw-json-rendered="true"' in _qw_pristine):
         log.info(
-            "[FIX-R2-3] QUICK_WINS_HTML_LEFT is richer (%d chars) than QUICK_WINS_HTML (%d chars) — using LEFT version",
-            len(_qw_left), len(_qw_main),
+            "[FIX-R3-5B] Restoring pristine QW HTML (%d chars) over enforcer-modified version (%d chars)",
+            len(_qw_pristine), len(_qw_main),
         )
-        sections["QUICK_WINS_HTML"] = _qw_left
-        sections["quick_wins"] = _qw_left
+        sections["QUICK_WINS_HTML"] = _qw_pristine
+        sections["QUICK_WINS_HTML_LEFT"] = _qw_pristine
+        sections["quick_wins"] = _qw_pristine
+
+    # =========================================================================
+    # FIX-R3-4B: FINAL hauptleistung limiter + concat repair
+    # Static template blocks (Final-Check, Sofort-Start, BC-Prose, Hero) are
+    # assembled AFTER the quality enforcer passes, so they may re-introduce
+    # full-text hauptleistung that FIX-3.1 already shortened.
+    # =========================================================================
+    try:
+        from services.content_quality_enforcer import _limit_hauptleistung_repetitions, fix_hauptleistung_concat
+        _hl_final = answers.get("hauptleistung", "")
+        if _hl_final and len(_hl_final) > 50:
+            sections = _limit_hauptleistung_repetitions(sections, _hl_final, max_full=3)
+            sections = fix_hauptleistung_concat(sections, _hl_final)
+            log.info(f"[{run_id}] [FIX-R3-4B] Applied final hauptleistung limiter + concat repair")
+    except Exception as _hl_err:
+        log.warning(f"[{run_id}] [FIX-R3-4B] Failed: {_hl_err}")
 
     # =========================================================================
     # FIX-528: PIPELINE SANITIZATION (decode HTML entities + complete sentences)

--- a/services/business_case_engine_v2.py
+++ b/services/business_case_engine_v2.py
@@ -702,7 +702,7 @@ def inject_canonical_to_sections(
                 if old_hours != _canon_hours or old_rate != _canon_rate:
                     annual = _canon_hours * _canon_rate * 12
                     return f"{_canon_hours:.0f}h/Monat × {_canon_rate:.0f}€/h × 12 = {annual:,.0f}€"
-                return m.group(0)
+                return str(m.group(0))
             _new = _re.sub(
                 r'(\d+(?:\.\d+)?)h/Monat\s*×\s*(\d+(?:\.\d+)?)€/h\s*×\s*12\s*=\s*[\d.,]+€',
                 _fix_roi_line, _roi_html,

--- a/services/business_case_engine_v2.py
+++ b/services/business_case_engine_v2.py
@@ -686,48 +686,103 @@ def inject_canonical_to_sections(
 
     log.info("[CANON] Injected %d values into sections (LOCKED)", updates)
 
+    # FIX-R3-3: Fix ROI derivation hours — the ROI explanation may have been built
+    # with DEFAULT_EFFORT_HOURS (40h) before canonical hours (e.g. 36h) were known.
+    # Replace the stale hours in the ROI HTML with canonical values.
+    _canon_hours = canonical.hours_saved_per_month
+    _canon_rate = canonical.hourly_rate_eur
+    for _roi_key in ("ROI_HTML", "business_roi", "BUSINESS_ROI_HTML"):
+        _roi_html = sections.get(_roi_key, "")
+        if _roi_html and isinstance(_roi_html, str) and "h/Monat" in _roi_html:
+            import re as _re
+            # Replace "40h/Monat × 95€/h × 12 = 45.600€" with canonical values
+            def _fix_roi_line(m: "re.Match") -> str:
+                old_hours = float(m.group(1))
+                old_rate = float(m.group(2))
+                if old_hours != _canon_hours or old_rate != _canon_rate:
+                    annual = _canon_hours * _canon_rate * 12
+                    return f"{_canon_hours:.0f}h/Monat × {_canon_rate:.0f}€/h × 12 = {annual:,.0f}€"
+                return m.group(0)
+            _new = _re.sub(
+                r'(\d+(?:\.\d+)?)h/Monat\s*×\s*(\d+(?:\.\d+)?)€/h\s*×\s*12\s*=\s*[\d.,]+€',
+                _fix_roi_line, _roi_html,
+            )
+            if _new != _roi_html:
+                sections[_roi_key] = _new
+                log.info("[FIX-R3-3] Fixed ROI derivation hours in %s: → %.0fh × %.0f€", _roi_key, _canon_hours, _canon_rate)
+
     # PLATIN+++ FIX 2.1: Repair empty <strong></strong> tags in BUSINESS_CASE_HTML
     # After canonical injection, the BC prose HTML may still have empty labels
     _repair_empty_strong_tags(sections, canonical)
 
-    # FIX-R2-1: Final safety net — if BC prose STILL has empty € placeholders,
-    # replace the entire Fließtext block with a canonical template.
+    # FIX-R3-2: UNCONDITIONALLY replace BC prose with static canonical template.
+    # The LLM generates different HTML structures each time, so pattern-matching
+    # can never reliably fix all variants.  The canonical template guarantees
+    # every value is correctly filled.
     _bc_html = sections.get("BUSINESS_CASE_HTML", "")
-    if _bc_html and isinstance(_bc_html, str):
+    if _bc_html and isinstance(_bc_html, str) and len(_bc_html) > 50:
         import re as _re
-        _has_empty = bool(_re.search(r'<strong>\s*€?\s*</strong>', _bc_html)) or \
-                     bool(_re.search(r'rund\s+€[\s.,;)]', _bc_html)) or \
-                     bool(_re.search(r'\(\s*€\s*\)', _bc_html))
-        if _has_empty:
-            _capex = f"{canonical.capex_eur:,.0f}".replace(",", ".")
-            _opex = f"{canonical.opex_month_eur:,.0f}".replace(",", ".")
-            _savings = f"{canonical.monthly_gross:,.0f}".replace(",", ".")
-            _payback = f"{canonical.payback_months:.1f}"
-            _roi = f"{canonical.roi_12m_net:.0f}"
-            _bc_prose = (
-                f'<h3>Investition und laufende Kosten</h3>'
-                f'<p>Die einmaligen Aufwände für Aufbau und Einführung liegen bei rund '
-                f'<strong>{_capex} €</strong>. Hinzu kommen monatliche Betriebskosten von rund '
-                f'<strong>{_opex} €</strong> – hauptsächlich für KI-Nutzung, Infrastruktur, '
-                f'Tools und Lizenzen.</p>'
-                f'<h3>Monatlicher Effekt</h3>'
-                f'<p>Im täglichen Einsatz ist eine realistische Entlastung von rund '
-                f'<strong>{_savings} €</strong> pro Monat erreichbar. Sie entsteht aus '
-                f'Zeitgewinn in Kernprozessen, weniger manuellen Schleifen und '
-                f'konsistenterer Ergebnisqualität.</p>'
-                f'<h3>Amortisation und ROI</h3>'
-                f'<p><strong>Einfache Rechnung:</strong> Investition ({_capex} €) '
-                f'geteilt durch monatliche Einsparung ({_savings} €) ergibt eine '
-                f'Amortisation nach <strong>{_payback} Monaten</strong>. '
-                f'Der ROI nach 12 Monaten liegt bei <strong>{_roi} %</strong>.</p>'
+        _capex = f"{canonical.capex_eur:,.0f}".replace(",", ".")
+        _opex = f"{canonical.opex_month_eur:,.0f}".replace(",", ".")
+        _savings = f"{canonical.monthly_gross:,.0f}".replace(",", ".")
+        _payback = f"{canonical.payback_months:.1f}".replace(".", ",")  # German comma
+        _roi = f"{canonical.roi_12m_net:.0f}"
+        _hours = f"{canonical.hours_saved_per_month:.0f}"
+        _rate = f"{canonical.hourly_rate_eur:.0f}"
+        # Resolve bundesland label from sections
+        _bl_label = str(
+            sections.get("BUNDESLAND_LABEL", "")
+            or sections.get("bundesland_label", "")
+            or sections.get("bundesland", "")
+            or ""
+        ).strip()
+        # Resolve hauptleistung short form
+        _hl_full = str(sections.get("hauptleistung", "") or "").strip()
+        _hl_short = _hl_full
+        if len(_hl_full) > 60:
+            for _sep in [",", ";", ".", " und ", " mit "]:
+                _pos = _hl_full.find(_sep)
+                if 15 < _pos < 80:
+                    _hl_short = _hl_full[:_pos]
+                    break
+            else:
+                _hl_short = _hl_full[:60].rsplit(" ", 1)[0]
+        _hl_context = f" bei {_hl_short}" if _hl_short else ""
+
+        _bc_prose = (
+            f'<h3>Investition und laufende Kosten</h3>'
+            f'<p><strong>Einmalige Investition (CAPEX):</strong> <strong>{_capex} €</strong>. '
+            f'<strong>Laufende Kosten (OPEX):</strong> <strong>{_opex} €/Monat</strong> – '
+            f'hauptsächlich für KI-Tools, Infrastruktur und Lizenzen.</p>'
+            f'<h3>Monatlicher Effekt</h3>'
+            f'<p>{_hl_context.lstrip(" bei ").capitalize() + ": i" if _hl_context else "I"}m täglichen Einsatz ist eine '
+            f'realistische Entlastung von rund <strong>{_savings} €/Monat</strong> erreichbar '
+            f'({_hours} h × {_rate} €/h). Sie entsteht aus Zeitgewinn in Kernprozessen, '
+            f'weniger manuellen Schleifen und konsistenterer Ergebnisqualität.</p>'
+            f'<h3>Amortisation und ROI</h3>'
+            f'<p><strong>Payback-Formel:</strong> {_capex} € ÷ {_savings} € '
+            f'= <strong>{_payback} Monate</strong>. '
+            f'Der ROI nach 12 Monaten liegt bei <strong>{_roi} %</strong> '
+            f'(→ siehe Business-Case-Tabelle).</p>'
+            f'<h3>Einordnung nach Unternehmensgröße</h3>'
+            f'<p>Als kleines Team wirkt sich Standardisierung besonders stark aus: '
+            f'Je mehr wiederkehrende Schritte in festen Workflows laufen, '
+            f'desto schneller amortisiert sich die Investition.</p>'
+        )
+        # Add Fördermöglichkeiten section if bundesland is known
+        if _bl_label and len(_bl_label) > 1:
+            _bc_prose += (
+                f'<h3>Fördermöglichkeiten</h3>'
+                f'<p>In <strong>{_bl_label}</strong> können Programme für Digitalisierungs- und '
+                f'KI-Vorhaben relevant sein. Eine Förderung kann die Amortisation verkürzen '
+                f'(→ siehe Förderpotenzial).</p>'
             )
-            # Replace the prose section but keep any BC table that might follow
-            # Look for the prose block (from first <h3> to the table or end)
-            _table_match = _re.search(r'(<table[\s\S]*)', _bc_html)
-            _table_part = _table_match.group(1) if _table_match else ""
-            sections["BUSINESS_CASE_HTML"] = _bc_prose + _table_part
-            sections["business_case"] = sections["BUSINESS_CASE_HTML"]
-            log.info("[FIX-R2-1] Replaced BC prose with canonical template (empty placeholders detected)")
+        # Preserve any BC table that follows the prose
+        _table_match = _re.search(r'(<table[\s\S]*)', _bc_html)
+        _table_part = _table_match.group(1) if _table_match else ""
+        sections["BUSINESS_CASE_HTML"] = _bc_prose + _table_part
+        sections["business_case"] = sections["BUSINESS_CASE_HTML"]
+        log.info("[FIX-R3-2] Replaced BC prose with canonical template (unconditional)")
 
     return updates
 
@@ -840,8 +895,11 @@ class ScenarioKPIs:
             log.warning("[G30] Unknown scenario name: %s, defaulting to 'realistic'", self.name)
             self.name = "realistic"
 
-        # Clamp ROI
-        self.roi_12m = max(MIN_ROI, min(MAX_ROI, self.roi_12m))
+        # FIX-R3-5C: Only apply MIN_ROI floor, not MAX_ROI cap.
+        # calculate_roi() already handles per-scenario capping (realistic=capped,
+        # optimistic/conservative=uncapped). Re-capping here made all 3 scenarios
+        # show identical 200% ROI (double-cap bug).
+        self.roi_12m = max(MIN_ROI, self.roi_12m)
 
         # Clamp payback
         if self.payback_months < MIN_PAYBACK_MONTHS:

--- a/services/content_quality_enforcer.py
+++ b/services/content_quality_enforcer.py
@@ -1145,6 +1145,40 @@ def inject_hauptleistung_recommendations(html: str, hauptleistung: str, current_
     return result
 
 
+def fix_hauptleistung_concat(sections: dict, hauptleistung: str) -> dict:
+    """
+    FIX-R3-4A: Repair missing space/period before hauptleistung injections.
+
+    After the enforcer aggressively inserts hauptleistung, it may be glued
+    directly to the previous word:  ")Beratung und..."  or  "UnternehmenBeratung"
+    This function inserts ". " where a word-character or ")" directly precedes
+    the hauptleistung text.
+    """
+    if not hauptleistung or len(hauptleistung) < 10:
+        return sections
+
+    # Use first 30 chars of hauptleistung for matching (avoids issues with long text)
+    hl_prefix = hauptleistung[:30]
+    hl_escaped = re.escape(hl_prefix)
+    # Pattern: word-char or ) directly followed by hauptleistung (no space)
+    concat_pattern = re.compile(r'(\w|\))(' + hl_escaped + r')', re.IGNORECASE)
+
+    total_fixes = 0
+    for key, val in sections.items():
+        if not isinstance(val, str) or key.startswith("_"):
+            continue
+        new_val = concat_pattern.sub(r'\1. \2', val)
+        if new_val != val:
+            fixes = len(concat_pattern.findall(val))
+            sections[key] = new_val
+            total_fixes += fixes
+
+    if total_fixes > 0:
+        log.info("[FIX-R3-4A] Fixed %d hauptleistung concat bugs (missing space/period)", total_fixes)
+
+    return sections
+
+
 def _count_hauptleistung_combined(html: str, hauptleistung: str) -> int:
     """
     FIX-R2-4: Count both full-text AND short-form hauptleistung occurrences.
@@ -2843,6 +2877,10 @@ def apply_all_quality_enforcers(sections: dict, hauptleistung: str = "", bundesl
     # 19.5 PLATIN+++ FIX 3.1: Limit hauptleistung full-text repetitions (max 3)
     if hauptleistung and len(hauptleistung) > 50:
         sections = _limit_hauptleistung_repetitions(sections, hauptleistung, max_full=3)
+
+    # 19.6 FIX-R3-4A: Repair concat bugs (")Beratung", "UnternehmenBeratung")
+    if hauptleistung and len(hauptleistung) > 10:
+        sections = fix_hauptleistung_concat(sections, hauptleistung)
 
     # 20. FIX-52x: Strip trailing sentence fragments (PRIO 4)
     sections = strip_trailing_sentence_fragments(sections)

--- a/tests/test_g30_business_case_engine_v2.py
+++ b/tests/test_g30_business_case_engine_v2.py
@@ -65,19 +65,22 @@ class TestScenarioKPIs:
         assert scenario.name == "realistic"
 
     def test_roi_clamped_to_max(self) -> None:
-        """Test ROI is clamped to maximum value."""
-        from services.business_case_engine_v2 import ScenarioKPIs, MAX_ROI
+        """FIX-R3-5C: __post_init__ only applies MIN_ROI floor, not MAX_ROI cap.
+        MAX_ROI capping is handled per-scenario in calculate_roi(apply_cap=True)
+        for realistic scenario only. Optimistic/conservative show uncapped values."""
+        from services.business_case_engine_v2 import ScenarioKPIs
 
         scenario = ScenarioKPIs(
             name="optimistic",
-            roi_12m=5000.0,  # Way above max
+            roi_12m=5000.0,  # Above MAX_ROI — kept uncapped for non-realistic scenarios
             payback_months=1.0,
             monthly_savings=10000.0,
             annual_savings=120000.0,
             investment_total=5000.0,
         )
 
-        assert scenario.roi_12m == MAX_ROI
+        # Optimistic scenario preserves uncapped ROI for meaningful variance
+        assert scenario.roi_12m == 5000.0
 
     def test_roi_clamped_to_min(self) -> None:
         """Test ROI is clamped to minimum value."""


### PR DESCRIPTION
FIX-R3-1: Format payback_months as German decimal on hero page
  (was raw float "1.6286644951140066")

FIX-R3-2: Unconditional BC prose replacement with canonical template
  (LLM-generated HTML had inconsistent empty placeholders)

FIX-R3-3: Fix ROI derivation hours — replace stale 40h with canonical
  (DEFAULT_EFFORT_HOURS=40 was baked into ROI explanation before
  canonical hours were known)

FIX-R3-4: Repair hauptleistung concat bugs + final limiter pass
  - fix_hauptleistung_concat() repairs ")Beratung" → "). Beratung"
  - Final limiter after QW reconciliation catches late re-introductions

FIX-R3-5A: Replace all go-digital references with BAFA-Beratung/KMU-innovativ
  - 5 hardcoded fallback texts in gpt_analyze.py
  - Extend blacklist scope to RECOMMENDATIONS + ROADMAP sections

FIX-R3-5B: Save pristine QW HTML before enforcer passes
  - Both QUICK_WINS_HTML and QUICK_WINS_HTML_LEFT were processed by enforcers, stripping PROBLEM/WIRKUNG/UMSETZUNG blocks
  - New _QUICK_WINS_PRISTINE key preserved from enforcer modification

FIX-R3-5C: Fix Monte-Carlo ROI double-capping
  - ScenarioKPIs.__post_init__ re-clamped all scenarios to MAX_ROI=200%
  - calculate_roi() already handles per-scenario capping
  - Now only MIN_ROI floor applied in __post_init__

4 files changed, test_roi_clamped_to_max updated to match new behavior. 5452 tests pass, 0 new failures.

https://claude.ai/code/session_01QS6WReACd1cMR14N8CsebZ