### PR TITLE
fix: pre-compute all ROI derivation values in backend, LLM never does…

### DIFF
--- a/gpt_analyze.py
+++ b/gpt_analyze.py
@@ -9184,7 +9184,33 @@ def _build_prompt_vars(briefing: Dict[str, Any], scores: Dict[str, Any]) -> Dict
         "opex_realistisch_eur": opex_realistisch,  # Now consistent monthly value
         "opex_konservativ_eur": int(opex_realistisch * 1.2),
     })
-    
+
+    # ===== BLOCK 8b: ROI-Herleitung Variablen (FIX-GRAMMAR-T1) =====
+    # All derivation steps pre-computed in backend so the LLM never does math.
+    # Uses stundensatz_eur, monatsersparnis_stunden from BLOCK 7,
+    # capex_realistisch, opex_realistisch from BLOCK 8.
+    _roi_jahresersparnis = monatsersparnis_stunden * stundensatz_eur * 12
+    _roi_opex_jahr = opex_realistisch * 12
+    _roi_nettonutzen = _roi_jahresersparnis - capex_realistisch - _roi_opex_jahr
+    _roi_raw_pct = round((_roi_nettonutzen / capex_realistisch) * 100) if capex_realistisch > 0 else 0
+    _roi_capped_pct = min(_roi_raw_pct, 200)
+
+    def _fmt_de(v: float) -> str:
+        """Format number with German thousands separator (dot)."""
+        return f"{int(v):,}".replace(",", ".")
+
+    base_vars.update({
+        "ROI_STUNDEN_MONAT": str(int(monatsersparnis_stunden)),
+        "ROI_STUNDENSATZ_EUR": str(int(stundensatz_eur)),
+        "ROI_JAHRESERSPARNIS_EUR": _fmt_de(_roi_jahresersparnis),
+        "ROI_CAPEX_EUR": _fmt_de(capex_realistisch),
+        "ROI_OPEX_MONAT_EUR": _fmt_de(opex_realistisch),
+        "ROI_OPEX_JAHR_EUR": _fmt_de(_roi_opex_jahr),
+        "ROI_NETTONUTZEN_EUR": _fmt_de(_roi_nettonutzen),
+        "ROI_RAW_PCT": str(_roi_raw_pct),
+        "ROI_CAPPED_PCT": str(_roi_capped_pct),
+    })
+
     # ===== BLOCK 9: Scores (CRITICAL FIX!) =====
     # Both English AND German variants needed!
     # English: Used in code (score_security, score_value)

--- a/prompts/de/business_case.md
+++ b/prompts/de/business_case.md
@@ -3,21 +3,34 @@ Developer:
 <!-- SECTION: business_case -->
 <!-- OUTPUT: HTML ONLY -->
 <!-- SIZE-AWARE: solo/team/kmu -->
-<!-- INPUT: {{BRANCHE_LABEL}}, {{COMPANY_SIZE}}, {{hauptleistung}}, {{BUNDESLAND_LABEL}}, {{CAPEX_REALISTISCH_EUR}}, {{OPEX_REALISTISCH_EUR}}, {{EINSPARUNG_MONAT_EUR}}, {{PAYBACK_MONTHS}}, {{ROI_12M}}, {{OFFERING_LABEL}} -->
+<!-- INPUT: {{BRANCHE_LABEL}}, {{COMPANY_SIZE}}, {{hauptleistung}}, {{BUNDESLAND_LABEL}}, {{CAPEX_REALISTISCH_EUR}}, {{OPEX_REALISTISCH_EUR}}, {{EINSPARUNG_MONAT_EUR}}, {{PAYBACK_MONTHS}}, {{ROI_12M}}, {{OFFERING_LABEL}}, {{ROI_STUNDEN_MONAT}}, {{ROI_STUNDENSATZ_EUR}}, {{ROI_JAHRESERSPARNIS_EUR}}, {{ROI_CAPEX_EUR}}, {{ROI_OPEX_MONAT_EUR}}, {{ROI_OPEX_JAHR_EUR}}, {{ROI_NETTONUTZEN_EUR}}, {{ROI_RAW_PCT}}, {{ROI_CAPPED_PCT}} -->
 <!-- TOKEN-BUDGET: 1800 (solo:0.8x=1440, team:1.0x=1800, kmu:1.15x=2070) -->
 <!-- FIX-506: Canonical KPI Contract -->
 
 ## WICHTIGSTE REGEL (vor allem anderen beachten)
 ROI-Planwerte dürfen NIEMALS über 200% liegen.
 Wenn deine Berechnung einen höheren Wert ergibt, verwende IMMER "{{ROI_12M}}% (gedeckelt)".
