### PR TITLE
fix: load newest analysis in strategy generate route and briefings

### DIFF
--- a/routes/briefings.py
+++ b/routes/briefings.py
@@ -283,7 +283,7 @@ async def get_briefing_validation(
         )
 
     # Get the analysis record
-    analysis = db.query(Analysis).filter(Analysis.briefing_id == briefing_id).first()
+    analysis = db.query(Analysis).filter(Analysis.briefing_id == briefing_id).order_by(Analysis.id.desc()).first()
 
     # Extract validation data from analysis meta
     # Use typed dicts to avoid mypy index errors

--- a/routes/strategy.py
+++ b/routes/strategy.py
@@ -367,7 +367,7 @@ async def generate_strategy_report_endpoint(
     # Load data needed for the pipeline
     analysis = db.query(Analysis).filter(
         Analysis.briefing_id == briefing_id
-    ).first()
+    ).order_by(Analysis.id.desc()).first()
 
     briefing_data = briefing.answers or {}
     strategy_questions_data = sq.to_dict()


### PR DESCRIPTION
The critical missing spot was routes/strategy.py:368 — the /generate endpoint loaded the oldest Analysis via .first() without order_by, then passed its meta as report1_data to the pipeline. This baked the stale score (90) into the LLM-generated sections at generation time.

The renderer fix (strategy_renderer.py) only helped for live score display on the cover, but the LLM sections already contained "90" from the pipeline input.

Also fixed routes/briefings.py:286 (validation endpoint).

Now all Analysis queries across the codebase use
.order_by(Analysis.id.desc()).first() consistently.

https://claude.ai/code/session_01C4mSsb344xmiJLFbxYbDRv