### PR TITLE
fix: pre-compute all financial values, LLM never does math

### DIFF
--- a/gpt_analyze.py
+++ b/gpt_analyze.py
@@ -13173,7 +13173,7 @@ def _generate_content_sections(briefing: Dict[str, Any], scores: Dict[str, Any])
         except Exception:
             pass
         # FIX-GRAMMAR-T1: Pass canonical OPEX for consistent net savings
-        _sofort_opex_monthly = float(sections.get("OPEX_REALISTISCH_EUR") or answers.get("OPEX_REALISTISCH_EUR") or 0)
+        _sofort_opex_monthly = float(sections.get("OPEX_REALISTISCH_EUR") or briefing.get("OPEX_REALISTISCH_EUR") or 0)
         sections["SOFORT_START_HTML"] = generate_sofort_start_html(
             hauptleistung=sofort_hauptleistung,
             branche=sofort_branche,

--- a/gpt_analyze.py
+++ b/gpt_analyze.py
@@ -9209,6 +9209,10 @@ def _build_prompt_vars(briefing: Dict[str, Any], scores: Dict[str, Any]) -> Dict
         "ROI_NETTONUTZEN_EUR": _fmt_de(_roi_nettonutzen),
         "ROI_RAW_PCT": str(_roi_raw_pct),
         "ROI_CAPPED_PCT": str(_roi_capped_pct),
+        # Sofort-Start / Netto-Ersparnis (consistent with BC)
+        "BRUTTO_ERSPARNIS_JAHR_EUR": _fmt_de(_roi_jahresersparnis),
+        "NETTO_ERSPARNIS_JAHR_EUR": _fmt_de(_roi_jahresersparnis - _roi_opex_jahr),
+        "TOOL_KOSTEN_JAHR_EUR": _fmt_de(_roi_opex_jahr),
     })
 
     # ===== BLOCK 9: Scores (CRITICAL FIX!) =====
@@ -13168,13 +13172,16 @@ def _generate_content_sections(briefing: Dict[str, Any], scores: Dict[str, Any])
             _sofort_rate, _ = get_hourly_rate(_sofort_size_norm)
         except Exception:
             pass
+        # FIX-GRAMMAR-T1: Pass canonical OPEX for consistent net savings
+        _sofort_opex_monthly = float(sections.get("OPEX_REALISTISCH_EUR") or answers.get("OPEX_REALISTISCH_EUR") or 0)
         sections["SOFORT_START_HTML"] = generate_sofort_start_html(
             hauptleistung=sofort_hauptleistung,
             branche=sofort_branche,
             company_size=sofort_size,
             zeitersparnis_prioritaet=sofort_zeit,
             stundensatz=_sofort_rate,
-            canon_hours_month=float(sections.get("CANON_HOURS_MONTH") or sections.get("monatsersparnis_stunden") or 36)  # FIX-B733-HOURS: fallback chain
+            canon_hours_month=float(sections.get("CANON_HOURS_MONTH") or sections.get("monatsersparnis_stunden") or 36),  # FIX-B733-HOURS: fallback chain
+            canon_opex_monthly=_sofort_opex_monthly,
         )
         log.info("[SOFORT-START] ✅ Generated Sofort-Start page for %s", sofort_branche[:30] if sofort_branche else "default")
     except Exception as e:

--- a/prompts/de/ki_stack_summary.md
+++ b/prompts/de/ki_stack_summary.md
@@ -76,12 +76,12 @@ INHALTLICHE STRUKTUR (5 feste Bausteine)
      3. Optimierung (Feintuning, Standards, Governance)
    - Jeder Schritt: 1–2 Sätze, klar verständlich und umsetzungsorientiert.
 
-4) 3 wichtigste Business-Case KPIs
-   - Realistische Werte aus dem Business Case:
-     - ROI-Rate (in %)
-     - Payback (Monate)
-     - Zeitersparnis/Monat (in Stunden oder Euro)
+4) 3 wichtigste Business-Case KPIs (NUR diese kanonischen Werte verwenden!)
+   - ROI-Rate: {{ROI_CAPPED_PCT}}% (EXAKT diesen Wert verwenden)
+   - Payback: {{PAYBACK_MONTHS}} Monate (EXAKT diesen Wert verwenden)
+   - Zeitersparnis: {{ROI_STUNDEN_MONAT}} Stunden/Monat (EXAKT diesen Wert verwenden)
    - Kurz kommentieren, was diese KPIs für die Entscheidungsebene bedeuten.
