### PR TITLE
fix: CSS page break rules for clean chapter starts and block protecti…

### DIFF
--- a/docs/QUALITY-AUDIT-CHECKLIST.md
+++ b/docs/QUALITY-AUDIT-CHECKLIST.md
@@ -1,0 +1,147 @@
+# Quality Audit Checklist — KI-Sicherheit.jetzt Report-Validierung
+
+**Zweck:** Diese Checkliste wird bei JEDEM Testrun durchlaufen — zusätzlich zur Fix-Validierung. Sie prüft das gesamte PDF aus Kundenperspektive.
+
+**Regel:** Jedes Problem wird mit Seite, Schwere (HIGH/MEDIUM/LOW), Kategorie und vermuteter Ursache dokumentiert.
+
+---
+
+## 1. Layout & Visuelles
+
+### 1.1 Seitenumbrüche
+- [ ] Jedes Hauptkapitel startet auf einer neuen Seite
+- [ ] Keine Überschrift allein am Seitenende ohne Folgetext
+- [ ] Cards/Boxen werden nicht durch Seitenumbrüche getrennt
+- [ ] Tabellen bleiben auf einer Seite (oder umbrechen sauber an Zeilen)
+- [ ] Transitions bleiben am Ende ihrer Section
+
+### 1.2 Weißraum
+- [ ] Keine Seite ist zu >40% leer (Weißraum-Wüste)
+- [ ] Kein unnötiger Leerraum zwischen Elementen
+- [ ] Seitenzahl ist ≤ 30 (Tradeoff Page Breaks vs. Kompaktheit)
+
+### 1.3 Typografie & Konsistenz
+- [ ] Überschriften-Hierarchie konsistent (h1→h2→h3)
+- [ ] Schriftgrößen einheitlich innerhalb gleicher Ebenen
+- [ ] Farbige Boxen haben konsistente Ränder und Padding
+- [ ] Alle Tabellen vollständig sichtbar (keine abgeschnittenen Spalten)
+
+### 1.4 Footer/Header
+- [ ] "Seite X / Y" auf jeder Seite korrekt
+- [ ] Report-ID und Datum konsistent
+- [ ] Seitenzählung nach Page Breaks korrekt
+
+---
+
+## 2. Inhaltliche Konsistenz
+
+### 2.1 Score-Konsistenz
+- [ ] Gesamtscore (92/100) überall identisch
+- [ ] Dimensions-Scores (Gov 88, Sich 85, Wert 94, Bef 93) überall gleich
+- [ ] Score-Interpretation stimmt mit Cover überein
+- [ ] Advisor Note stimmt mit Cover überein
+- [ ] Reifegrad-Label ("Leader", "exzellent") konsistent
+
+### 2.2 ROI-Konsistenz
+- [ ] ROI-Wert überall als "200%" oder "200% (gedeckelt)"
+- [ ] Amortisation überall identisch (1,6 Monate)
+- [ ] Investitionszahlen widerspruchsfrei
+- [ ] Zeitersparnis überall 36h/Monat (= 9h/Woche × 4)
+
+### 2.3 Branchenstring
+- [ ] "Beratung und Unterstützung für Unternehmen" ≤ 5x im gesamten PDF
+- [ ] Keine Stellen wo der String grammatikalisch nicht passt
+- [ ] Keine robotisch wirkenden Wiederholungen im Fließtext
+
+---
+
+## 3. Textqualität
+
+### 3.1 Filler & Generisches
+- [ ] Keine Absätze die für jede Branche passen würden (austauschbar)
+- [ ] Konkrete Bezüge zur Branche/Unternehmensgröße vorhanden
+- [ ] Empfehlungen sind spezifisch, nicht generisch
+
+### 3.2 Wiederholungen
+- [ ] Keine identischen Empfehlungen in verschiedenen Kapiteln
+- [ ] Keine Copy-Paste-artigen Textblöcke
+- [ ] Querverweise statt Wiederholung ("siehe Business Case")
+
+### 3.3 Tonalität
+- [ ] Durchgehend "Sie"-Anrede
+- [ ] Professionell aber nicht steif
+- [ ] Nicht zu werblich, nicht zu trocken
+- [ ] Advisor Note hat authentischen Wolf-Hohl-Ton
+
+### 3.4 Prompt-Leaks
+- [ ] Keine sichtbaren Variablen-Namen (z.B. `{{score_gesamt}}`)
+- [ ] Keine System-Instruktionen im Text
+- [ ] Keine Platzhalter die nicht aufgelöst wurden
+- [ ] Kein `Developer:` oder ähnliche Prompt-Marker
+
+---
+
+## 4. Technische Artefakte
+
+### 4.1 Rendering
+- [ ] Keine HTML-Tags als sichtbarer Text (`<strong>`, `<br>`, `&amp;`)
+- [ ] Keine Encoding-Probleme (Umlaute korrekt)
+- [ ] Keine broken-image-Icons
+
+### 4.2 Logos
+- [ ] Status dokumentieren (aktuell: nicht deployed, erwartet: 0 loaded)
+- [ ] Falls Platzhalter-Bilder sichtbar → notieren
+
+### 4.3 Links
+- [ ] TOC-Links klickbar
+- [ ] "Feedback geben" / "Web-Version" Links funktional
+
+### 4.4 Pipeline
+- [ ] Pipeline Grade = A
+- [ ] Consistency Grade = A
+- [ ] 0 Fallbacks
+- [ ] 0 Heals
+- [ ] HARD-BLOCK Eingriffe = 0 (für score_interpretation und advisor_note)
+
+---
+
+## 5. Issue-Tracking
+
+Bei jedem Testrun diese Tabelle fortführen:
+
+| Issue | TR2 | TR3 | TR4 | TR5 | TR6 | Trend |
+|---|---|---|---|---|---|---|
+| ROI Cappings | 20 | 18 | 14 | | | |
+| Logos loaded | 0 | 0 | 0 | | | |
+| Branchenstring Vorkommen | 10+ | ~10 | 5 | | | |
+| HARD-BLOCK Eingriffe | 4 | 4 | 1 | | | |
+| Seitenzahl | 23 | 22 | 22 | | | |
+| Weißraum-Seiten (>40% leer) | ? | ? | ? | | | |
+| Prompt-Leaks | ? | ? | 1 | | | |
+
+---
+
+## 6. Findings-Template
+
+Für jedes gefundene Problem:
+
+```
+Finding F-XX
+* Seite: X
+* Schwere: HIGH / MEDIUM / LOW
+* Kategorie: Layout / Inhalt / Technik / Konsistenz
+* Beschreibung: Was ist das Problem?
+* Vermutete Ursache: Template / CSS / Prompt / Pipeline
+* Fix-Aufwand: Quick Fix (1h) / Mittlerer Fix (halber Tag) / Größerer Umbau
+* Screenshot/Zitat: [falls vorhanden]
+```
+
+---
+
+## Nutzung
+
+1. Bei jedem Testrun: Checkliste Punkt für Punkt durchgehen
+2. Findings im Validierungs-Report dokumentieren
+3. Issue-Tracking-Tabelle aktualisieren
+4. Neue HIGH-Findings → sofort ins nächste Claude-Code-Briefing
+5. MEDIUM/LOW-Findings → sammeln für nächsten Batch-Fix

