### PR TITLE
fix: add gc_strategic_analysis to prompt manifest

### DIFF
--- a/prompts/prompt_manifest.json
+++ b/prompts/prompt_manifest.json
@@ -926,6 +926,14 @@
       "required": false,
       "output": "html"
     },
+    "gc_strategic_analysis": {
+      "title": "Strategische Gamechanger-Analyse",
+      "path": "gc_strategic_analysis.md",
+      "purpose": "Strategischer Bruchpunkt-Analyse für Gamechanger Deep Dive (KPA Section 1)",
+      "size_aware": true,
+      "required": false,
+      "output": "html"
+    },
     "gc_implementation_plan": {
       "title": "Gamechanger Implementierungsplan",
       "path": "gc_implementation_plan.md",


### PR DESCRIPTION
The section gc_strategic_analysis was missing from the de manifest in prompt_manifest.json, causing STRICT mode to reject it and leaving KPA Section 1 empty.

https://claude.ai/code/session_01G2ecxbm8VvB3kmGWAv8vGy