### PR TITLE
FIX J: Add email delivery for Strategy Report after PDF generation

### DIFF
--- a/services/email_templates.py
+++ b/services/email_templates.py
@@ -126,3 +126,56 @@ def render_deep_dive_email(recipient: str = "user") -> str:
     </div>
   </body>
 </html>"""
+
+
+def render_strategy_email(recipient: str = "user") -> str:
+    """Render email HTML for KI-Strategiebericht delivery.
+
+    Args:
+        recipient: "user" or "admin".
+    """
+    if recipient == "admin":
+        title = "Kopie: KI-Strategiebericht"
+        intro = "dies ist die Admin\u2011Kopie des KI-Strategieberichts."
+    else:
+        title = "Ihr KI-Strategiebericht"
+        intro = "Ihr pers\u00f6nlicher KI-Strategiebericht liegt vor."
+
+    body_text = (
+        "Basierend auf Ihrem KI-Readiness Assessment und Ihren strategischen "
+        "Zusatzangaben haben wir einen ma\u00dfgeschneiderten Strategiefahrplan "
+        "f\u00fcr Ihr Unternehmen erstellt \u2014 mit priorisierten Handlungsempfehlungen, "
+        "90-Tage-Implementierungsplan, ROI-Prognosen und passenden F\u00f6rderprogrammen."
+    )
+    cta = "Ihr KI-Strategiebericht ist als PDF angeh\u00e4ngt. Bei Fragen stehen wir Ihnen gerne zur Verf\u00fcgung."
+
+    return f"""<!doctype html>
+<html lang="de">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>{escape(title)}</title>
+    <style>
+      body{{font-family:-apple-system,Segoe UI,Roboto,Arial,sans-serif;color:#0f172a;line-height:1.5;margin:0;padding:0;background:#f6f9ff}}
+      .wrap{{max-width:640px;margin:0 auto;padding:24px}}
+      .card{{background:#fff;border:1px solid #e6edf3;border-radius:12px;padding:18px;box-shadow:0 6px 30px #18324a16}}
+      h1{{color:#0b3b8f;font-size:20px;margin:0 0 8px}}
+      p{{margin:8px 0;font-size:14px}}
+      .muted{{color:#64748b}}
+    </style>
+  </head>
+  <body>
+    <div class="wrap">
+      <div class="card">
+        <h1>{escape(title)}</h1>
+        <p>Guten Tag,</p>
+        <p>{escape(intro)}</p>
+        <p>{escape(body_text)}</p>
+        <p>{escape(cta)}</p>
+        <hr style="border:none;border-top:1px solid #e6edf3;margin:24px 0">
+        <p class="muted">Wolf Hohl \u2014 KI\u2011Sicherheit.jetzt</p>
+        <p class="muted">Hinweis: Diese E\u2011Mail wurde automatisch erzeugt.</p>
+      </div>
+    </div>
+  </body>
+</html>"""

--- a/services/strategy_pipeline.py
+++ b/services/strategy_pipeline.py
@@ -522,11 +522,95 @@ async def _generate_pdf(db_session: Any, briefing_id: int) -> None:
             sr.updated_at = datetime.now(timezone.utc)
             db_session.commit()
             logger.info("[Strategy %d] PDF generated (%d bytes)", briefing_id, len(pdf_bytes))
+
+            # FIX-J: Send email with PDF attachment (fire-and-forget)
+            try:
+                _send_strategy_email(briefing_id, pdf_bytes, db_session)
+                sr.email_sent = True
+                sr.email_sent_at = datetime.now(timezone.utc)
+                db_session.commit()
+            except Exception as mail_exc:
+                logger.error("[Strategy %d] Email sending failed: %s", briefing_id, mail_exc)
         else:
             logger.warning("[Strategy %d] PDF service returned no bytes", briefing_id)
 
     except Exception as exc:
         logger.error("[Strategy %d] PDF generation error: %s", briefing_id, exc, exc_info=True)
+
+
+# =============================================================================
+# EMAIL HELPER (FIX-J)
+# =============================================================================
+
+def _send_strategy_email(briefing_id: int, pdf_bytes: bytes, db_session: Any) -> None:
+    """Send KI-Strategiebericht PDF via email (same pattern as KPA)."""
+    import os
+    import time as _time
+
+    run_tag = f"STRATEGY-MAIL-{briefing_id}"
+
+    if os.getenv("DISABLE_EMAILS", "").lower() in ("1", "true", "yes", "on"):
+        logger.info("[%s] Emails disabled via DISABLE_EMAILS. Skipping.", run_tag)
+        return
+
+    try:
+        from gpt_analyze import (
+            _send_email_via_resend,
+            _determine_user_email,
+            _admin_recipients,
+            _mask_email,
+        )
+        from services.email_templates import render_strategy_email
+        from models import Briefing
+    except ImportError as exc:
+        logger.warning("[%s] Import failed, skipping email: %s", run_tag, exc)
+        return
+
+    briefing = db_session.query(Briefing).filter(Briefing.id == briefing_id).first()
+    if not briefing:
+        logger.warning("[%s] Briefing not found, skipping email.", run_tag)
+        return
+
+    user_email = _determine_user_email(db_session, briefing, None)
+
+    attachment = {
+        "filename": f"KI-Strategiebericht-{briefing_id}.pdf",
+        "content": pdf_bytes,
+        "mimetype": "application/pdf",
+    }
+    subject = "Ihr KI-Strategiebericht"
+
+    # --- User email ---
+    if user_email:
+        ok, err = _send_email_via_resend(
+            user_email,
+            subject,
+            render_strategy_email(recipient="user"),
+            attachments=[attachment],
+        )
+        if ok:
+            logger.info("[%s] Email sent to user %s", run_tag, _mask_email(user_email))
+        else:
+            logger.warning("[%s] User email failed: %s", run_tag, err)
+    else:
+        logger.warning("[%s] No user email found, skipping user email.", run_tag)
+
+    _time.sleep(0.6)  # Resend Rate Limit: max 2 req/sec
+
+    # --- Admin email ---
+    if os.getenv("ENABLE_ADMIN_NOTIFY", "1") in ("1", "true", "TRUE", "yes", "YES"):
+        for addr in _admin_recipients():
+            _time.sleep(0.6)
+            ok, err = _send_email_via_resend(
+                addr,
+                f"Kopie: KI-Strategiebericht — Briefing #{briefing_id}",
+                render_strategy_email(recipient="admin"),
+                attachments=[attachment],
+            )
+            if ok:
+                logger.info("[%s] Admin email sent to %s", run_tag, _mask_email(addr))
+            else:
+                logger.warning("[%s] Admin email failed for %s: %s", run_tag, _mask_email(addr), err)
 
 
 # =============================================================================


### PR DESCRIPTION
Strategy pipeline now sends the PDF via Resend email (same infrastructure as KPA) after successful PDF generation. Includes user + admin emails, respects DISABLE_EMAILS kill-switch and Resend rate limits.

Also adds render_strategy_email() template to email_templates.py.

https://claude.ai/code/session_01C4mSsb344xmiJLFbxYbDRv