### PR TITLE
fix(B18): add VENDOR_AUDIT_HTML to complex_html_sections whitelist

### DIFF
--- a/services/html_sanitizer.py
+++ b/services/html_sanitizer.py
@@ -1052,6 +1052,8 @@ def is_text_section(section_name: str) -> bool:
         'tool_comparison', 'benchmark_table',
         # v7.0: Quick Wins needs h3/h4 for structured boxes
         'quick_wins', 'quick_wins_html', 'quick_wins_html_left', 'quick_wins_html_right',
+        # FIX-B18: Vendor Audit uses h4, inline styles, flex layout — programmatically generated
+        'vendor_audit',
     }
 
     if any(exc in name_lower for exc in complex_html_sections):


### PR DESCRIPTION
The HTML sanitizer's text-section contract enforcement was converting h4 tags to divs and stripping inline styles from vendor audit cards, destroying the card structure and making audit flags invisible in the PDF.

Root cause: is_text_section() did not exempt VENDOR_AUDIT_HTML, so enforce_text_section_html_contract() processed programmatically-generated vendor cards as if they were GPT text output.

https://claude.ai/code/session_01NunERdDdnvHV8q9XzsPZ93