### PR TITLE
fix(BC-EUR): use structural regex patterns for OPEX + Nettonutzen lines

### DIFF
--- a/services/report_renderer.py
+++ b/services/report_renderer.py
@@ -1583,24 +1583,48 @@ def render(briefing_obj: Any,
                 html
             )
 
-            # FIX 2: OPEX annual line — "{opex}€/Monat × 12 = {VALUE}€"
-            if _bc_opex_m > 0:
-                html = re.sub(
-                    rf'({int(_bc_opex_m)})€/Monat\s*[×x]\s*12\s*=\s*[\d.,]+€',
-                    rf'\1€/Monat × 12 = {_bc_fmt(_bc_opex_annual)}€',
-                    html
-                )
-
-            # FIX 3: Nettonutzen line — recalculate the subtraction result
-            # Pattern: "{jahresersparnis}€ - {capex}€ - {opex_annual}€ = {VALUE}€"
+            # FIX 2: OPEX annual line — structural match for line 3 of ROI-Herleitung
+            # "Abzüglich laufende Jahreskosten: {X}€/Monat × 12 = {Y}€"
+            # Uses structural pattern (not value-specific) because both X and Y
+            # may already be corrupted (e.g., 180→80, 2.160→2.80).
             _j_fmt = _bc_fmt(_bc_jahresersparnis)
             _c_fmt = _bc_fmt(_bc_capex)
             _o_fmt = _bc_fmt(_bc_opex_annual)
+            _opex_m_display = _bc_fmt(_bc_opex_m) if _bc_opex_m >= 1000 else str(int(_bc_opex_m))
+            if _bc_opex_m > 0:
+                html = re.sub(
+                    r'(laufende Jahreskosten:\s*)\d[\d.,]*€/Monat\s*[×x]\s*12\s*=\s*[\d.,]+€',
+                    rf'\g<1>{_opex_m_display}€/Monat × 12 = {_o_fmt}€',
+                    html
+                )
+
+            # FIX 2b: OPEX in "So berechne ich" table — correct monthly display
+            # "Laufende Kosten (OPEX)</td><td ...>{X} €/Monat"
+            if _bc_opex_m > 0:
+                html = re.sub(
+                    r'(Laufende Kosten \(OPEX\)</td>\s*<td[^>]*>)\s*\d[\d.,]*\s*(€/Monat)',
+                    rf'\g<1>{_opex_m_display} \2',
+                    html
+                )
+
+            # FIX 3: Nettonutzen line — structural match for line 4 of ROI-Herleitung
+            # "Nettonutzen: {A}€ - {B}€ - {C}€ = {D}€"
+            # All four values may be corrupted, so match any numbers in this structure.
             html = re.sub(
-                rf'{re.escape(_j_fmt)}€\s*-\s*{re.escape(_c_fmt)}€\s*-\s*{re.escape(_o_fmt)}€\s*=\s*[\d.,]+€',
-                f'{_j_fmt}€ - {_c_fmt}€ - {_o_fmt}€ = {_bc_fmt(_bc_nettonutzen)}€',
+                r'(Nettonutzen:\s*)\d[\d.,]*€\s*-\s*\d[\d.,]*€\s*-\s*\d[\d.,]*€\s*=\s*\d[\d.,]*€',
+                rf'\g<1>{_j_fmt}€ - {_c_fmt}€ - {_o_fmt}€ = {_bc_fmt(_bc_nettonutzen)}€',
                 html
             )
+
+            # FIX 3b: ROI step 5 — "ROI (berechnet): {nettonutzen}€ / {capex}€ × 100 = {X}%"
+            # Ensure numerator matches corrected Nettonutzen
+            if _bc_capex > 0:
+                _roi_raw = (_bc_nettonutzen / _bc_capex) * 100
+                html = re.sub(
+                    r'(ROI \(berechnet\):\s*)\d[\d.,]*€\s*/\s*\d[\d.,]*€\s*[×x]\s*100\s*=\s*\d+%',
+                    rf'\g<1>{_bc_fmt(_bc_nettonutzen)}€ / {_c_fmt}€ × 100 = {_roi_raw:.0f}%',
+                    html
+                )
 
             # FIX 4: Scenario card monthly savings — recalculate from canonical values
             # Cards appear in order: optimistic, realistic, conservative


### PR DESCRIPTION
Bug B Restfix: The previous FIX-v7110-BC-EUR patterns for OPEX annual (line 3) and Nettonutzen (line 4) anchored on specific canonical values (e.g., "180€/Monat"), but these values were already corrupted in the HTML (e.g., "80€/Monat"). The patterns never matched, leaving lines 3+4 broken.

Fix: Replace value-specific patterns with structural patterns that match the ROI-Herleitung text structure regardless of corrupted values:
- FIX 2: Match "laufende Jahreskosten: {ANY}€/Monat × 12 = {ANY}€"
- FIX 2b: Correct OPEX in "So berechne ich" table
- FIX 3: Match "Nettonutzen: {ANY}€ - {ANY}€ - {ANY}€ = {ANY}€"
- FIX 3b: Correct ROI step 5 to match corrected Nettonutzen

Tested: Solo (OPEX=80 and OPEX=180 hypotheses), Team (no regression).

https://claude.ai/code/session_01Tb56DrqWHf4YKMdmt6k6Sf