### PR TITLE
fix(R4): 3 persistent bugs — raw float, empty BC, 40h ROI

### DIFF
--- a/gpt_analyze.py
+++ b/gpt_analyze.py
@@ -15180,6 +15180,10 @@ Gib NUR das angeforderte HTML-Fragment aus - keine Fragen, keine Hilfsangebote, 
         # 1. PAYBACK_MONTHS_FMT_DE - German decimal, 1 digit (e.g., "3,5")
         payback_raw = sections.get("PAYBACK_MONTHS", 0)
         sections["PAYBACK_MONTHS_FMT_DE"] = _fmt_de_decimal(payback_raw, 1)
+        # FIX-R4-1: Also overwrite PAYBACK_MONTHS itself with formatted string.
+        # The raw float (e.g. 1.6286644951140066) leaks through Jinja2 fallback
+        # and report_renderer placeholder replacement. Clean string prevents this.
+        sections["PAYBACK_MONTHS"] = sections["PAYBACK_MONTHS_FMT_DE"]
 
         # 2. TIME_SAVINGS_MONTH_HOURS_FMT - Integer, no ".0" (e.g., "25" not "25.0")
         # P0.3: Apply safety cap to ensure consistent hours display (25h → 20h for solo)
@@ -15209,6 +15213,85 @@ Gib NUR das angeforderte HTML-Fragment aus - keine Fragen, keine Hilfsangebote, 
 
         log.info(f"[{run_id}] ✅ [P0.1] Template bindings: PAYBACK={sections['PAYBACK_MONTHS_FMT_DE']}, "
                  f"HOURS={sections['TIME_SAVINGS_MONTH_HOURS_FMT']}, ROI_DISPLAY={sections['ROI_12M_DISPLAY_DE']}")
+
+        # =================================================================
+        # [FIX-R4-2] Statischen BC-Fließtext einsetzen — NACH Canonical-Injection.
+        # Ersetzt den LLM-generierten Fließtext (der leere €/%/Monaten-Felder hat)
+        # durch ein statisches Template mit Canonical-Werten.
+        # =================================================================
+        import re as _re_bc
+        bc_html = sections.get('BUSINESS_CASE_HTML', '')
+        if bc_html and isinstance(bc_html, str) and len(bc_html) > 50:
+            _bc_capex = str(sections.get('CAPEX_REALISTISCH_EUR', '5.000'))
+            _bc_opex = str(sections.get('OPEX_REALISTISCH_EUR', '350'))
+            _bc_einsparung = str(sections.get('EINSPARUNG_MONAT_EUR', '3.420'))
+            _bc_roi = str(sections.get('ROI_12M', '200'))
+            _bc_payback = str(sections.get('PAYBACK_MONTHS_FMT_DE', '1,6'))
+            _bc_hours = str(sections.get('CANON_HOURS_MONTH', '36'))
+            _bc_rate = str(sections.get('CANON_RATE_EUR', '95'))
+            _bc_bundesland = str(
+                sections.get('BUNDESLAND_LABEL', '')
+                or sections.get('bundesland_label', '')
+                or sections.get('bundesland', '')
+                or 'Ihrem Bundesland'
+            ).strip()
+            # Float-Payback formatieren falls nötig
+            try:
+                _pb = float(str(_bc_payback).replace(',', '.'))
+                _bc_payback = f"{_pb:.1f}".replace('.', ',')
+            except (ValueError, TypeError):
+                pass
+            # Format integers with dot-separator for German (5000 → 5.000)
+            try:
+                _bc_capex = f"{int(float(str(_bc_capex).replace('.', '').replace(',', '.'))):,}".replace(",", ".")
+            except (ValueError, TypeError):
+                pass
+            try:
+                _bc_einsparung = f"{int(float(str(_bc_einsparung).replace('.', '').replace(',', '.'))):,}".replace(",", ".")
+            except (ValueError, TypeError):
+                pass
+            try:
+                _bc_roi = f"{float(str(_bc_roi).replace(',', '.')):.0f}"
+            except (ValueError, TypeError):
+                pass
+
+            bc_prose = (
+                f'<h3>Investition und laufende Kosten</h3>\n'
+                f'<p>Die einmaligen Aufwände (CAPEX) für Aufbau und Einführung liegen bei rund '
+                f'<strong>{_bc_capex} €</strong>. Hinzu kommen monatliche Betriebskosten (OPEX) von rund '
+                f'<strong>{_bc_opex} €/Monat</strong> – hauptsächlich für KI-Tools, Infrastruktur und Lizenzen.</p>\n'
+                f'\n'
+                f'<h3>Monatlicher Effekt</h3>\n'
+                f'<p>Im täglichen Einsatz ist eine realistische Entlastung von rund '
+                f'<strong>{_bc_einsparung} € pro Monat</strong> erreichbar '
+                f'({_bc_hours} Stunden × {_bc_rate} €/Stunde). Sie entsteht aus '
+                f'Zeitgewinn in Kernprozessen, weniger manuellen Schleifen und '
+                f'konsistenterer Ergebnisqualität.</p>\n'
+                f'\n'
+                f'<h3>Amortisation und ROI</h3>\n'
+                f'<p><strong>Payback-Formel:</strong> Investition ({_bc_capex} €) ÷ '
+                f'monatliche Einsparung ({_bc_einsparung} €) = '
+                f'<strong>{_bc_payback} Monate</strong>.<br>\n'
+                f'<strong>ROI (12 Monate):</strong> <strong>{_bc_roi} %</strong> (gedeckelt).</p>\n'
+                f'\n'
+                f'<h3>Fördermöglichkeiten</h3>\n'
+                f'<p>In <strong>{_bc_bundesland}</strong> können Programme für Digitalisierungs- und '
+                f'KI-Vorhaben relevant sein (→ siehe Förderpotenzial).</p>'
+            )
+
+            # Ersetze den Fließtext-Teil, behalte die BC-Tabelle
+            table_match = _re_bc.search(r'<table', bc_html, _re_bc.IGNORECASE)
+            first_h3 = _re_bc.search(r'<h3', bc_html, _re_bc.IGNORECASE)
+
+            if table_match and first_h3:
+                sections['BUSINESS_CASE_HTML'] = bc_prose + '\n' + bc_html[table_match.start():]
+                sections['business_case'] = sections['BUSINESS_CASE_HTML']
+                log.info('[FIX-R4-2] BC prose replaced with static template')
+            elif first_h3:
+                # No table, replace everything
+                sections['BUSINESS_CASE_HTML'] = bc_prose
+                sections['business_case'] = sections['BUSINESS_CASE_HTML']
+                log.info('[FIX-R4-2] BC prose replaced with static template (no table found)')
 
     except Exception as e:
         log.warning(f"[{run_id}] ⚠️ [CANONICAL-BC] Failed to inject canonical values: {e}")

