### PR TITLE
feat: product hardening — Anthropic timeout, status endpoint, admin a…

### DIFF
--- a/routes/briefings.py
+++ b/routes/briefings.py
@@ -223,11 +223,22 @@ async def get_briefing_status(
         "done_at": briefing.done_at.isoformat() if briefing.done_at else None,
     }
 
-    # Include report URLs when done
+    # Include report URLs and PDF availability when done
     if briefing.status == "done":
         base_url = str(request.base_url).rstrip("/")
         response["report_url"] = f"{base_url}/api/report/html/{briefing_id}"
         response["pdf_url"] = f"{base_url}/api/report/pdf/{briefing_id}"
+
+        # Check PDF availability
+        from models import Report
+        report = (
+            db.query(Report)
+            .filter(Report.briefing_id == briefing_id, Report.status == "done")
+            .order_by(Report.id.desc())
+            .first()
+        )
+        response["pdf_available"] = bool(report and (report.pdf_url or report.pdf_bytes_len))
+        response["email_sent"] = bool(report and report.email_sent_user)
 
     # Include error only if failed
     if briefing.status == "failed" and briefing.error:

--- a/services/anthropic_client.py
+++ b/services/anthropic_client.py
@@ -240,8 +240,12 @@ def get_anthropic_client() -> Optional["anthropic.Anthropic"]:
         )
         return None
 
-    client = anthropic.Anthropic(api_key=api_key)
-    log.info("✅ Anthropic-Client initialisiert.")
+    _timeout = float(os.getenv("ANTHROPIC_TIMEOUT", "180"))  # seconds
+    client = anthropic.Anthropic(
+        api_key=api_key,
+        timeout=_timeout,
+    )
+    log.info("✅ Anthropic-Client initialisiert (timeout=%ss).", _timeout)
     return client
 
 

--- a/workers/briefings_worker.py
+++ b/workers/briefings_worker.py
@@ -211,6 +211,49 @@ def claim_next_briefing(db: Session) -> Optional[Briefing]:
         return None
 
 
+def _send_admin_error_alert(briefing: Briefing, error_msg: str, run_id: str) -> None:
+    """Send admin email alert when a briefing pipeline fails."""
+    try:
+        from gpt_analyze import _send_email_via_resend, _admin_recipients, _mask_email
+    except ImportError:
+        log.warning("[%s] Cannot import email helpers for admin alert", run_id)
+        return
+
+    if os.getenv("DISABLE_EMAILS", "").lower() in ("1", "true", "yes", "on"):
+        return
+
+    answers = getattr(briefing, "answers", {}) or {}
+    company_size = answers.get("unternehmensgroesse", "unknown")
+    user_email = ""
+    if briefing.user_id and briefing.user:
+        user_email = getattr(briefing.user, "email", "") or ""
+
+    subject = f"Report-Fehler: Briefing #{briefing.id}"
+    body = f"""
+    <div style="font-family:sans-serif;max-width:600px;">
+        <h2 style="color:#dc2626;">Report-Pipeline Fehler</h2>
+        <table style="border-collapse:collapse;width:100%;">
+            <tr><td style="padding:6px;font-weight:bold;">Briefing-ID:</td><td style="padding:6px;">{briefing.id}</td></tr>
+            <tr><td style="padding:6px;font-weight:bold;">Segment:</td><td style="padding:6px;">{company_size}</td></tr>
+            <tr><td style="padding:6px;font-weight:bold;">User-Email:</td><td style="padding:6px;">{user_email or 'N/A'}</td></tr>
+            <tr><td style="padding:6px;font-weight:bold;">Run-ID:</td><td style="padding:6px;">{run_id}</td></tr>
+            <tr><td style="padding:6px;font-weight:bold;">Zeitpunkt:</td><td style="padding:6px;">{datetime.now(timezone.utc).strftime('%Y-%m-%d %H:%M:%S UTC')}</td></tr>
+        </table>
+        <div style="margin-top:16px;padding:12px;background:#fef2f2;border-radius:8px;border:1px solid #fecaca;">
+            <strong>Fehler:</strong><br>
+            <pre style="white-space:pre-wrap;font-size:12px;">{error_msg[:2000]}</pre>
+        </div>
+    </div>
+    """
+
+    for addr in _admin_recipients():
+        ok, err = _send_email_via_resend(addr, subject, body)
+        if ok:
+            log.info("[%s] Admin error alert sent to %s", run_id, _mask_email(addr))
+        else:
+            log.warning("[%s] Admin error alert failed for %s: %s", run_id, _mask_email(addr), err)
+
+
 def process_briefing(db: Session, briefing: Briefing) -> bool:
     """
     Process a single briefing through the full analysis pipeline.
@@ -258,6 +301,12 @@ def process_briefing(db: Session, briefing: Briefing) -> bool:
         except Exception as db_err:
             log.error("[%s] Failed to update briefing status: %s", run_id, db_err)
             db.rollback()
+
+        # Send admin error notification (fire-and-forget)
+        try:
+            _send_admin_error_alert(briefing, str(e), run_id)
+        except Exception as alert_err:
+            log.warning("[%s] Admin error alert failed: %s", run_id, alert_err)
 
         return False
 


### PR DESCRIPTION
…lerts

Phase 2 - Anthropic timeout: Set explicit 180s timeout on Anthropic client (configurable via ANTHROPIC_TIMEOUT env var). Previously the client had no timeout and could hang indefinitely, blocking the worker.

Phase 3 - Status endpoint: Enrich GET /briefings/{id} with pdf_available and email_sent fields when status=done, enabling frontend status pages.

Phase 5 - Admin error alerting: Send email to admin recipients when a briefing pipeline fails. Includes briefing ID, segment, user email, error message, and timestamp. Fire-and-forget, never blocks pipeline.

Diagnosis summary:
- OpenAI: Already robust (3-phase retry + PLATIN fallback, 180s/300s timeouts)
- PDF: Already robust (3 retries, 90s timeout, transient/permanent distinction)
- Email: Already non-blocking, errors logged to DB
- Worker: Already has stale recovery (10min timeout, resets to accepted)
- Anthropic: WAS MISSING timeout — now fixed
- Status endpoint: WAS MISSING pdf_available — now fixed
- Admin alerts: WERE MISSING on pipeline failure — now fixed

https://claude.ai/code/session_01Smr9Luj8FHxt2uN9ZECyBz