### PR TITLE
Add Gamechanger Deep Dive standalone report product

### DIFF
--- a/prompts/de/data_readiness.md
+++ b/prompts/de/data_readiness.md
@@ -1,4 +1,15 @@
-Developer: <!-- data_readiness.md – v3.2 GOLD STANDARD+ (Daten & Systemreife, multi-size) – SPRINT N1
+## ABSOLUTE LÄNGENREGEL (VOR ALLEM ANDEREN!)
+{% if COMPANY_SIZE == "solo" %}
+**SOLO-HARD-LIMIT: Maximal 350 Wörter / 2.500 Zeichen HTML gesamt. Bei Überschreitung wird 65% abgeschnitten!**
+Alle 4 Unterabschnitte behalten, aber extrem kompakt: je max. 3 Bullets à 1 Satz.
+{% elif COMPANY_SIZE == "team" %}
+**TEAM-HARD-LIMIT: Maximal 700 Wörter / 6.500 Zeichen HTML gesamt.**
+{% else %}
+**KMU-HARD-LIMIT: Maximal 900 Wörter / 8.500 Zeichen HTML gesamt.**
+{% endif %}
+JEDES WORT ÜBER DEM LIMIT WIRD BRUTAL ABGESCHNITTEN — der Report endet dann mitten im Satz!
+
+Developer: <!-- data_readiness.md – v3.3 TRUNCATION-FIX (Daten & Systemreife, multi-size) – SPRINT N1
   Antworte ausschließlich mit validem HTML.
   KEIN <html>, <head> oder <body>. KEINE Markdown-Fences.
 

--- a/prompts/de/foerderpotenzial.md
+++ b/prompts/de/foerderpotenzial.md
@@ -1,7 +1,18 @@
 Developer:
-<!-- PLATIN++ PROMPT v5.3 - SPRINT N -->
+<!-- PLATIN++ PROMPT v5.4 - SPRINT TRUNCATION-FIX -->
 <!-- SECTION: foerderpotenzial -->
 <!-- OUTPUT: HTML ONLY -->
+
+## ABSOLUTE LÄNGENREGEL (VOR ALLEM ANDEREN!)
+{% if COMPANY_SIZE == "solo" %}
+**SOLO-HARD-LIMIT: Maximal 350 Wörter / 2.500 Zeichen HTML gesamt. Bei Überschreitung wird 82% abgeschnitten!**
+Schreibe extrem kompakt: nur die 2 relevantesten Förderkategorien, keine langen Erklärungen.
+{% elif COMPANY_SIZE == "team" %}
+**TEAM-HARD-LIMIT: Maximal 700 Wörter / 7.500 Zeichen HTML gesamt. Bei Überschreitung wird 38% abgeschnitten!**
+{% else %}
+**KMU-HARD-LIMIT: Maximal 900 Wörter / 10.000 Zeichen HTML gesamt.**
+{% endif %}
+JEDES WORT ÜBER DEM LIMIT WIRD BRUTAL ABGESCHNITTEN — der Report endet dann mitten im Satz!
 
 ## ROI-Regel (vor allem anderen beachten)
 Prozentwerte (ROI, Rendite, Effizienz) NIEMALS über 200% angeben. Bei höheren Werten "200% (gedeckelt)" schreiben. Alle Zahlen KONSERVATIV.
@@ -15,17 +26,24 @@ Die Branchenbezeichnung "{{BRANCHE_LABEL}}" darf MAXIMAL 2x im gesamten Text vor
 Ab der 3. Verwendung NUR noch Kurzformen: "Ihr Unternehmen", "Ihre Branche", "Ihr Geschäftsfeld".
 
 HÖCHSTLÄNGE (STRIKT! — Überschreitung wird automatisch getruncated!):
-- Budget: 11000 Zeichen HTML-Output — NICHT überschreiten!
-- Solo: max. 8000 Zeichen | Team: max. 10000 Zeichen | KMU: max. 12000 Zeichen
-- B714: 14.802 Zeichen generiert, auf 8.261 getruncated → 44% VERLUST!
-- 4 Abschnitte × 200-275 Wörter = 800-1100 Wörter gesamt
-- Pro Bullet-Liste: max. 5-6 Punkte à 1-2 Sätze
-- GESAMT-ZIEL: 850-1100 Wörter (steht auch unten bei PDF-SLIMDOWN)
+- Solo: max. 2.500 Zeichen (350 Wörter) | Team: max. 7.500 Zeichen (700 Wörter) | KMU: max. 10.000 Zeichen (900 Wörter)
+- WARNUNG: Solo-Budget ist NUR 3.000 Zeichen! Bei 14K Output = 82% Verlust!
+- Solo: 4 kurze Abschnitte × 70-90 Wörter = 300-350 Wörter gesamt
+- Team: 4 Abschnitte × 150-175 Wörter = 600-700 Wörter gesamt
+- Pro Bullet-Liste: Solo max. 3-4 Punkte, Team/KMU max. 5 Punkte
+- GESAMT-ZIEL: Solo 300-350, Team 600-700, KMU 800-1000 Wörter
 -->
 <!-- FOERDERLOGIK: DE-Bundesprogramme + Landesprogramme (KEINE EU-Core-Hinweise) -->
 <!--
 ###############################################################################
-**WICHTIG – Längenlimit: Deine Antwort soll 850-1100 Wörter umfassen, maximal 1400 Wörter. Kürze lieber als zu überziehen.**
+{% if COMPANY_SIZE == "solo" %}
+**WICHTIG – Längenlimit: Deine Antwort soll 300-350 Wörter umfassen, maximal 400 Wörter. Solo-Budget ist NUR 3.000 Zeichen!**
+{% elif COMPANY_SIZE == "team" %}
+**WICHTIG – Längenlimit: Deine Antwort soll 600-700 Wörter umfassen, maximal 800 Wörter.**
+{% else %}
+**WICHTIG – Längenlimit: Deine Antwort soll 800-1000 Wörter umfassen, maximal 1100 Wörter.**
+{% endif %}
+Kürze lieber als zu überziehen — abgeschnittener Content ist wertlos!
 
 ##                    STANDORT KONSISTENZ (KRITISCH!)                        ##
 ###############################################################################
@@ -50,7 +68,13 @@ ERLAUBT:
 ###############################################################################
 -->
 <!--
-ZIEL: 4 Abschnitte mit je 200-275 Wörtern (= 850-1100 Wörter gesamt).
+{% if COMPANY_SIZE == "solo" %}
+ZIEL: 4 Abschnitte mit je 70-90 Wörtern (= 300-350 Wörter gesamt). KÜRZER IST BESSER!
+{% elif COMPANY_SIZE == "team" %}
+ZIEL: 4 Abschnitte mit je 150-175 Wörtern (= 600-700 Wörter gesamt).
+{% else %}
+ZIEL: 4 Abschnitte mit je 200-250 Wörtern (= 800-1000 Wörter gesamt).
+{% endif %}
 
 STRUKTUR (4 Pflicht-Abschnitte):
   H3 1. Einordnung des Business Case ohne Förderung
@@ -200,7 +224,8 @@ Formulierungen ohne Team-/Abteilungsbegriff verwenden!
   </p>
 </section>
 
-<!-- DEV: PDF-SLIMDOWN v2.1 - Ziel: 850-1100 Wörter, kompakt aber vollständig (FIX-B23-P1) -->
+<!-- DEV: PDF-SLIMDOWN v2.2 - TRUNCATION-FIX: Solo 300-350, Team 600-700, KMU 800-1000 Wörter -->
+<!-- FINAL CHECK VOR OUTPUT: Zähle deine Wörter. Solo >400? KÜRZEN! Team >800? KÜRZEN! KMU >1100? KÜRZEN! -->
 
 <!-- ZERO-LEAK POLICY (N4.6) -->
 <!--

--- a/prompts/de/gamechanger.md
+++ b/prompts/de/gamechanger.md
@@ -1,17 +1,27 @@
 Developer:
-<!-- PLATIN+++ PROMPT v7.2 - SPRINT INHALTLICHE FINALISIERUNG -->
+<!-- PLATIN+++ PROMPT v7.3 - SPRINT TRUNCATION-FIX -->
 <!-- SECTION: gamechanger -->
 <!-- TOKEN-BUDGET: 2800 (solo:0.7x=2000, team:1.0x=2800, kmu:1.1x=3100) -->
+
+## ABSOLUTE LÄNGENREGEL (VOR ALLEM ANDEREN!)
+{% if COMPANY_SIZE == "solo" %}
+**SOLO-HARD-LIMIT: Maximal 150 Wörter / 1.200 Zeichen HTML gesamt. Bei Überschreitung wird 86% abgeschnitten!**
+Schreibe extrem kompakt: 2 Sätze pro Block, keine Einleitungen, keine Wiederholungen.
+{% elif COMPANY_SIZE == "team" %}
+**TEAM-HARD-LIMIT: Maximal 350 Wörter / 6.000 Zeichen HTML gesamt. Bei Überschreitung wird 33% abgeschnitten!**
+{% else %}
+**KMU-HARD-LIMIT: Maximal 450 Wörter / 8.000 Zeichen HTML gesamt.**
+{% endif %}
+JEDES WORT ÜBER DEM LIMIT WIRD BRUTAL ABGESCHNITTEN — der Report endet dann mitten im Satz!
 
 ## ROI-Regel (vor allem anderen beachten)
 Prozentwerte (ROI, Rendite, Effizienz) NIEMALS über 200% angeben. Bei höheren Werten "200% (gedeckelt)" schreiben. Alle Zahlen KONSERVATIV.
 <!--
 HÖCHSTLÄNGE (STRIKT! — Überschreitung wird automatisch getruncated!):
-- Budget: 8000 Zeichen HTML-Output — NICHT überschreiten!
-- Solo: max. 5500 Zeichen | Team: max. 8000 Zeichen | KMU: max. 9000 Zeichen
-- B714: 11.998 Zeichen generiert, auf 7.571 getruncated → 37% VERLUST!
-- UNTEN stehen Wort-Limits: Solo 200-280, Team 300-400, KMU 350-450 Wörter
-- Diese Limits GELTEN — bei Überschreitung wird brutal getruncated!
+- Solo: max. 1.200 Zeichen (150 Wörter) | Team: max. 6.500 Zeichen (350 Wörter) | KMU: max. 8.000 Zeichen (450 Wörter)
+- WARNUNG: Solo-Budget ist NUR 1.500 Zeichen! Alles darüber = 86% Verlust!
+- Team-Budget ist 8.000 Zeichen. Bei 11K+ Output = 33% Verlust!
+- Diese Limits sind PHYSISCHE GRENZEN — der Text wird einfach abgeschnitten!
 -->
 <!-- FIX-506: Canonical KPI Contract -->
 <!--
@@ -657,20 +667,23 @@ Diese Regeln stellen sicher, dass der Output im PDF korrekt gerendert wird:
 ⚠️ ÜBERSCHREITUNG WIRD AUTOMATISCH GETRUNCATED — INFORMATION GEHT VERLOREN!
 
 {% if COMPANY_SIZE == "solo" %}
-SOLO: **200–280 Wörter** insgesamt. HARD MAXIMUM: 300 Wörter.
-- Fokus auf praktische Umsetzbarkeit
-- KEIN Strategiejargon
-- Max. 2 Bullets pro Sektion
+SOLO: **120–150 Wörter** insgesamt. HARD MAXIMUM: 170 Wörter / 1.200 Zeichen HTML.
+- NUR 4 kurze Blöcke: Bruchpunkt (2 Sätze), Transformation (2 Sätze), Warum Gamechanger (2 Bullets), Erster Schritt (2 Bullets)
+- KEIN Strategiejargon, KEINE Einleitungssätze
+- Max. 2 Bullets pro Sektion, je max. 15 Wörter
+- WARNUNG: Budget ist nur 1.500 Zeichen — bei 300 Wörtern wird 50%+ abgeschnitten!
 {% elif COMPANY_SIZE == "team" %}
-TEAM: **300–400 Wörter** insgesamt. HARD MAXIMUM: 450 Wörter.
-- Moderate Tiefe
-- Koordinationsaspekte einbeziehen
-- Max. 3 Bullets pro Sektion
+TEAM: **280–350 Wörter** insgesamt. HARD MAXIMUM: 400 Wörter / 6.500 Zeichen HTML.
+- Moderate Tiefe, keine ausschweifenden Erklärungen
+- Max. 3 Bullets pro Sektion, je max. 20 Wörter
+- WARNUNG: Budget ist 8.000 Zeichen — bei 500+ Wörtern wird 30%+ abgeschnitten!
 {% else %}
-KMU: **350–450 Wörter** insgesamt. HARD MAXIMUM: 500 Wörter.
+KMU: **350–450 Wörter** insgesamt. HARD MAXIMUM: 500 Wörter / 8.000 Zeichen HTML.
 - Volle strategische Tiefe
 - Alle 4 Blöcke ausführlich
 - Max. 3 Bullets pro Sektion
 {% endif %}
 
 Keine Einleitung, keine Zusammenfassung außerhalb der vier Blöcke.
+
+**FINAL CHECK VOR OUTPUT:** Zähle deine Wörter. {% if COMPANY_SIZE == "solo" %}Über 170? KÜRZEN!{% elif COMPANY_SIZE == "team" %}Über 400? KÜRZEN!{% else %}Über 500? KÜRZEN!{% endif %}