--- a/services/business_case_engine_v2.py
+++ b/services/business_case_engine_v2.py
@@ -84,7 +84,7 @@ SCENARIO_NAMES = ["optimistic", "realistic", "conservative"]
 # Default values
 DEFAULT_INVESTMENT = 5000.0
 DEFAULT_MONTHLY_SAVINGS = 500.0
-DEFAULT_EFFORT_HOURS = 40.0
+DEFAULT_EFFORT_HOURS = 36.0  # FIX-R4-3: was 40.0, aligned with canonical default
 
 # Constraints
 MIN_ROI = -100.0  # -100% = total loss
@@ -1749,7 +1749,7 @@ def generate_scenarios(
 
 def generate_kpi_targets(
     scenarios: List[ScenarioKPIs],
-    baseline_effort_hours: float = 40.0,
+    baseline_effort_hours: float = 36.0,  # FIX-R4-3: was 40.0
 ) -> Tuple[Dict[str, float], Dict[str, float]]:
     """
     Generate KPI targets for 6 and 12 months.

--- a/services/prompt_loader.py
+++ b/services/prompt_loader.py
@@ -478,7 +478,7 @@ class CycleDetectingLoader:
 
     def list_templates(self) -> List[str]:
         """List available templates."""
-        return self._inner_loader.list_templates()
+        return list(self._inner_loader.list_templates())
 
     def load(self, environment: Any, name: str, globals: Optional[Dict[str, Any]] = None) -> Any:
         """
@@ -593,7 +593,7 @@ def _interpolate_text(
             # FIX-505: Disable template cache to ensure cycle detection works
             # (otherwise cached templates bypass get_source and our detection)
             env = Environment(
-                loader=cycle_loader,  # type: ignore[arg-type]
+                loader=cycle_loader,  # type: ignore[arg-type,unused-ignore]
                 autoescape=False,
                 cache_size=0,  # Disable cache to ensure get_source is called each time
             )

--- a/services/report_renderer.py
+++ b/services/report_renderer.py
@@ -731,7 +731,8 @@ def render(briefing_obj: Any,
             r'\{CAPEX_REALISTISCH_EUR\}': str(sections.get('CAPEX_REALISTISCH_EUR', '')),
             r'\{OPEX_REALISTISCH_EUR\}': str(sections.get('OPEX_REALISTISCH_EUR', '')),
             r'\{EINSPARUNG_MONAT_EUR\}': str(sections.get('EINSPARUNG_MONAT_EUR', '')),
-            r'\{PAYBACK_MONTHS\}': str(sections.get('PAYBACK_MONTHS', '')),
+            # FIX-R4-1: Format payback as German decimal, not raw float
+            r'\{PAYBACK_MONTHS\}': str(sections.get('PAYBACK_MONTHS_FMT_DE', '') or sections.get('PAYBACK_MONTHS', '')),
             r'\{ROI_12M\}': str(sections.get('ROI_12M', '')),
         }
         expr_replacements.update(single_brace_replacements)
@@ -748,7 +749,8 @@ def render(briefing_obj: Any,
             r'\{\{\s*CAPEX_REALISTISCH_EUR\s*\}\}': str(sections.get('CAPEX_REALISTISCH_EUR', '')),
             r'\{\{\s*OPEX_REALISTISCH_EUR\s*\}\}': str(sections.get('OPEX_REALISTISCH_EUR', '')),
             r'\{\{\s*EINSPARUNG_MONAT_EUR\s*\}\}': str(sections.get('EINSPARUNG_MONAT_EUR', '')),
-            r'\{\{\s*PAYBACK_MONTHS\s*\}\}': str(sections.get('PAYBACK_MONTHS', '')),
+            # FIX-R4-1: Format payback as German decimal, not raw float
+            r'\{\{\s*PAYBACK_MONTHS\s*\}\}': str(sections.get('PAYBACK_MONTHS_FMT_DE', '') or sections.get('PAYBACK_MONTHS', '')),
             r'\{\{\s*ROI_12M\s*\}\}': str(sections.get('ROI_12M', '')),
         }
         expr_replacements.update(simple_replacements)

--- a/services/roi_calculator.py
+++ b/services/roi_calculator.py
@@ -56,8 +56,8 @@ def calc_roi(
     """
     b = _briefing_to_dict(briefing)
 
-    # konservativ 40 h/Monat Einsparung ohne Quickwins-Angaben
-    hours = 40.0
+    # FIX-R4-3: Use canonical hours from briefing, fallback to 36 (not 40)
+    hours = float(b.get("CANON_HOURS_MONTH") or b.get("EINSPARUNG_STUNDEN_MONAT") or 36.0)
     if quickwins:
         s = 0.0
         for q in quickwins:


### PR DESCRIPTION
FIX-R4-1: Hero-Block raw float "1.6286644951140066 Monate"
  - Overwrite PAYBACK_MONTHS with formatted string after canonical injection (line 15186) so Jinja2 fallback never shows raw float
  - Fix report_renderer.py placeholder replacement to use PAYBACK_MONTHS_FMT_DE for {PAYBACK_MONTHS} and {{PAYBACK_MONTHS}}

FIX-R4-2: BC-Fließtext empty €/%/Monate fields
  - Add static BC prose template in gpt_analyze.py (not engine)
  - Called AFTER canonical injection + template binding = last word
  - Replaces LLM-generated prose before BC table with canonical values
  - Includes CAPEX, OPEX, Einsparung, Hours×Rate, Payback, ROI, Bundesland, Fördermöglichkeiten
  - Log marker: [FIX-R4-2] BC prose replaced with static template

FIX-R4-3: ROI-Herleitung uses 40h instead of canonical 36h
  - roi_calculator.py: default hours from briefing canonical or 36
  - business_case_engine_v2.py: DEFAULT_EFFORT_HOURS 40→36
  - business_case_engine_v2.py: generate_kpi_targets default 40→36

Also fixes pre-existing mypy errors in prompt_loader.py (list_templates return type, unused type:ignore).

5452 tests pass, 0 new failures. mypy: 0 errors (249 files checked).

https://claude.ai/code/session_01QS6WReACd1cMR14N8CsebZ