### PR TITLE
Fix SIZE_PROFILES nested structure access in apply_segment_budget

### DIFF
--- a/services/report_healer.py
+++ b/services/report_healer.py
@@ -3130,9 +3130,11 @@ def apply_segment_budget(
                 upper_key = upper_key + "_HTML"
             budget = budgets.get(upper_key)
         if budget is None:
-            # Fallback: SIZE_PROFILES als Single Source of Truth
+            # FIX-B37d: SIZE_PROFILES hat nested structure: SIZE_PROFILES[segment]["section_budgets"][key]
+            # Vorher wurde SIZE_PROFILES[segment][key] gesucht — fand nie etwas (Dict-Nesting-Bug)
             sp = SIZE_PROFILES.get(segment, {})
-            budget = sp.get(section_name, sp.get(section_name.upper() + "_HTML", default_budget))
+            sp_budgets = sp.get("section_budgets", sp)  # Fallback auf sp selbst falls kein Nesting
+            budget = sp_budgets.get(section_name, sp_budgets.get(section_name.upper() + "_HTML", default_budget))
         current_len = len(html)
 
         if current_len <= budget:


### PR DESCRIPTION
## Summary
Fixed a bug in the `apply_segment_budget` method where the fallback logic for retrieving budget values from `SIZE_PROFILES` was not accounting for the nested dictionary structure, causing budget lookups to always fail.

## Key Changes
- **Fixed dictionary nesting bug**: Updated the fallback budget lookup to correctly access `SIZE_PROFILES[segment]["section_budgets"][key]` instead of the incorrect `SIZE_PROFILES[segment][key]`
- **Added graceful fallback**: Implemented a fallback mechanism that uses the segment dictionary itself if the "section_budgets" key doesn't exist, ensuring backward compatibility
- **Improved code clarity**: Added detailed comments explaining the nested structure and the nature of the bug being fixed

## Implementation Details
The issue was in the budget fallback logic when budgets are not found in the initial lookup. The code was attempting to access budget values directly from the segment dictionary, but `SIZE_PROFILES` uses a nested structure where budgets are stored under a "section_budgets" key. This caused the fallback to never find matching budgets, always resulting in the default budget being used.

The fix extracts the "section_budgets" dictionary first, with a fallback to the segment dictionary itself for cases where the nested structure might not be present, ensuring robustness across different data formats.

https://claude.ai/code/session_012kCF1pF9EKK4yqzrCmRQL2