### PR TITLE
Fix orphan pages in PDF layout and grammar in Kernbotschaft

### DIFF
--- a/gpt_analyze.py
+++ b/gpt_analyze.py
@@ -19729,6 +19729,20 @@ NUR HTML ausgeben. Keine Erklärungen, keine Markdown-Fences."""
     except Exception as _pr_err:
         log.warning(f"[{run_id}] [FIX-B722-PRERENDER] Failed: {_pr_err}")
 
+    # =========================================================================
+    # FIX-GRAMMAR-3: FINAL safety net — period before "Schwerpunkte:" in Kernbotschaft
+    # Previous fixes at build-time (line ~16007) and B24-SWEEP (line ~18039) add the
+    # period correctly, but downstream post-processors (quality enforcer, hauptleistung
+    # limiter, pipeline sanitizers) can strip it.  This runs AFTER all post-processing,
+    # immediately before render(), so nothing can undo it.
+    # =========================================================================
+    _fci_final = sections.get("FINAL_CHECK_INTRO", "")
+    if isinstance(_fci_final, str) and "Schwerpunkte:" in _fci_final:
+        _fci_patched = re.sub(r'(\w)\s+(Schwerpunkte:)', r'\1. \2', _fci_final)
+        if _fci_patched != _fci_final:
+            sections["FINAL_CHECK_INTRO"] = _fci_patched
+            log.info(f"[{run_id}] [FIX-GRAMMAR-3] Inserted period before 'Schwerpunkte:' in FINAL_CHECK_INTRO")
+
     result = render(
         br,
         run_id=run_id,

--- a/templates/pdf_template_v7.html
+++ b/templates/pdf_template_v7.html
@@ -110,9 +110,9 @@ tr:last-child td { border-bottom: none; }
 /* ── Page Structure ─────────────────────────────────── */
 .page { max-width: 210mm; margin: 0 auto; }
 
-/* ══ PAGE BREAK RULES v7.1.3 (Puppeteer/Chromium) ═══ */
+/* ══ PAGE BREAK RULES v7.1.4 (Puppeteer/Chromium) ═══ */
 /* Selective breaks: only at major theme changes to avoid whitespace pages */
-.break-exec-to-action { break-before: page; }
+/* v7.1.4: .break-exec-to-action removed — T1 transition now inside #sofort-start */
 .break-action-to-imprint { break-before: page; }
 
 /* Major chapter starts — new page */
@@ -1295,15 +1295,16 @@ h1, h2, h3, h4 {
    ═══════════════════════════════════════════════════════ #}
 
 <!-- ═══ Break: Executive View → Action Guide ═══ -->
-<div class="break-exec-to-action">
-    {% if TRANSITION_EXEC_TO_ACTION and TRANSITION_EXEC_TO_ACTION|trim %}
-    <div class="section-transition">{{ TRANSITION_EXEC_TO_ACTION }}</div>
-    {% endif %}
-</div>
+{# v7.1.4: T1-transition moved INSIDE sofort-start to prevent orphan page.
+   Previously the transition sat between break-exec-to-action (break-before:page)
+   and #sofort-start (also break-before:page), creating an empty page. #}
 
 <!-- ═══════ SOFORT-START ═══════ -->
 {% if SOFORT_START_HTML and SOFORT_START_HTML|trim %}
 <section class="section {% if 'start' in skip_pages %}section-optional{% endif %}" id="sofort-start" data-category="action">
+    {% if TRANSITION_EXEC_TO_ACTION and TRANSITION_EXEC_TO_ACTION|trim %}
+    <div class="section-transition">{{ TRANSITION_EXEC_TO_ACTION }}</div>
+    {% endif %}
     <div class="level-indicator"><span class="level-dot level-dot-action"></span> ACTION GUIDE</div>
     <span class="badge badge-action">Umsetzung</span>
     <h2>{{ ui("sofort_start_title", "Ihr Sofort-Start") }}</h2>
@@ -1515,14 +1516,15 @@ h1, h2, h3, h4 {
 </section>
 {% endif %}
 
-{# v7.1: Übergang Risiko → Förderprogramme #}
-{% if TRANSITION_RISK_TO_FUNDING and TRANSITION_RISK_TO_FUNDING|trim %}
-<div class="section-transition">{{ TRANSITION_RISK_TO_FUNDING }}</div>
-{% endif %}
+{# v7.1.4: T3-transition moved INSIDE funding-section to prevent orphan page
+   (same fix as T1 — #funding-section has break-before:page) #}
 
 <!-- ═══════ FÖRDERPROGRAMME ═══════ -->
 {% if FUNDING_PATH_1 or FOERDERPOTENZIAL_HTML %}
 <section class="section" id="funding-section" data-category="finance">
+    {% if TRANSITION_RISK_TO_FUNDING and TRANSITION_RISK_TO_FUNDING|trim %}
+    <div class="section-transition">{{ TRANSITION_RISK_TO_FUNDING }}</div>
+    {% endif %}
     <div class="level-indicator"><span class="level-dot level-dot-action"></span> ACTION GUIDE</div>
     <div class="section-header">
         <div>


### PR DESCRIPTION
## Summary
This PR addresses two issues in the PDF template and analysis pipeline:
1. **Orphan page prevention**: Relocates transition sections inside their target sections to prevent empty pages caused by consecutive `break-before: page` rules
2. **Grammar fix**: Adds a final safety net to ensure periods are inserted before "Schwerpunkte:" in the Kernbotschaft section

## Key Changes

### PDF Template (v7.1.4)
- **Removed** the standalone `.break-exec-to-action` div wrapper that was creating an orphan page between Executive View and Action Guide sections
- **Moved** `TRANSITION_EXEC_TO_ACTION` inside the `#sofort-start` section to consolidate the page break with its content
- **Moved** `TRANSITION_RISK_TO_FUNDING` inside the `#funding-section` for the same reason (preventing orphan pages between Risk and Funding sections)
- Updated version comment from v7.1.3 to v7.1.4
- Added explanatory comments documenting the orphan page fix

### Analysis Pipeline (gpt_analyze.py)
- **Added** `FIX-GRAMMAR-3`: A final post-processing safety net that runs immediately before rendering
- Ensures periods are correctly inserted before "Schwerpunkte:" in `FINAL_CHECK_INTRO`
- Executes after all other post-processors to prevent downstream stripping of the period
- Includes logging to track when the fix is applied

## Implementation Details
The orphan page issue occurred because transition divs with `break-before: page` were positioned between two sections that also had `break-before: page`, creating empty pages. By moving transitions inside their target sections, they now share the same page break, eliminating the whitespace.

The grammar fix uses regex to detect and patch missing periods before "Schwerpunkte:" as a final safeguard, since earlier build-time fixes could be undone by downstream post-processors.

https://claude.ai/code/session_01AwmQ5s2ZnNxivQBnDXCTc7