--- a/gpt_analyze.py
+++ b/gpt_analyze.py
@@ -20355,6 +20355,7 @@ def run_briefing_pipeline(db: Session, briefing_id: int, email: Optional[str] = 
         pdf_options = {
             "format": "A4",
             "printBackground": True,
+            "preferCSSPageSize": True,
             "displayHeaderFooter": True,
             "headerTemplate": "<div></div>",
             "footerTemplate": footer_template,
@@ -20493,6 +20494,7 @@ def run_async(
         pdf_options = {
             "format": "A4",
             "printBackground": True,
+            "preferCSSPageSize": True,
             "displayHeaderFooter": True,
             "headerTemplate": "<div></div>",
             "footerTemplate": footer_template,

--- a/templates/pdf_template_v7.html
+++ b/templates/pdf_template_v7.html
@@ -110,15 +110,24 @@ tr:last-child td { border-bottom: none; }
 /* ── Page Structure ─────────────────────────────────── */
 .page { max-width: 210mm; margin: 0 auto; }
 
-/* ══ HARD PAGE BREAKS (max 3) ═══════════════════════ */
-/* .break-cover-to-toc removed — cover uses height:100vh (v7.1: page-break-after also removed) */
-.break-exec-to-action { page-break-before: always; }
-.break-action-to-imprint { page-break-before: always; }
+/* ══ PAGE BREAK RULES v7.1.2 (Puppeteer/Chromium) ═══ */
+/* .break-cover-to-toc removed — cover uses height:100vh */
+.break-exec-to-action { break-before: page; }
+.break-action-to-imprint { break-before: page; }
+
+/* Every main chapter starts on a new page */
+.section {
+    break-before: page;
+}
+/* Exceptions: Cover has its own page-break-after, TOC follows naturally */
+#cover, #cover + .section, .section:first-of-type {
+    break-before: auto;
+}
 
 /* ── Section Base ───────────────────────────────────── */
 .section {
     padding: var(--sp-xl) 0 var(--sp-lg);
-    page-break-inside: auto;
+    break-inside: auto;
 }
 
 /* ── Level Indicator ────────────────────────────────── */
@@ -738,8 +747,35 @@ tr:last-child td { border-bottom: none; }
     margin-bottom: var(--sp-xs);
 }
 
-/* ── Utility: no-break cards ────────────────────────── */
-.card-nobreak { page-break-inside: avoid; }
+/* ══ BLOCK PROTECTION v7.1.2 — keep cards/boxes together ═══ */
+/* Cards and info boxes */
+.mgmt-card, .decision-card, .funding-card, .kpi-card,
+.glance-box, .contact-box, .impressum-block,
+.reading-guide, .card-nobreak {
+    break-inside: avoid;
+}
+
+/* Headings must stay with following content */
+h1, h2, h3, h4 {
+    break-after: avoid;
+}
+
+/* Score displays and KPI rows */
+.mgmt-grid, .kpi-row, .dim-grid {
+    break-inside: avoid;
+}
+
+/* Appendix sections */
+.appendix-section {
+    break-before: page;
+    break-inside: auto;
+}
+
+/* Transitions stay with their section */
+.section-transition {
+    break-before: avoid;
+    break-inside: avoid;
+}
 
 /* ══════════════════════════════════════════════════════
    v7.1 NEUE ELEMENTE — Clean Corporate Plus
@@ -873,8 +909,9 @@ tr:last-child td { border-bottom: none; }
 /* ── Print enhancements ─────────────────────────────── */
 @media print {
     body { -webkit-print-color-adjust: exact; print-color-adjust: exact; }
-    .section { page-break-inside: auto; }
-    .card-nobreak, .mgmt-card, .decision-card, .funding-card, .kpi-card { page-break-inside: avoid; }
+    .section { break-inside: auto; }
+    .mgmt-card, .decision-card, .funding-card, .kpi-card,
+    .glance-box, .contact-box, .card-nobreak { break-inside: avoid; }
 }
     </style>
 </head>


### PR DESCRIPTION
…on (Puppeteer)

- Every .section gets break-before: page (chapters start on new pages)
- Cover and TOC exempted via :first-of-type / #cover selectors
- Block protection: mgmt-card, decision-card, funding-card, kpi-card, glance-box, contact-box stay together (break-inside: avoid)
- Headings kept with following content (break-after: avoid)
- Appendix sections get break-before: page
- Transition blocks protected from splitting
- Added preferCSSPageSize: true to both Puppeteer PDF option blocks
- Migrated hard page breaks to modern CSS syntax (break-before/after)

https://claude.ai/code/session_01MVzDimGK2yowp3FHXRF68D