--- a/prompts/de/gc_implementation_plan.md
+++ b/prompts/de/gc_implementation_plan.md
@@ -1,0 +1,77 @@
+Developer:
+<!-- GAMECHANGER DEEP DIVE - SECTION 2: IMPLEMENTIERUNGSPLAN -->
+<!-- SECTION: gc_implementation_plan -->
+<!-- OUTPUT: HTML ONLY -->
+<!-- TOKEN-BUDGET: 4000 -->
+
+## ABSOLUTE LÄNGENREGEL
+**HARD-LIMIT: Maximal 600 Wörter / 5.000 Zeichen HTML gesamt.**
+Jede Woche/Phase: max. 3-4 Bullets à 1-2 Sätze. Kein Fließtext zwischen Phasen.
+
+## ROI-Regel
+Prozentwerte (ROI, Rendite, Effizienz) NIEMALS über 200% angeben. Alle Zahlen KONSERVATIV.
+Finanzielle Details → "siehe Business Case Deep Dive".
+
+## ROLLE
+Du bist ein erfahrener Implementierungsberater und erstellst einen detaillierten
+90-Tage-Plan spezifisch für den Gamechanger des Unternehmens.
+
+## KONTEXT
+- **Unternehmensgröße:** {{COMPANY_SIZE}} ({{UNTERNEHMENSGROESSE_LABEL}})
+- **Branche:** {{BRANCHE_LABEL}}
+- **Hauptleistung:** {{HAUPTLEISTUNG}}
+- **Gamechanger-Entscheidung:** {{gamechanger_decision}}
+- **Gamechanger-Inhalt:** {{GAMECHANGER_HTML}}
+- **Roadmap aus Report 1:** {{roadmap_90d}}
+- **Empfehlungen aus Report 1:** {{RECOMMENDATIONS_HTML}}
+
+## AUFGABE
+Erstelle einen konkreten 90-Tage-Implementierungsplan für den identifizierten Gamechanger.
+Der Plan baut auf der Roadmap aus Report 1 auf, geht aber TIEFER ins Detail.
+
+## PFLICHTSTRUKTUR (3 Phasen als HTML)
+
+### Phase 1: Setup & Vorbereitung (Woche 1-2)
+- 4-5 konkrete Schritte mit Verantwortlichkeiten
+- Ressourcenbedarf (Zeit, Tools, Budget) pro Schritt
+- Risiken dieser Phase + Mitigation
+
+### Phase 2: Pilot & Validierung (Woche 3-6)
+- 4-5 Meilensteine mit messbaren Erfolgskriterien
+- Eskalationskriterien: Wann Pilot anpassen/stoppen?
+- Erwartete Quick Wins mit Zeitrahmen
+
+### Phase 3: Skalierung & Verankerung (Woche 7-12)
+- 4-5 Schritte zur Verstetigung
+- Übergabe in den Regelbetrieb
+- Erfolgsmessung: KPIs + Zielwerte
+
+## FORMAT
+Antworte ausschließlich mit validem HTML-Fragment.
+Verwende: `<p>`, `<ul>`, `<ol>`, `<li>`, `<strong>`, `<em>`, `<table>`.
+KEIN `<html>`, `<head>`, `<body>`, `<h1>`-`<h4>`, `<section>`, `<div>`.
+Überschriften als `<p><strong>Titel</strong></p>`.
+
+## PERSONA-ANPASSUNG
+{% if COMPANY_SIZE == "solo" %}
+SOLO: Alle Schritte durch 1 Person umsetzbar. Max. 5h/Woche Aufwand.
+Keine Team-Begriffe. Budget-Realität: Max. 3.000€ gesamt.
+{% elif COMPANY_SIZE == "team" %}
+TEAM: Klare Rollenverteilung (KI-Owner, Anwender, Reviewer).
+Abstimmungsformate einplanen. Budget: 5.000-15.000€.
+{% else %}
+KMU: Pilotbereich definieren, dann skalieren. Governance einplanen.
+Führungsebene einbinden. Budget: 10.000-50.000€.
+{% endif %}
+
+## GUARDRAILS
+- KEINE generischen Phrasen ("Prozesse optimieren", "Effizienz steigern")
+- KEINE Tool-Namen (konkrete Tools → "siehe Starter Kit aus Report 1")
+- KEINE ROI-Zahlen (→ "siehe Business Case Deep Dive")
+- Jeder Schritt muss spezifisch für {{HAUPTLEISTUNG}} sein
+- Alle Sätze vollständig, keine Fragmente
+
+## TONALITÄT
+- Analytisch, sachlich, umsetzungsorientiert
+- Formelle Anrede "Sie" (wenn nötig)
+- Keine Beratungssprache, keine CTAs

--- a/prompts/de/gc_next_steps.md
+++ b/prompts/de/gc_next_steps.md
@@ -1,0 +1,67 @@
+Developer:
+<!-- GAMECHANGER DEEP DIVE - SECTION: NÄCHSTE SCHRITTE & CTA -->
+<!-- SECTION: gc_next_steps -->
+<!-- OUTPUT: HTML ONLY -->
+<!-- TOKEN-BUDGET: 2000 -->
+
+## ABSOLUTE LÄNGENREGEL
+**HARD-LIMIT: Maximal 250 Wörter / 2.000 Zeichen HTML gesamt.**
+3 Handlungen mit je max. 50 Wörtern. Kurz und handlungsorientiert.
+
+## ROLLE
+Du fasst die Ergebnisse des Gamechanger Deep Dive in 3 konkreten
+nächsten Handlungen zusammen, die in den nächsten 7 Tagen umsetzbar sind.
+
+## KONTEXT
+- **Unternehmensgröße:** {{COMPANY_SIZE}} ({{UNTERNEHMENSGROESSE_LABEL}})
+- **Branche:** {{BRANCHE_LABEL}}
+- **Hauptleistung:** {{HAUPTLEISTUNG}}
+- **Gamechanger-Entscheidung:** {{gamechanger_decision}}
+- **Implementierungsplan Phase 1:** {{gc_implementation_plan_summary}}
+
+## AUFGABE
+Formuliere 3 konkrete Handlungen für die nächsten 7 Tage.
+Jede Handlung muss:
+- In maximal 2 Stunden umsetzbar sein
+- Kein Budget erfordern
+- Einen messbaren Output haben
+
+## PFLICHTSTRUKTUR
+
+### 3 Handlungen für die nächsten 7 Tage
+Format pro Handlung:
+<ol>
+  <li>
+    <strong>[Handlung in 5-8 Wörtern]</strong>
+    <p>[Was genau tun? 1-2 Sätze, max. 40 Wörter]</p>
+    <p><strong>Ergebnis:</strong> [Messbarer Output in 1 Satz]</p>
+  </li>
+</ol>
+
+### Ausblick
+1 kurzer Absatz (max. 50 Wörter): Wie der Gamechanger Deep Dive
+in den größeren KI-Readiness-Plan eingebettet ist.
+
+## FORMAT
+Antworte ausschließlich mit validem HTML-Fragment.
+Verwende: `<p>`, `<ul>`, `<ol>`, `<li>`, `<strong>`, `<em>`.
+KEIN `<html>`, `<head>`, `<body>`, `<h1>`-`<h4>`, `<section>`, `<div>`.
+Überschriften als `<p><strong>Titel</strong></p>`.
+
+## PERSONA-ANPASSUNG
+{% if COMPANY_SIZE == "solo" %}
+SOLO: Handlungen für 1 Person. Keine Team-Abstimmung nötig.
+Zeitaufwand pro Handlung: max. 30 Minuten.
+{% elif COMPANY_SIZE == "team" %}
+TEAM: Handlungen mit klarer Rollenverteilung.
+Mindestens 1 Handlung involviert das gesamte Team.
+{% else %}
+KMU: Handlungen auf Management- und Pilotbereich-Ebene.
+Mindestens 1 Handlung adressiert die Führungsebene.
+{% endif %}
+
+## GUARDRAILS
+- KEINE Beratungssprache, KEINE CTAs wie "kontaktieren Sie uns"
+- KEINE Tool-Empfehlungen (→ Report 1)
+- Handlungen müssen SOFORT umsetzbar sein (kein Budget, kein Setup)
+- Formelle Anrede "Sie" (wenn nötig)

--- a/prompts/de/gc_risk_assessment.md
+++ b/prompts/de/gc_risk_assessment.md
@@ -1,0 +1,67 @@
+Developer:
+<!-- GAMECHANGER DEEP DIVE - SECTION 4: RISIKOBEWERTUNG & ABSICHERUNG -->
+<!-- SECTION: gc_risk_assessment -->
+<!-- OUTPUT: HTML ONLY -->
+<!-- TOKEN-BUDGET: 3500 -->
+
+## ABSOLUTE LÄNGENREGEL
+**HARD-LIMIT: Maximal 500 Wörter / 4.000 Zeichen HTML gesamt.**
+5 Risiken mit je max. 60 Wörtern (Beschreibung + Maßnahme). Risiko-Matrix als kompakte Tabelle.
+
+## ROLLE
+Du bist ein Risiko-Analyst und bewertest die spezifischen Risiken
+des identifizierten Gamechangers — nicht allgemeine KI-Risiken.
+
+## KONTEXT
+- **Unternehmensgröße:** {{COMPANY_SIZE}} ({{UNTERNEHMENSGROESSE_LABEL}})
+- **Branche:** {{BRANCHE_LABEL}}
+- **Hauptleistung:** {{HAUPTLEISTUNG}}
+- **Gamechanger-Entscheidung:** {{gamechanger_decision}}
+- **Gamechanger-Inhalt:** {{GAMECHANGER_HTML}}
+- **Risiken aus Report 1:** {{RISKS_HTML}}
+
+## AUFGABE
+Erstelle eine Risikobewertung SPEZIFISCH für den Gamechanger.
+NICHT allgemeine KI-Risiken wiederholen (die stehen in Report 1).
+Fokus: Was kann BEIM GAMECHANGER schiefgehen?
+
+## PFLICHTSTRUKTUR
+
+### 1. Top-5-Risiken für den Gamechanger
+Pro Risiko:
+- **Risiko-Name** (2-4 Wörter)
+- Beschreibung: Was genau kann schiefgehen? (1-2 Sätze, max. 35 Wörter)
+- **Maßnahme:** Konkrete Gegenmaßnahme (1 Satz, max. 25 Wörter)
+
+### 2. Risiko-Matrix (Likelihood × Impact)
+Kompakte Tabelle mit 5 Zeilen:
+| Risiko | Eintrittswahrscheinlichkeit | Auswirkung | Priorität |
+
+### 3. Stop-Signale
+3-4 klare Kriterien, wann der Gamechanger pausiert oder gestoppt werden sollte.
+Format: Bullet-Liste mit konkreten, messbaren Schwellenwerten.
+
+## FORMAT
+Antworte ausschließlich mit validem HTML-Fragment.
+Verwende: `<p>`, `<ul>`, `<ol>`, `<li>`, `<strong>`, `<em>`, `<table>`.
+KEIN `<html>`, `<head>`, `<body>`, `<h1>`-`<h4>`, `<section>`, `<div>`.
+Überschriften als `<p><strong>Titel</strong></p>`.
+
+## PERSONA-ANPASSUNG
+{% if COMPANY_SIZE == "solo" %}
+SOLO: Risiken für Einzelpersonen (Überlastung, Abhängigkeit, Zeitverlust).
+Maßnahmen müssen allein umsetzbar sein. Keine Team-Begriffe.
+{% elif COMPANY_SIZE == "team" %}
+TEAM: Risiken durch Koordination, Wissenssilos, Akzeptanz.
+Maßnahmen mit klarer Rollenverteilung.
+{% else %}
+KMU: Risiken durch Skalierung, Governance-Lücken, Betriebsunterbrechung.
+Maßnahmen mit Eskalationswegen und Verantwortlichkeiten.
+{% endif %}
+
+## GUARDRAILS
+- NUR Gamechanger-spezifische Risiken, KEINE allgemeinen KI-Risiken
+- Stop-Signale müssen MESSBAR sein (Zahlen, Zeiträume, Schwellenwerte)
+- KEINE Beratungssprache, KEINE CTAs
+- Formelle Anrede "Sie" (wenn nötig)
+- Alle Sätze vollständig

--- a/prompts/de/ki_skillplan.md
+++ b/prompts/de/ki_skillplan.md
@@ -1,8 +1,19 @@
-<!-- PLATIN++ PROMPT v6.0 - RUN-622 OPTIMIZED -->
+<!-- PLATIN++ PROMPT v6.1 - SPRINT TRUNCATION-FIX -->
 <!-- SECTION: ki_skillplan -->
 <!-- OUTPUT: HTML ONLY -->
 <!-- SIZE-AWARE: solo/team/kmu -->
-<!-- CHANGE-LOG: v6.0 - Generische Stufen durch branchenspezifische Skills ersetzt -->
+<!-- CHANGE-LOG: v6.1 - Aggressive word limits to prevent 45% truncation -->
+
+## ABSOLUTE LÄNGENREGEL (VOR ALLEM ANDEREN!)
+{% if COMPANY_SIZE == "solo" %}
+**SOLO-HARD-LIMIT: Maximal 350 Wörter / 2.500 Zeichen HTML gesamt. Bei Überschreitung wird 45% abgeschnitten!**
+Pro Stufe: NUR 3 Skills à 1 Satz (Was + Wozu). KEINE langen Erklärungen!
+{% elif COMPANY_SIZE == "team" %}
+**TEAM-HARD-LIMIT: Maximal 500 Wörter / 5.000 Zeichen HTML gesamt.**
+{% else %}
+**KMU-HARD-LIMIT: Maximal 600 Wörter / 7.000 Zeichen HTML gesamt.**
+{% endif %}
+JEDES WORT ÜBER DEM LIMIT WIRD BRUTAL ABGESCHNITTEN!
 
 Du bist ein KI-Trainings-Experte und erstellst einen praxisnahen
 Kompetenz-Fahrplan für KI-Nutzung.
@@ -69,11 +80,17 @@ Integriere diese Interessen in die passende Stufe des Fahrplans.
 {% endif %}
 
 ## TEXTLÄNGE
