### PR TITLE
fix(test): mock feedparser in test_research_pipeline to prevent CI hang

### DIFF
--- a/tests/test_g14_stability.py
+++ b/tests/test_g14_stability.py
@@ -455,13 +455,18 @@ class TestG14_Integration:
         # All imports successful
         assert True
 
+    @pytest.mark.timeout(10)
     def test_research_pipeline_with_circuit_breaker(self):
         """Test research pipeline respects circuit breaker."""
         pytest.importorskip("bs4", reason="bs4 required for research_pipeline")
+        from unittest.mock import patch
+
         from services.research_pipeline import run_research
 
-        # Run with minimal answers (will use fallbacks)
-        result = run_research({})
+        # Mock feedparser to avoid real network calls that hang in CI
+        mock_feed = type("Feed", (), {"entries": [], "bozo": False, "feed": {}})()
+        with patch("services.research_clients.feedparser.parse", return_value=mock_feed):
+            result = run_research({})
 
         assert "TOOLS_TABLE_HTML" in result
         assert "FUNDING_TABLE_HTML" in result


### PR DESCRIPTION
test_research_pipeline_with_circuit_breaker calls run_research({}) which invokes feedparser.parse(url) with no timeout. In CI, the SSL socket read blocks until the 60s pytest timeout kills the entire test suite. Mock feedparser.parse to return an empty feed object.

https://claude.ai/code/session_01QS6WReACd1cMR14N8CsebZ