### PR TITLE
Fix SVG sizing issues in LLM-generated content

### DIFF
--- a/gpt_analyze.py
+++ b/gpt_analyze.py
@@ -3657,6 +3657,20 @@ def _apply_pdf_inline_styles(html: str) -> str:
 
     result = pre_pattern.sub(add_pre_style, result)
 
+    # FIX-VISUAL-P0: SVGs ohne width/height bekommen feste Größe
+    # LLM generiert <svg viewBox="0 0 24 24"> ohne Dimensionen → Puppeteer rendert sie riesig
+    result = re.sub(
+        r'<svg(?![^>]*(?:width|height)\s*=)([^>]*)>',
+        r'<svg width="24" height="24"\1>',
+        result
+    )
+    # Zusätzlich: SVGs mit style="width:100%" o.ä. begrenzen
+    result = re.sub(
+        r'(<svg[^>]*)\s+style="[^"]*(?:width|height)\s*:\s*(?:100%|[2-9]\d{2,}px)[^"]*"',
+        r'\1 style="width:24px;height:24px"',
+        result
+    )
+
     # Fix 4: Replace emojis with custom SVG icons for reliable PDF rendering
     # Uses the icon_system module with branded SVG icons
     result = replace_emojis_with_icons(result, size=18)

--- a/templates/pdf_template.html
+++ b/templates/pdf_template.html
@@ -3865,6 +3865,54 @@
         }
 
         /* ================================================
+           FIX-VISUAL-P0: Globale SVG-Size-Guards für LLM-Output
+           Problem: LLM generiert SVGs ohne class-Attribute,
+           bestehende Guards greifen nicht
+           ================================================ */
+
+        /* Alle SVGs in section-body begrenzen, unabhängig von class */
+        .section-body svg {
+            max-width: 48px !important;
+            max-height: 48px !important;
+            display: inline-block !important;
+            vertical-align: middle !important;
+        }
+
+        /* AUSNAHMEN: Charts, Donut, Score — diese NICHT begrenzen! */
+        .donut-chart svg,
+        .chart-container svg,
+        svg.donut-svg,
+        .hero-page svg,
+        .score-badge svg,
+        [class*="chart"] svg,
+        [class*="donut"] svg,
+        .kpi-card svg,
+        .metric-card svg {
+            max-width: none !important;
+            max-height: none !important;
+        }
+
+        /* Standalone-SVGs (direkt als Kind von Containern) noch kleiner */
+        .section-body > svg,
+        .section-body > div > svg,
+        .section-body > p > svg {
+            max-width: 40px !important;
+            max-height: 40px !important;
+        }
+
+        /* LLM-generierte Inline-Font-Size auf Emojis begrenzen */
+        .section-body span[style*="font-size"] {
+            font-size: 24px !important;
+            line-height: 1.2 !important;
+        }
+
+        /* Bilder in LLM-Output begrenzen (außer Charts/Logos) */
+        .section-body img:not([class*="chart"]):not([class*="logo"]):not([class*="donut"]):not([class*="tuev"]):not([class*="tüv"]) {
+            max-width: 80px !important;
+            max-height: 80px !important;
+        }
+
+        /* ================================================
            TAKEAWAY - Content Quality Pack v1.2
            "Wenn Sie nur eines tun:" individueller Startpunkt
            ================================================ */


### PR DESCRIPTION
## Summary
Fixes visual rendering issues where SVGs generated by the LLM without explicit dimensions were rendering at oversized scales in PDF output. Implements both server-side normalization and client-side CSS guards to ensure consistent SVG sizing.

## Key Changes

- **gpt_analyze.py**: Added regex-based SVG dimension normalization
  - Injects `width="24" height="24"` attributes into SVGs missing explicit dimensions
  - Removes problematic inline styles that set width/height to 100% or excessive pixel values
  - Prevents Puppeteer from rendering dimensionless SVGs at full viewport size

- **pdf_template.html**: Added comprehensive CSS size guards for LLM-generated content
  - Global constraint: All SVGs in `.section-body` limited to 48×48px max
  - Whitelist exceptions for charts, donuts, score badges, and KPI cards (no size limits)
  - Stricter limits (40×40px) for standalone SVGs directly nested in containers
  - Font-size normalization for inline spans (24px max) to prevent emoji overflow
  - Image size constraints (80×80px max) excluding chart/logo assets

## Implementation Details

The fix uses a two-layer approach:
1. **Server-side (Python)**: Normalizes SVG markup before PDF generation to ensure all SVGs have explicit dimensions
2. **Client-side (CSS)**: Provides defensive styling to catch any remaining edge cases and prevent layout breakage

The CSS uses `!important` flags and attribute selectors to reliably override inline styles while maintaining exceptions for intentionally large chart components.

https://claude.ai/code/session_013VjvQyYXxNyesyWxC2Hnop