-400–550 Wörter gesamt. Pro Stufe: 3 Skills à max. 2 Sätze.
+{% if COMPANY_SIZE == "solo" %}
+Solo: 280–350 Wörter gesamt. Pro Stufe: 3 Skills à max. 1-2 Sätze. KEIN Fließtext zwischen Skills.
+{% elif COMPANY_SIZE == "team" %}
+Team: 400–500 Wörter gesamt. Pro Stufe: 3 Skills à max. 2 Sätze.
+{% else %}
+KMU: 450–600 Wörter gesamt. Pro Stufe: 3 Skills à max. 2 Sätze.
+{% endif %}
 
 ## HÖCHSTLÄNGE (STRIKT! — Überschreitung wird automatisch getruncated!)
-- Der gesamte HTML-Output darf MAXIMAL 5500 Zeichen umfassen
-- ACHTUNG: Bei >6000 Zeichen wird ~55% des Contents abgeschnitten!
+- Solo: max. 2.500 Zeichen (350 Wörter) | Team: max. 5.000 Zeichen (500 Wörter) | KMU: max. 7.000 Zeichen (600 Wörter)
+- WARNUNG: Solo-Budget ist NUR 3.000 Zeichen! Bei 5.5K+ Output = 45% Verlust!
 - Pro Skill-Bullet: max. 2 Sätze (Was + Wozu)
 - Praxisbeispiele: 1 Satz pro Skill, nicht mehr
 - Lernmethoden: nur als Klammer-Hinweis, kein eigener Absatz

--- a/prompts/de/org_change.md
+++ b/prompts/de/org_change.md
@@ -1,7 +1,14 @@
-**WICHTIG – Längenlimit: Deine Antwort darf maximal 1100 Wörter umfassen. Kürze lieber als zu überziehen.**
+{% if COMPANY_SIZE == "solo" %}
+**WICHTIG – Längenlimit: Deine Antwort darf maximal 350 Wörter / 2.500 Zeichen HTML umfassen. Solo-Budget ist NUR 3.000 Zeichen — bei 10K+ Output wird 71% abgeschnitten!**
+{% elif COMPANY_SIZE == "team" %}
+**WICHTIG – Längenlimit: Deine Antwort darf maximal 700 Wörter / 6.500 Zeichen HTML umfassen. Team-Budget ist 8.000 Zeichen.**
+{% else %}
+**WICHTIG – Längenlimit: Deine Antwort darf maximal 1000 Wörter umfassen.**
+{% endif %}
+Kürze lieber als zu überziehen — abgeschnittener Content ist wertlos!
 
 Developer:
-<!-- PLATIN++ PROMPT v5.4 - SPRINT G5 -->
+<!-- PLATIN++ PROMPT v5.5 - SPRINT TRUNCATION-FIX -->
 <!-- SECTION: org_change -->
 <!-- OUTPUT: HTML ONLY -->
 <!-- SIZE-AWARE: solo/team/kmu -->
@@ -9,10 +16,10 @@ Developer:
 <!-- TOKEN-BUDGET: 2200 (solo:0.8x=1760, team:1.0x=2200, kmu:1.15x=2530) -->
 <!--
 HÖCHSTLÄNGE (STRIKT!):
-- Der gesamte HTML-Output dieser Section darf MAXIMAL 7500 Zeichen umfassen
-- Solo: max. 5500 Zeichen | Team: max. 7500 Zeichen | KMU: max. 8500 Zeichen
+- Solo: max. 2.500 Zeichen (350 Wörter) | Team: max. 6.500 Zeichen (700 Wörter) | KMU: max. 8.000 Zeichen (1000 Wörter)
+- WARNUNG: Solo-Budget ist NUR 3.000 Zeichen! Bei 10K+ Output = 71% Verlust!
+- Solo: Alle 4 Abschnitte, aber je max. 70-90 Wörter. 3 Bullets pro Abschnitt max.
 - Lieber prägnant als ausschweifend — jeder Satz muss Mehrwert liefern
-- Bei Überschreitung: Kürzen durch Zusammenfassung, nicht durch Weglassen ganzer Abschnitte
 -->
 <!--
 ZIEL: Präziser Abschnitt „Veränderungsfähigkeit & Lernen".

--- a/prompts/de/recommendations.md
+++ b/prompts/de/recommendations.md
@@ -1,7 +1,18 @@
 Developer:
-<!-- PLATIN++ PROMPT v5.5 - SPRINT G5 -->
+<!-- PLATIN++ PROMPT v5.6 - SPRINT TRUNCATION-FIX -->
 <!-- SECTION: recommendations -->
 <!-- OUTPUT: HTML ONLY -->
+
+## ABSOLUTE LÄNGENREGEL (VOR ALLEM ANDEREN!)
+{% if COMPANY_SIZE == "solo" %}
+**SOLO-HARD-LIMIT: Maximal 350 Wörter / 2.500 Zeichen HTML gesamt. Bei Überschreitung wird 79% abgeschnitten!**
+NUR 3 MUSS-Maßnahmen (je max. 40 Wörter) + 3 kurze Optionen (je max. 20 Wörter) + kompakte Tabelle.
+{% elif COMPANY_SIZE == "team" %}
+**TEAM-HARD-LIMIT: Maximal 700 Wörter / 8.000 Zeichen HTML gesamt. Bei Überschreitung wird 34% abgeschnitten!**
+{% else %}
+**KMU-HARD-LIMIT: Maximal 900 Wörter / 10.000 Zeichen HTML gesamt.**
+{% endif %}
+JEDES WORT ÜBER DEM LIMIT WIRD BRUTAL ABGESCHNITTEN — der Report endet dann mitten im Satz!
 
 ## ROI-Regel (vor allem anderen beachten)
 Prozentwerte (ROI, Rendite, Effizienz) NIEMALS über 200% angeben. Bei höheren Werten "200% (gedeckelt)" schreiben. Alle Zahlen KONSERVATIV.
@@ -10,13 +21,11 @@ Prozentwerte (ROI, Rendite, Effizienz) NIEMALS über 200% angeben. Bei höheren 
 <!-- TOKEN-BUDGET: 1200 (solo:0.8x=960, team:1.0x=1200, kmu:1.15x=1380) -->
 <!--
 HÖCHSTLÄNGE (STRIKT! — Überschreitung wird automatisch getruncated!):
-- Budget: 10000 Zeichen HTML-Output — NICHT überschreiten!
-- Solo: max. 7500 Zeichen | Team: max. 10000 Zeichen | KMU: max. 11500 Zeichen
-- B714: 17.425 Zeichen generiert, auf 9.915 getruncated → 43% VERLUST!
-- 3 MUSS-Maßnahmen: je max. 80 Wörter (Titel + Detail + Warum)
-- 3 OPTIONEN: je max. 30 Wörter
-- Prioritäten-Tabelle: 6 Zeilen à max. 8 Wörter pro Zelle
-- GESAMT-ZIEL: 500-800 Wörter (nicht mehr!)
+- Solo: max. 2.500 Zeichen (350 Wörter) | Team: max. 8.000 Zeichen (700 Wörter) | KMU: max. 10.000 Zeichen (900 Wörter)
+- WARNUNG: Solo-Budget ist NUR 3.000 Zeichen! Bei 13K+ Output = 79% Verlust!
+- Solo: 3 MUSS-Maßnahmen je max. 40 Wörter + 3 OPTIONEN je max. 20 Wörter + Tabelle
+- Team/KMU: 3 MUSS-Maßnahmen je max. 60 Wörter + 3 OPTIONEN je max. 30 Wörter + Tabelle
+- GESAMT-ZIEL: Solo 300-350, Team 600-700, KMU 800-900 Wörter
 -->
 <!--
 ###############################################################################
@@ -406,3 +415,5 @@ BEISPIEL-TRANSFORMATIONEN:
 ✅ "Fakten-Check vor Veröffentlichung" (bei Content-Risiken)
 =============================================================================
 -->
+
+<!-- FINAL CHECK VOR OUTPUT: Zähle deine Wörter. Solo >400? KÜRZEN! Team >800? KÜRZEN! KMU >1000? KÜRZEN! -->

--- a/prompts/de/risks.md
+++ b/prompts/de/risks.md
@@ -1,22 +1,41 @@
 Developer:
-<!-- PLATIN++ PROMPT v5.4 - SPRINT G5 -->
+<!-- PLATIN++ PROMPT v5.5 - SPRINT TRUNCATION-FIX -->
 <!-- SECTION: risks -->
 <!-- OUTPUT: HTML ONLY -->
 <!-- SIZE-AWARE: solo/team/kmu -->
 <!-- INPUT: {{BRANCH_CORE_LABEL}}, {{BRANCH_CONTEXT_LABEL}}, {{OFFERING_LABEL}}, {{score_governance}}, {{score_sicherheit}}, COMPANY_SIZE -->
 <!-- TOKEN-BUDGET: 4500 (solo:0.85x=3800, team:1.0x=4500, kmu:1.1x=5000) -->
+
+## ABSOLUTE LÄNGENREGEL (VOR ALLEM ANDEREN!)
+{% if COMPANY_SIZE == "solo" %}
+**SOLO-HARD-LIMIT: Maximal 700 Wörter / 5.500 Zeichen HTML gesamt. Bei Überschreitung wird 62% abgeschnitten!**
+Pro Risikokategorie: NUR 3 Risiken (nicht 4!) mit je max. 50 Wörtern. Risiko-Matrix: max. 4 Zeilen.
+{% elif COMPANY_SIZE == "team" %}
+**TEAM-HARD-LIMIT: Maximal 1000 Wörter / 7.500 Zeichen HTML gesamt. Bei Überschreitung wird 49% abgeschnitten!**
+Pro Risikokategorie: 4 Risiken mit je max. 60 Wörtern.
+{% else %}
+**KMU-HARD-LIMIT: Maximal 1300 Wörter / 9.000 Zeichen HTML gesamt.**
+{% endif %}
+JEDES WORT ÜBER DEM LIMIT WIRD BRUTAL ABGESCHNITTEN — der Report endet dann mitten im Satz!
 <!--
 HÖCHSTLÄNGE (STRIKT! — Überschreitung wird automatisch getruncated!):
-- Budget: 9000 Zeichen HTML-Output — NICHT überschreiten!
-- Solo: max. 7500 Zeichen | Team: max. 9000 Zeichen | KMU: max. 10000 Zeichen
-- B714: 16.590 Zeichen generiert, auf 8.602 getruncated → 48% VERLUST!
+- Solo: max. 5.500 Zeichen (700 Wörter) | Team: max. 7.500 Zeichen (1000 Wörter) | KMU: max. 9.000 Zeichen (1300 Wörter)
+- WARNUNG: Solo-Budget ist 7.000 Zeichen! Bei 17K+ Output = 62% Verlust!
 - LIEBER KOMPAKT UND VOLLSTÄNDIG als ausführlich und dann abgeschnitten
-- 4 Risiken × 85 Wörter = 340 Wörter pro Section × 4 Sections = ~1360 Wörter
-- Risiko-Matrix: max. 5 Zeilen à 1 Satz pro Zelle
-- GESAMT-ZIEL: 1000-1500 Wörter (nicht mehr!)
+- Solo: 3 Risiken × 50 Wörter × 4 Kategorien = 600 Wörter + Matrix 100 Wörter = 700 max
+- Team: 4 Risiken × 60 Wörter × 4 Kategorien = 960 Wörter + Matrix = 1000 max
+- Risiko-Matrix: Solo max. 4 Zeilen, Team/KMU max. 5 Zeilen
+- GESAMT-ZIEL: Solo 600-700, Team 800-1000, KMU 1000-1300 Wörter
 -->
 <!--
-ZIEL: 5 Abschnitte mit je 200-300 Wörtern (= 1000-1500 Wörter gesamt). WICHTIG: Alle Sätze MÜSSEN vollständig sein - keine Abbrüche!
+{% if COMPANY_SIZE == "solo" %}
+ZIEL: 5 Abschnitte, je max. 140 Wörter (= 600-700 Wörter gesamt). Solo: NUR 3 Risiken pro Kategorie!
+{% elif COMPANY_SIZE == "team" %}
+ZIEL: 5 Abschnitte, je max. 200 Wörter (= 800-1000 Wörter gesamt).
+{% else %}
+ZIEL: 5 Abschnitte mit je 200-260 Wörtern (= 1000-1300 Wörter gesamt).
+{% endif %}
+WICHTIG: Alle Sätze MÜSSEN vollständig sein - keine Abbrüche!
 
 KURZLABELS (VERPFLICHTEND!):
 - {{BRANCH_CORE_LABEL}} = Branche in 8-12 Wörtern
@@ -260,7 +279,8 @@ SEKTION-LIMITS:
   </p>
 </section>
 
-<!-- DEV: PDF-SLIMDOWN v2.0 - Ziel: 600-800 Wörter, kompakt aber vollständig -->
+<!-- DEV: PDF-SLIMDOWN v2.1 - TRUNCATION-FIX: Solo 600-700, Team 800-1000, KMU 1000-1300 Wörter -->
+<!-- FINAL CHECK VOR OUTPUT: Zähle deine Wörter. Solo >750? KÜRZEN! Team >1100? KÜRZEN! -->
 
 <!-- ZERO-LEAK POLICY (N4.6) -->
 <!--

--- a/prompts/de/roadmap_90d.md
+++ b/prompts/de/roadmap_90d.md
@@ -4,16 +4,10 @@ Developer:
 <!-- PHASE 3: Maximum personalization using ALL 5 Goldnuggets -->
 
 ## ABSOLUTE LÄNGENREGEL (VOR ALLEM ANDEREN!)
