### PR TITLE
B28: Strict name-based KPI injection & extended funding blacklist

### DIFF
--- a/b25_enforcer.py
+++ b/b25_enforcer.py
@@ -195,36 +195,20 @@ def enforce_b25_canonical_kpis(
             .replace(" ", "_")
         )
 
-        # Check by section name
+        # STRICT name-based matching only (no content fallback — B28)
         needs_injection = any(
-            kpi_key in section_lower for kpi_key in KPI_SECTION_KEYS
+            section_lower == kpi_key or section_lower == f"{kpi_key}_html"
+            for kpi_key in KPI_SECTION_KEYS
         )
 
-        # Fallback: check by content (catches custom section names)
-        if not needs_injection and content:
-            stripped = _quick_strip(content) if is_html else content
-            if KPI_CONTENT_PATTERN.search(stripped):
-                needs_injection = True
-
         if needs_injection and content:
-            if is_html:
-                # Inject as hidden div with plain text inside.
-                # After _strip_html(), the plain text becomes visible
-                # and appears FIRST (prepended), so re.search() + break
-                # matches it before any divergent values in the section.
-                html_injection = (
-                    f'<!-- [FIX-B25-CANONICAL] -->'
-                    f'<div class="kpi-canonical" '
-                    f'style="display:none;font-size:0;height:0;overflow:hidden">'
-                    f'{canonical_block}'
-                    f'</div>'
-                )
-                modified_sections[section_name] = html_injection + content
-            else:
-                modified_sections[section_name] = canonical_block + content
+            # B28: Plain-text prepend for both HTML and text modes.
+            # No hidden-div wrapper — plain text survives _strip_html()
+            # and is found first by re.search() + break in _extract_kpis().
+            modified_sections[section_name] = canonical_block + content
 
             _b25_enforced += 1
