### PR TITLE
fix: Deep Dive PDF — add missing date + fix Amortisation label

### DIFF
--- a/services/gamechanger_deep_dive.py
+++ b/services/gamechanger_deep_dive.py
@@ -749,6 +749,9 @@ def render_deep_dive_html(sections: Dict[str, str],
         # Merge sections and context for template
         template_vars = {**sections, **context}
         template_vars['report_type'] = 'gamechanger_deep_dive'
+        # Set report_date for "Generiert am" display (same pattern as Report 1)
+        from datetime import datetime
+        template_vars['report_date'] = datetime.now().strftime("%d.%m.%Y")
         # Use kundencode (company identifier) as company_name, NOT hauptleistung
         template_vars['company_name'] = (
             context.get('kundencode')

--- a/templates/gamechanger_deep_dive_v1.html
+++ b/templates/gamechanger_deep_dive_v1.html
@@ -487,7 +487,7 @@ h1, h2, h3, h4 {
         </div>
         <div class="kpi-card">
             <div class="kpi-value" style="color: var(--c-deep);">
-                {{ canonical_bc.payback|default(0)|round(1) }} M.
+                {{ canonical_bc.payback|default(0)|round(1)|string|replace('.', ',') }} Mon.
             </div>
             <div class="kpi-label">Amortisation</div>
         </div>


### PR DESCRIPTION
Issue 1: "Generiert am" on Impressum page was missing the date. Added report_date (DD.MM.YYYY) to template vars using same pattern as Report 1.

Issue 2: Cover KPI showed "M." (ambiguous) instead of "Mon." for Amortisation. Changed to "Mon." and added German decimal format (comma instead of dot).

https://claude.ai/code/session_01PscdLJGyy5xzHfB9Ps39qY