-{% if COMPANY_SIZE == "solo" %}
-**SOLO-HARD-LIMIT: Maximal 400 Wörter / 2.500 Zeichen HTML gesamt. Bei Überschreitung wird 71% abgeschnitten!**
-NUR die 4 Phasen mit je 3 kurzen Bullets + Erwartete Effekte. KEINE Booster-Sektionen (KPI-Tracking, Micro-Change etc.) — diese passen nicht ins Budget!
-{% elif COMPANY_SIZE == "team" %}
-**TEAM-HARD-LIMIT: Maximal 800 Wörter / 5.000 Zeichen HTML gesamt. Bei Überschreitung wird 41% abgeschnitten!**
-4 Phasen + Erwartete Effekte + max. 1 kurze Booster-Sektion. Booster-Sektionen stark kürzen!
-{% else %}
-**KMU-HARD-LIMIT: Maximal 1000 Wörter / 7.000 Zeichen HTML gesamt.**
-{% endif %}
+**HARD-LIMITS (Solo: 400 Wörter / 2.500 Zeichen | Team: 800 / 5.000 | KMU: 1000 / 7.000)**
 JEDES WORT ÜBER DEM LIMIT WIRD BRUTAL ABGESCHNITTEN — der Report endet dann mitten im Satz!
+Solo: NUR 4 Phasen × 3 Bullets + Effekte. KEINE Booster-Sektionen — passen nicht ins Budget!
+Team: 4 Phasen + Effekte + max. 1 kurze Booster-Sektion. Booster-Sektionen stark kürzen!
 <!--
 ###############################################################################
 ##   🚨🚨🚨 CRITICAL HAUPTLEISTUNG LIMIT - NON-NEGOTIABLE 🚨🚨🚨           ##

--- a/prompts/de/roadmap_90d.md
+++ b/prompts/de/roadmap_90d.md
@@ -1,7 +1,19 @@
 Developer:
-<!-- PLATIN+++ PROMPT v7.1 - PHASE 3 HYPER-PERSONALIZATION -->
+<!-- PLATIN+++ PROMPT v7.2 - SPRINT TRUNCATION-FIX -->
 <!-- SECTION: roadmap_90d -->
 <!-- PHASE 3: Maximum personalization using ALL 5 Goldnuggets -->
+
+## ABSOLUTE LÄNGENREGEL (VOR ALLEM ANDEREN!)
+{% if COMPANY_SIZE == "solo" %}
+**SOLO-HARD-LIMIT: Maximal 400 Wörter / 2.500 Zeichen HTML gesamt. Bei Überschreitung wird 71% abgeschnitten!**
+NUR die 4 Phasen mit je 3 kurzen Bullets + Erwartete Effekte. KEINE Booster-Sektionen (KPI-Tracking, Micro-Change etc.) — diese passen nicht ins Budget!
+{% elif COMPANY_SIZE == "team" %}
+**TEAM-HARD-LIMIT: Maximal 800 Wörter / 5.000 Zeichen HTML gesamt. Bei Überschreitung wird 41% abgeschnitten!**
+4 Phasen + Erwartete Effekte + max. 1 kurze Booster-Sektion. Booster-Sektionen stark kürzen!
+{% else %}
+**KMU-HARD-LIMIT: Maximal 1000 Wörter / 7.000 Zeichen HTML gesamt.**
+{% endif %}
+JEDES WORT ÜBER DEM LIMIT WIRD BRUTAL ABGESCHNITTEN — der Report endet dann mitten im Satz!
 <!--
 ###############################################################################
 ##   🚨🚨🚨 CRITICAL HAUPTLEISTUNG LIMIT - NON-NEGOTIABLE 🚨🚨🚨           ##
@@ -69,11 +81,12 @@ VERBOTEN: <h1>, <h2>, <h3>, <h4>, <section>, <article>
 <!-- TOKEN-BUDGET: 2800 (solo:0.8x=2240, team:1.0x=2800, kmu:1.15x=3220) -->
 <!--
 HÖCHSTLÄNGE (STRIKT! — Section wird bei Überschreitung automatisch getruncated!):
-- Solo: max. 5000 Zeichen HTML-Output | Team: max. 5800 Zeichen | KMU: max. 6500 Zeichen
-- PILOT_PLAN Budget: 6000 Zeichen — NICHT überschreiten!
-- Jede Phase: max. 3-4 Bullets à 1-2 Sätze
+- Solo: max. 2.500 Zeichen (400 Wörter) | Team: max. 5.000 Zeichen (800 Wörter) | KMU: max. 7.000 Zeichen (1000 Wörter)
+- WARNUNG: Solo-Budget ist NUR 3.000 Zeichen! Bei 9K+ Output = 71% Verlust!
+- Solo: NUR 4 Phasen × 3 Bullets + Effekte. KEINE Booster-Sektionen!
+- Team: 4 Phasen × 3-4 Bullets + Effekte + max. 1 kurze Booster-Sektion
+- Jede Phase: max. 3 Bullets à 1 Satz (nicht mehr!)
 - Lieber konkret und kurz als ausführlich und generisch
-- Überschreitung >20% führt zu harter Kürzung durch die Pipeline!
 -->
 
 <!--

--- a/prompts/de/strategie_governance.md
+++ b/prompts/de/strategie_governance.md
@@ -1,14 +1,5 @@
-{% if COMPANY_SIZE == "solo" %}
-**WICHTIG – Längenlimit: Deine Antwort darf maximal 400 Wörter / 2.500 Zeichen HTML umfassen. Solo-Budget ist NUR 3.000 Zeichen — bei 5.5K Output wird 48% abgeschnitten!**
-{% elif COMPANY_SIZE == "team" %}
-**WICHTIG – Längenlimit: Deine Antwort darf maximal 800 Wörter / 7.500 Zeichen HTML umfassen.**
-{% else %}
-**WICHTIG – Längenlimit: Deine Antwort darf maximal 1100 Wörter umfassen.**
-{% endif %}
-Kürze lieber als zu überziehen — abgeschnittener Content ist wertlos!
-
 Developer:
-<!-- PLATIN++ PROMPT v5.4 - SPRINT TRUNCATION-FIX -->
+<!-- PLATIN++ PROMPT v5.3 G17.S - SPRINT TRUNCATION-FIX -->
 <!-- SECTION: strategie_governance -->
 <!-- OUTPUT: HTML ONLY -->
 <!-- SIZE-AWARE: solo/team/kmu -->
@@ -25,6 +16,8 @@ HÖCHSTLÄNGE (STRIKT! — Überschreitung wird automatisch getruncated!):
 - Solo: Strategische Leitlinien max. 4 Punkte à 1-2 Sätze + Mini-Governance max. 60 Wörter
 - Steuerung & KI-Kultur: Solo max. je 40 Wörter
 -->
+**HARD-LIMITS (Solo: 400 Wörter / 2.500 Zeichen | Team: 800 / 7.500 | KMU: 1100 / 9.000)**
+Kürze lieber als zu überziehen — abgeschnittener Content ist wertlos!
 <!-- WORD_MINIMUM_SOLO: 150 (G17.S: erhöht von 130 wg. Mini-Governance-Booster) -->
 <!--
 ZIEL: Strategische Einordnung zu KI-Strategie & Governance.

--- a/prompts/de/strategie_governance.md
+++ b/prompts/de/strategie_governance.md
@@ -1,7 +1,14 @@
-**WICHTIG – Längenlimit: Deine Antwort darf maximal 1200 Wörter umfassen. Kürze lieber als zu überziehen.**
+{% if COMPANY_SIZE == "solo" %}
+**WICHTIG – Längenlimit: Deine Antwort darf maximal 400 Wörter / 2.500 Zeichen HTML umfassen. Solo-Budget ist NUR 3.000 Zeichen — bei 5.5K Output wird 48% abgeschnitten!**
+{% elif COMPANY_SIZE == "team" %}
+**WICHTIG – Längenlimit: Deine Antwort darf maximal 800 Wörter / 7.500 Zeichen HTML umfassen.**
+{% else %}
+**WICHTIG – Längenlimit: Deine Antwort darf maximal 1100 Wörter umfassen.**
+{% endif %}
+Kürze lieber als zu überziehen — abgeschnittener Content ist wertlos!
 
 Developer:
-<!-- PLATIN++ PROMPT v5.3 - SPRINT G17.S -->
+<!-- PLATIN++ PROMPT v5.4 - SPRINT TRUNCATION-FIX -->
 <!-- SECTION: strategie_governance -->
 <!-- OUTPUT: HTML ONLY -->
 <!-- SIZE-AWARE: solo/team/kmu -->
@@ -13,11 +20,10 @@ Die Branchenbezeichnung "{{BRANCHE_LABEL}}" darf MAXIMAL 2x im gesamten Text vor
 Ab der 3. Verwendung NUR noch Kurzformen: "Ihr Unternehmen", "Ihre Branche", "Ihr Geschäftsfeld".
 
 HÖCHSTLÄNGE (STRIKT! — Überschreitung wird automatisch getruncated!):
-- Der gesamte HTML-Output darf MAXIMAL 8500 Zeichen umfassen
-- Solo: max. 7000 Zeichen | Team: max. 8500 Zeichen | KMU: max. 9000 Zeichen
-- Strategische Leitlinien: max. 5 Punkte à 2-3 Sätze
-- Solo Mini-Governance: max. 80 Wörter
-- ACHTUNG: Bei >9000 Zeichen wird ~20% des Contents abgeschnitten!
+- Solo: max. 2.500 Zeichen (400 Wörter) | Team: max. 7.500 Zeichen (800 Wörter) | KMU: max. 9.000 Zeichen (1100 Wörter)
+- WARNUNG: Solo-Budget ist NUR 3.000 Zeichen! Bei 5.5K+ Output = 48% Verlust!
+- Solo: Strategische Leitlinien max. 4 Punkte à 1-2 Sätze + Mini-Governance max. 60 Wörter
+- Steuerung & KI-Kultur: Solo max. je 40 Wörter
 -->
 <!-- WORD_MINIMUM_SOLO: 150 (G17.S: erhöht von 130 wg. Mini-Governance-Booster) -->
 <!--

--- a/prompts/de/unternehmensprofil_markt.md
+++ b/prompts/de/unternehmensprofil_markt.md
@@ -1,7 +1,14 @@
-**WICHTIG – Längenlimit: Deine Antwort darf maximal 1100 Wörter umfassen. Kürze lieber als zu überziehen.**
+{% if COMPANY_SIZE == "solo" %}
+**WICHTIG – Längenlimit: Deine Antwort darf maximal 350 Wörter / 2.500 Zeichen HTML umfassen. Solo-Budget ist NUR 3.000 Zeichen — bei 13K Output wird 78% abgeschnitten!**
+{% elif COMPANY_SIZE == "team" %}
+**WICHTIG – Längenlimit: Deine Antwort darf maximal 700 Wörter / 6.500 Zeichen HTML umfassen. Team-Budget ist 8.000 Zeichen.**
+{% else %}
+**WICHTIG – Längenlimit: Deine Antwort darf maximal 1000 Wörter umfassen.**
+{% endif %}
+Kürze lieber als zu überziehen — abgeschnittener Content ist wertlos!
 
 Developer:
-<!-- unternehmensprofil_markt.md – v5.0 GOLD STANDARD+ (branch-aware, size-aware, context-integrated)
+<!-- unternehmensprofil_markt.md – v5.1 TRUNCATION-FIX (branch-aware, size-aware, context-integrated)
      Antworte ausschließlich mit validem HTML.
      KEIN <html>, <head> oder <body>. KEINE Markdown-Fences.
 
@@ -67,11 +74,10 @@ Developer:
        - Ton: nüchtern, sachlich, strategisch, gut lesbar für Geschäftsführung.
 
      HÖCHSTLÄNGE (STRIKT! — Überschreitung wird automatisch getruncated!):
-       - Der gesamte HTML-Output darf MAXIMAL 7500 Zeichen umfassen
-       - Solo: max. 6000 Zeichen | Team: max. 7500 Zeichen | KMU: max. 8000 Zeichen
-       - Marktkontext: max. 4 Bullets à 1-2 Sätze (NICHT ausführlich erklären)
-       - Wettbewerbsposition: max. 3 Bullets (Vorteil/Nachteil/Hebel)
-       - ACHTUNG: Bei >8000 Zeichen wird ~35% des Contents abgeschnitten!
+       - Solo: max. 2.500 Zeichen (350 Wörter) | Team: max. 6.500 Zeichen (700 Wörter) | KMU: max. 8.000 Zeichen (1000 Wörter)
+       - WARNUNG: Solo-Budget ist NUR 3.000 Zeichen! Bei 13K+ Output = 78% Verlust!
+       - Solo: Marktkontext max. 3 Bullets à 1 Satz, Wettbewerb max. 3 kurze Bullets
+       - Team/KMU: Marktkontext max. 4 Bullets à 1-2 Sätze, Wettbewerb max. 3 Bullets
 
      THEMEN-OWNERSHIP (verbindlich):
        - Diese Section: OWNER für Unternehmensprofil, Marktkontext, KI-Potenzial, Wettbewerb

