### PR TITLE
Audit: Solo/Team Segment-Konsistenz nach FIX-B36a

### DIFF
--- a/AUDIT_ERGEBNIS_SOLO_TEAM.md
+++ b/AUDIT_ERGEBNIS_SOLO_TEAM.md
@@ -1,0 +1,457 @@
+# AUDIT: Solo & Team Segment-Konsistenz nach FIX-B36a
+
+**Datum:** 2026-02-28
+**Scope:** Budget-Konsistenz aller segment-abhängigen Dateien (solo/team/kmu)
+**Anlass:** FIX-B36a erhöhte KMU-Budgets; Solo/Team-Budgets proportional gesetzt aber NICHT log-validiert
+**Auditor:** Claude Code Audit Pipeline
+
+---
+
+## 1. Executive Summary
+
+1. **KRITISCH:** Die Healer-SEGMENT_BUDGETS für Solo und Team wurden bei FIX-B36a **NICHT** proportional (55%/75% von KMU) angepasst. Solo/Team-Budgets stehen noch auf den alten, niedrigen Werten und verursachen **exakt denselben 50-78% Content-Verlust**, der für KMU behoben wurde.
+2. **KRITISCH:** SIZE_PROFILES (config/size_profiles.py) — die vom GLOBAL-TRUNCATION genutzt werden — haben für Solo ebenfalls drastisch zu niedrige Werte (17-38% von KMU statt 55%).
+3. **HOCH:** KMU-only Plaintext-Budgets (17 lowercase Sections) fehlen für Solo und Team komplett — diese Sections fallen auf `_default` (solo=1000, team=1500).
+4. **MITTEL:** FIX-B726-COMPACT entfernt identische 14 Sections für alle Segmente ohne Differenzierung.
+5. **MITTEL:** Drei unabhängige Budget-Systeme (SIZE_PROFILES → GLOBAL-TRUNCATION → SEGMENT_BUDGETS → Healer) ohne zentrale Synchronisation.
+
+---
+
+## 2. Budget-Konsistenz-Matrix
+
+### 2.1 Drei Budget-Systeme im Überblick
+
+| System | Datei | Genutzt von | Stage |
+|--------|-------|-------------|-------|
+| `SIZE_PROFILES.section_budgets` | `config/size_profiles.py` | GLOBAL-TRUNCATION in `gpt_analyze.py` (L13461) | Pre-Render |
+| `SEGMENT_BUDGETS` | `services/report_healer.py` (L2741) | `apply_segment_budget()` | Pre-Render (nach GLOBAL) |
+| `SOLO_COMPACT_WORD_LIMITS` | `services/solo_compact_engine.py` (L165) | `process_for_solo_compact()` | Pre-Render (Solo only) |
+| WP4 Compact Guard | `services/solo_compact_engine.py` (L650) | `check_and_apply_compact_guard()` | Post-Render |
+
+**Budget-Hierarchie im Healer** (L3082-3093):
+1. Exact match in SEGMENT_BUDGETS → Healer-lokale Tabelle
+2. Uppercase_HTML-Mapping in SEGMENT_BUDGETS
+3. SIZE_PROFILES-Fallback (nur wenn 1+2 nicht matchen)
+4. `_default` aus SEGMENT_BUDGETS
+
+### 2.2 SOLO Budget-Vergleich — Kritische Sections
+
+| Section | SIZE_PROFILES (GLOBAL) | Healer SEGMENT_BUDGETS | KMU Healer (B36a) | Solo/KMU Ratio | Soll (55%) | DELTA | Status |
+|---------|----------------------|----------------------|-------------------|---------------|------------|-------|--------|
+| EXECUTIVE_SUMMARY_HTML | 4.000 | **2.000** | 6.000 | 33% | 3.300 | **-1.300** | KRITISCH |
+| PILOT_PLAN_HTML | 3.000 | **1.200** | 5.000 | 24% | 2.750 | **-1.550** | KRITISCH |
+| DATA_READINESS_HTML | 3.000 | **1.200** | 6.000 | 20% | 3.300 | **-2.100** | KRITISCH |
+| MONETARISIERUNG_HTML | 3.000 | **1.200** | 4.000 | 30% | 2.200 | **-1.000** | KRITISCH |
+| KI_SKILLPLAN_HTML | 3.000 | **1.200** | 4.000 | 30% | 2.200 | **-1.000** | KRITISCH |
+| TECHNOLOGIE_PROZESSE_HTML | 3.000 | **2.000** | 8.000 | 25% | 4.400 | **-2.400** | KRITISCH |
+| UNTERNEHMENSPROFIL_MARKT_HTML | 3.000 | 5.000 | 14.000 | 36% | 7.700 | **-2.700** | HOCH |
+| SOFORT_START_HTML | (kein SP) | **1.500** | 8.000 | 19% | 4.400 | **-2.900** | KRITISCH |
+| TEMPLATES_START_HTML | (kein SP) | **2.500** | 8.000 | 31% | 4.400 | **-1.900** | HOCH |
+| FOERDERPOTENZIAL_HTML | 3.000 | 5.000 | 12.000 | 42% | 6.600 | **-1.600** | HOCH |
+| ORG_CHANGE_HTML | 3.000 | 4.000 | 10.000 | 40% | 5.500 | **-1.500** | HOCH |
+| STRATEGIE_GOVERNANCE_HTML | 3.000 | 5.000 | 10.000 | 50% | 5.500 | -500 | OK~ |
+| TOOLS_EMPFEHLUNGEN_HTML | 3.000 | 5.000 | 8.000 | 63% | 4.400 | +600 | OK |
+| ROADMAP_90D_HTML | 3.000 | 5.000 | 8.000 | 63% | 4.400 | +600 | OK |
+| ROADMAP_12M_HTML | 8.000 | 8.000 | 14.000 | 57% | 7.700 | +300 | OK |
+| BRANCH_DEEP_DIVE_HTML | 3.000 | 12.000 | 14.000 | 86% | 7.700 | +4.300 | OK |
+| QUICK_WINS_HTML | 8.000 | 8.000 | 12.000 | 67% | 6.600 | +1.400 | OK |
+| WETTBEWERB_BENCHMARK_HTML | 2.000 | 5.000 | 8.000 | 63% | 4.400 | +600 | OK |
+| KI_AKTIVITAETEN_ZIELE_HTML | 2.000 | 2.000 | 5.000 | 40% | 2.750 | **-750** | MITTEL |
+| `_default` | 1.000 | **1.000** | 3.000 | 33% | 1.650 | **-650** | HOCH |
+
+### 2.3 TEAM Budget-Vergleich — Kritische Sections
+
+| Section | SIZE_PROFILES (GLOBAL) | Healer SEGMENT_BUDGETS | KMU Healer (B36a) | Team/KMU Ratio | Soll (75%) | DELTA | Status |
+|---------|----------------------|----------------------|-------------------|---------------|------------|-------|--------|
+| EXECUTIVE_SUMMARY_HTML | 7.000 | **3.000** | 6.000 | 50% | 4.500 | **-1.500** | KRITISCH |
+| PILOT_PLAN_HTML | 6.000 | **1.800** | 5.000 | 36% | 3.750 | **-1.950** | KRITISCH |
+| DATA_READINESS_HTML | 8.000 | **1.800** | 6.000 | 30% | 4.500 | **-2.700** | KRITISCH |
+| MONETARISIERUNG_HTML | 6.000 | **1.800** | 4.000 | 45% | 3.000 | **-1.200** | KRITISCH |
+| KI_SKILLPLAN_HTML | 6.000 | **1.800** | 4.000 | 45% | 3.000 | **-1.200** | KRITISCH |
+| TECHNOLOGIE_PROZESSE_HTML | 8.000 | **3.000** | 8.000 | 38% | 6.000 | **-3.000** | KRITISCH |
+| UNTERNEHMENSPROFIL_MARKT_HTML | 8.000 | **5.000** | 14.000 | 36% | 10.500 | **-5.500** | KRITISCH |
+| STRATEGIE_GOVERNANCE_HTML | 9.000 | **5.000** | 10.000 | 50% | 7.500 | **-2.500** | HOCH |
+| TOOLS_EMPFEHLUNGEN_HTML | 9.000 | **5.000** | 8.000 | 63% | 6.000 | **-1.000** | HOCH |
+| SOFORT_START_HTML | (kein SP) | **2.000** | 8.000 | 25% | 6.000 | **-4.000** | KRITISCH |
+| TEMPLATES_START_HTML | (kein SP) | **3.500** | 8.000 | 44% | 6.000 | **-2.500** | HOCH |
+| BRANCH_DEEP_DIVE_HTML | 8.000 | **6.000** | 14.000 | 43% | 10.500 | **-4.500** | HOCH |
+| KI_AKTIVITAETEN_ZIELE_HTML | 3.000 | 3.000 | 5.000 | 60% | 3.750 | **-750** | MITTEL |
+| ROADMAP_90D_HTML | 6.000 | 5.000 | 8.000 | 63% | 6.000 | **-1.000** | HOCH |
+| FOERDERPOTENZIAL_HTML | 9.000 | 12.000 | 12.000 | 100% | 9.000 | +3.000 | OK |
+| ORG_CHANGE_HTML | 8.000 | 9.000 | 10.000 | 90% | 7.500 | +1.500 | OK |
+| ROADMAP_12M_HTML | 8.500 | 12.000 | 14.000 | 86% | 10.500 | +1.500 | OK |
+| QUICK_WINS_HTML | 7.000 | 10.000 | 12.000 | 83% | 9.000 | +1.000 | OK |
+| WETTBEWERB_BENCHMARK_HTML | 5.000 | 8.000 | 8.000 | 100% | 6.000 | +2.000 | OK |
+| `_default` | 2.500 | **1.500** | 3.000 | 50% | 2.250 | **-750** | HOCH |
+
+### 2.4 SIZE_PROFILES Solo/KMU Ratio — GLOBAL-TRUNCATION Budgets
+
+Die SIZE_PROFILES werden von GLOBAL-TRUNCATION (gpt_analyze.py L13461) genutzt und begrenzen Content VOR dem Healer:
+
+| Section | Solo SP | KMU SP | Ratio | Soll 55% | Status |
+|---------|---------|--------|-------|----------|--------|
+| EXECUTIVE_SUMMARY_HTML | 4.000 | 14.000 | 29% | 7.700 | KRITISCH |
+| STRATEGIE_GOVERNANCE_HTML | 3.000 | 18.000 | 17% | 9.900 | KRITISCH |
+| TOOLS_EMPFEHLUNGEN_HTML | 3.000 | 18.000 | 17% | 9.900 | KRITISCH |
+| FOERDERPOTENZIAL_HTML | 3.000 | 18.000 | 17% | 9.900 | KRITISCH |
+| UNTERNEHMENSPROFIL_MARKT_HTML | 3.000 | 16.000 | 19% | 8.800 | KRITISCH |
+| ORG_CHANGE_HTML | 3.000 | 16.000 | 19% | 8.800 | KRITISCH |
+| RECOMMENDATIONS_HTML | 3.000 | 20.000 | 15% | 11.000 | KRITISCH |
+| TECHNOLOGIE_PROZESSE_HTML | 3.000 | 12.000 | 25% | 6.600 | KRITISCH |
+| PILOT_PLAN_HTML | 3.000 | 8.000 | 38% | 4.400 | HOCH |
+| DATA_READINESS_HTML | 3.000 | 10.000 | 30% | 5.500 | HOCH |
+| MONETARISIERUNG_HTML | 3.000 | 8.000 | 38% | 4.400 | HOCH |
+| GAMECHANGER_HTML | 1.500 | 16.000 | 9% | 8.800 | **EXTREM** |
+| RISKS_HTML | 7.000 | 18.000 | 39% | 9.900 | HOCH |
+
+**Hinweis:** GAMECHANGER und RISKS sind in `BUDGET_EXEMPT_SECTIONS` des Healers, daher greift die SP-Begrenzung hier hauptsächlich beim GLOBAL-TRUNCATION.
+
+### 2.5 Fehlende Plaintext-Budgets (Solo/Team)
+
+KMU hat 17 explizite Plaintext-Section-Budgets (L3022-3038). Solo und Team haben KEINE.
+
+Für Sections die per Plaintext-Key (`"strategie_governance"`) ankommen:
+- **Healer Tier 2** mapped auf `"STRATEGIE_GOVERNANCE_HTML"` → findet den HTML-Budget → OK
+- **Aber `"roadmap"` → `"ROADMAP_HTML"` → NICHT in SEGMENT_BUDGETS** → fällt auf SIZE_PROFILES → fällt auf `_default`
+
+| Plaintext-Key | KMU Budget | Solo (Tier 2 Mapping) | Solo effektiv | Verlust |
+|---------------|-----------|----------------------|--------------|---------|
+| `roadmap` | 10.000 | → `ROADMAP_HTML` nicht gefunden | `_default`=1.000 | **90%** |
+| `ki_stack_summary` | 5.000 | → `KI_STACK_SUMMARY_HTML` nicht gefunden | `_default`=1.000 | **80%** |
+
+---
+
+## 3. Konflikte — sortiert nach Priorität
+
+### Priorität 1: BLOCKER — B36-Budgets werden zunichte gemacht
+
+#### K1: Solo Healer-Budgets nicht B36-proportional [BLOCKER]
+- **Datei:** `services/report_healer.py` L2742-2830 (SEGMENT_BUDGETS → "solo")
+- **Problem:** 11 Sections haben Budgets bei 20-33% von KMU statt der angestrebten 55%
+- **Betroffene Sections:** EXECUTIVE_SUMMARY (2000), PILOT_PLAN (1200), DATA_READINESS (1200), MONETARISIERUNG (1200), KI_SKILLPLAN (1200), TECHNOLOGIE_PROZESSE (2000), SOFORT_START (1500), TEMPLATES_START (2500), UNTERNEHMENSPROFIL_MARKT (5000→7700), ORG_CHANGE (4000→5500), FOERDERPOTENZIAL (5000→6600)
+- **Risiko:** 10/10
+- **Empfohlene Werte:** Alle auf 55% der KMU-B36a-Werte setzen (siehe Tabelle 2.2)
+
+#### K2: Team Healer-Budgets nicht B36-proportional [BLOCKER]
+- **Datei:** `services/report_healer.py` L2832-2920 (SEGMENT_BUDGETS → "team")
+- **Problem:** 10 Sections haben Budgets bei 30-50% von KMU statt der angestrebten 75%
+- **Betroffene Sections:** EXECUTIVE_SUMMARY (3000→4500), PILOT_PLAN (1800→3750), DATA_READINESS (1800→4500), MONETARISIERUNG (1800→3000), KI_SKILLPLAN (1800→3000), TECHNOLOGIE_PROZESSE (3000→6000), SOFORT_START (2000→6000), UNTERNEHMENSPROFIL_MARKT (5000→10500), STRATEGIE_GOVERNANCE (5000→7500), TEMPLATES_START (3500→6000)
+- **Risiko:** 10/10
+- **Empfohlene Werte:** Alle auf 75% der KMU-B36a-Werte setzen (siehe Tabelle 2.3)
+
+#### K3: Solo SIZE_PROFILES Budgets zu niedrig für GLOBAL-TRUNCATION [BLOCKER]
+- **Datei:** `config/size_profiles.py` L67-100 (solo → section_budgets)
+- **Problem:** Solo SP-Budgets liegen bei 9-38% von KMU. Da GLOBAL-TRUNCATION diese Werte nutzt, wird Content VOR dem Healer bereits zu stark gekürzt.
+- **Betroffene Sections:** GAMECHANGER (1500 → 8800), STRATEGIE_GOVERNANCE (3000 → 9900), TOOLS_EMPFEHLUNGEN (3000 → 9900), FOERDERPOTENZIAL (3000 → 9900), UNTERNEHMENSPROFIL_MARKT (3000 → 8800), ORG_CHANGE (3000 → 8800)
+- **Risiko:** 9/10
+- **Aber:** GAMECHANGER, RISKS, RECOMMENDATIONS sind `BUDGET_EXEMPT` im Healer. Dennoch begrenzt GLOBAL-TRUNCATION den Content vor dem Healer.
+- **Hinweis:** Solo-Sections sollen bewusst kürzer sein als KMU. 55% von KMU ist ein guter Ausgangspunkt, aber einige Solo-Sections (z.B. GAMECHANGER) brauchen möglicherweise weniger weil der Report insgesamt kompakter ist. **Log-Validierung empfohlen.**
+
+#### K4: Fehlende Solo/Team Plaintext-Budgets [BLOCKER für "roadmap", "ki_stack_summary"]
+- **Datei:** `services/report_healer.py` — Solo/Team Sections
+- **Problem:** KMU hat 17 Plaintext-Budgets (L3022-3038), Solo/Team haben 0
+- **Kritischste Keys:** `"roadmap"` → `_default`=1000 (statt KMU: 10000), `"ki_stack_summary"` → `_default`=1000 (statt KMU: 5000)
+- **Risiko:** 8/10 (nur wenn Plaintext-Keys genutzt werden, meistens kommen HTML-Keys)
+
+### Priorität 2: Inkonsistenzen die Truncation verursachen könnten
+
+#### K5: WP4 Compact Guard kann B36-Erhöhungen zunichte machen
+- **Datei:** `services/solo_compact_engine.py` L650-664
+- **Problem:** HTML-Größen-Schwellen (solo:300KB, team:500KB, kmu:550KB) wurden bei B36 nicht angepasst. Größere Section-Budgets → mehr HTML → eher Compact Guard Trigger.
+- **Risiko:** 6/10 (nur relevant wenn Gesamtgröße Schwelle überschreitet)
+- **Aktueller Wert:** kmu=550KB
+- **Empfehlung:** Nach B37-Budget-Erhöhungen Monitoring der HTML-Gesamtgröße, ggf. KMU-Schwelle auf 650KB erhöhen
+
+#### K6: FIX-B726-COMPACT entfernt gleiche Sections für alle Segmente
+- **Datei:** `gpt_analyze.py` L17062-17087
+- **Problem:** 14 Appendix-Sections werden für solo, team UND kmu identisch entfernt
+- **Risiko:** 5/10 (wahrscheinlich gewollt, aber KMU hat mehr Seitenbudget → könnte mehr Sections behalten)
+- **Empfehlung:** Differenzierung prüfen — KMU könnte GLOSSAR_HTML und KICKOFF_VORLAGE_HTML behalten
+
+#### K7: Team SIZE_PROFILES teilweise unter 75% von KMU
+- **Datei:** `config/size_profiles.py` L157-190 (team → section_budgets)
+- **Problem:** Team SP-Budgets liegen bei 50-67% von KMU statt 75% für: EXECUTIVE_SUMMARY (7000/14000=50%), RECOMMENDATIONS (10000/20000=50%), STRATEGIE_GOVERNANCE (9000/18000=50%)
+- **Risiko:** 5/10 (GLOBAL-TRUNCATION nutzt diese Werte)
+- **Empfehlung:** Team SP-Budgets auf 75% von KMU anheben
+
+#### K8: text_healing.py universelle 50-Wort-Grenze
+- **Datei:** `services/text_healing.py` L1032
+- **Problem:** `truncate_to_complete_sentence(max_words=50)` schneidet ALLE Absätze auf 50 Wörter — segment-unabhängig
+- **Risiko:** 4/10 (wird aus `_aggressive_text_truncation` in gpt_analyze.py aufgerufen, greift nur bei AGGRESSIVE-TRUNCATION)
+
+#### K9: content_quality_enforcer solo 500-Wort-Floor für RISKS
+- **Datei:** `services/content_quality_enforcer.py` L3566
+- **Problem:** `apply_risks_solo_padding()` erzwingt min 500 Wörter für RISKS_HTML bei Solo — hardcodiert, nicht aus SIZE_PROFILES
+- **Risiko:** 3/10 (RISKS ist BUDGET_EXEMPT, daher kein Truncation-Konflikt; aber könnte zu unerwartet langem Content führen)
+
+#### K10: report_validator.py MIN_SECTION_LENGTH_BY_SIZE weicht von SIZE_PROFILES ab
+- **Datei:** `services/report_validator.py` L750-806
+- **Problem:** Validator hat eigene min_words-Tabelle die teilweise von SIZE_PROFILES abweicht
+  - Validator team executive_summary: 120 vs SP: 140
+  - Validator team tools_empfehlungen: 190 vs SP: 190 (OK)
+  - Validator team transparency_box: 150 vs SP: 120
+- **Risiko:** 3/10 (kleine Abweichungen, Validator ist weniger strikt)
+
+### Priorität 3: Nice-to-have Optimierungen
+
+#### K11: Solo _default Budget sehr niedrig
+- **Datei:** `services/report_healer.py` L2830
+- **Problem:** Solo `_default`=1000 chars, KMU `_default`=3000. Jede ungemappte Section bekommt nur 1000 chars.
+- **Risiko:** 2/10 (betrifft nur Sections ohne expliziten Budget-Eintrag)
+- **Empfehlung:** Solo `_default` auf 1650 (55% von 3000)
+
+#### K12: _SECTION_MAX_TOKENS nicht segment-abhängig
+- **Datei:** `gpt_analyze.py` L1289-1333
+- **Problem:** LLM generiert für alle Segmente gleich viel Content (5000-8000 tokens). Dann wird für Solo/Team 50-78% davon gelöscht.
+- **Risiko:** 2/10 (funktional korrekt, aber ineffizient — kostet unnötige API-Tokens)
+- **Empfehlung:** Langfristig segment-abhängige Token-Limits für LLM-Calls
+
+#### K13: Legacy platin_min_words nicht segment-abhängig
+- **Datei:** `gpt_analyze.py` L11772-11793
+- **Problem:** `platin_min_words` Dictionary nutzt fixe Werte (z.B. gamechanger=850) für alle Segmente, obwohl Solo nur 100 min_words hat
+- **Risiko:** 2/10 (triggert nur 2-Pass-Expand, generiert mehr Content der dann sowieso getrimmt wird)
+
+---
+
+## 4. Implementierungsplan
+
+### FIX-B37a: Solo SEGMENT_BUDGETS proportional erhöhen [BLOCKER]
+
+**Datei:** `services/report_healer.py` — SEGMENT_BUDGETS → "solo"
+
+Alle Werte auf **55% der KMU-B36a-Werte** setzen (aufgerundet auf 100er):
+
+```python
+"solo": {
+    "EXECUTIVE_SUMMARY_HTML": 3300,    # war 2000, 55% von 6000
+    "QUICK_WINS_HTML": 8000,           # bleibt (67% > 55%)
+    "QUICK_WINS_HTML_LEFT": 8000,      # bleibt
+    "ROADMAP_90D_HTML": 5000,          # bleibt (63% > 55%)
+    "ROADMAP_12M_HTML": 8000,          # bleibt (57% ≈ 55%)
+    "RECOMMENDATIONS_HTML": 8300,      # war 6000, 55% von 15000
+    "RISKS_HTML": 35000,              # BUDGET_EXEMPT, bleibt
+    "GAMECHANGER_HTML": 1500,          # BUDGET_EXEMPT, bleibt
+    "FOERDERPOTENZIAL_HTML": 6600,     # war 5000, 55% von 12000
+    "ORG_CHANGE_HTML": 5500,           # war 4000, 55% von 10000
+    "BUSINESS_CASE_HTML": 10000,       # bleibt (BUSINESS_CASE hat FIX-BC1 Override)
+    "PILOT_PLAN_HTML": 2800,           # war 1200, 55% von 5000
+    "DATA_READINESS_HTML": 3300,       # war 1200, 55% von 6000
+    "STRATEGIE_GOVERNANCE_HTML": 5500, # war 5000, 55% von 10000
+    "UNTERNEHMENSPROFIL_MARKT_HTML": 7700,  # war 5000, 55% von 14000
+    "MONETARISIERUNG_HTML": 2200,      # war 1200, 55% von 4000
+    "KI_SKILLPLAN_HTML": 2200,         # war 1200, 55% von 4000
+    "TOOLS_EMPFEHLUNGEN_HTML": 5000,   # bleibt (63% > 55%)
+    "TECHNOLOGIE_PROZESSE_HTML": 4400, # war 2000, 55% von 8000
+    # ... Engine-Sections bleiben ...
+    "BRANCH_DEEP_DIVE_HTML": 12000,    # bleibt (86% > 55%)
+    "AI_ACT_SUMMARY_HTML": 3300,       # war 2000, 55% von 6000
+    "TEMPLATES_START_HTML": 4400,      # war 2500, 55% von 8000
+    "SOFORT_START_HTML": 4400,         # war 1500, 55% von 8000
+    "WETTBEWERB_BENCHMARK_HTML": 5000, # bleibt (63%)
+    "KI_AKTIVITAETEN_ZIELE_HTML": 2800, # war 2000, 55% von 5000
+    "_default": 1650,                  # war 1000, 55% von 3000
+}
+```
+
+### FIX-B37b: Team SEGMENT_BUDGETS proportional erhöhen [BLOCKER]
+
+**Datei:** `services/report_healer.py` — SEGMENT_BUDGETS → "team"
+
+Alle Werte auf **75% der KMU-B36a-Werte** setzen (aufgerundet):
+
+```python
+"team": {
+    "EXECUTIVE_SUMMARY_HTML": 4500,    # war 3000, 75% von 6000
+    "QUICK_WINS_HTML": 10000,          # bleibt (83% > 75%)
+    "QUICK_WINS_HTML_LEFT": 10000,     # bleibt
+    "ROADMAP_90D_HTML": 6000,          # war 5000, 75% von 8000
+    "ROADMAP_12M_HTML": 12000,         # bleibt (86% > 75%)
+    "RECOMMENDATIONS_HTML": 12000,     # bleibt (80% > 75%)
+    "RISKS_HTML": 35000,              # BUDGET_EXEMPT, bleibt
+    "GAMECHANGER_HTML": 10000,         # BUDGET_EXEMPT, bleibt
+    "FOERDERPOTENZIAL_HTML": 12000,    # bleibt (100% > 75%)
+    "ORG_CHANGE_HTML": 9000,           # bleibt (90% > 75%)
+    "BUSINESS_CASE_HTML": 8000,        # bleibt (80% > 75%)
+    "PILOT_PLAN_HTML": 3800,           # war 1800, 75% von 5000
+    "DATA_READINESS_HTML": 4500,       # war 1800, 75% von 6000
+    "STRATEGIE_GOVERNANCE_HTML": 7500, # war 5000, 75% von 10000
+    "UNTERNEHMENSPROFIL_MARKT_HTML": 10500, # war 5000, 75% von 14000
+    "MONETARISIERUNG_HTML": 3000,      # war 1800, 75% von 4000
+    "KI_SKILLPLAN_HTML": 3000,         # war 1800, 75% von 4000
+    "TOOLS_EMPFEHLUNGEN_HTML": 6000,   # war 5000, 75% von 8000
+    "TECHNOLOGIE_PROZESSE_HTML": 6000, # war 3000, 75% von 8000
+    # ... Engine-Sections bleiben ...
+    "BRANCH_DEEP_DIVE_HTML": 10500,    # war 6000, 75% von 14000
+    "AI_ACT_SUMMARY_HTML": 4500,       # war 3000, 75% von 6000
+    "TEMPLATES_START_HTML": 6000,      # war 3500, 75% von 8000
+    "SOFORT_START_HTML": 6000,         # war 2000, 75% von 8000
+    "WETTBEWERB_BENCHMARK_HTML": 8000, # bleibt (100% ≥ 75%)
+    "KI_AKTIVITAETEN_ZIELE_HTML": 3800, # war 3000, 75% von 5000
+    "_default": 2250,                  # war 1500, 75% von 3000
+}
+```
+
+### FIX-B37c: Solo/Team Plaintext-Budgets hinzufügen [HOCH]
+
+**Datei:** `services/report_healer.py` — SEGMENT_BUDGETS → "solo" und "team"
+
+17 Plaintext-Einträge analog zu KMU hinzufügen (proportional):
+
+```python
+# Solo (55% von KMU):
+"executive_summary": 2200,    "strategie_governance": 4400,
+"technologie_prozesse": 3300,  "tools_empfehlungen": 3300,
+"templates_start": 3300,       "branch_deep_dive": 6600,
+"unternehmensprofil_markt": 5500, "roadmap": 5500,
+"roadmap_90d": 3300,           "data_readiness": 2800,
+"ki_stack_summary": 2800,      "pilot_plan": 2200,
+"monetarisierung": 1650,       "ki_skillplan": 1650,
+"org_change": 4400,            "business_case": 4400,
+"foerderpotenzial": 5500,
+
+# Team (75% von KMU):
+"executive_summary": 3000,    "strategie_governance": 6000,
+"technologie_prozesse": 4500,  "tools_empfehlungen": 4500,
+"templates_start": 4500,       "branch_deep_dive": 9000,
+"unternehmensprofil_markt": 7500, "roadmap": 7500,
+"roadmap_90d": 4500,           "data_readiness": 3800,
+"ki_stack_summary": 3800,      "pilot_plan": 3000,
+"monetarisierung": 2250,       "ki_skillplan": 2250,
+"org_change": 6000,            "business_case": 6000,
+"foerderpotenzial": 7500,
+```
+
+### FIX-B37d: Solo SIZE_PROFILES Budgets anpassen [HOCH]
+
+**Datei:** `config/size_profiles.py` — SIZE_PROFILES → "solo" → section_budgets
+
+Die Solo-SP-Budgets sind zu niedrig für die GLOBAL-TRUNCATION. Anpassen auf **55% von KMU-SP**:
+
+```python
+# Nur Sections anpassen die unter 55% liegen:
+"EXECUTIVE_SUMMARY_HTML": 7700,    # war 4000, 55% von 14000
+"RECOMMENDATIONS_HTML": 11000,     # war 3000, 55% von 20000
+"FOERDERPOTENZIAL_HTML": 9900,     # war 3000, 55% von 18000
+"ORG_CHANGE_HTML": 8800,           # war 3000, 55% von 16000
+"STRATEGIE_GOVERNANCE_HTML": 9900, # war 3000, 55% von 18000
+"UNTERNEHMENSPROFIL_MARKT_HTML": 8800, # war 3000, 55% von 16000
+"TOOLS_EMPFEHLUNGEN_HTML": 9900,   # war 3000, 55% von 18000
+"TECHNOLOGIE_PROZESSE_HTML": 6600, # war 3000, 55% von 12000
+"PILOT_PLAN_HTML": 4400,           # war 3000, 55% von 8000
+"DATA_READINESS_HTML": 5500,       # war 3000, 55% von 10000
+"MONETARISIERUNG_HTML": 4400,      # war 3000, 55% von 8000
+"KI_SKILLPLAN_HTML": 4400,         # war 3000, 55% von 8000
+"GAMECHANGER_HTML": 8800,          # war 1500, 55% von 16000
+"RISKS_HTML": 9900,                # war 7000, 55% von 18000
+```
+
+**ACHTUNG:** Solo-SP-Erhöhungen müssen mit dem max_pages=25 Solo-Limit und dem 300KB HTML-Threshold kompatibel bleiben. **Log-basierte Validierung ERFORDERLICH** vor Deployment!
+
+### FIX-B37e: Team SIZE_PROFILES Budgets nachziehen [MITTEL]
+
+**Datei:** `config/size_profiles.py` — SIZE_PROFILES → "team" → section_budgets
+
+Team SP auf 75% von KMU-SP anheben wo < 75%:
+
+```python
+"EXECUTIVE_SUMMARY_HTML": 10500,   # war 7000, 75% von 14000
+"RECOMMENDATIONS_HTML": 15000,     # war 10000, 75% von 20000
+"STRATEGIE_GOVERNANCE_HTML": 13500, # war 9000, 75% von 18000
+"TOOLS_EMPFEHLUNGEN_HTML": 13500,  # war 9000, 75% von 18000
+"GAMECHANGER_HTML": 12000,         # war 8000, 75% von 16000
+"FOERDERPOTENZIAL_HTML": 13500,    # war 9000, 75% von 18000
+"ORG_CHANGE_HTML": 12000,          # war 8000, 75% von 16000
+"BUSINESS_CASE_HTML": 12000,       # war 8000, 75% von 16000
+"UNTERNEHMENSPROFIL_MARKT_HTML": 12000, # war 8000, 75% von 16000
+```
+
+### FIX-B37f: sanity_check_profiles erweitern [NICE-TO-HAVE]
+
+**Datei:** `config/size_profiles.py` — `sanity_check_profiles()`
+
+Zusätzliche Prüfungen einbauen:
+1. Solo-Budget >= 55% von KMU-Budget (±5% Toleranz)
+2. Team-Budget >= 75% von KMU-Budget (±5% Toleranz)
+3. Healer SEGMENT_BUDGETS >= SIZE_PROFILES für gleiche Section+Segment
+
+---
+
+## 5. Empfehlung
+
+### Sofort ändern (vor nächstem Deploy):
+1. **FIX-B37a** + **FIX-B37b**: Healer SEGMENT_BUDGETS Solo/Team proportional erhöhen → `services/report_healer.py`
+2. **FIX-B37c**: Plaintext-Budgets für Solo/Team hinzufügen → `services/report_healer.py`
+
+### Nach Testrun ändern:
+3. **FIX-B37d**: Solo SIZE_PROFILES anpassen → `config/size_profiles.py`
+   - **Risiko:** Könnte Solo-Reports über max_pages=25 / 300KB treiben
+   - **Vorher:** Einen Solo-Testrun mit aktuellen Werten + Logging der HTML-Größe
+4. **FIX-B37e**: Team SIZE_PROFILES nachziehen → `config/size_profiles.py`
+
+### Nicht jetzt (Monitoring + langfristig):
+5. FIX-B726-COMPACT Segment-Differenzierung (K6)
+6. Segment-abhängige _SECTION_MAX_TOKENS (K12)
+7. WP4 Compact Guard Schwellen-Monitoring (K5)
+
+### Dateien die NICHT geändert werden müssen:
+- `b25_enforcer.py` — Keine segment-abhängige Budget-Logik
+- `services/text_healing.py` — Keine segment-abhängige Logik
+- `services/pipeline_sanitizers.py` — Keine segment-abhängige Logik
+- `services/report_renderer.py` — Nur Labels, keine Budgets
+- `services/solo_final_pass.py` — Nur Sprach-Normalisierung, keine Budgets
+
+---
+
+## 6. Risiko-Zusammenfassung
+
+| FIX | Risiko | Impact | Dateien | Aufwand |
+|-----|--------|--------|---------|---------|
+| B37a | 10/10 | Solo-Content 50-78% zu kurz | report_healer.py | ~30 min |
+| B37b | 10/10 | Team-Content 50-78% zu kurz | report_healer.py | ~30 min |
+| B37c | 8/10 | Plaintext-Sections auf _default | report_healer.py | ~15 min |
+| B37d | 9/10 | GLOBAL-TRUNCATION killt Solo-Content | size_profiles.py | ~20 min (+ Testrun) |
+| B37e | 5/10 | GLOBAL-TRUNCATION limitiert Team | size_profiles.py | ~15 min |
+| B37f | 2/10 | Keine automatische Konsistenz-Prüfung | size_profiles.py | ~30 min |
+
+---
+
+## 7. Anhang: Vollständige Datei-Abhängigkeiten
+
+```
+gpt_analyze.py (20151 Zeilen)
+├── GLOBAL-TRUNCATION (L13415) → config/size_profiles.py::get_section_budget()
+├── POST-TRIM-HEAL (L13561) → config/size_profiles.py::get_min_words()
+├── FIX-B726-COMPACT (L17062) → Entfernt 14 Sections für alle Segmente
+├── FIX-629 POST-TRIM-HEAL (L15988) → config/size_profiles.py::get_min_words()
+├── COMPACT_REPORT_MODE (L8728) → solo+team=compact, kmu=full (aber B724 erzwingt auch kmu)
+└── _SECTION_MAX_TOKENS (L1289) → NICHT segment-abhängig
+
+services/report_healer.py
+├── SEGMENT_BUDGETS (L2741) → Drei lokale Budget-Tabellen (solo/team/kmu)
+├── apply_segment_budget() (L3045) → Hierarchie: SEGMENT_BUDGETS > SIZE_PROFILES > _default
+├── BUDGET_EXEMPT_SECTIONS (L3077) → RISKS, GAMECHANGER, RECOMMENDATIONS, etc.
+├── FIX-B36b Clean Ending (L3171) → Entfernt "..." Truncation-Artefakte
+└── FIX-G Sentence Trimming (L3146) → Guard bei 80% von Budget
+
+config/size_profiles.py
+├── SIZE_PROFILES (L29) → section_budgets + min_words pro Segment
+├── get_section_budget() (L356) → Wird von GLOBAL-TRUNCATION und POST-TRIM-HEAL genutzt
+├── get_min_words() (L372) → Wird von GLOBAL-TRUNCATION, POST-TRIM-HEAL, Validator genutzt
+└── sanity_check_profiles() (L388) → Prüft budget >= min_words * 7
+
+services/solo_compact_engine.py
+├── SOLO_COMPACT_WORD_LIMITS (L165) → max_words für Solo-Light-Sections
+├── MAX_PAGES_BY_SIZE (L650) → solo=16, team=70, kmu=45
+├── HTML_COMPACT_THRESHOLD_BY_SIZE (L661) → solo=300KB, team=500KB, kmu=550KB
+└── TEAM_KMU_LOW_PRIORITY_SECTIONS (L670) → Sections die bei Compact gedroppt werden
+
+services/content_quality_enforcer.py
+├── SOLO_TERM_REPLACEMENTS (L28) → Enterprise-zu-Solo Sprach-Normalisierung
+├── apply_risks_solo_padding() (L3549) → Hardcodierter 500-Wort-Floor für Solo RISKS
+└── apply_risk_truncation() (L3474) → Hardcodierter 2500-Char-Limit für AI_ACT_SUMMARY
+
+services/report_validator.py
+├── MIN_SECTION_LENGTH_BY_SIZE (L750) → Eigene min_words pro Segment (teilweise ≠ SIZE_PROFILES)
+├── MAX_REPORT_PAGES_BY_SIZE (L818) → solo=25, team=35, kmu=45
+└── SIZE_FORBIDDEN (L528) → Segment-spezifische verbotene Begriffe
+```

