### PR TITLE
fix: 4 cosmetic fixes — naming, Tausendertrenner, KPI labels

### DIFF
--- a/services/business_case_engine_v2.py
+++ b/services/business_case_engine_v2.py
@@ -2072,6 +2072,13 @@ def business_case_report_to_html(
             "summary_title": "Assessment",
             "funding_note": "Funding effect",
         }
+        kpi_key_labels = {
+            "roi": "ROI",
+            "payback_progress": "Payback Progress",
+            "time_savings_hours": "Time Savings",
+            "monthly_savings": "Monthly Savings",
+            "automation_rate": "Automation Rate",
+        }
     else:
         # Fix-Batch J2: 100% German labels
         labels = {
@@ -2089,6 +2096,13 @@ def business_case_report_to_html(
             "kpi_12m": "12-Monats-Ziele",
             "summary_title": "Bewertung",
             "funding_note": "Fördereffekt",
+        }
+        kpi_key_labels = {
+            "roi": "ROI",
+            "payback_progress": "Amortisierung",
+            "time_savings_hours": "Zeitersparnis",
+            "monthly_savings": "Monatl. Ersparnis",
+            "automation_rate": "Automatisierungsgrad",
         }
 
     # Scenario colors
@@ -2173,7 +2187,7 @@ def business_case_report_to_html(
             for key, value in list(report.kpi_targets_6m.items())[:4]:
                 # FIX-B17: Cap ROI KPI values at MAX_ROI for consistency
                 _kpi_val = min(MAX_ROI, value) if "roi" in key.lower() else value
-                display_key = key.replace("_", " ").title()
+                display_key = kpi_key_labels.get(key, key.replace("_", " ").title())
                 unit = "%" if "roi" in key or "rate" in key or "progress" in key else ("h" if "hours" in key else "€")
                 html_parts.append(f'''
                     <div style="display:flex;justify-content:space-between;padding:4px 0;font-size:10pt;">
@@ -2192,7 +2206,7 @@ def business_case_report_to_html(
             for key, value in list(report.kpi_targets_12m.items())[:4]:
                 # FIX-B17: Cap ROI KPI values at MAX_ROI for consistency
                 _kpi_val = min(MAX_ROI, value) if "roi" in key.lower() else value
-                display_key = key.replace("_", " ").title()
+                display_key = kpi_key_labels.get(key, key.replace("_", " ").title())
                 unit = "%" if "roi" in key or "rate" in key or "progress" in key else ("h" if "hours" in key else "€")
                 html_parts.append(f'''
                     <div style="display:flex;justify-content:space-between;padding:4px 0;font-size:10pt;">

--- a/services/report_renderer.py
+++ b/services/report_renderer.py
@@ -1514,7 +1514,7 @@ def render(briefing_obj: Any,
             # HTML structure: <div style="...">VALUE€</div><div ...>Netto-Ersparnis*</div>
             # The value PRECEDES the label (not after), and uses Python :, format (commas)
             # Match: any €-amount in a div immediately before "Netto-Ersparnis"
-            _netto_ersparnis_comma = f"{int(_netto_ersparnis):,}"  # Python :, format (commas)
+            _netto_ersparnis_comma = f"{int(_netto_ersparnis):,}".replace(",", ".")  # German thousands separator
             html = re.sub(
                 r'(<div[^>]*>)\s*([\d.,]+)\s*€\s*(</div>\s*<div[^>]*>\s*Netto-Ersparnis)',
                 rf'\g<1>{_netto_ersparnis_comma}€\3',

--- a/services/sofort_start_generator.py
+++ b/services/sofort_start_generator.py
@@ -1144,7 +1144,7 @@ def generate_sofort_start_html(
                 <div style="font-size: 11px; color: #64748b;">pro Jahr</div>
             </div>
             <div style="background: white; border-radius: 6px; padding: 12px;">
-                <div style="font-size: 24px; font-weight: 700; color: #166534;">{savings['net_savings']:,}€</div>
+                <div style="font-size: 24px; font-weight: 700; color: #166534;">{f"{savings['net_savings']:,}".replace(",", ".")}€</div>
                 <div style="font-size: 11px; color: #64748b;">Netto-Ersparnis*</div>
             </div>
         </div>
@@ -1339,7 +1339,7 @@ def generate_entscheidungsvorlage_html(
             <h4 style="font-size: 13px; font-weight: 600; margin: 16px 0 8px 0;">Erwarteter Nutzen:</h4>
             <ul style="font-size: 13px; margin: 0; padding-left: 20px;">
                 <li>Zeitersparnis: ca. {savings['hours_per_week']} Stunden/Woche</li>
-                <li>Jährliche Ersparnis: ca. {savings['net_savings']:,}€ (netto)</li>
+                <li>Jährliche Ersparnis: ca. {f"{savings['net_savings']:,}".replace(",", ".")}€ (netto)</li>
                 <li>Qualitätssteigerung bei Routineaufgaben</li>
             </ul>
             

--- a/templates/gamechanger_deep_dive_v1.html
+++ b/templates/gamechanger_deep_dive_v1.html
@@ -506,7 +506,7 @@ h1, h2, h3, h4 {
         </div>
         <div class="dd-toc-entry">
             <span class="dd-toc-num">3</span>
-            <span>Business Case Deep Dive</span>
+            <span>Detaillierter Business Case</span>
         </div>
         <div class="dd-toc-entry">
             <span class="dd-toc-num">4</span>
@@ -525,7 +525,7 @@ h1, h2, h3, h4 {
 <div class="section" id="dd-bruchpunkt">
     <div class="section-header">
         <div>
-            <span class="badge badge-deep">Deep Dive</span>
+            <span class="badge badge-deep">Vertiefung</span>
             <span class="section-kicker">Abschnitt 1</span>
             <h2><span class="section-num">1</span> Strategischer Bruchpunkt</h2>
         </div>
@@ -579,7 +579,7 @@ h1, h2, h3, h4 {
         <div>
             <span class="badge badge-finance">Finanzen</span>
             <span class="section-kicker">Abschnitt 3</span>
-            <h2><span class="section-num">3</span> Business Case Deep Dive</h2>
+            <h2><span class="section-num">3</span> Detaillierter Business Case</h2>
         </div>
         <span class="section-pill">
             <span style="width:6px;height:6px;border-radius:50%;background:var(--c-cat-finance);"></span>
@@ -691,7 +691,7 @@ h1, h2, h3, h4 {
 
 <!-- GDPR Mini Disclaimer -->
 <div class="gdpr-mini">
-    Dieser Deep Dive nutzt Unternehmensdaten aus dem KI-Readiness Report. Verarbeitung auf Basis von Art. 6 (1) b DSGVO.
+    Diese KI-Potenzial-Analyse nutzt Unternehmensdaten aus dem KI-Readiness Report. Verarbeitung auf Basis von Art. 6 (1) b DSGVO.
     <a href="https://ki-sicherheit.jetzt/datenschutz" target="_blank">Datenschutzerkl&auml;rung</a>
 </div>
 


### PR DESCRIPTION
Fix 1: Replace customer-visible "Deep Dive" with German labels in gamechanger_deep_dive_v1.html — "Detaillierter Business Case" (section title), "Vertiefung" (badge), corrected Impressum text.

Fix 2: Fix Tausendertrenner "17,040€" → "17.040€" — the report_renderer.py post-processor was using Python comma format without .replace(",", "."). Also fixed source in sofort_start_generator.py.

Fix 3: KPI target labels now use explicit German mapping instead of key.replace("_", " ").title() which produced English labels like "Time Savings Hours", "Monthly Savings", "Roi".

Fix 4: ROI field in Realistisch scenario — investigated, no code issue found. All 3 scenario cards render all fields unconditionally (lines 2128-2155).

https://claude.ai/code/session_01Smr9Luj8FHxt2uN9ZECyBz