-            logger.debug(
+            logger.info(
                 f"[FIX-B25-CANONICAL] Injected into: {section_name}"
             )
         else:
@@ -292,12 +276,23 @@ def sanitize_roi_values_in_content(
 # ============================================================
 
 FUNDING_BLACKLIST = [
+    # go-digital (alle Varianten)
     "go-digital",
     "go-digital!",
     "Go-Digital",
     "go digital",
     "Go Digital",
     "godigital",
+    # KMU-innovativ (NEU in B28)
+    "KMU-innovativ",
+    "kmu-innovativ",
+    "KMU innovativ",
+    "kmu innovativ",
+    # Digitalbonus (NEU in B28)
+    "Digitalbonus",
+    "digitalbonus",
+    "Digital-Bonus",
+    "digital-bonus",
 ]
 
 

--- a/test_b25_enforcer.py
+++ b/test_b25_enforcer.py
@@ -74,14 +74,14 @@ report_data = {
 }
 result, count = enforce_b25_canonical_kpis(sections, report_data, is_html=True)
 
-check("executive_summary injected", "kpi-canonical" in result["executive_summary"])
-check("roi_analysis injected", "kpi-canonical" in result["roi_analysis"])
+check("executive_summary injected", "KPI-CANONICAL-START" in result["executive_summary"])
+check("roi_analysis injected", "KPI-CANONICAL-START" in result["roi_analysis"])
 check("legal_notice NOT injected", result["legal_notice"] == sections["legal_notice"])
 check("appendix NOT injected", result["appendix"] == sections["appendix"])
 check(f"Injection count = 2 (got {count})", count == 2)
 
 # ============================================================
-print("\n📋 TEST 4: Section injection — content-based detection")
+print("\n📋 TEST 4: Content-based fallback REMOVED (B28 — strict name-only)")
 # ============================================================
 sections2 = {
     "custom_xyz": "<p>Der ROI beträgt 150% und ist damit positiv.</p>",
@@ -89,9 +89,9 @@ sections2 = {
 }
 result2, count2 = enforce_b25_canonical_kpis(sections2, report_data, is_html=True)
 
-check("custom_xyz injected (content detection)", "kpi-canonical" in result2["custom_xyz"])
+check("custom_xyz NOT injected (no content fallback)", result2["custom_xyz"] == sections2["custom_xyz"])
 check("random_section NOT injected", result2["random_section"] == sections2["random_section"])
-check(f"Count = 1 (got {count2})", count2 == 1)
+check(f"Count = 0 (got {count2})", count2 == 0)
 
 # ============================================================
 print("\n📋 TEST 5: Plain text mode (is_html=False)")
@@ -186,7 +186,7 @@ result10, count10 = enforce_b25_canonical_kpis(
     is_html=True,
 )
 check("Nested extraction works", count10 == 1)
-check("Block contains 180%", "180%" in result10["executive_summary"])
+check("Block contains 180%", "180%" in result10.get("executive_summary", ""))
 
 # ============================================================
 print("\n📋 TEST 11: Non-string values in sections dict (B27.1 regression)")
@@ -235,6 +235,53 @@ try:
     check("Blacklist preserves int", cleaned_mixed["score_gesamt"] == 92)
 except Exception as e:
     check(f"Blacklist handles mixed dict (GOT: {e})", False)
+
+# ============================================================
+print("\n📋 TEST 12: Realistic section dict — only named sections get injection")
+# ============================================================
+sections_realistic = {
+    # These SHOULD get injection (KPI sections)
+    "executive_summary": "<h2>Summary</h2><p>Overview text</p>",
+    "roi_analysis": "<div>ROI details</div>",
+    "automation_roadmap": "<div>Automation plan</div>",
+    "financial_summary": "<div>Costs and benefits</div>",
+    "tools_analysis": "<div>Tool recommendations</div>",
+    # These should NOT get injection (non-KPI sections)
+    "vendor_audit": "<div>Vendor risk assessment with ROI mention</div>",
+    "benchmark": "<div>Industry benchmark with ROI comparison</div>",
+    "legal_notice": "<p>Impressum</p>",
+    "strategy": "<div>Strategy recommendations</div>",
+    "appendix": "<div>Appendix</div>",
+    # Non-string values (should be skipped)
+    "score_gesamt": 92,
+    "score_governance": 88,
+    "is_platin": True,
+}
+report_data_12 = {"roi_percent": 200.0, "payback_months": 1.6, "tools_count": 4}
+result_12, count_12 = enforce_b25_canonical_kpis(sections_realistic, report_data_12, is_html=True)
+
+check(f"Injection count 4-6 (got {count_12})", 4 <= count_12 <= 6)
+check("vendor_audit NOT injected", "KPI-CANONICAL" not in result_12.get("vendor_audit", ""))
+check("benchmark NOT injected", "KPI-CANONICAL" not in result_12.get("benchmark", ""))
+check("Non-string preserved", result_12["score_gesamt"] == 92)
+
+# ============================================================
+print("\n📋 TEST 13: Extended blacklist covers KMU-innovativ and Digitalbonus")
+# ============================================================
+sections_funding = {
+    "automation_roadmap": (
+        "Empfohlene Förderprogramme:\n"
+        "- go-digital: Digitalisierung\n"
+        "- KMU-innovativ: Innovationsförderung\n"
+        "- Digitalbonus: Bayerische Förderung\n"
+        "- KI-Invest: KI-Förderung\n"
+    ),
+}
+cleaned_13 = apply_funding_blacklist(sections_funding)
+check("go-digital removed", "go-digital" not in cleaned_13["automation_roadmap"])
+check("KMU-innovativ removed", "kmu-innovativ" not in cleaned_13["automation_roadmap"].lower())
+check("Digitalbonus removed", "digitalbonus" not in cleaned_13["automation_roadmap"].lower())
+check("KI-Invest preserved", "KI-Invest" in cleaned_13["automation_roadmap"])
 
 # ============================================================
 # Summary


### PR DESCRIPTION
## Summary
This PR implements B28 changes to enforce stricter KPI injection logic and expands the funding program blacklist. The key change removes content-based fallback detection in favor of strict section name matching, simplifies the HTML injection mechanism, and adds support for blocking additional German funding programs.

## Key Changes

- **Strict name-based KPI injection (B28)**: Replaced content-pattern fallback with exact section name matching. Only sections with names matching `KPI_SECTION_KEYS` (or their `_html` variants) now receive canonical KPI injection. This prevents false-positive injections in custom sections with KPI-related content.

- **Simplified HTML injection**: Removed the hidden `<div>` wrapper approach in favor of plain-text prepending for both HTML and text modes. The canonical block is now directly prepended to content, ensuring it survives HTML stripping and is found first by extraction logic.

- **Extended funding blacklist**: Added support for blocking "KMU-innovativ" and "Digitalbonus" German funding programs (with multiple case/spacing variants), in addition to existing "go-digital" entries.

- **Logging level adjustment**: Changed injection logging from `debug` to `info` level for better visibility.

- **Test updates**: Updated test expectations to reflect strict name-only matching (TEST 4 now expects 0 injections instead of 1), added realistic section dictionary test (TEST 12), and added funding blacklist validation test (TEST 13).

## Implementation Details

- The matching logic now uses exact equality checks (`section_lower == kpi_key`) rather than substring matching, preventing partial name matches from triggering injection.
- Removed `KPI_CONTENT_PATTERN` fallback logic entirely from the injection decision path.
- Plain-text canonical blocks are now consistently used across both HTML and plain-text modes, simplifying the code path and ensuring consistent behavior.
- Test coverage expanded to validate that non-KPI sections (e.g., "vendor_audit", "benchmark") are not injected even when containing KPI-related keywords.

https://claude.ai/code/session_01C7f8eYMc6f2VhLC5gu79Tx