--- a/AUDIT_VERSIONSCHECK_B36.md
+++ b/AUDIT_VERSIONSCHECK_B36.md
@@ -1,0 +1,384 @@
+# AUDIT: Versions-Check report_healer.py + SIZE_PROFILES Konflikt-Analyse
+
+**Datum:** 2026-02-28
+**Scope:** Versions-Identifikation report_healer.py, SIZE_PROFILES-Konflikte, Budget-Quellen, Compact-Schwellen
+**Branch:** `claude/audit-pipeline-segments-9MYM3`
+
+---
+
+## 1. Versions-Ergebnis: VERSION V1 (nur KMU)
+
+### Beweis-Tabelle
+
+| Check | Erwartung FINAL | Ist-Wert | Match? |
+|-------|----------------|----------|--------|
+| CHECK 1: `FIX-B36a` Treffer | ≥20 | **20** | OK |
+| CHECK 2: KMU STRATEGIE_GOVERNANCE | 10000 | **10000** (L2940) | OK |
+| CHECK 3: Solo EXECUTIVE_SUMMARY | 3500 | **2000** (L2743) | **FAIL** |
+| CHECK 4: Plaintext-Budgets solo/team | vorhanden | **nur KMU** (L3022-3038) | **FAIL** |
+| CHECK 5: `FIX-B36b` Treffer | ≥2 | **2** | OK |
+| CHECK 6: `_default` solo/team/kmu | 1500/2000/3000 | **1000/1500/3000** (L2830/2920/3040) | **FAIL** |
+
+### Diagnose
+
+```
+CHECK 1: FIX-B36a = 20 Treffer                    → B36a-Kommentare vorhanden ✓
+CHECK 2: KMU STRATEGIE_GOVERNANCE = 10000 (L2940)  → KMU-Budgets erhöht ✓
+CHECK 3: Solo EXECUTIVE_SUMMARY = 2000 (L2743)     → Solo NICHT erhöht ✗ (soll 3500)
+         Team EXECUTIVE_SUMMARY = 3000 (L2833)     → Team NICHT erhöht ✗ (soll 4500)
+CHECK 4: Plaintext-Budgets nur in KMU (L3022-3038) → Solo/Team haben KEINE ✗
+CHECK 5: FIX-B36b = 2 Treffer                      → Clean Ending vorhanden ✓
+CHECK 6: _default solo=1000 (L2830)                 → NICHT erhöht ✗ (soll 1500)
+         _default team=1500 (L2920)                 → NICHT erhöht ✗ (soll 2000)
+         _default kmu=3000 (L3040)                  → Korrekt ✓
+```
+
+### Fazit
+
+**VERSION V1 (nur KMU):** FIX-B36a ist vorhanden und hat die KMU-Budgets korrekt erhöht.
+Aber Solo- und Team-Budgets wurden **NICHT** aktualisiert:
+- Solo EXECUTIVE_SUMMARY steht bei 2000 statt 3500
+- Team EXECUTIVE_SUMMARY steht bei 3000 statt 4500
+- Solo/Team haben keine Plaintext-Budgets
+- Solo/Team `_default` nicht erhöht
+
+**Aktion:** Solo+Team Budgets fehlen. FINAL-Version muss deployed werden.
+
+---
+
+## 2. SIZE_PROFILES Konflikt-Tabelle
+
+### Erklärung der Spalten
+- **SP** = `config/size_profiles.py` → `SIZE_PROFILES[segment]["section_budgets"]`
+- **Healer** = `services/report_healer.py` → `SEGMENT_BUDGETS[segment]`
+- **Konflikt** = SP < Healer bedeutet: GLOBAL-TRUNCATION (gpt_analyze.py L13461) kürzt Content auf SP-Wert, BEVOR der Healer ihn sieht. Der höhere Healer-Wert ist dann wirkungslos.
+
+### Solo: SIZE_PROFILES vs Healer SEGMENT_BUDGETS
+
+| Section | SP solo | Healer solo | SP < Healer? | Impact |
+|---------|---------|-------------|--------------|--------|
+| EXECUTIVE_SUMMARY_HTML | 4000 (L68) | 2000 (L2743) | Nein | Healer ist Bottleneck |
+| STRATEGIE_GOVERNANCE_HTML | 3000 (L81) | 5000 (L2756) | **JA: -2000** | SP killt Content vor Healer |
+| TECHNOLOGIE_PROZESSE_HTML | 3000 (L86) | 2000 (L2761) | Nein | Healer ist Bottleneck |
+| UNTERNEHMENSPROFIL_MARKT_HTML | 3000 (L82) | 5000 (L2757) | **JA: -2000** | SP killt Content vor Healer |
+| PILOT_PLAN_HTML | 3000 (L79) | 1200 (L2754) | Nein | Healer ist Bottleneck |
+| DATA_READINESS_HTML | 3000 (L80) | 1200 (L2755) | Nein | Healer ist Bottleneck |
+| TOOLS_EMPFEHLUNGEN_HTML | 3000 (L85) | 5000 (L2760) | **JA: -2000** | SP killt Content vor Healer |
+| TEMPLATES_START_HTML | _(kein SP-Eintrag)_ | 2500 (L2782) | **JA** | SP→_default=1000 (L99) |
+| SOFORT_START_HTML | _(kein SP-Eintrag)_ | 1500 (L2794) | **JA** | SP→_default=1000 (L99) |
+| BRANCH_DEEP_DIVE_HTML | 3000 (L92) | 12000 (L2774) | **JA: -9000** | SP killt 75% vor Healer |
+| GAMECHANGER_HTML | 1500 (L75) | 1500 (L2750) | Gleich | Healer EXEMPT (L3077) |
+| RECOMMENDATIONS_HTML | 3000 (L73) | 6000 (L2748) | **JA: -3000** | SP killt Content vor Healer |
+| FOERDERPOTENZIAL_HTML | 3000 (L76) | 5000 (L2751) | **JA: -2000** | SP killt Content vor Healer |
+| ORG_CHANGE_HTML | 3000 (L77) | 4000 (L2752) | **JA: -1000** | SP killt Content vor Healer |
+| QUICK_WINS_HTML | 8000 (L69) | 8000 (L2744) | Gleich | OK |
+| ROADMAP_12M_HTML | 8000 (L72) | 8000 (L2747) | Gleich | OK |
+| MONETARISIERUNG_HTML | 3000 (L83) | 1200 (L2758) | Nein | Healer ist Bottleneck |
+| KI_SKILLPLAN_HTML | 3000 (L84) | 1200 (L2759) | Nein | Healer ist Bottleneck |
+
+**Solo-Konflikte: 8 Sections** wo SP den Content vor dem Healer beschneidet.
+
+Besonders kritisch:
+- `BRANCH_DEEP_DIVE_HTML`: SP=3000 vs Healer=12000 → SP killt 75% des Contents
+- `RECOMMENDATIONS_HTML`: SP=3000 vs Healer=6000 → SP killt 50% (aber BUDGET_EXEMPT im Healer!)
+- `TEMPLATES_START_HTML`: SP=_default(1000) vs Healer=2500 → kein SP-Eintrag!
+- `SOFORT_START_HTML`: SP=_default(1000) vs Healer=1500 → kein SP-Eintrag!
+
+**Wichtig:** GAMECHANGER_HTML, RISKS_HTML, RECOMMENDATIONS_HTML sind `BUDGET_EXEMPT_SECTIONS` im Healer (L3077). Für diese greift NUR der SP-Wert via GLOBAL-TRUNCATION.
+
+### Team: SIZE_PROFILES vs Healer SEGMENT_BUDGETS
+
+| Section | SP team | Healer team | SP < Healer? | Impact |
+|---------|---------|-------------|--------------|--------|
+| EXECUTIVE_SUMMARY_HTML | 7000 (L158) | 3000 (L2833) | Nein | Healer ist Bottleneck |
+| STRATEGIE_GOVERNANCE_HTML | 9000 (L171) | 5000 (L2846) | Nein | Healer ist Bottleneck |
+| TECHNOLOGIE_PROZESSE_HTML | 8000 (L176) | 3000 (L2851) | Nein | Healer ist Bottleneck |
+| UNTERNEHMENSPROFIL_MARKT_HTML | 8000 (L172) | 5000 (L2847) | Nein | Healer ist Bottleneck |
+| PILOT_PLAN_HTML | 6000 (L169) | 1800 (L2844) | Nein | Healer ist Bottleneck |
+| DATA_READINESS_HTML | 8000 (L170) | 1800 (L2845) | Nein | Healer ist Bottleneck |
+| TOOLS_EMPFEHLUNGEN_HTML | 9000 (L175) | 5000 (L2850) | Nein | Healer ist Bottleneck |
+| TEMPLATES_START_HTML | _(kein SP-Eintrag)_ | 3500 (L2872) | **JA** | SP→_default=2500 (L189) |
+| SOFORT_START_HTML | _(kein SP-Eintrag)_ | 2000 (L2884) | Nein | SP→_default=2500 > 2000 |
+| BRANCH_DEEP_DIVE_HTML | 8000 (L182) | 6000 (L2864) | Nein | Healer ist Bottleneck |
+| GAMECHANGER_HTML | 8000 (L165) | 10000 (L2840) | **JA: -2000** | Healer EXEMPT, SP ist Limit |
+| RECOMMENDATIONS_HTML | 10000 (L163) | 12000 (L2838) | **JA: -2000** | Healer EXEMPT, SP ist Limit |
+| FOERDERPOTENZIAL_HTML | 9000 (L166) | 12000 (L2841) | **JA: -3000** | SP killt Content vor Healer |
+| ORG_CHANGE_HTML | 8000 (L167) | 9000 (L2842) | **JA: -1000** | SP killt Content vor Healer |
+| QUICK_WINS_HTML | 7000 (L159) | 10000 (L2834) | **JA: -3000** | SP killt Content vor Healer |
+| ROADMAP_12M_HTML | 8500 (L162) | 12000 (L2837) | **JA: -3500** | SP killt Content vor Healer |
+| MONETARISIERUNG_HTML | 6000 (L173) | 1800 (L2848) | Nein | Healer ist Bottleneck |
+| KI_SKILLPLAN_HTML | 6000 (L174) | 1800 (L2849) | Nein | Healer ist Bottleneck |
+
+**Team-Konflikte: 7 Sections** wo SP den Content vor dem Healer beschneidet.
+
+Besonders kritisch:
+- `ROADMAP_12M_HTML`: SP=8500 vs Healer=12000 → 3500 chars unnötig gelöscht
+- `QUICK_WINS_HTML`: SP=7000 vs Healer=10000 → 3000 chars unnötig gelöscht
+- `FOERDERPOTENZIAL_HTML`: SP=9000 vs Healer=12000 → 3000 chars unnötig gelöscht
+
+### KMU: SIZE_PROFILES vs Healer SEGMENT_BUDGETS
+
+| Section | SP kmu | Healer kmu (B36a) | SP < Healer? | Impact |
+|---------|--------|-------------------|--------------|--------|
+| EXECUTIVE_SUMMARY_HTML | 14000 (L243) | 6000 (L2927) | Nein | Healer ist Bottleneck |
+| STRATEGIE_GOVERNANCE_HTML | 18000 (L256) | 10000 (L2940) | Nein | Healer ist Bottleneck |
+| TECHNOLOGIE_PROZESSE_HTML | 12000 (L261) | 8000 (L2945) | Nein | Healer ist Bottleneck |
+| UNTERNEHMENSPROFIL_MARKT_HTML | 16000 (L257) | 14000 (L2941) | Nein | Healer ist Bottleneck |
+| PILOT_PLAN_HTML | 8000 (L254) | 5000 (L2938) | Nein | Healer ist Bottleneck |
+| DATA_READINESS_HTML | 10000 (L255) | 6000 (L2939) | Nein | Healer ist Bottleneck |
+| TOOLS_EMPFEHLUNGEN_HTML | 18000 (L260) | 8000 (L2944) | Nein | Healer ist Bottleneck |
+| TEMPLATES_START_HTML | _(kein SP-Eintrag)_ | 8000 (L2970) | **JA** | SP→_default=3000 (L263) |
+| SOFORT_START_HTML | _(kein SP-Eintrag)_ | 8000 (L2982) | **JA** | SP→_default=3000 (L263) |
+| BRANCH_DEEP_DIVE_HTML | _(kein SP-Eintrag)_ | 14000 (L2962) | **JA** | SP→_default=3000 (L263) |
+
+**KMU-Konflikte: 3 Sections** ohne SP-Eintrag, aber mit hohem Healer-Budget.
+
+**Kritisch:** `BRANCH_DEEP_DIVE_HTML` hat SP=_default(3000) vs Healer=14000.
+Da BRANCH_DEEP_DIVE im `truncation_targets` steht (gpt_analyze.py L13421), wird der Content
+auf 3000 chars begrenzt, obwohl der Healer 14000 erlaubt.
+
+**Hinweis:** `TEMPLATES_START_HTML` und `SOFORT_START_HTML` stehen NICHT in `truncation_targets` (L13418-13422), daher greift die SP-Begrenzung für diese Sections NICHT via GLOBAL-TRUNCATION. Der Healer-Wert ist maßgeblich.
+
+---
+
+## 3. gpt_analyze.py Budget-Quellen
+
+### 3.1 GLOBAL-TRUNCATION (L13415-13559)
+
+```
+Quelle:  config/size_profiles.py → get_section_budget(segment, key)
+Import:  L13427: from config.size_profiles import get_section_budget, get_min_words
+Aufruf:  L13461: _budget = get_section_budget(_trunc_segment, key)
+```
+
+**Antwort auf Kernfrage:** JA — gpt_analyze.py nutzt `SIZE_PROFILES.section_budgets` direkt als Budget-Quelle für GLOBAL-TRUNCATION.
+
+**Konsequenz:** Wenn SIZE_PROFILES niedrigere Werte hat als SEGMENT_BUDGETS im Healer, wird Content VOR dem Healer beschnitten. Die B36-Erhöhungen im Healer sind dann **wirkungslos** für die betroffenen Sections.
+
+### 3.2 Truncation Targets (L13418-13422)
+
+Nur diese 14 Sections durchlaufen GLOBAL-TRUNCATION:
+```
+RISKS_HTML, GAMECHANGER_HTML, FOERDERPOTENZIAL_HTML, RECOMMENDATIONS_HTML,
+ORG_CHANGE_HTML, BUSINESS_CASE_HTML, PILOT_PLAN_HTML, ROADMAP_12M_HTML,
+DATA_READINESS_HTML, STRATEGIE_GOVERNANCE_HTML, UNTERNEHMENSPROFIL_MARKT_HTML,
+MONETARISIERUNG_HTML, KI_SKILLPLAN_HTML, QUICK_WINS_HTML
+```
+
+**NICHT in Targets** (keine GLOBAL-TRUNCATION):
+```
+EXECUTIVE_SUMMARY_HTML, ROADMAP_90D_HTML, TOOLS_EMPFEHLUNGEN_HTML,
+TECHNOLOGIE_PROZESSE_HTML, BRANCH_DEEP_DIVE_HTML*, TEMPLATES_START_HTML,
+SOFORT_START_HTML, WETTBEWERB_BENCHMARK_HTML, KI_AKTIVITAETEN_ZIELE_HTML
+```
+
+*BRANCH_DEEP_DIVE_HTML steht in der target-Liste (L13421)!
+
+### 3.3 Budget-Override: FIX-BC1 (L13462-13466)
+
+```python
+if key in ("BUSINESS_CASE_HTML", "business_case") and _budget < 5000:
+    _budget = 5000  # Override für zu enge Budgets
+```
+
+Dies ist der EINZIGE hardcodierte Budget-Override in GLOBAL-TRUNCATION.
+
+### 3.4 POST-TRIM-HEAL (L13561-13664 + L15987-16053)
+
+Zwei separate Healing-Loops:
+
+**Loop 1** (L13561): Nach GLOBAL-TRUNCATION, 4 kritische Sections:
+```python
+_heal_critical_sections = ["gamechanger", "roadmap_12m", "executive_summary", "tools_empfehlungen"]
+```
+- Nutzt `get_min_words()` aus SIZE_PROFILES
+- Max 2 Iterationen
+- Heilt Sections die unter min_words gefallen sind
+
+**Loop 2** (L15987, FIX-629): POST-TRIM-HEAL Guard, 4 kritische Sections:
+```python
+_HEAL_CRITICAL_SECTIONS = ["executive_summary", "tools_empfehlungen", "gamechanger", "roadmap_12m"]
+```
+- Gleiche 4 Sections wie Loop 1
+- Gap-Limit: innerhalb 30 Wörter unter Minimum (L16028)
+- Expandiert auf min_words + 20
+
+**Risiko:** Sections die NICHT in den Heal-Listen stehen (STRATEGIE_GOVERNANCE, TECHNOLOGIE_PROZESSE, PILOT_PLAN, DATA_READINESS, etc.) werden nach Truncation NICHT geheilt.
+
+### 3.5 RESCUE LOOP (L16246)
+
+Ein dritter Healing-Mechanismus für SECTION_TOO_SHORT Validierungsfehler:
+- Hat KEIN Gap-Limit (anders als POST-TRIM-HEAL)
+- Greift erst beim Quality Gate
+- Erweitert jede Section die unter min_words steht
+
+### 3.6 Vollständige Budget-Kette
+
+```
+LLM generiert Content
+  ↓ (max_tokens: NICHT segment-abhängig, L1289)
+  ↓
+GLOBAL-TRUNCATION (gpt_analyze.py L13415)
+  Budget-Quelle: SIZE_PROFILES.section_budgets ← HIER GREIFEN SP-WERTE
+  Nur für 14 Sections in truncation_targets
+  ↓
+POST-TRIM-HEAL Loop 1 (gpt_analyze.py L13561)
+  min_words-Quelle: SIZE_PROFILES.min_words
+  Nur für 4 Sections: gamechanger, roadmap_12m, executive_summary, tools_empfehlungen
+  ↓
+Content Quality Enforcer (content_quality_enforcer.py)
+  Segment-abhängig: Solo-Term-Replacement, Solo-RISKS-Padding
+  ↓
+POST-TRIM-HEAL Loop 2 (gpt_analyze.py L15987)
+  min_words-Quelle: SIZE_PROFILES.min_words
+  Nur für 4 Sections, nur innerhalb 30-Wort-Gap
+  ↓
+RESCUE LOOP (gpt_analyze.py L16246)
+  Jede Section unter min_words, kein Gap-Limit
+  ↓
+Healer apply_segment_budget() (report_healer.py L3045)
+  Budget-Quelle: SEGMENT_BUDGETS ← HIER GREIFEN HEALER-WERTE
+  Hierarchie: exact > uppercase_HTML > SIZE_PROFILES fallback > _default
+  ↓
+BUDGET_EXEMPT bypass (L3077)
+  RISKS, GAMECHANGER, RECOMMENDATIONS, VENDOR_AUDIT, etc.
+  ↓
+Sentence-Trimming FIX-G (report_healer.py L3146)
+  Guard bei 80% von Budget
+  ↓
+FIX-B36b Clean Ending Check
+  Entfernt "..." Truncation-Artefakte
+  ↓
+WP4 Compact Guard (solo_compact_engine.py L699)
+  Post-Render, wenn HTML > KB/Seiten-Schwelle
+```
+
+---
+
+## 4. solo_compact_engine.py Schwellenwerte
+
+### 4.1 Compact-Auslösung (L650-664)
+
+| Parameter | Solo | Team | KMU | Datei:Zeile |
+|-----------|------|------|-----|-------------|
+| MAX_PAGES | 16 | 70 | 45 | solo_compact_engine.py:650-654 |
+| HTML_COMPACT_THRESHOLD_KB | 300 | 500 | 550 | solo_compact_engine.py:661-664 |
+
+**Trigger-Logik** (L726-736):
+```python
+needs_compact = False
+if size_kb > threshold:  needs_compact = True   # HTML > KB-Schwelle
+if pages > max_pages:    needs_compact = True   # Seiten > Max
+```
+
+Beide Bedingungen sind ODER-verknüpft.
+
+### 4.2 Solo-Kompaktierung: SOLO_COMPACT_WORD_LIMITS (L165-172)
+
+Wenn Solo-Compact triggert, gelten diese **harten Wort-Limits**:
+
+| Section | Word-Limit | ~Char-Äquivalent (×7) | Healer-Budget | Problem? |
+|---------|-----------|----------------------|---------------|----------|
+| EXECUTIVE_SUMMARY_HTML | 400 | ~2800 | 2000 | Nein (Healer enger) |
+| QUICK_WINS_HTML | 600 | ~4200 | 8000 | **JA** — Compact killt 47% |
+| ROADMAP_90D_HTML | 500 | ~3500 | 5000 | Nein (Compact enger) |
+| ROADMAP_12M_HTML | 600 | ~4200 | 8000 | **JA** — Compact killt 47% |
+| PILOT_PLAN_HTML | 400 | ~2800 | 1200 | Nein (Healer enger) |
+| DATA_READINESS_HTML | 300 | ~2100 | 1200 | Nein (Healer enger) |
+
+### 4.3 Risikoanalyse: B36-Budgets → Compact-Trigger
+
+**Aktuelles Solo-HTML-Budget (Summe der Healer SEGMENT_BUDGETS):**
+```
+Solo Content-Sections:    ~130.000 chars ≈ 127KB (nur text, ohne HTML-Overhead)
+Mit HTML-Overhead (×1.5):  ~190KB
+Schwelle:                  300KB
+Headroom:                  ~110KB (37%)
+```
+
+**Nach FINAL-Version (55% von KMU):**
+```
+Solo Content-Sections:    ~200.000 chars ≈ 195KB (geschätzt)
+Mit HTML-Overhead (×1.5):  ~293KB
+Schwelle:                  300KB
+Headroom:                  ~7KB (2%) ← KRITISCH KNAPP!
+```
+
+**Antwort auf Kernfrage:** JA — nach FINAL B36-Deployment besteht ein **hohes Risiko** dass Solo die 300KB-Schwelle erreicht. Das würde die Solo-Kompaktierung auslösen, die dann QUICK_WINS und ROADMAP_12M auf 600 Wörter kürzt und weitere Sections droppt.
+
+**Empfehlung:** Solo HTML_COMPACT_THRESHOLD auf 400KB erhöhen, BEVOR die Solo-Budgets erhöht werden.
+
+### 4.4 Team/KMU WP4 Compact Guard
+
+Wenn Team/KMU die Schwelle überschreitet, werden Low-Priority-Sections gedroppt (L670-683):
+```
+Tier 1: FUNDING_BRANCH_ALIGNMENT, TOOLS_FUNDING_ALIGNMENT, TOOLS_BRANCH_ALIGNMENT,
+        AUTOMATION_ROADMAP, ROI_TRACKING, BUSINESS_CASE_SIM, KICKOFF
+Tier 2: MARKET_INSIGHTS, NEWS_BOX
+```
+
+Zusätzlich werden zu lange Text-Blöcke (>800 chars) per Regex gekürzt (L791-800).
+
+---
+
+## 5. Empfehlung: Was muss als nächstes gefixt werden?
+
+### Priorität 1: SOFORT (vor nächstem Deploy)
+
+| # | Was | Wo | Warum |
+|---|-----|-----|-------|
+| **B37a** | Solo SEGMENT_BUDGETS auf 55% von KMU setzen | report_healer.py L2742-2830 | Solo-Content wird um 50-78% gekürzt |
+| **B37b** | Team SEGMENT_BUDGETS auf 75% von KMU setzen | report_healer.py L2832-2920 | Team-Content wird um 50-78% gekürzt |
+| **B37c** | Solo/Team Plaintext-Budgets hinzufügen | report_healer.py (neu, nach L2829/L2919) | "roadmap" etc. fallen auf _default=1000/1500 |
+| **B37d** | Solo/Team `_default` erhöhen | report_healer.py L2830, L2920 | solo: 1000→1500, team: 1500→2000 |
+
+### Priorität 2: VOR Solo-Budget-Deploy
+
+| # | Was | Wo | Warum |
+|---|-----|-----|-------|
+| **B37e** | Solo HTML_COMPACT_THRESHOLD auf 400KB | solo_compact_engine.py L662 | Sonst triggert Compact bei ~300KB nach Budget-Erhöhung |
+
+### Priorität 3: NACH Testrun
+
+| # | Was | Wo | Warum |
+|---|-----|-----|-------|
+| **B37f** | Solo SIZE_PROFILES.section_budgets erhöhen | size_profiles.py L67-99 | 8 Sections wo SP < Healer → GLOBAL-TRUNCATION killt Content |
+| **B37g** | Team SIZE_PROFILES.section_budgets nachziehen | size_profiles.py L157-189 | 7 Sections wo SP < Healer |
+| **B37h** | KMU SP: BRANCH_DEEP_DIVE, TEMPLATES_START, SOFORT_START hinzufügen | size_profiles.py L242-263 | Fehlen komplett, fallen auf _default=3000 |
+| **B37i** | Sanity-Check erweitern: SP ≥ Healer prüfen | size_profiles.py L388 | Automatische Erkennung von SP/Healer-Konflikten |
+
+### Priorität 4: Monitoring
+
+| # | Was | Wo | Warum |
+|---|-----|-----|-------|
+| **B37j** | HTML-Größe nach B37a/b loggen | gpt_analyze.py / report_renderer.py | Compact-Trigger-Risiko überwachen |
+| **B37k** | POST-TRIM-HEAL auf alle Sections erweitern | gpt_analyze.py L13565, L16001 | Nur 4 Sections werden geheilt, viele andere fallen durch |
+
+---
+
+## 6. Zusammenfassung der Konflikte
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  SIZE_PROFILES (config/size_profiles.py)                        │
+│  → Genutzt von: GLOBAL-TRUNCATION (gpt_analyze.py L13461)      │
+│  → Problem: Solo-Werte zu niedrig (1500-3000 chars)             │
+│  → 8 Solo-Konflikte, 7 Team-Konflikte, 3 KMU-Konflikte         │
+│                                                                 │
+│  GLOBAL-TRUNCATION kürzt auf SP-Wert                            │
+│          ↓                                                      │
+│  POST-TRIM-HEAL expandiert NUR 4 Sections                       │
+│          ↓                                                      │
+│  SEGMENT_BUDGETS (report_healer.py L2741)                       │
+│  → Problem: Solo/Team noch auf pre-B36 Werten                   │
+│  → Healer kürzt NOCHMAL auf niedrigere Werte                    │
+│          ↓                                                      │
+│  WP4 Compact Guard (solo_compact_engine.py L699)                │
+│  → Risiko: Solo 300KB-Schwelle nach B37 knapp                   │
+│  → Compact DROPPT ganze Sections oder kürzt auf 600 Wörter      │
+│                                                                 │
+│  DREIFACH-TRUNCATION für Solo/Team:                              │
+│  GPT Output → SP-Cap → Healer-Cap → Compact-Cap                 │
+│  Jeder Schritt kann Content vernichten                           │
+└─────────────────────────────────────────────────────────────────┘
+```


### PR DESCRIPTION
Vollständige Analyse aller 10 segment-abhängigen Dateien:
- 13 Konflikte identifiziert (4 BLOCKER, 6 HOCH, 3 MITTEL)
- Budget-Konsistenz-Matrix für alle kritischen Sections
- Implementierungsplan FIX-B37a bis B37f

Kernbefund: Solo/Team Healer-SEGMENT_BUDGETS wurden bei FIX-B36a NICHT proportional (55%/75% von KMU) angepasst. Verursacht exakt denselben 50-78% Content-Verlust wie der KMU-Bug.

https://claude.ai/code/session_01BJT19fyqU3Rx6JMjhUjcCE