### PR TITLE
fix: ROI regex greedy match bug + explicit FALLSTUDIEN type annotation

### DIFF
--- a/services/report_validator.py
+++ b/services/report_validator.py
@@ -2533,7 +2533,8 @@ class ReportValidator:
         roi_pattern = r"(\d{2,3})\s*%"
 
         # WP2: Context-aware ROI pattern - only flag percentages near ROI keywords
-        roi_context_pattern = r"(?:ROI|Rendite|Return|Amortis)[^.]{0,30}(\d{2,3})\s*%"
+        # Non-greedy [^.]{0,30}? prevents consuming digits that belong to the percentage
+        roi_context_pattern = r"(?:ROI|Rendite|Return|Amortis)[^.]{0,30}?(\d{2,3})\s*%"
 
         # Sections where ROI is PROHIBITED (per prompt requirement)
         prohibited_roi_sections = [

--- a/services/sofort_start_generator.py
+++ b/services/sofort_start_generator.py
@@ -1847,7 +1847,7 @@ def generate_30_tage_challenge_html_v2(
 # BRANCHEN-FALLSTUDIEN (Idee #5)
 # =============================================================================
 
-FALLSTUDIEN = {
+FALLSTUDIEN: Dict[str, Dict[str, Any]] = {
     "beratung": {
         "titel": "Unternehmensberater spart 12 Stunden pro Woche",
         "unternehmen": "Solo-Berater, Strategieberatung",


### PR DESCRIPTION
1. report_validator.py: Changed roi_context_pattern from greedy [^.]{0,30} to non-greedy [^.]{0,30}? — the greedy variant consumed digits belonging to the percentage number (e.g. captured "84" from "284%"), causing the context check to miss valid ROI values. The fallback pattern caught them, but in some CI environments this led to test failures.

2. sofort_start_generator.py: Added explicit Dict[str, Dict[str, Any]] type annotation to FALLSTUDIEN constant to prevent mypy from inferring an overly specific union type that could cause attr-defined errors on dictionary value access in some mypy versions.

https://claude.ai/code/session_01XG1z8Etuht2jkn5SmFQu3g