--- a/routes/report.py
+++ b/routes/report.py
@@ -821,3 +821,112 @@ def get_report_pdf(
     """
     # Delegate to the new robust endpoint (reuses on-demand generation logic)
     return get_report_pdf_v2(briefing_id=briefing_id, db=db, auth=auth)
+
+
+# ---------------------------------------------------------------------------
+# Gamechanger Deep Dive — Standalone Report Product
+# ---------------------------------------------------------------------------
+
+class GamechangerDeepDiveRequest(BaseModel):
+    """Request model for Gamechanger Deep Dive report generation."""
+    briefing_id: int = Field(ge=0, description="ID of the briefing (must have completed Report 1)")
+
+
+@router.post("/gamechanger-deep-dive")
+async def generate_gamechanger_deep_dive(
+    payload: GamechangerDeepDiveRequest,
+) -> Dict[str, Any]:
+    """
+    Generate a Gamechanger Deep Dive report (standalone 6-8 page product).
+
+    Requires a completed Report 1 for the given briefing_id.
+    No new questionnaire — all data comes from Report 1.
+
+    Sections:
+    1. Strategischer Bruchpunkt (expanded from Report 1)
+    2. 90-Tage Implementierungsplan (LLM-generated)
+    3. Business Case Deep Dive (DETERMINISTIC — no LLM)
+    4. Risikobewertung & Absicherung (LLM-generated)
+    5. Nächste Schritte (LLM-generated)
+
+    Returns:
+        {"ok": True, "html": "<full HTML>", "briefing_id": int}
+    """
+    try:
+        from services.gamechanger_deep_dive import generate_gamechanger_report
+    except ImportError as exc:
+        raise HTTPException(
+            status_code=503,
+            detail=f"Gamechanger Deep Dive module unavailable: {exc}",
+        ) from exc
+
+    log.info(
+        "[GC-DEEP-DIVE] Generating Deep Dive for briefing_id=%d",
+        payload.briefing_id,
+    )
+
+    try:
+        result = await asyncio.get_event_loop().run_in_executor(
+            None,
+            lambda: generate_gamechanger_report(payload.briefing_id),
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except Exception as exc:
+        log.error(
+            "[GC-DEEP-DIVE] Generation failed for briefing %d: %s",
+            payload.briefing_id, exc,
+        )
+        raise HTTPException(
+            status_code=500,
+            detail=f"Deep Dive generation failed: {exc.__class__.__name__}: {exc}",
+        ) from exc
+
+    html = result.get("html", "")
+    sections = result.get("sections", {})
+
+    log.info(
+        "[GC-DEEP-DIVE] Generated: briefing_id=%d html_size=%d sections=%s",
+        payload.briefing_id, len(html), list(sections.keys()),
+    )
+
+    return {
+        "ok": True,
+        "briefing_id": payload.briefing_id,
+        "html": html,
+        "html_size": len(html),
+        "sections_generated": list(sections.keys()),
+    }
+
+
+@router.get("/gamechanger-deep-dive/html/{briefing_id}")
+async def get_gamechanger_deep_dive_html(
+    briefing_id: int,
+) -> HTMLResponse:
+    """
+    Generate and return the Gamechanger Deep Dive as HTML.
+
+    This is a convenience GET endpoint that generates and returns HTML directly.
+    For production use, prefer the POST endpoint to separate generation from retrieval.
+    """
+    try:
+        from services.gamechanger_deep_dive import generate_gamechanger_report
+    except ImportError as exc:
+        raise HTTPException(
+            status_code=503,
+            detail=f"Gamechanger Deep Dive module unavailable: {exc}",
+        ) from exc
+
+    try:
+        result = await asyncio.get_event_loop().run_in_executor(
+            None,
+            lambda: generate_gamechanger_report(briefing_id),
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except Exception as exc:
+        log.error("[GC-DEEP-DIVE] HTML generation failed: %s", exc)
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+    html = result.get("html", "")
+    return HTMLResponse(content=html, media_type="text/html; charset=utf-8")

--- a/services/gamechanger_deep_dive.py
+++ b/services/gamechanger_deep_dive.py
@@ -1,0 +1,565 @@
+# -*- coding: utf-8 -*-
+"""
+Gamechanger Deep Dive — Standalone 6-8 Page Report
+====================================================
+
+Generates an expanded Gamechanger analysis as a separate product.
+All data comes from an existing Report 1 (briefing_id).
+
+Sections:
+1. Strategischer Bruchpunkt (expanded from Report 1 gamechanger)
+2. Implementierungsplan (LLM-generated)
+3. Business Case Deep Dive (DETERMINISTIC — no LLM!)
+4. Risikobewertung & Absicherung (LLM-generated)
+5. Nächste Schritte (LLM-generated)
+
+Version: 1.0.0
+"""
+from __future__ import annotations
+
+import logging
+import math
+from typing import Any, Dict, List, Optional
+
+log = logging.getLogger(__name__)
+
+
+# =============================================================================
+# 1. CONTEXT BUILDER
+# =============================================================================
+
+def build_gamechanger_context(report1_sections: Dict[str, Any],
+                               briefing: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    Build context bundle from Report 1 data for Deep Dive generation.
+
+    Args:
+        report1_sections: Sections dict from Report 1 Analysis.meta["sections"]
+        briefing: Briefing.answers dict
+
+    Returns:
+        Context dict with all data needed for Deep Dive generation.
+    """
+    # Scores
+    scores = {
+        'score_gesamt': report1_sections.get('score_gesamt', 0),
+        'score_governance': report1_sections.get('score_governance', 0),
+        'score_sicherheit': report1_sections.get('score_sicherheit', 0),
+        'score_wertschoepfung': report1_sections.get('score_wertschoepfung', 0),
+        'score_befaehigung': report1_sections.get('score_befaehigung', 0),
+        'score_rating': report1_sections.get('score_rating', ''),
+    }
+
+    # Segment info
+    company_size = (
+        briefing.get('COMPANY_SIZE')
+        or report1_sections.get('COMPANY_SIZE')
+        or 'solo'
+    )
+
+    segment_info = {
+        'COMPANY_SIZE': company_size,
+        'UNTERNEHMENSGROESSE_LABEL': briefing.get('unternehmensgroesse', ''),
+        'BRANCHE_LABEL': (
+            briefing.get('branche')
+            or report1_sections.get('BRANCHE_LABEL', '')
+        ),
+        'HAUPTLEISTUNG': (
+            briefing.get('hauptleistung')
+            or report1_sections.get('HAUPTLEISTUNG', '')
+        ),
+    }
+
+    # Gamechanger content from Report 1
+    gamechanger = {
+        'gamechanger_decision': report1_sections.get('GAMECHANGER_DECISION_HTML', ''),
+        'GAMECHANGER_HTML': report1_sections.get('GAMECHANGER_HTML', ''),
+        '_GC_SNAPSHOT_642': report1_sections.get('_GC_SNAPSHOT_642', ''),
+    }
+
+    # Business Case canonical values
+    canonical_bc = _extract_canonical_bc(report1_sections, briefing)
+
+    # Supporting content from Report 1
+    supporting = {
+        'RISKS_HTML': report1_sections.get('RISKS_HTML', ''),
+        'VENDOR_AUDIT_HTML': report1_sections.get('VENDOR_AUDIT_HTML', ''),
+        'roadmap_90d': report1_sections.get('PILOT_PLAN_HTML', ''),
+        'RECOMMENDATIONS_HTML': report1_sections.get('RECOMMENDATIONS_HTML', ''),
+        'STARTER_KIT_HTML': report1_sections.get('STARTER_KIT_HTML', ''),
+    }
+
+    return {**scores, **segment_info, **gamechanger, 'canonical_bc': canonical_bc, **supporting}
+
+
+def _extract_canonical_bc(sections: Dict[str, Any],
+                           briefing: Dict[str, Any]) -> Dict[str, Any]:
+    """Extract canonical business case values from Report 1 data."""
+    def _safe_float(val: Any, default: float = 0.0) -> float:
+        if val is None:
+            return default
+        try:
+            # Handle German format "1.234,56" and strings like "95€/h"
+            s = str(val).replace('€', '').replace('/h', '').replace('.', '').replace(',', '.').strip()
+            return float(s) if s else default
+        except (ValueError, TypeError):
+            return default
+
+    hours = _safe_float(
+        sections.get('CANON_HOURS_MONTH') or sections.get('monatsersparnis_stunden'),
+        36.0
+    )
+    rate = _safe_float(
+        sections.get('CANON_RATE_EUR'),
+        95.0
+    )
+    capex = _safe_float(
+        briefing.get('CAPEX_REALISTISCH_EUR') or sections.get('CAPEX_REALISTISCH_EUR'),
+        5000.0
+    )
+    opex = _safe_float(
+        briefing.get('OPEX_REALISTISCH_EUR') or sections.get('OPEX_REALISTISCH_EUR'),
+        150.0
+    )
+    roi = _safe_float(
+        sections.get('ROI_12M') or briefing.get('ROI_12M'),
+        60.0
+    )
+    payback = _safe_float(
+        sections.get('PAYBACK_MONTHS') or briefing.get('PAYBACK_MONTHS'),
+        6.0
+    )
+
+    return {
+        'hours': hours,
+        'rate': rate,
+        'capex': capex,
+        'opex': opex,
+        'roi': roi,
+        'payback': payback,
+    }
+
+
+# =============================================================================
+# 2. BUSINESS CASE DEEP DIVE — DETERMINISTIC CALCULATOR
+# =============================================================================
+
+def calculate_bc_deep_dive(canonical_bc: Dict[str, float]) -> Dict[str, Any]:
+    """
+    Calculate Business Case Deep Dive with sensitivity analysis + 3-year projection.
+
+    DETERMINISTIC — no LLM involved. Pure math.
+
+    Args:
+        canonical_bc: Dict with keys: hours, rate, capex, opex, roi, payback
+
+    Returns:
+        Dict with 'sensitivity' and 'projection' results.
+    """
+    base_hours = canonical_bc.get('hours', 36)
+    rate = canonical_bc.get('rate', 95)
+    capex = canonical_bc.get('capex', 5000)
+    opex_month = canonical_bc.get('opex', 150)
+
+    # Sensitivity analysis
+    scenarios = [
+        ('-20%', 0.8),
+        ('-10%', 0.9),
+        ('Basis', 1.0),
+        ('+10%', 1.1),
+        ('+20%', 1.2),
+    ]
+
+    sensitivity = []
+    for label, modifier in scenarios:
+        hours_adj = base_hours * modifier
+        monthly_savings = hours_adj * rate
+        yearly_savings = monthly_savings * 12
+        yearly_opex = opex_month * 12
+        net_benefit_12m = yearly_savings - capex - yearly_opex
+
+        roi_raw = (net_benefit_12m / capex * 100) if capex > 0 else 0
+        roi_capped = min(roi_raw, 200)
+
+        net_monthly = monthly_savings - opex_month
+        if net_monthly > 0:
+            payback_months = capex / net_monthly
+        else:
+            payback_months = float('inf')
+
+        sensitivity.append({
+            'label': label,
+            'hours_month': round(hours_adj, 1),
+            'monthly_savings': round(monthly_savings),
+            'yearly_savings': round(yearly_savings),
+            'net_benefit_12m': round(net_benefit_12m),
+            'roi_raw': round(roi_raw, 1),
+            'roi_capped': round(roi_capped, 1),
+            'payback_months': round(payback_months, 1) if payback_months != float('inf') else '—',
+        })
+
+    # 3-year projection
+    projection = []
+    for year in [1, 2, 3]:
+        cumulative_savings = base_hours * rate * 12 * year
+        cumulative_cost = capex + (opex_month * 12 * year)
+        cumulative_net = cumulative_savings - cumulative_cost
+
+        projection.append({
+            'year': year,
+            'cumulative_savings': round(cumulative_savings),
+            'cumulative_cost': round(cumulative_cost),
+            'cumulative_net': round(cumulative_net),
+        })
+
+    # Break-even month (when cumulative net becomes positive)
+    net_monthly = (base_hours * rate) - opex_month
+    if net_monthly > 0:
+        break_even_month = math.ceil(capex / net_monthly)
+    else:
+        break_even_month = None
+
+    return {
+        'sensitivity': sensitivity,
+        'projection': projection,
+        'break_even_month': break_even_month,
+        'base': {
+            'hours': base_hours,
+            'rate': rate,
+            'capex': capex,
+            'opex_month': opex_month,
+        },
+    }
+
+
+def render_bc_deep_dive_html(bc_data: Dict[str, Any]) -> str:
+    """
+    Render the Business Case Deep Dive as HTML.
+
+    DETERMINISTIC — no LLM. Pure template rendering.
+    """
+    def _fmt(val: Any) -> str:
+        """Format number with German locale (dots as thousands separator)."""
+        if isinstance(val, str):
+            return val
+        if isinstance(val, float) and val == float('inf'):
+            return '—'
+        try:
+            n = int(round(float(val)))
+            return f"{n:,}".replace(',', '.')
+        except (ValueError, TypeError):
+            return str(val)
+
+    sensitivity = bc_data.get('sensitivity', [])
+    projection = bc_data.get('projection', [])
+    base = bc_data.get('base', {})
+    break_even = bc_data.get('break_even_month')
+
+    # Build sensitivity table
+    sens_rows = []
+    for s in sensitivity:
+        roi_display = f"{s['roi_capped']}%" if s['roi_raw'] <= 200 else f"200% (gedeckelt)"
+        payback_display = f"{s['payback_months']} Mon." if s['payback_months'] != '—' else '—'
+        row_class = ' class="highlight"' if s['label'] == 'Basis' else ''
+        sens_rows.append(
+            f'<tr{row_class}>'
+            f'<td><strong>{s["label"]}</strong></td>'
+            f'<td>{_fmt(s["hours_month"])} h/Mon.</td>'
+            f'<td>{_fmt(s["monthly_savings"])} €/Mon.</td>'
+            f'<td>{_fmt(s["net_benefit_12m"])} €</td>'
+            f'<td>{roi_display}</td>'
+            f'<td>{payback_display}</td>'
+            f'</tr>'
+        )
+
+    # Build projection table
+    proj_rows = []
+    for p in projection:
+        net_class = ' class="positive"' if p['cumulative_net'] > 0 else ' class="negative"'
+        proj_rows.append(
+            f'<tr>'
+            f'<td><strong>Jahr {p["year"]}</strong></td>'
+            f'<td>{_fmt(p["cumulative_savings"])} €</td>'
+            f'<td>{_fmt(p["cumulative_cost"])} €</td>'
+            f'<td{net_class}>{_fmt(p["cumulative_net"])} €</td>'
+            f'</tr>'
+        )
+
+    break_even_text = (
+        f'<p><strong>Break-Even:</strong> Monat {break_even} '
+        f'(bei Basis-Szenario mit {_fmt(base.get("hours", 0))} h/Mon. Einsparung)</p>'
+    ) if break_even else (
+        '<p><strong>Break-Even:</strong> Nicht innerhalb von 12 Monaten erreichbar '
+        'bei aktuellem Szenario.</p>'
+    )
+
+    html = f"""
+<p><strong>Sensitivitätsanalyse</strong></p>
+<p>Was passiert, wenn die tatsächliche Zeitersparnis vom Basisszenario abweicht?
+Die folgende Tabelle zeigt die Auswirkungen auf ROI und Amortisation.</p>
+
+<table class="table">
+<thead>
+<tr>
+<th>Szenario</th>
+<th>Einsparung</th>
+<th>Monatl. Nutzen</th>
+<th>Nettonutzen (12M)</th>
+<th>ROI</th>
+<th>Amortisation</th>
+</tr>
+</thead>
+<tbody>
+{"".join(sens_rows)}
+</tbody>
+</table>
+
+<p><strong>Annahmen:</strong> Stundensatz {_fmt(base.get("rate", 0))} €,
+Einmalinvestition {_fmt(base.get("capex", 0))} €,
+laufende Kosten {_fmt(base.get("opex_month", 0))} €/Monat.</p>
+
+{break_even_text}
+
+<p><strong>3-Jahres-Projektion</strong></p>
+<p>Kumulative Betrachtung über 3 Jahre bei Basis-Szenario:</p>
+
+<table class="table">
+<thead>
+<tr>
+<th>Zeitraum</th>
+<th>Kumul. Einsparung</th>
+<th>Kumul. Kosten</th>
+<th>Kumul. Nettonutzen</th>
+</tr>
+</thead>
+<tbody>
+{"".join(proj_rows)}
+</tbody>
+</table>
+
+<p>Die Investition ist konservativ gerechnet. Bei höherer Adoption steigen
+die Einsparungen überproportional, da die Einmalinvestition bereits gedeckt ist.</p>
+"""
+    return html.strip()
+
+
+# =============================================================================
+# 3. SECTION GENERATOR (LLM Calls)
+# =============================================================================
+
+def generate_deep_dive_sections(context: Dict[str, Any]) -> Dict[str, str]:
+    """
+    Generate all Deep Dive sections.
+
+    - Section 1 (Strategischer Bruchpunkt): Expanded from Report 1 data (no new LLM call)
+    - Section 2 (Implementierungsplan): LLM-generated
+    - Section 3 (Business Case Deep Dive): DETERMINISTIC
+    - Section 4 (Risikobewertung): LLM-generated
+    - Section 5 (Nächste Schritte): LLM-generated
+
+    Returns:
+        Dict mapping section keys to HTML content.
+    """
+    sections: Dict[str, str] = {}
+
+    # Section 1: Use expanded gamechanger from Report 1
+    gc_decision = context.get('gamechanger_decision', '')
+    gc_html = context.get('GAMECHANGER_HTML', '')
+    gc_snapshot = context.get('_GC_SNAPSHOT_642', '')
+    sections['GC_BRUCHPUNKT_HTML'] = gc_decision or gc_snapshot or gc_html
+
+    # Section 3: Deterministic BC Deep Dive
+    bc_data = calculate_bc_deep_dive(context.get('canonical_bc', {}))
+    sections['BC_DEEP_DIVE_HTML'] = render_bc_deep_dive_html(bc_data)
+
+    # Sections 2, 4, 5: LLM-generated
+    llm_sections = [
+        ('GC_IMPL_PLAN_HTML', 'gc_implementation_plan'),
+        ('GC_RISK_HTML', 'gc_risk_assessment'),
+        ('GC_NEXT_STEPS_HTML', 'gc_next_steps'),
+    ]
+
+    for html_key, prompt_name in llm_sections:
+        try:
+            html = _generate_gc_section(prompt_name, context)
+            sections[html_key] = html
+        except Exception as exc:
+            log.error("[GC-DEEP-DIVE] Failed to generate %s: %s", prompt_name, exc)
+            sections[html_key] = f'<p><em>[Section {prompt_name} konnte nicht generiert werden.]</em></p>'
+
+    return sections
+
+
+def _generate_gc_section(prompt_name: str, context: Dict[str, Any]) -> str:
+    """Generate a single Deep Dive section via LLM."""
+    try:
+        from services.prompt_loader import load_prompt, _interpolate
+    except ImportError:
+        log.error("[GC-DEEP-DIVE] Cannot import prompt_loader")
+        return '<p><em>[Prompt-System nicht verfügbar]</em></p>'
+
+    # Build vars dict from context
+    vars_dict = {
+        'COMPANY_SIZE': context.get('COMPANY_SIZE', 'solo'),
+        'UNTERNEHMENSGROESSE_LABEL': context.get('UNTERNEHMENSGROESSE_LABEL', ''),
+        'BRANCHE_LABEL': context.get('BRANCHE_LABEL', ''),
+        'HAUPTLEISTUNG': context.get('HAUPTLEISTUNG', ''),
+        'gamechanger_decision': context.get('gamechanger_decision', ''),
+        'GAMECHANGER_HTML': context.get('GAMECHANGER_HTML', ''),
+        'RISKS_HTML': context.get('RISKS_HTML', ''),
+        'RECOMMENDATIONS_HTML': context.get('RECOMMENDATIONS_HTML', ''),
+        'roadmap_90d': context.get('roadmap_90d', ''),
+        'gc_implementation_plan_summary': '',  # Filled after impl plan is generated
+    }
+
+    try:
+        prompt_text = load_prompt(prompt_name, lang="de", vars_dict=vars_dict)
+    except Exception as exc:
+        log.error("[GC-DEEP-DIVE] Failed to load prompt %s: %s", prompt_name, exc)
+        return f'<p><em>[Prompt {prompt_name} nicht gefunden]</em></p>'
+
+    if not isinstance(prompt_text, str) or not prompt_text.strip():
+        return f'<p><em>[Prompt {prompt_name} leer]</em></p>'
+
+    # Call LLM
+    try:
+        from services.llm_client import LLMClient, LLMCallResult
+        client = LLMClient()
+
+        def _call_openai(max_tokens: int = 4000, section: str = "", **kwargs) -> Optional[str]:
+            import openai
+            import os
+            api_key = os.environ.get("OPENAI_API_KEY", "")
+            if not api_key:
+                log.error("[GC-DEEP-DIVE] No OPENAI_API_KEY")
+                return None
+
+            oai_client = openai.OpenAI(api_key=api_key)
+            response = oai_client.chat.completions.create(
+                model=os.environ.get("OPENAI_MODEL", "gpt-4o"),
+                messages=[{"role": "user", "content": prompt_text}],
+                max_tokens=max_tokens,
+                temperature=0.4,
+            )
+            return response.choices[0].message.content if response.choices else None
+
+        result = client.call_with_retry(
+            call_fn=_call_openai,
+            section=f"gc_deepdive_{prompt_name}",
+            max_tokens=4000,
+        )
+
+        if result.success and result.content:
+            return result.content
+        else:
+            log.warning("[GC-DEEP-DIVE] LLM call failed for %s", prompt_name)
+            return f'<p><em>[{prompt_name} konnte nicht generiert werden]</em></p>'
+
+    except Exception as exc:
+        log.error("[GC-DEEP-DIVE] LLM error for %s: %s", prompt_name, exc)
+        return f'<p><em>[Fehler bei {prompt_name}: {exc}]</em></p>'
+
+
+# =============================================================================
+# 4. REPORT ASSEMBLER
+# =============================================================================
+
+def generate_gamechanger_report(briefing_id: int) -> Dict[str, Any]:
+    """
+    Main entry point: Generate a complete Gamechanger Deep Dive report.
+
+    Args:
+        briefing_id: ID of the briefing (must have a completed Report 1)
+
+    Returns:
+        Dict with 'html', 'sections', 'context' keys.
+    """
+    from models import Briefing, Analysis
+    from core.db import get_session
+
+    with get_session() as db:
+        # 1. Load briefing
+        briefing = db.get(Briefing, briefing_id)
+        if not briefing:
+            raise ValueError(f"Briefing {briefing_id} not found")
+
+        # 2. Load latest analysis (Report 1)
+        analysis = (
+            db.query(Analysis)
+            .filter(Analysis.briefing_id == briefing_id)
+            .order_by(Analysis.id.desc())
+            .first()
+        )
+        if not analysis:
+            raise ValueError(f"No analysis found for briefing {briefing_id}")
+
+        report1_sections = analysis.sections
+        answers = briefing.answers or {}
+
+    # 3. Build context
+    context = build_gamechanger_context(report1_sections, answers)
+    log.info(
+        "[GC-DEEP-DIVE] Context built for briefing %d: size=%s, branche=%s",
+        briefing_id, context.get('COMPANY_SIZE'), context.get('BRANCHE_LABEL')
+    )
+
+    # 4. Generate sections
+    sections = generate_deep_dive_sections(context)
+
+    # 5. Render HTML
+    html = render_deep_dive_html(sections, context)
+
+    return {
+        'html': html,
+        'sections': sections,
+        'context': context,
+    }
+
+
+def render_deep_dive_html(sections: Dict[str, str],
+                           context: Dict[str, Any]) -> str:
+    """
+    Render the Deep Dive report as complete HTML using Jinja2 template.
+    """
+    try:
+        from jinja2 import Environment, FileSystemLoader
+        import os
+
+        template_dir = os.path.join(os.path.dirname(os.path.dirname(__file__)), 'templates')
+        env = Environment(loader=FileSystemLoader(template_dir), autoescape=False)
+        template = env.get_template('gamechanger_deep_dive_v1.html')
+
+        # Merge sections and context for template
+        template_vars = {**sections, **context}
+        template_vars['report_type'] = 'gamechanger_deep_dive'
+        template_vars['company_name'] = context.get('HAUPTLEISTUNG', 'Ihr Unternehmen')
+
+        return template.render(**template_vars)
+
+    except Exception as exc:
+        log.error("[GC-DEEP-DIVE] Template rendering failed: %s", exc)
+        # Fallback: simple concatenation
+        return _fallback_html(sections, context)
+
+
+def _fallback_html(sections: Dict[str, str], context: Dict[str, Any]) -> str:
+    """Fallback HTML if template rendering fails."""
+    company = context.get('HAUPTLEISTUNG', 'Ihr Unternehmen')
+    branche = context.get('BRANCHE_LABEL', '')
+
+    parts = [
+        f'<h1>Gamechanger Deep Dive: {company}</h1>',
+        f'<p>Branche: {branche}</p>',
+        '<hr>',
+        '<h2>1. Strategischer Bruchpunkt</h2>',
+        sections.get('GC_BRUCHPUNKT_HTML', ''),
+        '<h2>2. Implementierungsplan</h2>',
+        sections.get('GC_IMPL_PLAN_HTML', ''),
+        '<h2>3. Business Case Deep Dive</h2>',
+        sections.get('BC_DEEP_DIVE_HTML', ''),
+        '<h2>4. Risikobewertung & Absicherung</h2>',
+        sections.get('GC_RISK_HTML', ''),
+        '<h2>5. Nächste Schritte</h2>',
+        sections.get('GC_NEXT_STEPS_HTML', ''),
+    ]
+    return '\n'.join(parts)

--- a/templates/gamechanger_deep_dive_v1.html
+++ b/templates/gamechanger_deep_dive_v1.html
@@ -1,0 +1,704 @@
+<!-- Gamechanger Deep Dive Template v1.0.0 "Clean Corporate Plus" — 2026-03-06 -->
+<!-- Engine: Puppeteer/Chromium · Backend: FastAPI/Jinja2 · Design: McKinsey/BCG -->
+<!-- Based on: pdf_template_v7.html — same CSS Design System -->
+<!DOCTYPE html>
+<html lang="de">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Gamechanger Deep Dive – {{ company_name or HAUPTLEISTUNG or 'Ihr Unternehmen' }}</title>
+    <style>
+/* ═══════════════════════════════════════════════════════
+   v1.0 GAMECHANGER DEEP DIVE — Clean Corporate Plus
+   Cloned from pdf_template_v7.html Design System
+   Typography: Inter (unified family)
+   Colors: 3 primary + grays + deep-dive purple accent
+   ═══════════════════════════════════════════════════════ */
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap');
+
+/* ── Page Setup ─────────────────────────────────────── */
+@page {
+    size: A4;
+    margin: 12mm 12mm 15mm 12mm;
+    @bottom-right {
+        content: "Seite " counter(page) " von " counter(pages);
+        font-size: 7.5pt;
+        color: #9CA3AF;
+        font-family: 'Inter', system-ui, sans-serif;
+    }
+}
+
+/* ── Design Tokens ──────────────────────────────────── */
+:root {
+    /* Primary */
+    --c-primary: #1E3A5F;
+    --c-accent: #10B981;
+    --c-warning: #F59E0B;
+    /* Deep Dive accent */
+    --c-deep: #8b5cf6;
+    --c-deep-light: #f5f3ff;
+    --c-deep-border: #c4b5fd;
+    /* Grays */
+    --c-text: #374151;
+    --c-text-2: #6B7280;
+    --c-text-3: #9CA3AF;
+    --c-border: #E5E7EB;
+    --c-bg: #F9FAFB;
+    --c-white: #ffffff;
+    /* Semantic */
+    --c-success: #10B981;
+    --c-danger: #EF4444;
+    --c-info: #3B82F6;
+    /* Category Colors */
+    --c-cat-strategy: #3b82f6;
+    --c-cat-action: #10b981;
+    --c-cat-risk: #ef4444;
+    --c-cat-finance: #f59e0b;
+    --c-cat-deep: #8b5cf6;
+    /* Typography */
+    --font: 'Inter', system-ui, -apple-system, sans-serif;
+    /* Spacing */
+    --sp-xs: 4px;
+    --sp-sm: 8px;
+    --sp-md: 16px;
+    --sp-lg: 24px;
+    --sp-xl: 32px;
+    --sp-2xl: 48px;
+    /* Radius */
+    --r-sm: 4px;
+    --r-md: 8px;
+    --r-lg: 12px;
+}
+
+/* ── Base Reset ─────────────────────────────────────── */
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+body {
+    font-family: var(--font);
+    font-size: 10pt;
+    line-height: 1.6;
+    color: var(--c-text);
+    background: var(--c-white);
+    -webkit-font-smoothing: antialiased;
+    orphans: 4;
+    widows: 4;
+}
+
+/* ── Typography Scale ───────────────────────────────── */
+h1 { font-size: 28pt; font-weight: 700; color: var(--c-primary); line-height: 1.15; letter-spacing: -0.02em; }
+h2 { font-size: 18pt; font-weight: 700; color: var(--c-primary); line-height: 1.25; letter-spacing: -0.01em; margin: 0; }
+h3 { font-size: 13pt; font-weight: 600; color: var(--c-primary); line-height: 1.3; margin: var(--sp-md) 0 var(--sp-sm); }
+h4 { font-size: 11pt; font-weight: 600; color: var(--c-text); line-height: 1.4; margin: var(--sp-sm) 0 var(--sp-xs); }
+
+p { margin: var(--sp-sm) 0; }
+a { color: var(--c-primary); text-decoration: none; }
+strong { font-weight: 600; }
+.small { font-size: 8.5pt; }
+.muted { color: var(--c-text-3); }
+.text-2 { color: var(--c-text-2); }
+
+/* ── Lists & Tables ─────────────────────────────────── */
+ul, ol { padding-left: 1.5em; margin: var(--sp-sm) 0; }
+li { margin-bottom: var(--sp-xs); }
+table { width: 100%; border-collapse: collapse; font-size: 9.5pt; margin: var(--sp-md) 0; }
+th { background: var(--c-bg); font-weight: 600; text-align: left; padding: 8px 10px; border-bottom: 2px solid var(--c-border); font-size: 8.5pt; text-transform: uppercase; letter-spacing: 0.05em; color: var(--c-text-2); }
+td { padding: 8px 10px; border-bottom: 1px solid var(--c-border); vertical-align: top; }
+tr:last-child td { border-bottom: none; }
+tr.highlight td { background: #f0fdf4; font-weight: 600; }
+td.positive { color: var(--c-success); font-weight: 600; }
+td.negative { color: var(--c-danger); font-weight: 600; }
+
+/* ── Page Structure ─────────────────────────────────── */
+.page { max-width: 210mm; margin: 0 auto; }
+
+/* ══ PAGE BREAK RULES ═══════════════════════════════ */
+#dd-implementation,
+#dd-business-case,
+#dd-risk-assessment,
+#dd-next-steps {
+    break-before: page;
+}
+
+/* ── Section Base ───────────────────────────────────── */
+.section {
+    padding: var(--sp-xl) 0 var(--sp-lg);
+    break-inside: auto;
+}
+
+/* ── Section Header ─────────────────────────────────── */
+.section-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: var(--sp-md);
+    margin-bottom: var(--sp-md);
+}
+.section-kicker {
+    display: block;
+    font-size: 9pt;
+    font-weight: 500;
+    color: var(--c-text-2);
+    margin-bottom: 2px;
+}
+.section-pill {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 8pt;
+    color: var(--c-text-2);
+    background: var(--c-bg);
+    padding: 4px 10px;
+    border-radius: 20px;
+    white-space: nowrap;
+    flex-shrink: 0;
+    margin-top: 4px;
+}
+
+/* ── Category Badges ────────────────────────────────── */
+.badge {
+    display: inline-block;
+    font-size: 7.5pt;
+    font-weight: 600;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    padding: 2px 8px;
+    border-radius: 3px;
+    margin-bottom: var(--sp-xs);
+}
+.badge-strategy { background: #eff6ff; color: var(--c-cat-strategy); }
+.badge-action   { background: #ecfdf5; color: #047857; }
+.badge-risk     { background: #fef2f2; color: #b91c1c; }
+.badge-finance  { background: #fffbeb; color: #b45309; }
+.badge-deep     { background: #f5f3ff; color: var(--c-cat-deep); }
+
+/* ── Glance Box ─────────────────────────────────────── */
+.glance-box {
+    font-size: 10pt;
+    line-height: 1.5;
+    padding: 10px 14px;
+    border-radius: var(--r-sm);
+    margin-bottom: var(--sp-lg);
+    background: var(--c-bg);
+    border-left: 3px solid var(--c-border);
+}
+.glance-box strong { font-weight: 600; color: var(--c-text); }
+.glance-strategy { border-left-color: var(--c-cat-strategy); }
+.glance-action   { border-left-color: var(--c-cat-action); }
+.glance-risk     { border-left-color: var(--c-cat-risk); }
+.glance-finance  { border-left-color: var(--c-cat-finance); }
+.glance-deep     { border-left-color: var(--c-cat-deep); }
+
+/* ── Section Body ───────────────────────────────────── */
+.section-body {
+    font-size: 10pt;
+    line-height: 1.65;
+}
+.section-body p + p { margin-top: 6px; }
+.section-body h4 + p { margin-top: 4px; }
+.section-body p, .section-body li { orphans: 3; widows: 3; }
+.section-body h3 { margin-top: var(--sp-lg); }
+
+/* ══════════════════════════════════════════════════════
+   DEEP DIVE COVER PAGE
+   ══════════════════════════════════════════════════════ */
+.cover {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    text-align: center;
+    height: 100vh;
+    padding: var(--sp-2xl) var(--sp-xl);
+    overflow: hidden;
+}
+.cover-accent {
+    width: 80px;
+    height: 4px;
+    border-radius: 2px;
+    background: linear-gradient(90deg, var(--c-deep), var(--c-primary));
+    margin: 0 auto var(--sp-xl);
+}
+.cover-eyebrow {
+    font-size: 9pt;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--c-text-3);
+    margin-bottom: var(--sp-lg);
+}
+.cover-subtitle {
+    font-size: 12pt;
+    color: var(--c-deep);
+    font-style: italic;
+    margin-bottom: var(--sp-xs);
+}
+.cover-meta {
+    font-size: 10.5pt;
+    color: var(--c-text-2);
+}
+.cover-meta strong { color: var(--c-text); }
+
+/* Deep Dive Icon */
+.dd-icon {
+    width: 100px;
+    height: 100px;
+    border-radius: 50%;
+    background: linear-gradient(135deg, var(--c-deep-light), #ede9fe);
+    border: 3px solid var(--c-deep-border);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    margin: var(--sp-xl) auto;
+}
+.dd-icon-inner {
+    font-size: 42pt;
+    line-height: 1;
+}
+
+/* KPI Cards */
+.kpi-row {
+    display: grid;
+    grid-template-columns: 1fr 1fr 1fr;
+    gap: 12px;
+    margin: var(--sp-xl) 0;
+    max-width: 500px;
+}
+.kpi-card {
+    text-align: center;
+    padding: 14px 10px;
+    background: var(--c-bg);
+    border-radius: var(--r-md);
+}
+.kpi-value {
+    font-size: 22pt;
+    font-weight: 700;
+    line-height: 1.2;
+}
+.kpi-label {
+    font-size: 8.5pt;
+    color: var(--c-text-3);
+    margin-top: 2px;
+}
+
+/* Table of Contents (inline) */
+.dd-toc {
+    text-align: left;
+    max-width: 400px;
+    margin: var(--sp-xl) auto 0;
+    border: 1px solid var(--c-border);
+    border-radius: var(--r-md);
+    padding: var(--sp-md);
+}
+.dd-toc-title {
+    font-size: 9pt;
+    font-weight: 600;
+    color: var(--c-text-2);
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    margin-bottom: var(--sp-sm);
+}
+.dd-toc-entry {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 6px 0;
+    border-bottom: 1px solid #F3F4F6;
+    font-size: 9.5pt;
+    color: var(--c-text);
+}
+.dd-toc-entry:last-child { border-bottom: none; }
+.dd-toc-num {
+    width: 22px;
+    height: 22px;
+    border-radius: 50%;
+    background: var(--c-deep-light);
+    color: var(--c-deep);
+    font-size: 8pt;
+    font-weight: 700;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+}
+
+/* ══════════════════════════════════════════════════════
+   SECTION-SPECIFIC STYLES
+   ══════════════════════════════════════════════════════ */
+
+/* Section number circle */
+.section-num {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 32px;
+    height: 32px;
+    border-radius: 50%;
+    background: var(--c-deep);
+    color: white;
+    font-size: 14pt;
+    font-weight: 700;
+    margin-right: var(--sp-sm);
+    vertical-align: middle;
+}
+
+/* Sensitivity table highlight */
+.table tr.highlight td {
+    background: #f0fdf4;
+    font-weight: 600;
+}
+.table td.positive,
+td.positive {
+    color: var(--c-success);
+    font-weight: 600;
+}
+.table td.negative,
+td.negative {
+    color: var(--c-danger);
+    font-weight: 600;
+}
+
+/* Risk matrix styling */
+.risk-high { color: var(--c-danger); font-weight: 600; }
+.risk-medium { color: var(--c-warning); font-weight: 600; }
+.risk-low { color: var(--c-success); font-weight: 600; }
+
+/* Next steps action cards */
+.action-card {
+    background: var(--c-bg);
+    border-left: 3px solid var(--c-deep);
+    border-radius: var(--r-sm);
+    padding: 12px 16px;
+    margin-bottom: var(--sp-md);
+    page-break-inside: avoid;
+}
+
+/* ══════════════════════════════════════════════════════
+   BLOCK PROTECTION — keep cards/boxes together
+   ══════════════════════════════════════════════════════ */
+.glance-box, .kpi-card, .action-card, .card-nobreak {
+    break-inside: avoid;
+}
+h1, h2, h3, h4 {
+    break-after: avoid;
+}
+.kpi-row {
+    break-inside: avoid;
+}
+
+/* ── Contact Box ─────────────────────────────────────── */
+.contact-box {
+    text-align: center;
+    padding: 20px;
+    background: var(--c-bg);
+    border-radius: var(--r-lg);
+    margin-top: var(--sp-lg);
+}
+.contact-name { font-size: 12pt; font-weight: 700; color: #111827; }
+.contact-org  { font-size: 9.5pt; color: var(--c-text-2); margin-top: 2px; }
+.contact-btns { margin-top: 12px; }
+.btn {
+    display: inline-block;
+    padding: 8px 20px;
+    border-radius: 6px;
+    text-decoration: none;
+    font-weight: 600;
+    font-size: 9.5pt;
+    margin: 0 4px;
+    color: white;
+}
+.btn-primary { background: var(--c-primary); }
+.btn-accent  { background: var(--c-accent); }
+.btn-deep    { background: var(--c-deep); }
+
+/* ── Impressum ─────────────────────────────────────── */
+.impressum-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr 1fr;
+    gap: var(--sp-lg);
+    margin-bottom: var(--sp-lg);
+}
+.impressum-block h4 { font-size: 10pt; margin-bottom: var(--sp-sm); }
+.impressum-block p { font-size: 9pt; color: var(--c-text-2); line-height: 1.6; }
+.impressum-divider { height: 1px; background: var(--c-border); margin: var(--sp-lg) 0; }
+.gdpr-mini {
+    font-size: 7.5pt;
+    color: var(--c-text-3);
+    text-align: center;
+    padding: var(--sp-md) 0;
+    margin-top: var(--sp-lg);
+    border-top: 1px solid var(--c-border);
+}
+
+/* ── Print enhancements ─────────────────────────────── */
+@media print {
+    body { -webkit-print-color-adjust: exact; print-color-adjust: exact; }
+    .section { break-inside: auto; }
+    .glance-box, .kpi-card, .action-card, .card-nobreak { break-inside: avoid; }
+}
+    </style>
+</head>
+<body>
+
+{# ═══════════════════════════════════════════════════════
+   COMPUTED VARIABLES
+   ═══════════════════════════════════════════════════════ #}
+{% set company = company_name or HAUPTLEISTUNG or 'Ihr Unternehmen' %}
+{% set branche = BRANCHE_LABEL|default('') %}
+{% set size_label = UNTERNEHMENSGROESSE_LABEL|default('') %}
+{% set report_date_display = report_date|default('') %}
+
+{# ═══════════════════════════════════════════════════════
+   PAGE 1: COVER — Deep Dive Branding
+   ═══════════════════════════════════════════════════════ #}
+<div class="cover" id="dd-cover">
+    <div class="cover-accent"></div>
+    <div class="cover-eyebrow">
+        Gamechanger Deep Dive · {{ report_date_display }}
+    </div>
+
+    <!-- Deep Dive Icon -->
+    <div class="dd-icon">
+        <span class="dd-icon-inner">&#x1F50D;</span>
+    </div>
+
+    <div style="margin-bottom: var(--sp-lg); max-width: 600px;">
+        <h1 style="color: var(--c-deep);">Gamechanger<br>Deep Dive</h1>
+        <p class="cover-subtitle">Vertiefende Analyse Ihres strategischen KI-Bruchpunkts</p>
+        <p class="cover-meta">
+            Unternehmen: <strong>{{ company }}</strong>
+            {% if branche %}<span class="muted"> · </span>{{ branche }}{% endif %}
+            {% if size_label %}<span class="muted"> · </span>{{ size_label }}{% endif %}
+        </p>
+    </div>
+
+    <!-- KPI Summary -->
+    {% if canonical_bc %}
+    <div class="kpi-row">
+        <div class="kpi-card">
+            <div class="kpi-value" style="color: var(--c-accent);">
+                {{ canonical_bc.hours|default(0)|round(0)|int }}h
+            </div>
+            <div class="kpi-label">Einsparung/Monat</div>
+        </div>
+        <div class="kpi-card">
+            <div class="kpi-value" style="color: #c2410c;">
+                {{ canonical_bc.roi|default(0)|round(0)|int }}%
+            </div>
+            <div class="kpi-label">ROI (12 Monate)</div>
+        </div>
+        <div class="kpi-card">
+            <div class="kpi-value" style="color: var(--c-deep);">
+                {{ canonical_bc.payback|default(0)|round(1) }} M.
+            </div>
+            <div class="kpi-label">Amortisation</div>
+        </div>
+    </div>
+    {% endif %}
+
+    <!-- Mini Table of Contents -->
+    <div class="dd-toc">
+        <div class="dd-toc-title">Inhalt</div>
+        <div class="dd-toc-entry">
+            <span class="dd-toc-num">1</span>
+            <span>Strategischer Bruchpunkt</span>
+        </div>
+        <div class="dd-toc-entry">
+            <span class="dd-toc-num">2</span>
+            <span>90-Tage Implementierungsplan</span>
+        </div>
+        <div class="dd-toc-entry">
+            <span class="dd-toc-num">3</span>
+            <span>Business Case Deep Dive</span>
+        </div>
+        <div class="dd-toc-entry">
+            <span class="dd-toc-num">4</span>
+            <span>Risikobewertung &amp; Absicherung</span>
+        </div>
+        <div class="dd-toc-entry">
+            <span class="dd-toc-num">5</span>
+            <span>Konkrete n&auml;chste Schritte</span>
+        </div>
+    </div>
+</div>
+
+{# ═══════════════════════════════════════════════════════
+   PAGE 2-3: SECTION 1 — Strategischer Bruchpunkt
+   ═══════════════════════════════════════════════════════ #}
+<div class="section" id="dd-bruchpunkt">
+    <div class="section-header">
+        <div>
+            <span class="badge badge-deep">Deep Dive</span>
+            <span class="section-kicker">Abschnitt 1</span>
+            <h2><span class="section-num">1</span> Strategischer Bruchpunkt</h2>
+        </div>
+        <span class="section-pill">
+            <span style="width:6px;height:6px;border-radius:50%;background:var(--c-deep);"></span>
+            Gamechanger-Analyse
+        </span>
+    </div>
+
+    <div class="glance-box glance-deep">
+        <strong>Auf einen Blick:</strong> Die erweiterte Analyse Ihres strategischen KI-Wendepunkts
+        mit konkreten Handlungsempfehlungen.
+    </div>
+
+    <div class="section-body">
+        {{ GC_BRUCHPUNKT_HTML|safe }}
+    </div>
+</div>
+
+{# ═══════════════════════════════════════════════════════
+   PAGE 3-4: SECTION 2 — Implementierungsplan
+   ═══════════════════════════════════════════════════════ #}
+<div class="section" id="dd-implementation">
+    <div class="section-header">
+        <div>
+            <span class="badge badge-action">Umsetzung</span>
+            <span class="section-kicker">Abschnitt 2</span>
+            <h2><span class="section-num">2</span> 90-Tage Implementierungsplan</h2>
+        </div>
+        <span class="section-pill">
+            <span style="width:6px;height:6px;border-radius:50%;background:var(--c-cat-action);"></span>
+            Fahrplan
+        </span>
+    </div>
+
+    <div class="glance-box glance-action">
+        <strong>Auf einen Blick:</strong> Ihr konkreter 3-Phasen-Plan zur Umsetzung des Gamechanger-Szenarios
+        in 90 Tagen.
+    </div>
+
+    <div class="section-body">
+        {{ GC_IMPL_PLAN_HTML|safe }}
+    </div>
+</div>
+
+{# ═══════════════════════════════════════════════════════
+   PAGE 4-5: SECTION 3 — Business Case Deep Dive
+   ═══════════════════════════════════════════════════════ #}
+<div class="section" id="dd-business-case">
+    <div class="section-header">
+        <div>
+            <span class="badge badge-finance">Finanzen</span>
+            <span class="section-kicker">Abschnitt 3</span>
+            <h2><span class="section-num">3</span> Business Case Deep Dive</h2>
+        </div>
+        <span class="section-pill">
+            <span style="width:6px;height:6px;border-radius:50%;background:var(--c-cat-finance);"></span>
+            Deterministisch berechnet
+        </span>
+    </div>
+
+    <div class="glance-box glance-finance">
+        <strong>Auf einen Blick:</strong> Sensitivit&auml;tsanalyse, 3-Jahres-Projektion und Break-Even-Berechnung
+        f&uuml;r Ihren Gamechanger — rein datenbasiert, keine KI-generierte Sch&auml;tzung.
+    </div>
+
+    <div class="section-body">
+        {{ BC_DEEP_DIVE_HTML|safe }}
+    </div>
+</div>
+
+{# ═══════════════════════════════════════════════════════
+   PAGE 5-6: SECTION 4 — Risikobewertung
+   ═══════════════════════════════════════════════════════ #}
+<div class="section" id="dd-risk-assessment">
+    <div class="section-header">
+        <div>
+            <span class="badge badge-risk">Risiko</span>
+            <span class="section-kicker">Abschnitt 4</span>
+            <h2><span class="section-num">4</span> Risikobewertung &amp; Absicherung</h2>
+        </div>
+        <span class="section-pill">
+            <span style="width:6px;height:6px;border-radius:50%;background:var(--c-cat-risk);"></span>
+            Top-5-Risiken
+        </span>
+    </div>
+
+    <div class="glance-box glance-risk">
+        <strong>Auf einen Blick:</strong> Die f&uuml;nf gr&ouml;&szlig;ten Risiken f&uuml;r Ihr Gamechanger-Szenario
+        mit Eintrittswahrscheinlichkeit, Auswirkung und konkreten Gegenma&szlig;nahmen.
+    </div>
+
+    <div class="section-body">
+        {{ GC_RISK_HTML|safe }}
+    </div>
+</div>
+
+{# ═══════════════════════════════════════════════════════
+   PAGE 6-7: SECTION 5 — Nächste Schritte & CTA
+   ═══════════════════════════════════════════════════════ #}
+<div class="section" id="dd-next-steps">
+    <div class="section-header">
+        <div>
+            <span class="badge badge-action">Aktion</span>
+            <span class="section-kicker">Abschnitt 5</span>
+            <h2><span class="section-num">5</span> N&auml;chste Schritte</h2>
+        </div>
+        <span class="section-pill">
+            <span style="width:6px;height:6px;border-radius:50%;background:var(--c-cat-action);"></span>
+            7-Tage-Aktionen
+        </span>
+    </div>
+
+    <div class="glance-box glance-action">
+        <strong>Auf einen Blick:</strong> 3 konkrete Handlungen f&uuml;r die n&auml;chsten 7 Tage,
+        die Sie sofort umsetzen k&ouml;nnen — ohne Budget, ohne Setup.
+    </div>
+
+    <div class="section-body">
+        {{ GC_NEXT_STEPS_HTML|safe }}
+    </div>
+
+    <!-- Contact Box -->
+    <div class="contact-box" style="margin-top: var(--sp-xl);">
+        <p class="contact-name">Wolf Hohl</p>
+        <p class="contact-org">KI-Sicherheit.jetzt — Ihr Partner f&uuml;r KI-Readiness</p>
+        <div class="contact-btns">
+            <a href="https://ki-sicherheit.jetzt" class="btn btn-deep">Website besuchen</a>
+            <a href="mailto:kontakt@ki-sicherheit.jetzt" class="btn btn-primary">Kontakt aufnehmen</a>
+        </div>
+    </div>
+</div>
+
+{# ═══════════════════════════════════════════════════════
+   PAGE 7-8: IMPRESSUM
+   ═══════════════════════════════════════════════════════ #}
+<div class="section" id="dd-impressum" style="break-before: page;">
+    <div class="impressum-grid">
+        <div class="impressum-block">
+            <h4>Impressum</h4>
+            <p><strong>Verantwortlich f&uuml;r den Inhalt:</strong><br>
+            KI-Sicherheit.jetzt – Wolf Hohl<br>
+            Greifswalder Str. 224a<br>
+            10405 Berlin</p>
+            <p>E-Mail: kontakt@ki-sicherheit.jetzt</p>
+        </div>
+        <div class="impressum-block">
+            <h4>Haftungsausschluss</h4>
+            <p>Dieses Dokument dient ausschlie&szlig;lich der Information. Trotz sorgf&auml;ltiger Pr&uuml;fung &uuml;bernehmen wir keine Haftung f&uuml;r Vollst&auml;ndigkeit oder Richtigkeit.</p>
+            <h4>Urheberrecht</h4>
+            <p>Alle Inhalte unterliegen dem deutschen Urheberrecht.</p>
+        </div>
+        <div class="impressum-block">
+            <h4>Hinweis zum EU AI Act</h4>
+            <p>Dieses Dokument informiert &uuml;ber Pflichten, Risiken und F&ouml;rderm&ouml;glichkeiten beim Einsatz von KI. Es ersetzt keine Rechtsberatung.</p>
+        </div>
+    </div>
+    <div class="impressum-divider"></div>
+    <p class="small muted" style="text-align: center;">
+        Basierend auf Daten aus dem KI-Readiness Report 1. Keine erneute Befragung erforderlich.
+    </p>
+</div>
+
+<!-- GDPR Mini Disclaimer -->
+<div class="gdpr-mini">
+    Dieser Deep Dive nutzt Unternehmensdaten aus dem KI-Readiness Report. Verarbeitung auf Basis von Art. 6 (1) b DSGVO.
+    <a href="https://ki-sicherheit.jetzt/datenschutz" target="_blank">Datenschutzerkl&auml;rung</a>
+</div>
+
+<p class="small" style="text-align: center; color: var(--c-text-3); margin-top: var(--sp-lg);">
+    Gamechanger Deep Dive v1.0 · Design: Clean Corporate Plus · Generiert am {{ report_date_display }}
+</p>
+
+</body>
+</html>


### PR DESCRIPTION
## Summary

Introduces a new **Gamechanger Deep Dive** standalone report product—a 6-8 page expanded analysis that builds on completed Report 1 data. This is a new revenue stream that requires no additional questionnaire, reusing existing briefing data to generate deeper insights into the identified strategic KI breakpoint.

## Key Changes

### New Template & Service
- **`templates/gamechanger_deep_dive_v1.html`** (704 lines)
  - Complete HTML/CSS template with "Clean Corporate Plus" design system
  - 5-section structure: Cover page + 4 content sections with page breaks
  - Responsive typography, KPI cards, risk matrices, and action cards
  - Print-optimized with orphan/widow control and block protection

- **`services/gamechanger_deep_dive.py`** (565 lines)
  - `build_gamechanger_context()`: Extracts Report 1 data (scores, gamechanger content, business case values)
  - `calculate_bc_deep_dive()`: **Deterministic** (no LLM) business case calculator with sensitivity analysis and 3-year projections
  - `render_bc_deep_dive_html()`: Renders sensitivity tables and break-even analysis
  - `generate_deep_dive_sections()`: Orchestrates section generation (reuses Report 1 content for Section 1, calls LLM for Sections 2/4/5, deterministic math for Section 3)
  - `generate_gamechanger_report()`: Main entry point that loads briefing, builds context, generates sections, and renders final HTML

### API Endpoints
- **`routes/report.py`** additions:
  - `POST /gamechanger-deep-dive`: Accepts `briefing_id`, generates full report HTML
  - `GET /gamechanger-deep-dive/html/{briefing_id}`: Retrieves cached HTML
  - `GET /gamechanger-deep-dive/pdf/{briefing_id}`: Renders PDF via Puppeteer

### New Prompts (German)
- **`prompts/de/gc_implementation_plan.md`**: 90-day implementation roadmap (3 phases, 600-word limit)
- **`prompts/de/gc_risk_assessment.md`**: Gamechanger-specific risk matrix and mitigation (500-word limit)
- **`prompts/de/gc_next_steps.md`**: 3 actionable next steps for 7-day sprint (250-word limit)

### Prompt Updates
Updated existing prompts with **hard word limits** to prevent truncation:
- `foerderpotenzial.md`: Added size-aware limits (solo: 350w, team: 700w, kmu: 900w)
- `gamechanger.md`: Added size-aware limits (solo: 150w, team: 350w, kmu: 450w)
- `risks.md`, `ki_skillplan.md`, `recommendations.md`, `roadmap_90d.md`, `strategie_governance.md`, `unternehmensprofil_markt.md`, `org_change.md`, `data_readiness.md`: All updated with explicit truncation warnings and size-aware budgets

## Notable Implementation Details

1. **No New Questionnaire**: All data sourced from existing Report 1 (briefing_id lookup)
2. **Deterministic Business Case**: Section 3 uses pure math (no LLM) for sensitivity analysis, break-even calculation, and 3-year projections—ensures financial accuracy
3. **Reuse & Expansion**: Section 1 (Strategischer Bruchpunkt) reuses Report 1 gamechanger content; Sections 2/4/5 expand with LLM-generated implementation, risk, and next-steps content
4. **Strict Length Control**: All new prompts enforce hard character limits with explicit truncation warnings to prevent mid-sentence cutoffs
5. **Print-Ready Design**: Template includes page breaks, orphan/widow control, and block-protection CSS for reliable PDF rendering

## Product Positioning

- **Target**: Clients who completed Report 1 and want deeper analysis of

https://claude.ai/code/session_01VbYFKCxTe1YLt645jSDdJy