+   - KEINE eigenen KPI-Werte erfinden oder berechnen!
 
 5) Branch Badge + Risikoindikator
    - Branch-Label: {{BRANCH_SHORT_LABEL}}.

--- a/services/sofort_start_generator.py
+++ b/services/sofort_start_generator.py
@@ -1011,10 +1011,11 @@ def get_branche_key(branche: str) -> str:
     return "default"
 
 
-def calculate_yearly_savings(hours_per_week: int, hourly_rate: int = 80, company_size: str = "solo") -> dict:
+def calculate_yearly_savings(hours_per_week: int, hourly_rate: int = 80, company_size: str = "solo", canon_opex_monthly: float = 0) -> dict:
     """Berechnet Jahresersparnis (Idee #3 + #6).
 
     PLATIN+++ FIX 1.1/1.4: Uses canonical hourly rate and OPEX from single source of truth.
+    FIX-GRAMMAR-T1: canon_opex_monthly overrides size-based OPEX when provided.
     """
     # PLATIN+++ FIX 1.1: Use canonical rate if default was passed
     if hourly_rate == 80:
@@ -1027,7 +1028,11 @@ def calculate_yearly_savings(hours_per_week: int, hourly_rate: int = 80, company
     savings_per_year = hours_per_year * hourly_rate
 
     # PLATIN+++ FIX 1.4: Use canonical OPEX instead of hardcoded 240€
-    tool_costs_per_year = _get_canonical_opex_yearly(company_size)
+    # FIX-GRAMMAR-T1: Prefer explicit canonical OPEX over size-based default
+    if canon_opex_monthly > 0:
+        tool_costs_per_year = int(canon_opex_monthly * 12)
+    else:
+        tool_costs_per_year = _get_canonical_opex_yearly(company_size)
     net_savings = savings_per_year - tool_costs_per_year
 
     return {
@@ -1052,7 +1057,8 @@ def generate_sofort_start_html(
     company_size: str = "solo",
     zeitersparnis_prioritaet: str = "",
     stundensatz: int = 0,
-    canon_hours_month: float = 0  # FIX-B732: CANON hours for consistency
+    canon_hours_month: float = 0,  # FIX-B732: CANON hours for consistency
+    canon_opex_monthly: float = 0,  # FIX-GRAMMAR-T1: CANON OPEX for consistency
 ) -> str:
     """
     Generiert die SOFORT_START_HTML Section.
@@ -1098,7 +1104,7 @@ def generate_sofort_start_html(
         if _b732_hours_week != hours_per_week:
             hours_per_week = _b732_hours_week
 
-    savings = calculate_yearly_savings(hours_per_week, stundensatz, company_size)
+    savings = calculate_yearly_savings(hours_per_week, stundensatz, company_size, canon_opex_monthly=canon_opex_monthly)
     
     # Personalisiere den ersten Schritt
     erster_schritt = branche_data["erster_schritt"]


### PR DESCRIPTION
Three sources of LLM calculation errors fixed with one root cause:

1. ROI-Herleitung S.11-12: 350×12 = 4.110€ (correct: 4.200€) → Already fixed: 9 pre-computed ROI_* template variables in _build_prompt_vars(), business_case.md uses exact template

2. Sofort-Start S.5: Netto-Ersparnis 36.240€ (correct: 43.320€) → Pass canonical OPEX (350€/m) to sofort_start_generator via canon_opex_monthly param, ensuring tool_costs = 4.200€/yr matches BusinessCase. Added NETTO_ERSPARNIS_JAHR_EUR, BRUTTO_ERSPARNIS_JAHR_EUR, TOOL_KOSTEN_JAHR_EUR variables.

3. Starter-Kit S.12: 85h/7mo vs BusinessCase 36h/1.6mo → Injected canonical KPI values (ROI_CAPPED_PCT, PAYBACK_MONTHS, ROI_STUNDEN_MONAT) into ki_stack_summary.md prompt so LLM uses exact canonical values instead of hallucinating different KPIs.

https://claude.ai/code/session_01AwmQ5s2ZnNxivQBnDXCTc7