### PR TITLE
Template v7 quality fixes: empty page, TOC badges, emoji strip, CSS p…

### DIFF
--- a/services/report_renderer.py
+++ b/services/report_renderer.py
@@ -30,6 +30,54 @@ from services.pipeline_sanitizers import fix_double_encoded_utf8
 
 log = logging.getLogger(__name__)
 
+# Emoji regex for stripping emojis from backend-generated HTML blocks
+_EMOJI_RE = re.compile(
+    "["
+    "\U0001F600-\U0001F64F"  # Emoticons
+    "\U0001F300-\U0001F5FF"  # Misc Symbols and Pictographs
+    "\U0001F680-\U0001F6FF"  # Transport and Map Symbols
+    "\U0001F1E0-\U0001F1FF"  # Flags
+    "\U0001F900-\U0001F9FF"  # Supplemental Symbols
+    "\U0001FA00-\U0001FA6F"  # Chess Symbols
+    "\U0001FA70-\U0001FAFF"  # Symbols Extended-A
+    "\U00002702-\U000027B0"  # Dingbats
+    "\U000024C2-\U0001F251"  # Enclosed characters
+    "\U0000FE0F"             # Variation Selector-16
+    "\U0000200D"             # Zero Width Joiner
+    "\U00002600-\U000026FF"  # Misc Symbols
+    "\U00002700-\U000027BF"  # Dingbats
+    "\U0000FE00-\U0000FE0F"  # Variation Selectors
+    "\U0000231A-\U0000231B"  # Watch, Hourglass
+    "\U000023E9-\U000023F3"  # Various symbols
+    "\U000023F8-\U000023FA"  # Various symbols
+    "\U000025AA-\U000025AB"  # Squares
+    "\U000025B6\U000025C0"   # Play/Reverse buttons
+    "\U000025FB-\U000025FE"  # Squares
+    "\U00002B05-\U00002B07"  # Arrows
+    "\U00002B1B-\U00002B1C"  # Squares
+    "\U00002B50\U00002B55"   # Star, Circle
+    "\U00003030\U0000303D"   # Wavy Dash, Part Alternation Mark
+    "\U00003297\U00003299"   # Circled Ideographs
+    "]+",
+    flags=re.UNICODE
+)
+
+
+def _strip_emojis(text: str) -> str:
+    """Remove all emojis from a string. Safe for HTML content."""
+    if not text or not isinstance(text, str):
+        return text
+    return _EMOJI_RE.sub("", text)
+
+
+def _strip_emojis_from_context(context: dict) -> dict:
+    """Strip emojis from all *_HTML template variables in the render context."""
+    for key in list(context.keys()):
+        if isinstance(context[key], str) and (key.endswith("_HTML") or key.endswith("_html")):
+            context[key] = _strip_emojis(context[key])
+    return context
+
+
 # N3: Pre-compute a single regex pattern for O(n) leak detection instead of O(n*phrases)
 # This matches ANY leak phrase in a single pass through the HTML
 _LEAK_PATTERN = re.compile(
@@ -874,7 +922,8 @@ def render(briefing_obj: Any,
     if _a2_fixes > 0:
         log.info("[A2] Total template phrases stripped: %d", _a2_fixes)
 
-
+    # V7: Strip emojis from all backend-generated HTML blocks
+    _strip_emojis_from_context(ctx)
 
     html = env.get_template(tpl_name).render(**ctx)
 

--- a/templates/pdf_template_v7.html
+++ b/templates/pdf_template_v7.html
@@ -111,7 +111,7 @@ tr:last-child td { border-bottom: none; }
 .page { max-width: 210mm; margin: 0 auto; }
 
 /* ══ HARD PAGE BREAKS (max 3) ═══════════════════════ */
-.break-cover-to-toc { page-break-before: always; }
+/* .break-cover-to-toc removed — cover uses page-break-after: always */
 .break-exec-to-action { page-break-before: always; }
 .break-action-to-imprint { page-break-before: always; }
 
@@ -219,7 +219,15 @@ tr:last-child td { border-bottom: none; }
     font-size: 10pt;
     line-height: 1.65;
 }
+.section-body p + p { margin-top: 6px; }
+.section-body h4 + p { margin-top: 4px; }
+.section-body p, .section-body li { orphans: 3; widows: 3; }
 .section-body h3 { margin-top: var(--sp-lg); }
+
+/* ── Funding section spacing ──────────────────────────── */
+#funding-section .section-body p { margin-bottom: 8px; }
+#funding-section .section-body ul,
+#funding-section .section-body ol { margin: 8px 0 12px; }
 
 /* ── Cross-Reference Link ───────────────────────────── */
 .xref {
@@ -242,8 +250,10 @@ tr:last-child td { border-bottom: none; }
     justify-content: center;
     align-items: center;
     text-align: center;
-    min-height: 100vh;
+    height: 100vh;
     padding: var(--sp-2xl) var(--sp-xl);
+    overflow: hidden;
+    page-break-after: always;
 }
 .cover-accent {
     width: 60px;
@@ -413,7 +423,7 @@ tr:last-child td { border-bottom: none; }
 .toc-entry {
     display: flex;
     align-items: center;
-    gap: 8px;
+    gap: 10px;
     padding: 6px 0;
     border-bottom: 1px solid #F3F4F6;
     text-decoration: none;
@@ -421,7 +431,8 @@ tr:last-child td { border-bottom: none; }
     font-size: 9.5pt;
 }
 .toc-entry:hover { background: var(--c-bg); }
-.toc-entry-cat { width: 50px; flex-shrink: 0; }
+.toc-entry-cat { flex-shrink: 0; min-width: 65px; }
+.toc-entry .badge { margin-right: 4px; }
 .toc-entry-title { flex: 1; font-weight: 500; }
 .toc-audience {
     font-size: 7.5pt;
@@ -860,7 +871,7 @@ tr:last-child td { border-bottom: none; }
 </div>
 
 <!-- ═══════ TABLE OF CONTENTS ═══════ -->
-<div class="section break-cover-to-toc" id="toc" data-category="strategy">
+<div class="section" id="toc" data-category="strategy">
     <div style="margin-bottom: var(--sp-lg);">
         <span class="badge badge-strategy">Strategie</span>
         <h2>Inhaltsverzeichnis</h2>
@@ -875,10 +886,10 @@ tr:last-child td { border-bottom: none; }
         <span class="toc-level-title">Executive View</span>
         <span class="toc-level-sub">5 Min · Für Entscheider</span>
     </div>
-    <a href="#cover" class="toc-entry"><span class="toc-entry-cat badge badge-strategy">Strategie</span><span class="toc-entry-title">Cover &amp; Score-Übersicht</span></a>
-    <a href="#toc" class="toc-entry"><span class="toc-entry-cat badge badge-strategy">Strategie</span><span class="toc-entry-title">Inhaltsverzeichnis</span></a>
-    <a href="#mgmt-summary" class="toc-entry"><span class="toc-entry-cat badge badge-strategy">Strategie</span><span class="toc-entry-title">Management Summary</span></a>
-    <a href="#decision" class="toc-entry"><span class="toc-entry-cat badge badge-strategy">Strategie</span><span class="toc-entry-title">Entscheidungsvorlage</span></a>
+    <a href="#cover" class="toc-entry"><span class="toc-entry-cat badge badge-strategy">Strategie</span> <span class="toc-entry-title">Cover &amp; Score-Übersicht</span></a>
+    <a href="#toc" class="toc-entry"><span class="toc-entry-cat badge badge-strategy">Strategie</span> <span class="toc-entry-title">Inhaltsverzeichnis</span></a>
+    <a href="#mgmt-summary" class="toc-entry"><span class="toc-entry-cat badge badge-strategy">Strategie</span> <span class="toc-entry-title">Management Summary</span></a>
+    <a href="#decision" class="toc-entry"><span class="toc-entry-cat badge badge-strategy">Strategie</span> <span class="toc-entry-title">Entscheidungsvorlage</span></a>
 
     <!-- ACTION GUIDE (Dynamic TOC) -->
     <div class="toc-level-header toc-level-header-action" style="margin-top: var(--sp-md);">


### PR DESCRIPTION
…olish

Fix 1 (CRITICAL): Remove empty page 2 between Cover and TOC
- Cover: height instead of min-height, add overflow:hidden + page-break-after:always
- Remove .break-cover-to-toc class from CSS and HTML

Fix 2 (CRITICAL): TOC badges merging with titles
- Increase .toc-entry gap 8px→10px, .toc-entry-cat min-width:65px
- Add .toc-entry .badge margin-right:4px
- Add whitespace between badge and title spans in static TOC entries

Fix 3 (IMPORTANT): Emoji strip in backend
- Add _strip_emojis() and _strip_emojis_from_context() to report_renderer
- Strip emojis from all *_HTML variables before template.render()

Fix 4: CSS polish
- .section-body: p+p margin, h4+p margin, orphans/widows:3
- #funding-section: paragraph and list spacing

https://claude.ai/code/session_01MVzDimGK2yowp3FHXRF68D