### PR TITLE
FIX D2: Add embed_logos_in_html call to gamechanger + strategy pipelines

### DIFF
--- a/services/gamechanger_deep_dive.py
+++ b/services/gamechanger_deep_dive.py
@@ -823,7 +823,13 @@ def generate_gamechanger_report(briefing_id: int) -> Dict[str, Any]:
     # 5. Render HTML
     html = render_deep_dive_html(sections, context)
 
-    # 5b. Final Break-Even enforcement on assembled HTML (belt-and-suspenders)
+    # 5b. Embed logos as base64 for PDF service compatibility
+    # (PDF service has no access to local files — must inline before sending)
+    from utils.logo_embedder import embed_logos_in_html
+    _tpl_dir = os.path.join(os.path.dirname(os.path.dirname(__file__)), 'templates')
+    html = embed_logos_in_html(html, _tpl_dir)
+
+    # 5c. Final Break-Even enforcement on assembled HTML (belt-and-suspenders)
     if canonical_payback > 0:
         html = _enforce_kpa_break_even(html, canonical_payback)
 

--- a/services/strategy_pipeline.py
+++ b/services/strategy_pipeline.py
@@ -487,6 +487,13 @@ async def _generate_pdf(db_session: Any, briefing_id: int) -> None:
             return
 
         html_content = render_strategy_html(sr, db_session)
+
+        # Embed logos as base64 for PDF service compatibility
+        from utils.logo_embedder import embed_logos_in_html
+        import os
+        _tpl_dir = os.path.join(os.path.dirname(os.path.dirname(__file__)), 'templates')
+        html_content = embed_logos_in_html(html_content, _tpl_dir)
+
         logger.info("[Strategy %d] Rendering PDF (%d chars HTML)", briefing_id, len(html_content))
 
         result = await asyncio.to_thread(


### PR DESCRIPTION
The gamechanger deep dive and strategy report pipelines rendered HTML with <img src="filename.webp"> tags but never called embed_logos_in_html() to convert them to base64 data URIs. The PDF service (Puppeteer) has no access to local files, so logos appeared as broken image icons.

Report 1 already had this call in report_renderer.py:1354. Now added to:
- gamechanger_deep_dive.py: generate_gamechanger_report() after render_deep_dive_html() (covers all code paths: route handler, auto-trigger, direct call)
- strategy_pipeline.py: _generate_pdf() after render_strategy_html()

Both use the same absolute template_dir resolution pattern as Report 1.

https://claude.ai/code/session_01C4mSsb344xmiJLFbxYbDRv