### PR TITLE
fix(B19): exempt VENDOR_AUDIT_HTML from redundant-block stripping

### DIFF
--- a/services/pipeline_sanitizers.py
+++ b/services/pipeline_sanitizers.py
@@ -603,9 +603,11 @@ def sanitize_all_sections(
             stats['variable_leaks_stripped'] = stats.get('variable_leaks_stripped', 0) + i1_rem
 
         # FIX-I4: Strip redundant content blocks
-        cleaned, i4_rem = strip_redundant_blocks(cleaned, key)
-        if i4_rem > 0:
-            stats['redundant_blocks_stripped'] = stats.get('redundant_blocks_stripped', 0) + i4_rem
+        # FIX-B19: Skip vendor_audit — identical flag badges across vendor cards are intentional
+        if 'vendor_audit' not in key.lower():
+            cleaned, i4_rem = strip_redundant_blocks(cleaned, key)
+            if i4_rem > 0:
+                stats['redundant_blocks_stripped'] = stats.get('redundant_blocks_stripped', 0) + i4_rem
 
         sanitized[key] = cleaned
         stats['entities_decoded'] += result.entities_decoded


### PR DESCRIPTION
The [FIX-I4] redundancy detector in pipeline_sanitizers.py was stripping 7 flag badge divs from VENDOR_AUDIT_HTML because identical audit flag texts (e.g. "Hohes Anbieter-Risiko") appear across multiple vendor cards. The detector kept the first occurrence (ChatGPT) and removed duplicates from Claude and Tavily cards, leaving their flag sections empty.

Skip vendor_audit sections from strip_redundant_blocks() since repeated flag badges across different vendor cards are intentional, not duplicates.

https://claude.ai/code/session_01NunERdDdnvHV8q9XzsPZ93