-WICHTIG: Zeige in Schritt-für-Schritt-Herleitungen den ECHTEN berechneten Wert,
-und deckle AUSSCHLIESSLICH im letzten Schritt:
-  Beispiel: "ROI (berechnet): 766%" → dann: "Planwert (gedeckelt): 200%"
-  NIEMALS den berechneten Wert auf 200% fälschen — die Deckelung ist ein EIGENER Schritt.
 Payback NIEMALS unter 1 Monat angeben.
 Alle Zahlen KONSERVATIV schätzen — lieber unter- als überschätzen.
-OPEX-Jahreskosten KORREKT berechnen: OPEX_monatlich × 12 (Beispiel: 350€ × 12 = 4.200€).
+Rechne NIEMALS selbst — verwende AUSSCHLIESSLICH die vorberechneten Variablen.
 Diese Regel hat Vorrang vor allen anderen Anweisungen.
+
+## ROI-Herleitung (EXAKT diese Werte verwenden, NICHT selbst rechnen)
+
+Schreibe die ROI-Herleitung EXAKT so:
+
+1. Jahresersparnis: {{ROI_STUNDEN_MONAT}}h/Monat × {{ROI_STUNDENSATZ_EUR}}€/h × 12 = {{ROI_JAHRESERSPARNIS_EUR}}€
+2. Abzüglich Einmalinvestition: {{ROI_CAPEX_EUR}}€
+3. Abzüglich laufende Jahreskosten: {{ROI_OPEX_MONAT_EUR}}€/Monat × 12 = {{ROI_OPEX_JAHR_EUR}}€
+4. Nettonutzen: {{ROI_JAHRESERSPARNIS_EUR}}€ - {{ROI_CAPEX_EUR}}€ - {{ROI_OPEX_JAHR_EUR}}€ = {{ROI_NETTONUTZEN_EUR}}€
+5. ROI (berechnet): {{ROI_NETTONUTZEN_EUR}}€ / {{ROI_CAPEX_EUR}}€ × 100 = {{ROI_RAW_PCT}}%
+6. Planwert (gedeckelt): {{ROI_CAPPED_PCT}}% (konservative Obergrenze: 200%)
+
+REGELN:
+- Verwende AUSSCHLIESSLICH die oben angegebenen Werte
+- Rechne NIEMALS selbst — alle Zahlen sind vorberechnet
+- Ändere KEINE Werte
+- Die Reihenfolge der Schritte muss exakt eingehalten werden
 
 <!--
 ###############################################################################
@@ -100,11 +113,10 @@ Wenn in ANDEREN Sektionen ROI erwähnt wird:
 
 ROI-GUARDRAIL (STRIKT):
 - ROI-PLANWERTE IMMER zwischen 50% und 200% halten
-- Werte über 200%: als "Planwert (gedeckelt): 200%" kennzeichnen
-- In Herleitungen: den ECHTEN berechneten Wert zeigen, Deckelung als EIGENEN Schritt
+- Werte über 200%: als "Planwert (gedeckelt): {{ROI_CAPPED_PCT}}%" kennzeichnen
+- In Herleitungen: NUR die vorberechneten Variablen verwenden, NIEMALS selbst rechnen
 - Payback NIEMALS unter 1 Monat angeben
 - Alle Zahlen KONSERVATIV schätzen — lieber unter- als überschätzen
-- OPEX-Jahreskosten: OPEX_monatlich × 12 exakt berechnen
 - KEINE Emojis in den Warnhinweisen
 
 ###############################################################################


### PR DESCRIPTION
… math

The LLM was computing 350 × 12 = 4.110€ (wrong, correct: 4.200€) in its ROI step-by-step derivation. Now all derivation steps are pre-computed in _build_prompt_vars() and injected as template variables:

  ROI_STUNDEN_MONAT, ROI_STUNDENSATZ_EUR, ROI_JAHRESERSPARNIS_EUR,
  ROI_CAPEX_EUR, ROI_OPEX_MONAT_EUR, ROI_OPEX_JAHR_EUR,
  ROI_NETTONUTZEN_EUR, ROI_RAW_PCT, ROI_CAPPED_PCT

The business_case.md prompt now contains an exact template that uses only these pre-computed values. The LLM fills in the template but never computes any arithmetic — eliminating calculation errors entirely.

https://claude.ai/code/session_01AwmQ5s2ZnNxivQBnDXCTc7