### PR TITLE
Fix payback calculation, path resolution, and content limits

### DIFF
--- a/services/gamechanger_deep_dive.py
+++ b/services/gamechanger_deep_dive.py
@@ -221,12 +221,19 @@ def _extract_canonical_bc(sections: Dict[str, Any],
                  roi, size_key)
         roi = 200.0
 
-    # Recalculate payback from capped values if needed
-    net_monthly = (hours * rate) - opex
-    if net_monthly > 0 and capex > 0:
-        payback = round(capex / net_monthly, 1)
-    elif net_monthly <= 0:
-        payback = 99.0
+    # FIX-C: Use R1 PAYBACK_MONTHS directly for consistency (R1 uses realistic
+    # scenario with conservative buffer). Only recalculate if R1 didn't provide one.
+    r1_payback = _safe_float(sections.get('PAYBACK_MONTHS'), 0.0)
+    if r1_payback > 0:
+        payback = r1_payback
+        log.info("[GC-DEEP-DIVE] Using R1 PAYBACK_MONTHS=%.1f (not recalculating)", payback)
+    else:
+        net_monthly = (hours * rate) - opex
+        if net_monthly > 0 and capex > 0:
+            payback = round(capex / net_monthly, 1)
+        elif net_monthly <= 0:
+            payback = 99.0
+        log.info("[GC-DEEP-DIVE] R1 PAYBACK_MONTHS missing, recalculated=%.1f", payback)
 
     return {
         'hours': hours,

--- a/services/report_healer.py
+++ b/services/report_healer.py
@@ -3077,7 +3077,7 @@ SEGMENT_BUDGETS: Dict[str, Dict[str, int]] = {
         "RECOMMENDATIONS_HTML": 15000,  # FIX-629b
         "RISKS_HTML": 35000,  # B9: Cards+SVG+Heatmap = ~29KB
         "GAMECHANGER_HTML": 12000,
-        "FOERDERPOTENZIAL_HTML": 12000,  # FIX-B22-P2: was 10000, needs ≥800 words
+        "FOERDERPOTENZIAL_HTML": 16000,  # FIX-A: was 12000, LLM delivers ~14.6K (4 sections)
         "ORG_CHANGE_HTML": 10000,  # FIX-629b
         "BUSINESS_CASE_HTML": 10000,  # FIX-629b
         "PILOT_PLAN_HTML": 5000,  # FIX-B36a: was 2000, observed 4835 chars → trimmed to 1845 (62% lost!)
@@ -3182,7 +3182,7 @@ SEGMENT_BUDGETS: Dict[str, Dict[str, int]] = {
         "ki_skillplan": 3000,
         "org_change": 8000,
         "business_case": 8000,
-        "foerderpotenzial": 10000,
+        "foerderpotenzial": 16000,  # FIX-A: was 10000, matches FOERDERPOTENZIAL_HTML
 
         "_default": 3000,  # FIX-B36a: was 2000, safer default for unmapped sections
     },

--- a/utils/logo_embedder.py
+++ b/utils/logo_embedder.py
@@ -211,6 +211,15 @@ def get_logo_base64_map(
     """
     logo_map: Dict[str, str] = {}
     template_path = Path(template_dir)
+
+    # FIX-B: Resolve relative paths against project root to avoid CWD issues
+    # on Railway (worker processes may have different CWD than expected).
+    if not template_path.is_absolute():
+        project_root = Path(__file__).resolve().parent.parent
+        template_path = project_root / template_path
+    template_path = template_path.resolve()
+    log.debug("[LOGO-EMBED] Resolved template_dir: %s", template_path)
+
     total_original = 0
     total_optimized = 0
 


### PR DESCRIPTION
## Summary
This PR addresses three separate issues across the codebase:
1. Payback period calculation now uses R1's provided value when available instead of always recalculating
2. Logo embedder resolves relative paths against project root to fix Railway deployment issues
3. Content size limits for Förderungspotenzial sections are increased to accommodate LLM output

## Key Changes

- **gamechanger_deep_dive.py**: Modified payback period logic to prefer R1's `PAYBACK_MONTHS` value when available, only recalculating if missing. Added logging to track which calculation method was used.

- **logo_embedder.py**: Added path resolution logic to convert relative template paths to absolute paths based on project root. This prevents issues on Railway where worker processes may have different working directories than expected.

- **report_healer.py**: Increased `FOERDERPOTENZIAL_HTML` content limit from 12,000 to 16,000 characters and `foerderpotenzial` prompt limit from 10,000 to 16,000 characters to accommodate LLM output (~14.6K observed for 4-section content).

## Implementation Details

- The payback calculation now follows a two-tier approach: use R1's value if provided (which includes conservative buffers), otherwise fall back to local recalculation
- Path resolution uses `Path(__file__).resolve().parent.parent` to reliably locate the project root regardless of current working directory
- Content limits were increased based on observed LLM output sizes to prevent truncation while maintaining reasonable bounds

https://claude.ai/code/session_01C4mSsb344xmiJLFbxYbDRv