### PR TITLE
fix: add missing test dependencies (fastapi, cffi) to requirements-te…

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -8,6 +8,8 @@ httpx==0.27.2
 
 # Core dependencies (required for gpt_analyze imports in tests)
 SQLAlchemy>=2.0,<2.1
+fastapi>=0.111,<0.116
+cffi>=1.0
 pydantic[email]>=2.9,<3.0
 pydantic-settings>=2.4,<3.0
 jinja2>=3.1,<4.0


### PR DESCRIPTION
…st.txt

103 test failures and 9 errors were caused by missing packages:
- sqlalchemy was listed but fastapi was not, causing ModuleNotFoundError for all tests importing from main.py or using fastapi.testclient
- cffi was missing, causing cryptography Rust binding panic when routes/auth.py imported PyJWT

https://claude.ai/code/session_01RD79hnc5BYa9UyPme3Z9Ys