### PR TITLE
Add final Solo terminology cleanup pass and improve validator redundancy detection

### DIFF
--- a/gpt_analyze.py
+++ b/gpt_analyze.py
@@ -16470,8 +16470,11 @@ Digitalisierungs- und KI-Vorhaben relevant sein
     # === SOLO TERMINOLOGY FINAL CLEANUP (pre-validator) ===
     # Runs after all post-healer restores (Quick Wins pristine, GC snapshot, etc.)
     # to catch blacklisted terms that were re-introduced after healing.
+    # NOTE: Uses raw unternehmensgroesse — final_solo_terminology_cleanup handles
+    # solo detection internally (solo, 1, einzelunternehmer, etc.).
     try:
-        _solo_cleanup_fixes = final_solo_terminology_cleanup(sections, persona)
+        _solo_raw_seg = (answers.get("unternehmensgroesse", "") or "").strip()
+        _solo_cleanup_fixes = final_solo_terminology_cleanup(sections, _solo_raw_seg)
         if _solo_cleanup_fixes > 0:
             log.info(f"[{run_id}] [SOLO-FINAL-CLEANUP] Pre-validator: fixed {_solo_cleanup_fixes} sections")
     except Exception as _solo_cleanup_err:

--- a/gpt_analyze.py
+++ b/gpt_analyze.py
@@ -117,7 +117,7 @@ from field_registry import fields  # added by Patch03
 from models import Analysis, Briefing, Report, User
 from services.report_renderer import render
 from services.text_healing import heal_all_text_blocks, heal_text_block
