### PR TITLE
Fix compact report section removal to use HTML comments

### DIFF
--- a/gpt_analyze.py
+++ b/gpt_analyze.py
@@ -17461,7 +17461,7 @@ Digitalisierungs- und KI-Vorhaben relevant sein
                         # =================================================================
                         # FIX-B726-COMPACT: Remove appendix sections for compact reports
                         # Template-Conditionals sind unzuverlaessig (bool/string mismatch)
-                        # Deshalb hier die Sections direkt leeren
+                        # Deshalb hier die Sections auf HTML-Kommentar setzen (nicht leeren, sonst HARD STOP)
                         # =================================================================
                         try:
                             _compact_size = sections.get("COMPANY_SIZE", "") or ""
@@ -17492,7 +17492,7 @@ Digitalisierungs- und KI-Vorhaben relevant sein
                                 _compact_removed = 0
                                 for _ck in _compact_remove:
                                         if sections.get(_ck):
-                                            sections[_ck] = ""
+                                            sections[_ck] = "<!-- removed-by-compact -->"
                                             _compact_removed += 1
                                 sections["COMPACT_REPORT_MODE"] = True
                                 log.info("[FIX-B726-COMPACT] Removed %d appendix sections for %s", _compact_removed, _compact_size)


### PR DESCRIPTION
## Summary
Modified the compact report generation logic to replace removed appendix sections with HTML comments instead of empty strings, preventing downstream processing errors.

## Key Changes
- Changed section removal strategy in compact report mode from setting sections to empty strings (`""`) to using HTML comment placeholders (`"<!-- removed-by-compact -->"`)
- Updated the corresponding comment to clarify that sections are set to HTML comments rather than being emptied, noting that empty sections cause a "HARD STOP" error
- This fix addresses the FIX-B726-COMPACT issue where template conditionals were unreliable due to bool/string type mismatches

## Implementation Details
- The change affects the `_r4()` function's compact report section removal logic
- Instead of completely clearing section content (which apparently triggers downstream errors), sections are now marked with an HTML comment that preserves the section structure while indicating removal
- This approach maintains compatibility with template processing while preventing the hard stop error that occurred with empty sections

https://claude.ai/code/session_012ro8X7Gh6iXULMPWpeybpZ