### PR TITLE
fix(pdf): Gamechanger-Label-Boxen + Page-Break + Prompt (P5)

### DIFF
--- a/gpt_analyze.py
+++ b/gpt_analyze.py
@@ -3583,6 +3583,114 @@ def get_foerderprogramme_for_report(
 # ==================== ENDE PHASE 4 INTEGRATION ====================
 
 
+def _apply_gamechanger_label_boxes(html: str) -> str:
+    """
+    Wendet farbige Box-Styles auf Gamechanger-Labels an (P5-Fix).
+
+    Unterstützt drei Formate:
+    - <p><strong>Label:</strong> Text</p>            (inline)
+    - <p><strong>Label:</strong></p>                  (standalone, Text folgt separat)
+    - <li><strong>Label:</strong> Text</li>           (list items)
+
+    Wird im Compact-Skipped-Pfad aufgerufen, damit Labels auch ohne
+    den vollen Legacy-Pipeline gestylt werden.
+    """
+    if not html:
+        return html
+
+    # Guard: Wenn bereits Box-Styles vorhanden, nicht nochmal anwenden
+    if 'border-left: 4px solid #7c3aed' in html or 'border-left:4px solid #7c3aed' in html:
+        return html
+
+    result = html
+
+    _BOX_GROUPS = [
+        # Gamechanger-Patterns (lila Akzent)
+        {
+            "labels": [
+                "Bisher", "Denkfehler", "Konsequenz",
+                "Neue Logik", "Architektur", "Erweiterungseffekt",
+                "Marktposition", "Kapazitätssprung", "Produktkern",
+                "Skalierungsfähigkeit", "Wissenskapitalisierung",
+                "Strukturwandel", "Modellrolle", "Strukturfehler",
+            ],
+            "bg": "linear-gradient(135deg, #f5f3ff 0%, #ede9fe 100%)",
+            "border": "#7c3aed",
+            "label_color": "#6d28d9",
+        },
+        # Risiko/Stop-Patterns (rot)
+        {
+            "labels": ["Stop-Regel", "Risiko", "Warnung", "Achtung"],
+            "bg": "#fef2f2",
+            "border": "#dc2626",
+            "label_color": "#b91c1c",
+        },
+        # Erfolg/Meilenstein-Patterns (grün)
+        {
+            "labels": ["Meilenstein", "Erfolgskriterium", "Ergebnis", "Wirkung"],
+            "bg": "#f0fdf4",
+            "border": "#16a34a",
+            "label_color": "#15803d",
+        },
+        # Hinweis/Info-Patterns (gelb)
+        {
+            "labels": ["Hinweis", "Beachten", "Wichtig", "Tipp"],
+            "bg": "#fffbeb",
+            "border": "#f59e0b",
+            "label_color": "#d97706",
+        },
+    ]
+
+    for group in _BOX_GROUPS:
+        bg = group["bg"]
+        border = group["border"]
+        label_color = group["label_color"]
+
+        box_style = (
+            f'style="background: {bg}; '
+            f'border-left: 4px solid {border}; '
+            f'padding: 12px 16px; margin: 12px 0; '
+            f'border-radius: 0 8px 8px 0;"'
+        )
+        label_style = f'style="color: {label_color} !important;"'
+
+        for label in group["labels"]:
+            escaped = re.escape(label)
+
+            # Pattern 1: <p><strong>Label:</strong> Text im selben Tag</p>
+            p_inline = (
+                rf'<p([^>]*)>\s*<strong([^>]*)>\s*{escaped}\s*:?\s*</strong>\s*:?\s*(.+?)</p>'
+            )
+            r_inline = (
+                rf'<div {box_style}><p\1><strong\2 {label_style}>'
+                rf'{label}:</strong> \3</p></div>'
+            )
+            result = re.sub(p_inline, r_inline, result, flags=re.DOTALL | re.IGNORECASE)
+
+            # Pattern 2: <p><strong>Label:</strong></p> (standalone — Text folgt separat)
+            p_standalone = (
+                rf'<p([^>]*)>\s*<strong([^>]*)>\s*{escaped}\s*:?\s*</strong>\s*:?\s*</p>'
+            )
+            r_standalone = (
+                rf'<div {box_style}><p\1><strong\2 {label_style}>'
+                rf'{label}:</strong></p></div>'
+            )
+            result = re.sub(p_standalone, r_standalone, result, flags=re.IGNORECASE)
+
+            # Pattern 3: <li><strong>Label:</strong> Text</li>
+            p_li = (
+                rf'<li([^>]*)>\s*<strong([^>]*)>\s*{escaped}\s*:?\s*</strong>\s*:?\s*(.+?)</li>'
+            )
+            r_li = (
+                rf'<li\1 {box_style}><strong\2 {label_style}>'
+                rf'{label}:</strong> \3</li>'
+            )
+            result = re.sub(p_li, r_li, result, flags=re.DOTALL | re.IGNORECASE)
+
+    log.info("[P5-FIX1] Applied gamechanger label boxes (changed: %s)", result != html)
+    return result
+
+
 def _apply_pdf_inline_styles(html: str) -> str:
     """
     Apply inline styles for Puppeteer PDF rendering compatibility.
@@ -13925,13 +14033,18 @@ Gib den erweiterten HTML-Inhalt aus (mindestens {_heal_target_words} Wörter):
                             _gc_words_after, _gc_min_words, _gc_words_before,
                         )
                         gamechanger_html = _gc_pre_compact
+                        # P5-Fix: Apply label boxes to reverted content too
+                        gamechanger_html = _apply_gamechanger_label_boxes(gamechanger_html)
                     else:
                         log.info(f"[CI-DESIGN] Gamechanger compact: {len(gamechanger_html)} chars ({_gc_words_after} words)")
                 else:
+                    # P5-Fix: Labels trotzdem mit Box-Styles versehen
+                    gamechanger_html = _apply_gamechanger_label_boxes(gamechanger_html)
                     log.info(
                         f"[CI-DESIGN][FIX-620] Gamechanger compact SKIPPED: "
                         f"{_gc_words_before} words < {_gc_compact_threshold} threshold "
-                        f"(min_words={_gc_min_words}, preserving full content for validator)"
+                        f"(min_words={_gc_min_words}, preserving full content for validator, "
+                        f"P5 label-boxes applied)"
                     )
             else:
                 # Fallback: Alter Flow

--- a/prompts/de/gamechanger.md
+++ b/prompts/de/gamechanger.md
@@ -170,6 +170,27 @@ BEISPIEL - SO NICHT:
 BEISPIEL - SO JA:
 ✅ <li><strong>Bisher:</strong> Jede Analyse startet bei Null, obwohl 70%
    der Logik wiederkehrend ist.</li> [= 15 Wörter = PERFEKT!]
+
+=============================================================================
+LABEL-FORMAT (KRITISCH FÜR RENDERING — PFLICHT!)
+=============================================================================
+Labels (Bisher, Neue Logik, Architektur, Konsequenz etc.) MÜSSEN exakt so
+formatiert werden, damit das Rendering-System farbige Boxen erzeugen kann:
+
+✅ RICHTIG — Text im SELBEN Tag wie das Label:
+<p><strong>Bisher:</strong> Der alte Ansatz war zeitintensiv.</p>
+<li><strong>Neue Logik:</strong> Automatisierte Vorlagen statt Neuentwicklung.</li>
+
+❌ FALSCH — Label und Text in GETRENNTEN Tags:
+<p><strong>Bisher:</strong></p>
+<p>Der alte Ansatz war zeitintensiv.</p>
+
+REGEL: Der Text MUSS im SELBEN <p> oder <li>-Tag wie das <strong>Label:</strong> stehen!
+
+LISTEN VERWENDEN (PFLICHT):
+- Nutze <ul><li> für Aufzählungen statt langer Fließtext-Absätze
+- Mindestens 2-3 Listen pro Gamechanger-Section
+- Listen lockern den Text visuell auf
 =============================================================================
 -->
 

--- a/prompts/en/gamechanger.md
+++ b/prompts/en/gamechanger.md
@@ -73,6 +73,27 @@ EXAMPLE - WRONG:
 EXAMPLE - CORRECT:
 ✅ <li><strong>Previously:</strong> Each analysis starts from zero, even though 70%
    of the logic is recurring.</li> [= 15 words = PERFECT!]
+
+=============================================================================
+LABEL FORMAT (CRITICAL FOR RENDERING — MANDATORY!)
+=============================================================================
+Labels (Previously, New Logic, Architecture, Consequence etc.) MUST be formatted
+exactly like this so the rendering system can create colored boxes:
+
+✅ CORRECT — Text in the SAME tag as the label:
+<p><strong>Previously:</strong> The old approach was time-consuming.</p>
+<li><strong>New Logic:</strong> Automated templates instead of custom development.</li>
+
+❌ WRONG — Label and text in SEPARATE tags:
+<p><strong>Previously:</strong></p>
+<p>The old approach was time-consuming.</p>
+
+RULE: The text MUST be in the SAME <p> or <li> tag as the <strong>Label:</strong>!
+
+USE LISTS (MANDATORY):
+- Use <ul><li> for enumerations instead of long prose paragraphs
+- At least 2-3 lists per Gamechanger section
+- Lists visually break up the text
 =============================================================================
 -->
 

--- a/templates/pdf_template.html
+++ b/templates/pdf_template.html
@@ -1732,6 +1732,16 @@
         .section-body {
             page-break-inside: avoid;
         }
+        /* P5-Fix: Risiken-Section darf umbrechen (hat oft viel Content) */
+        .section[data-chapter="risiken"] .section-body {
+            page-break-inside: auto;
+        }
+        /* Auch für Qualitäts/Transparenz/Akzeptanz-Risiken falls separates Kapitel */
+        .section[data-chapter="qualitaet"] .section-body,
+        .section[data-chapter="transparenz"] .section-body,
+        .section[data-chapter="akzeptanz"] .section-body {
+            page-break-inside: auto;
+        }
         .quick-win, .quick-win-card, .quick-win-card-new {
             page-break-inside: avoid;
         }


### PR DESCRIPTION
- Neue Funktion _apply_gamechanger_label_boxes() für Label-Styling
- Compact-Skipped-Pfad ruft jetzt Label-Box-Processing auf
- Compact-Revert-Pfad ruft jetzt Label-Box-Processing auf
- Unterstützt inline (<p><strong>Label:</strong> Text</p>) und standalone (<p><strong>Label:</strong></p>) Formate
- Guard gegen doppelte Anwendung (prüft ob border-left bereits vorhanden)
- Page-Break CSS für Risiken-Section: auto statt avoid
- Prompt DE/EN: Label-Format-Anweisung (Text im selben Tag)
- Prompt DE/EN: Verstärkte Listen-Anweisung

Fixes: Gamechanger-Labels S.33-36 ohne Hintergrund (#P5-FIX1)
Fixes: S.29 Page-Break schneidet Content ab (#P5-FIX2)
Fixes: Label-Format im Prompt klargestellt (#P5-FIX3)

Review-Score: 84 → 87-88 erwartet

https://claude.ai/code/session_01PkrqKy291JPBZE9jC1Ya5B