-from services.report_healer import heal_report_html, heal_final_html, format_payback_de  # FIX-A-G: Report healing pipeline
+from services.report_healer import heal_report_html, heal_final_html, format_payback_de, final_solo_terminology_cleanup  # FIX-A-G: Report healing pipeline
 from services.pdf_client import render_pdf_from_html, build_footer_template
 from services.icon_system import (
     replace_emojis_with_icons,
@@ -16467,6 +16467,16 @@ Digitalisierungs- und KI-Vorhaben relevant sein
         log.warning("[%s] [FIX-642] GAMECHANGER_HTML destroyed (%d→%d words), restoring snapshot (%d words)", run_id, _gc_snap_w, _gc_cur_w, _gc_snap_w)
         sections["GAMECHANGER_HTML"] = _gc_snap
         sections["gamechanger"] = _gc_snap
+    # === SOLO TERMINOLOGY FINAL CLEANUP (pre-validator) ===
+    # Runs after all post-healer restores (Quick Wins pristine, GC snapshot, etc.)
+    # to catch blacklisted terms that were re-introduced after healing.
+    try:
+        _solo_cleanup_fixes = final_solo_terminology_cleanup(sections, persona)
+        if _solo_cleanup_fixes > 0:
+            log.info(f"[{run_id}] [SOLO-FINAL-CLEANUP] Pre-validator: fixed {_solo_cleanup_fixes} sections")
+    except Exception as _solo_cleanup_err:
+        log.warning(f"[{run_id}] [SOLO-FINAL-CLEANUP] Failed: {_solo_cleanup_err}")
+
     # === SPRINT N2: VALIDATE AND HEAL - Wolf 2025-12 ===
     # FIX-517C TASK 4: Two-stage validation (raw = pre-final-enforcer, final = post-final-enforcer)
     # Stage 1 (RAW): validate BEFORE final enforcer pass → truthful pre-cleanup metrics
@@ -16485,11 +16495,17 @@ Digitalisierungs- und KI-Vorhaben relevant sein
     # copy (xx) with identical content. The validator sees them as duplicates.
     _ALIAS_SECTIONS_RAW = {"PILOT_PLAN_HTML", "roadmap", "ROADMAP_HTML", "ROADMAP_90D_HTML", "roadmap_90d", "_GC_SNAPSHOT_642"}  # FIX-B721: GC backup is not a real section
 
+    # FIX-REDUNDANCY: Known copy-keys that are identical to their source
+    _KNOWN_COPY_KEYS = {"QUICK_WINS_HTML_LEFT"}
+
     def _is_shadow_key_redundancy(err) -> bool:
-        """Check if a REDUNDANCY warning is between an HTML key and its shadow."""
+        """Check if a REDUNDANCY warning is between an HTML key and its shadow/copy."""
         section_str = getattr(err, "section", "") or ""
         # Section field format: "DATA_READINESS_HTML, data_readiness" or similar
         parts = [p.strip() for p in section_str.split(",")]
+        # Check if any part is a known copy-key
+        if any(p in _KNOWN_COPY_KEYS for p in parts):
+            return True
         # Check if any pair is HTML_KEY + logical_name (shadow)
         for p in parts:
             if p.endswith("_HTML"):
@@ -18457,6 +18473,15 @@ Digitalisierungs- und KI-Vorhaben relevant sein
         except Exception as _tp2_err:
             log.warning(f"[{run_id}] [FIX-B721-TYPO-PASS2] Failed: {_tp2_err}")
 
+        # === SOLO TERMINOLOGY FINAL CLEANUP (pre-final-validator) ===
+        # Second pass catches terms re-introduced by final enforcers.
+        try:
+            _solo_final_fixes = final_solo_terminology_cleanup(sections, persona)
+            if _solo_final_fixes > 0:
+                log.info(f"[{run_id}] [SOLO-FINAL-CLEANUP] Pre-final-validator: fixed {_solo_final_fixes} sections")
+        except Exception as _solo_final_err:
+            log.warning(f"[{run_id}] [SOLO-FINAL-CLEANUP] Pre-final-validator failed: {_solo_final_err}")
+
         _final_valid, _final_errors, _final_healed = validate_and_heal(sections, answers)
         _final_critical = [e for e in _final_errors if e.severity == "CRITICAL"]
         _final_warnings = [e for e in _final_errors if e.severity == "WARNING"]
@@ -18465,9 +18490,15 @@ Digitalisierungs- und KI-Vorhaben relevant sein
         # section aliases AND shadow-key pairs (HTML_KEY + logical_name with identical content).
         _ALIAS_SECTIONS = {"PILOT_PLAN_HTML", "roadmap", "ROADMAP_HTML", "ROADMAP_90D_HTML", "roadmap_90d", "_GC_SNAPSHOT_642"}  # FIX-B721: GC backup is not a real section
 
+        # FIX-REDUNDANCY: Known copy-keys that are identical to their source
+        _KNOWN_COPY_KEYS_FINAL = {"QUICK_WINS_HTML_LEFT"}
+
         def _is_shadow_redundancy(err) -> bool:
             section_str = getattr(err, "section", "") or ""
             parts = [p.strip() for p in section_str.split(",")]
+            # Check if any part is a known copy-key
+            if any(p in _KNOWN_COPY_KEYS_FINAL for p in parts):
+                return True
             for p in parts:
                 if p.endswith("_HTML"):
                     logical = p.replace("_HTML", "").lower()

--- a/services/report_healer.py
+++ b/services/report_healer.py
@@ -73,6 +73,7 @@ __all__ = [
     "BOILERPLATE_PATTERNS",
     "PAYBACK_PATTERNS_DE",
     "SOLO_BLACKLIST_TERMS",
+    "final_solo_terminology_cleanup",
     "BUSINESS_CASE_LABEL_LOCALIZATION_DE",
     "BoilerplatePattern",
     "PaybackPattern",
@@ -891,8 +892,9 @@ SOLO_TERM_REPLACEMENTS: Dict[str, str] = {
     "Rollout": "Einführung",
     "Deployment": "Bereitstellung",
     # TASK 2: Additional terms from validator warnings
-    "Executive": "Kurzfassung",
+    # NOTE: Phrase-level "Executive Summary" MUST come before bare "Executive"
     "Executive Summary": "Kurzfassung",
+    "Executive": "Kurzfassung",
     "executive": "kurzfassung",
     "Layer": "Ebene",
     "Layers": "Ebenen",
@@ -1069,6 +1071,82 @@ SOLO_REMOVE_PATTERNS: List[str] = [
     r"(?:Enterprise|Multi-Team)\s+(?:Architektur|Rollout|Deployment)",
     r"(?:Skalierung|Scaling)\s+(?:auf|für)\s+(?:mehrere|viele)\s+(?:Teams|Abteilungen)",
 ]
+
+
+# =============================================================================
+# FINAL SOLO TERMINOLOGY CLEANUP (pre-validator safety net)
+# =============================================================================
+
+def final_solo_terminology_cleanup(
+    sections: Dict[str, Any],
+    segment: str,
+) -> int:
+    """
+    Final safety-net pass to replace Solo-blacklisted terms in ALL sections.
+
+    Runs AFTER the healer and all post-healer restores (Quick Wins pristine,
+    Gamechanger snapshot, etc.) but BEFORE the validator. This catches terms
+    that were re-introduced by post-healer section restores.
+
+    Only modifies sections for segment='solo'. Returns number of fixes applied.
+
+    Mutates sections dict in-place for efficiency.
+    """
+    if not sections or not segment:
+        return 0
+
+    seg_lower = str(segment).strip().lower()
+    if seg_lower not in ("solo", "1", "einzelunternehmer", "selbstständig", "freiberufler"):
+        return 0
+
+    total_fixes = 0
+
+    # Iterate all sections and apply replacements
+    for key in list(sections.keys()):
+        val = sections[key]
+        if not isinstance(val, str) or not val or key.startswith("_"):
+            continue
+        if len(val) < 10:
+            continue
+
+        original = val
+
+        # Step 1: Apply phrase-level replacements first (longer matches first)
+        for phrase, replacement in SOLO_TERM_REPLACEMENTS_EXTENDED.items():
+            if phrase in val:
+                val = val.replace(phrase, replacement)
+
+        # Step 2: Apply blacklist enforcement with word boundaries
+        for term in SOLO_BLACKLIST_TERMS:
+            pattern = re.compile(r'\b' + re.escape(term) + r'\b', re.IGNORECASE)
+            fallback = SOLO_BLACKLIST_FALLBACKS.get(term, "")
+
+            def _replace_match(m: re.Match[str]) -> str:
+                matched = m.group(0)
+                if not fallback:
+                    return ""
+                if matched.isupper():
+                    return fallback.upper()
+                elif matched.islower():
+                    return fallback.lower()
+                elif matched[0].isupper():
+                    return fallback[0].upper() + fallback[1:] if len(fallback) > 1 else fallback.upper()
+                return fallback
+
+            val = pattern.sub(_replace_match, val)
+
+        if val != original:
+            sections[key] = val
+            total_fixes += 1
+
+    if total_fixes > 0:
+        log.info(
+            "[SOLO-FINAL-CLEANUP] Applied terminology fixes to %d sections",
+            total_fixes,
+        )
+
+    return total_fixes
+
 
 # =============================================================================
 # TASK 3: Business-Case Label Localization (English → German)

--- a/services/report_validator.py
+++ b/services/report_validator.py
@@ -986,6 +986,8 @@ class ReportValidator:
         "strategie_governance": "STRATEGIE_GOVERNANCE_HTML",
         "unternehmensprofil_markt": "UNTERNEHMENSPROFIL_MARKT_HTML",
         "technologie_prozesse": "TECHNOLOGIE_PROZESSE_HTML",
+        # FIX-REDUNDANCY: QUICK_WINS_HTML_LEFT is a copy of QUICK_WINS_HTML
+        "QUICK_WINS_HTML_LEFT": "QUICK_WINS_HTML",
     }
 
     # FIX-RC2: Sections excluded from Solo-Compact rendering.
@@ -2361,6 +2363,12 @@ class ReportValidator:
         "pilot_plan",
         "SCORE_DRIVERS_HTML",
         "score_drivers",
+        # FIX-REDUNDANCY: These sections naturally summarize/reference content from
+        # other sections (skills plan, policy mini). Redundancy warnings are false positives.
+        "KI_SKILLPLAN_HTML",
+        "ki_skillplan",
+        "AI_POLICY_MINI_HTML",
+        "ai_policy_mini",
     ]
 
     def _check_redundancy(self) -> None:
@@ -2587,6 +2595,13 @@ class ReportValidator:
                 # Only report first occurrence per section
                 continue
 
+    # Sections known to use bullet-point/list-item style content where
+    # short fragments are intentional (e.g., "Nutzen: Zeitersparnis.")
+    INCOMPLETE_SENTENCE_EXCLUDED_SECTIONS = {
+        "ADVISOR_NOTE_HTML", "advisor_note",
+        "REIFEGRAD_SOWHAT_HTML", "reifegrad_sowhat",
+    }
+
     def _check_incomplete_sentences(self) -> None:
         """
         Sprint P1.5-4: Check for incomplete sentence fragments.
@@ -2623,24 +2638,29 @@ class ReportValidator:
         ]
 
         # WARNING patterns - less severe fragments
+        # FIX-FRAG: Only match before </p> tags, not </li> (list items allow fragments)
         warning_patterns = [
             r"\bEntwicklung eines\.\s",
             r"\bErstellung einer\.\s",
             r"\bAusbau eines\.\s",
             r"\bVerbesserung der\.\s",
-            r"\beines\.\s*</",  # Ends with "eines." before HTML tag
-            r"\beiner\.\s*</",  # Ends with "einer." before HTML tag
-            r"\beinem\.\s*</",  # Ends with "einem." before HTML tag
-            # Sentences ending with "und" (incomplete enumeration)
-            r"\bund\.\s*</",
-            r"\bsowie\.\s*</",
+            r"\beines\.\s*</p>",   # Ends with "eines." before closing paragraph
+            r"\beiner\.\s*</p>",   # Ends with "einer." before closing paragraph
+            r"\beinem\.\s*</p>",   # Ends with "einem." before closing paragraph
+            # Sentences ending with "und" (incomplete enumeration) - only in paragraphs
+            r"\bund\.\s*</p>",
+            r"\bsowie\.\s*</p>",
         ]
 
-        for section_name, content in self.sections.items():
+        # FIX-FRAG: Use canonical_sections to avoid duplicate warnings for shadow keys
+        for section_name, content in self.canonical_sections.items():
             if not isinstance(content, str):
                 continue
             # FIX-RC2: Skip non-rendered compact sections
             if self._is_compact_excluded(section_name):
+                continue
+            # FIX-FRAG: Skip sections known to use bullet-point/list-item style
+            if section_name in self.INCOMPLETE_SENTENCE_EXCLUDED_SECTIONS:
                 continue
 
             # Check CRITICAL patterns


### PR DESCRIPTION
## Summary
This PR introduces a final safety-net pass for Solo segment terminology cleanup that runs before validation, and improves the validator's handling of known redundant sections and incomplete sentence detection.

## Key Changes

### Solo Terminology Cleanup
- **New function `final_solo_terminology_cleanup()`** in `report_healer.py`: A pre-validator pass that catches Solo-blacklisted terms re-introduced by post-healer section restores (Quick Wins pristine, Gamechanger snapshot, etc.)
  - Applies phrase-level replacements first (longer matches prioritized)
  - Enforces blacklist terms with word boundaries and case-aware fallback replacements
  - Runs after all post-healer restores but before validation
  - Added to `__all__` exports in `report_healer.py`

- **Integration in `gpt_analyze.py`**: Two invocation points for the cleanup function
  - First pass after post-healer restores (before raw validation)
  - Second pass after final enforcers (before final validation)
  - Both wrapped in try-except with logging for observability

### Validator Improvements
- **Redundancy detection refinement** in `report_validator.py`:
  - Added `QUICK_WINS_HTML_LEFT` to known copy-key mappings (maps to `QUICK_WINS_HTML`)
  - Extended `REDUNDANCY_EXCLUDED_SECTIONS` to include `KI_SKILLPLAN_HTML` and `AI_POLICY_MINI_HTML` (sections that naturally summarize/reference other content)
  - Updated `_is_shadow_key_redundancy()` helper to check for known copy-keys

- **Incomplete sentence detection improvements**:
  - New `INCOMPLETE_SENTENCE_EXCLUDED_SECTIONS` set for sections using bullet-point/list-item style (e.g., `ADVISOR_NOTE_HTML`, `REIFEGRAD_SOWHAT_HTML`)
  - Refined warning patterns to only match before `</p>` tags, not `</li>` (list items intentionally allow fragments)
  - Changed to iterate over `canonical_sections` to avoid duplicate warnings for shadow keys
  - Added skip logic for excluded sections

### Minor Fixes
- **German terminology ordering** in `report_healer.py`: Reordered "Executive Summary" before bare "Executive" with explanatory comment to ensure phrase-level matches take precedence
- **Export addition**: Added `final_solo_terminology_cleanup` to imports in `gpt_analyze.py`

## Implementation Details
- The cleanup function uses regex with word boundaries (`\b`) for accurate term matching
- Case-aware replacement logic preserves original casing (UPPER, lower, Title case)
- Both cleanup passes include logging for debugging and monitoring
- Validator improvements reduce false-positive redundancy and incomplete sentence warnings for known patterns

https://claude.ai/code/session_015TjuAtYfdBmpgqjmfNynUr