### PR TITLE
fix: add score_interpretation + advisor_note to prompt_manifest.json

### DIFF
--- a/prompts/prompt_manifest.json
+++ b/prompts/prompt_manifest.json
@@ -909,6 +909,22 @@
       "size_aware": false,
       "required": false,
       "output": "html"
+    },
+    "score_interpretation": {
+      "title": "Score-Interpretation",
+      "path": "score_interpretation.md",
+      "purpose": "Einordnung der Dimensions-Scores (Governance, Sicherheit, Wertschöpfung, Befähigung)",
+      "size_aware": false,
+      "required": false,
+      "output": "html"
+    },
+    "advisor_note": {
+      "title": "Persönliche Einschätzung",
+      "path": "advisor_note.md",
+      "purpose": "Wolf-Hohl-Persona: persönliche Advisor-Einschätzung",
+      "size_aware": false,
+      "required": false,
+      "output": "html"
     }
   },
   "en": {


### PR DESCRIPTION
Both sections were missing from the manifest, causing STRICT mode to block them → legacy fallback → filler output → HARD-BLOCK removal.

https://claude.ai/code/session_01MVzDimGK2yowp3FHXRF68D