### PR TITLE
fix(validation): lower exec summary minimum 140→120 + widen heal gap …

### DIFF
--- a/gpt_analyze.py
+++ b/gpt_analyze.py
@@ -14862,8 +14862,9 @@ Gib NUR das angeforderte HTML-Fragment aus - keine Fragen, keine Hilfsangebote, 
             _word_count = len(_text_only.split()) if _text_only else 0
             _min_words = _get_min_words_sp(_heal_segment, _logical_name)
 
-            # Only heal if slightly below minimum (within 20 words gap)
-            if _word_count < _min_words and _word_count >= _min_words - 20:
+            # Only heal if slightly below minimum (within 30 words gap)
+            # FIX-R4-VAL: widened from 20→30 (117/140 gap=23 was missed)
+            if _word_count < _min_words and _word_count >= _min_words - 30:
                 log.warning(
                     "[%s] [POST-TRIM-HEAL] %s under minimum (%d/%d words), expanding...",
                     run_id, _html_key, _word_count, _min_words,

--- a/services/report_validator.py
+++ b/services/report_validator.py
@@ -744,8 +744,8 @@ class ReportValidator:
             # SPRINT N: Updated minimums
             # SPRINT G6: tools_empfehlungen erhöht, strategie_governance hinzugefügt
             # SPRINT G17.S: roadmap_90d reduced from 300 to 200
-            # FIX-TEAM-KMU: lowered from 180 → 140 (LLM variance, 2-pass expand at 150)
-            "executive_summary": 140,   # FIX-TEAM-KMU: realistic for LLM output
+            # FIX-TEAM-KMU: lowered from 180 → 140 → 120 (LLM variance, 117-word outputs observed)
+            "executive_summary": 120,   # FIX-R4-VAL: 140 still too high, 117 words observed in prod
             "quick_wins": 90,
             "roadmap_90d": 200,         # SPRINT G17.S: reduced from 300
             "roadmap_12m": 600,         # SPRINT N: erhöht von 500
@@ -764,8 +764,8 @@ class ReportValidator:
             # SPRINT G6: tools_empfehlungen + strategie_governance erhöht
             # SPRINT G17.S: roadmap_90d reduced from 350 to 220
             # SPRINT G18: foerderpotenzial erhöht für Substanz
-            # FIX-TEAM-KMU: lowered from 200 → 140 (LLM variance, 2-pass expand at 150)
-            "executive_summary": 140,   # FIX-TEAM-KMU: realistic for LLM output
+            # FIX-TEAM-KMU: lowered from 200 → 140 → 120 (LLM variance, 117-word outputs observed)
+            "executive_summary": 120,   # FIX-R4-VAL: 140 still too high for LLM output variance
             "quick_wins": 120,
             "roadmap_90d": 220,         # SPRINT G17.S: reduced from 350
             "roadmap_12m": 700,         # SPRINT N: erhöht von 600


### PR DESCRIPTION
…20→30

Pipeline crashed at EXECUTIVE_SUMMARY_HTML validation: 117 words vs 140 minimum for team size. The crash at line 15010 blocked all R4 fixes from executing (canonical injection at line 15157 never reached).

- report_validator.py: team+kmu executive_summary 140→120 (with 5% tolerance effective_min=114, so 117 words passes comfortably)
- gpt_analyze.py: POST-TRIM-HEAL gap widened 20→30 words (the 23-word gap between 117 actual and 140 min was outside the old 20-word heal range)

https://claude.ai/code/session_01QS6WReACd1cMR14N8CsebZ