### PR TITLE
Fix Break-Even consistency and improve terminology for Solo persona

### DIFF
--- a/gpt_analyze.py
+++ b/gpt_analyze.py
@@ -92,6 +92,7 @@ import json
 import logging
 import os
 import re
+import time
 import threading
 import uuid
 import html
@@ -20539,6 +20540,7 @@ def _send_emails(db: Session, rep: Report, br: Briefing, pdf_url: Optional[str],
                 log.warning("[%s] ⚠️ Could not generate briefing summary HTML: %s", run_id, str(e))
 
             for addr in _admin_recipients():
+                time.sleep(0.6)  # Resend Rate Limit: max 2 req/sec
                 ok, err = _send_email_via_resend(
                     addr,
                     f"Neuer KI‑Status‑Report – Analysis #{rep.analysis_id} / Briefing #{rep.briefing_id}",

--- a/routes/report.py
+++ b/routes/report.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import logging
+import time
 from datetime import datetime, timezone
 import asyncio
 from typing import Any, Dict, Optional, Union
@@ -1009,9 +1010,12 @@ def _send_deep_dive_email(
         else:
             log.warning("[%s] No user email found, skipping user email.", run_tag)
 
+        time.sleep(0.6)  # Resend Rate Limit: max 2 req/sec
+
         # --- Admin email ---
         if os.getenv("ENABLE_ADMIN_NOTIFY", "1") in ("1", "true", "TRUE", "yes", "YES"):
             for addr in _admin_recipients():
+                time.sleep(0.6)  # Resend Rate Limit: max 2 req/sec
                 ok, err = _send_email_via_resend(
                     addr,
                     f"Kopie: KI-Potenzial-Analyse — Briefing #{briefing_id}",

--- a/services/gamechanger_deep_dive.py
+++ b/services/gamechanger_deep_dive.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import logging
 import math
 import os
+import re
 import time
 import traceback
 from typing import Any, Dict, List, Optional
@@ -698,6 +699,33 @@ def _generate_gc_section(prompt_name: str, context: Dict[str, Any]) -> str:
 
 
 # =============================================================================
+# 3b. BREAK-EVEN ENFORCER (Safety Net)
+# =============================================================================
+
+def _enforce_kpa_break_even(html: str, canonical_payback: float) -> str:
+    """Safety Net: Enforce Break-Even in KPA to match canonical payback value.
+
+    The sensitivity table is deterministic, but the LLM-generated prose may
+    state a different Break-Even month.  This regex pass corrects it.
+    """
+    be_month = math.ceil(canonical_payback)
+
+    # Pattern: "Break-Even: Monat X" or "Break-even: Monat X"
+    pattern = r'(Break-[Ee]ven:\s*Monat\s*)\d+'
+    replacement = rf'\g<1>{be_month}'
+
+    new_html = re.sub(pattern, replacement, html)
+
+    if new_html != html:
+        log.info(
+            "[KPA-BE-FIX] Break-Even enforced to Monat %d (canonical payback=%.1f)",
+            be_month, canonical_payback,
+        )
+
+    return new_html
+
+
+# =============================================================================
 # 4. REPORT ASSEMBLER
 # =============================================================================
 
@@ -753,6 +781,13 @@ def generate_gamechanger_report(briefing_id: int) -> Dict[str, Any]:
 
     # 4. Generate sections
     sections = generate_deep_dive_sections(context)
+
+    # 4b. Enforce Break-Even consistency in LLM-generated sections
+    canonical_payback = bc.get('payback', 0)
+    if canonical_payback > 0:
+        for key in sections:
+            if isinstance(sections[key], str):
+                sections[key] = _enforce_kpa_break_even(sections[key], canonical_payback)
 
     # 5. Render HTML
     html = render_deep_dive_html(sections, context)

--- a/services/report_healer.py
+++ b/services/report_healer.py
@@ -1000,8 +1000,20 @@ SOLO_TERM_REPLACEMENTS_EXTENDED: Dict[str, str] = {
     "plattform": "lösung",
     "Skalierung": "Wachstum",
     "skalierung": "wachstum",
-    "Engine": "Modul",
-    "engine": "modul",
+    # Modul → Baustein (Solo-Persona: "Modul" klingt zu technisch)
+    # Longer forms MUST come first to prevent partial replacement
+    "Modulen": "Bausteinen",
+    "modulen": "bausteinen",
+    "Module": "Bausteine",
+    "module": "bausteine",
+    "modularer": "flexibler",
+    "modulares": "flexibles",
+    "modulare": "flexible",
+    "modular": "flexibel",
+    "Modul": "Baustein",
+    "modul": "baustein",
+    "Engine": "Baustein",
+    "engine": "baustein",
     "Baukasten": "Werkzeugkasten",
     "baukasten": "werkzeugkasten",
     # Additional enterprise terms
@@ -1028,6 +1040,7 @@ SOLO_BLACKLIST_TERMS: List[str] = [
     "Framework",
     "Pipeline",
     "Deployment",
+    "Modul",
     "Konzern",
     # FIX: Added Stack variants - commonly leak in SOLO reports
     "Tech-Stack",
@@ -1057,7 +1070,8 @@ SOLO_BLACKLIST_FALLBACKS: Dict[str, str] = {
     # TASK 2: Additional fallbacks
     "Plattform": "Lösung",
     "Skalierung": "Wachstum",
-    "Engine": "Modul",
+    "Engine": "Baustein",
+    "Modul": "Baustein",
     "Baukasten": "Werkzeugkasten",
     # FIX: Stack variants - commonly leak in SOLO reports
     "Tech-Stack": "Werkzeugkasten",

--- a/tests/test_solo_quality_gate.py
+++ b/tests/test_solo_quality_gate.py
@@ -141,7 +141,7 @@ class TestTask2SoloBlacklistTerms:
         assert "Kennzahlen" in result or "Übersicht" in result
         assert "Protokoll" in result or "Prüfung" in result
         assert "Ebene" in result
-        assert "Modul" in result
+        assert "Baustein" in result
         assert "Wachstum" in result
 
     def test_governance_executive_audit_fully_replaced(self):


### PR DESCRIPTION
## Summary
This PR addresses two key issues: (1) enforces Break-Even month consistency between LLM-generated prose and canonical payback calculations in KPA reports, and (2) improves terminology alignment for the Solo persona by replacing technical terms with more accessible alternatives.

## Key Changes

### Break-Even Enforcement (gamechanger_deep_dive.py)
- Added `_enforce_kpa_break_even()` function that uses regex to correct LLM-generated Break-Even month statements to match the canonical payback value
- Integrated the enforcement into the report generation pipeline to sanitize all generated sections
- Includes logging to track when corrections are applied

### Terminology Improvements (report_healer.py)
- Replaced "Modul/Module/modulare/etc." with "Baustein/Bausteine/flexible/etc." throughout sanitization rules
- Changed "Engine" → "Baustein" (instead of "Modul") for consistency
- Reordered replacement patterns to process longer forms first, preventing partial replacements
- Added "Modul" to the enterprise terms blocklist to catch remaining instances
- Updated fallback rules to use "Baustein" as the target term

### Rate Limiting (routes/report.py, gpt_analyze.py)
- Added 0.6-second delays between email sends to respect Resend API rate limits (max 2 req/sec)
- Applied to both user and admin email notifications

### Test Updates (tests/test_solo_quality_gate.py)
- Updated assertion to expect "Baustein" instead of "Modul" in Solo quality gate tests

## Implementation Details
- The Break-Even enforcer is deterministic and only modifies HTML when a mismatch is detected
- Terminology replacements use case-sensitive patterns to handle German capitalization rules
- Rate limiting uses simple `time.sleep()` calls to ensure compliance with email service constraints

https://claude.ai/code/session_01FUZ14E9Fx2BWSV58ZFDGpF