### PR TITLE
Distinguish between routing 404s and business-logic 404s

### DIFF
--- a/main.py
+++ b/main.py
@@ -420,6 +420,21 @@ async def legacy_briefing_async_endpoint(
 # ---------------------------------------------------------------------------
 @app.exception_handler(404)
 async def not_found_handler(request: Request, exc) -> JSONResponse:
+    # Distinguish between "no route matched" (Starlette default detail="Not Found")
+    # and business-logic 404s raised explicitly by endpoint handlers.
+    detail = getattr(exc, "detail", None)
+    if detail and detail != "Not Found":
+        # Business-logic 404 from an endpoint — pass through the original detail
+        return JSONResponse(
+            status_code=404,
+            content={
+                "error": "not_found",
+                "detail": detail,
+                "path": str(request.url.path),
+            },
+            media_type="application/json; charset=utf-8",
+        )
+    # No matching route
     return JSONResponse(
         status_code=404,
         content={


### PR DESCRIPTION
## Summary
Enhanced the 404 exception handler to differentiate between "no route matched" errors (Starlette default) and explicit 404 errors raised by endpoint handlers for business logic reasons.

## Key Changes
- Modified the `not_found_handler` to inspect the exception's `detail` attribute
- Business-logic 404s (with custom detail messages) are now passed through with their original detail preserved
- Route-not-found errors (default "Not Found" detail) continue to use the standard response format
- Both response types include the request path for debugging purposes

## Implementation Details
The handler now checks if the exception detail differs from Starlette's default "Not Found" message. When a custom detail is present, it indicates the 404 was intentionally raised by application code (e.g., resource not found in database) rather than a routing miss. This allows clients to distinguish between these two scenarios while maintaining backward compatibility for standard routing errors.

https://claude.ai/code/session_01XG1z8Etuht2jkn5SmFQu3g