### PR TITLE
Fix readiness score calculation and add formatting markers

### DIFF
--- a/prompts/de/gc_implementation_plan.md
+++ b/prompts/de/gc_implementation_plan.md
@@ -71,6 +71,15 @@ Führungsebene einbinden. Budget: 10.000-50.000€.
 - Jeder Schritt muss spezifisch für {{HAUPTLEISTUNG}} sein
 - Alle Sätze vollständig, keine Fragmente
 
+## FORMATIERUNGS-MARKER
+Verwende folgende Marker in deinem HTML-Output, wo sie inhaltlich passen:
+- Beginne mit einer Zusammenfassung: <p><strong>Auf einen Blick:</strong> ...Kernaussage...</p>
+- Markiere praktische Tipps mit: <p><strong>Tipp:</strong> ...konkreter Tipp...</p>
+- Markiere Warnungen mit: <p><strong>Wichtig:</strong> ...kritischer Hinweis...</p>
+- Markiere Empfehlungen mit: <p><strong>Empfehlung:</strong> ...Handlungsempfehlung...</p>
+- Verwende "Quick Win" für schnell umsetzbare Maßnahmen.
+Nutze "Auf einen Blick:" maximal 1× (am Anfang). Andere Marker nur wo inhaltlich passend.
+
 ## TONALITÄT
 - Analytisch, sachlich, umsetzungsorientiert
 - Formelle Anrede "Sie" (wenn nötig)

--- a/prompts/de/gc_next_steps.md
+++ b/prompts/de/gc_next_steps.md
@@ -65,3 +65,10 @@ Mindestens 1 Handlung adressiert die Führungsebene.
 - KEINE Tool-Empfehlungen (→ Report 1)
 - Handlungen müssen SOFORT umsetzbar sein (kein Budget, kein Setup)
 - Formelle Anrede "Sie" (wenn nötig)
+
+## FORMATIERUNGS-MARKER
+Verwende folgende Marker in deinem HTML-Output, wo sie inhaltlich passen:
+- Markiere praktische Tipps mit: <p><strong>Tipp:</strong> ...konkreter Tipp...</p>
+- Markiere Empfehlungen mit: <p><strong>Empfehlung:</strong> ...Handlungsempfehlung...</p>
+- Verwende "Quick Win" für schnell umsetzbare Maßnahmen.
+Andere Marker nur wo inhaltlich passend — nicht erzwingen.

--- a/prompts/de/gc_risk_assessment.md
+++ b/prompts/de/gc_risk_assessment.md
@@ -65,3 +65,12 @@ Maßnahmen mit Eskalationswegen und Verantwortlichkeiten.
 - KEINE Beratungssprache, KEINE CTAs
 - Formelle Anrede "Sie" (wenn nötig)
 - Alle Sätze vollständig
+
+## FORMATIERUNGS-MARKER
+Verwende folgende Marker in deinem HTML-Output, wo sie inhaltlich passen:
+- Beginne mit einer Zusammenfassung: <p><strong>Auf einen Blick:</strong> ...Kernaussage...</p>
+- Markiere praktische Tipps mit: <p><strong>Tipp:</strong> ...konkreter Tipp...</p>
+- Markiere Warnungen mit: <p><strong>Wichtig:</strong> ...kritischer Hinweis...</p>
+- Markiere Empfehlungen mit: <p><strong>Empfehlung:</strong> ...Handlungsempfehlung...</p>
+- Verwende "Quick Win" für schnell umsetzbare Maßnahmen.
+Nutze "Auf einen Blick:" maximal 1× (am Anfang). Andere Marker nur wo inhaltlich passend.

--- a/prompts/de/gc_strategic_analysis.md
+++ b/prompts/de/gc_strategic_analysis.md
@@ -87,4 +87,13 @@ KMU: Unternehmensperspektive. "Ihr Unternehmen". Abteilungslogik möglich.
 - Keine Beratungssprache, keine CTAs, keine Buzzwords
 - Ruhig und fundiert — der Leser soll Vertrauen in die Analyse haben
 
+## FORMATIERUNGS-MARKER
+Verwende folgende Marker in deinem HTML-Output, wo sie inhaltlich passen:
+- Beginne mit einer Zusammenfassung: <p><strong>Auf einen Blick:</strong> ...Kernaussage...</p>
+- Markiere praktische Tipps mit: <p><strong>Tipp:</strong> ...konkreter Tipp...</p>
+- Markiere Warnungen mit: <p><strong>Wichtig:</strong> ...kritischer Hinweis...</p>
+- Markiere Empfehlungen mit: <p><strong>Empfehlung:</strong> ...Handlungsempfehlung...</p>
+- Verwende "Quick Win" für schnell umsetzbare Maßnahmen.
+Nutze "Auf einen Blick:" maximal 1× (am Anfang). Andere Marker nur wo inhaltlich passend.
+
 WICHTIG: Antworte NUR mit dem HTML-Inhalt. Keine Chat-Floskeln, keine Fragen, keine Einleitungen.

--- a/prompts/strategy_prompts.py
+++ b/prompts/strategy_prompts.py
@@ -25,7 +25,16 @@ REGELN:
 9. Jede Section hat 400-800 Wörter (Exec Summary: 200-300 Wörter).
 10. Quellenangaben am Ende jeder Section als <div class="sources">.
 11. STILREGEL BRANCHENNAME: Verwende den Branchennamen maximal 3× pro Section. Nutze danach Variationen: "Ihr Unternehmen", "Ihr Betrieb", "Ihre Branche", "in Ihrem Bereich", "in Ihrem Sektor", "für Betriebe Ihrer Größe", "in Ihrem Marktumfeld". Vermeide Konstruktionen wie "In der XY-branche" — schreibe stattdessen "In Ihrem Marktumfeld" oder "In Ihrem Sektor".
-12. Verwende "Ihr Unternehmen" / den Firmennamen maximal 3× pro Abschnitt. Variiere mit "Sie", "Ihr Team", "Ihr Betrieb"."""
+12. Verwende "Ihr Unternehmen" / den Firmennamen maximal 3× pro Abschnitt. Variiere mit "Sie", "Ihr Team", "Ihr Betrieb".
+13. FORMATIERUNGS-MARKER: Verwende folgende Marker in deinem HTML-Output, wo sie inhaltlich passen:
+   - Beginne Zusammenfassungen am Anfang einer Section mit: <p><strong>Auf einen Blick:</strong> ...Kernaussage in 2-3 Sätzen...</p>
+   - Markiere praktische Tipps mit: <p><strong>Tipp:</strong> ...konkreter Tipp...</p>
+   - Markiere Warnungen/Risiken mit: <p><strong>Wichtig:</strong> ...Warnung oder kritischer Hinweis...</p>
+   - Markiere strategische Empfehlungen mit: <p><strong>Empfehlung:</strong> ...konkrete Handlungsempfehlung...</p>
+   - Verwende "Quick Win" für schnell umsetzbare Maßnahmen.
+   Diese Marker werden vom Post-Processor automatisch in gestylte Boxen umgewandelt.
+   Nutze "Auf einen Blick:" maximal 1× pro Section (am Anfang). "Tipp:", "Wichtig:", "Empfehlung:" wo inhaltlich sinnvoll, aber nicht erzwingen.
+14. Schreibe NIEMALS "Ohne Angaben" oder "keine Angaben" — wenn ein Wert fehlt, formuliere den Satz um oder lasse ihn weg."""
 
 
 # =============================================================================

--- a/services/strategy_pipeline.py
+++ b/services/strategy_pipeline.py
@@ -125,9 +125,29 @@ async def generate_strategy_report(
             if _v > 0:
                 _stored.append((_key, _v))
         _stored_max = max((v for _, v in _stored), default=0)
-        _score = max(_live, _stored_max)
-        logger.info("[Strategy %d] Score: R1-formula dims=%r base=%d bonus=%d live=%d stored_max=%d → using %d",
-                    briefing_id, _dim_vals, _base, _qb, _live, _stored_max, _score)
+        # FIX-Iv4b: Prefer live calculation when dimension data exists.
+        # max(live, stored) is wrong: stored score_gesamt can be post-bonus
+        # from an older formula (int(float()) rounding), causing stale values
+        # to override the correct live calculation.
+        if any(_dim_vals):
+            _score = _live  # Dimension data present → trust live calc
+        else:
+            _score = _stored_max  # Legacy data without dimensions → use stored
+        logger.info("[Strategy %d] Score: R1-formula dims=%r base=%d bonus=%d live=%d stored_max=%d → using %d (live_preferred=%s)",
+                    briefing_id, _dim_vals, _base, _qb, _live, _stored_max, _score, any(_dim_vals))
+
+        # Reifegrad label: fallback to live calculation if not stored
+        _reifegrad_label = report1_sections.get("score_rating", "")
+        if not _reifegrad_label and _score > 0:
+            try:
+                from services.extra_sections import get_score_context
+                _size_raw = briefing_data.get("unternehmensgroesse", "klein")
+                _sc_ctx = get_score_context(_score, _size_raw, lang="de")
+                _reifegrad_label = _sc_ctx.get("score_rating", "")
+                logger.info("[Strategy %d] reifegrad_label computed on-demand: %s", briefing_id, _reifegrad_label)
+            except Exception:
+                pass
+
         base_context = {
             "branche": (briefing_data.get("branche", "") or "").title(),
             "segment": _segment_label(briefing_data.get("unternehmensgroesse", "")),
@@ -135,8 +155,8 @@ async def generate_strategy_report(
             "bundesland": briefing_data.get("bundesland", ""),
             "firmenname": briefing_data.get("unternehmen_name", "Ihr Unternehmen"),
             "readiness_score": _score,
-            "reifegrad": report1_sections.get("score_rating", ""),
-            "reifegrad_label": report1_sections.get("score_rating", ""),
+            "reifegrad": _reifegrad_label,
+            "reifegrad_label": _reifegrad_label,
             # Strategy questions
             "s1_budget": strategy_questions.get("s1_budget", ""),
             "s2_zeitrahmen": strategy_questions.get("s2_zeitrahmen", ""),

--- a/services/strategy_pipeline.py
+++ b/services/strategy_pipeline.py
@@ -152,7 +152,7 @@ async def generate_strategy_report(
             "branche": (briefing_data.get("branche", "") or "").title(),
             "segment": _segment_label(briefing_data.get("unternehmensgroesse", "")),
             "mitarbeiter": briefing_data.get("mitarbeiter", ""),
-            "bundesland": briefing_data.get("bundesland", ""),
+            "bundesland": _bundesland_label(briefing_data.get("bundesland", "")),
             "firmenname": briefing_data.get("unternehmen_name", "Ihr Unternehmen"),
             "readiness_score": _score,
             "reifegrad": _reifegrad_label,
@@ -426,6 +426,20 @@ async def _call_anthropic(prompt: str, system_prompt: str, section: str, max_tok
 # =============================================================================
 # HELPER FUNCTIONS
 # =============================================================================
+
+def _bundesland_label(raw: str) -> str:
+    """Map raw bundesland code to readable label for prompts."""
+    _map = {
+        "bw": "Baden-Württemberg", "by": "Bayern", "be": "Berlin",
+        "bb": "Brandenburg", "hb": "Bremen", "hh": "Hamburg",
+        "he": "Hessen", "mv": "Mecklenburg-Vorpommern", "ni": "Niedersachsen",
+        "nw": "Nordrhein-Westfalen", "rp": "Rheinland-Pfalz", "sl": "Saarland",
+        "sn": "Sachsen", "st": "Sachsen-Anhalt", "sh": "Schleswig-Holstein",
+        "th": "Thüringen",
+    }
+    key = str(raw or "").strip().lower()
+    return _map.get(key, str(raw or ""))
+
 
 def _segment_label(raw: str) -> str:
     """Map raw unternehmensgroesse value to a readable segment label for prompts."""

--- a/services/strategy_renderer.py
+++ b/services/strategy_renderer.py
@@ -89,13 +89,30 @@ def render_strategy_html(sr: Any, db_session: Any) -> str:
 
     _stored_max = max((v for _, v in _stored_candidates), default=0)
 
-    # Use whichever is higher: live calculation or stored value
-    readiness_score = max(_live_score, _stored_max)
+    # FIX-Iv4b: Prefer live calculation when dimension data exists.
+    # max(live, stored) is wrong: stored score_gesamt can be post-bonus
+    # from an older formula (int(float()) rounding), causing stale values
+    # to override the correct live calculation.
+    if any(_dim_scores):
+        readiness_score = _live_score  # Dimension data present → trust live calc
+    else:
+        readiness_score = _stored_max  # Legacy data without dimensions → use stored
     logger.info(
-        "[Strategy-Score] briefing_id=%s R1-formula dims=%r base=%d bonus=%d live=%d stored_max=%d → using %d",
-        sr.briefing_id, _dim_scores, _base_score, _quality_bonus, _live_score, _stored_max, readiness_score,
+        "[Strategy-Score] briefing_id=%s R1-formula dims=%r base=%d bonus=%d live=%d stored_max=%d → using %d (live_preferred=%s)",
+        sr.briefing_id, _dim_scores, _base_score, _quality_bonus, _live_score, _stored_max, readiness_score, any(_dim_scores),
     )
     reifegrad_label = report1_sections.get("score_rating", "")
+
+    # Reifegrad label: fallback to live calculation if not stored
+    if not reifegrad_label and readiness_score > 0:
+        try:
+            from services.extra_sections import get_score_context
+            _size_raw = briefing_data.get("unternehmensgroesse", "klein")
+            _sc_ctx = get_score_context(readiness_score, _size_raw, lang="de")
+            reifegrad_label = _sc_ctx.get("score_rating", "")
+            logger.info("[Strategy-Score] reifegrad_label computed on-demand: %s", reifegrad_label)
+        except Exception:
+            pass
 
     # Branche: capitalize for display
     branche_raw = briefing_data.get("branche", "")

--- a/templates/strategy_report.html
+++ b/templates/strategy_report.html
@@ -942,7 +942,7 @@ sup.src-ref {
 
     {# ── Macro: Chapter Separator with inline styles for Puppeteer ── #}
     {% macro chapter_sep(num, title, subtitle) %}
-    <div class="chapter-separator page-break" style="height:100vh;display:flex;flex-direction:column;justify-content:center;align-items:center;text-align:center;background:linear-gradient(135deg, #0a1628 0%, #1a5276 60%, #0e1f3d 100%);color:#ffffff;page-break-before:always;position:relative;overflow:hidden">
+    <div class="chapter-separator page-break" style="height:100vh;display:flex;flex-direction:column;justify-content:center;align-items:center;text-align:center;background-color:#0a1628;background:linear-gradient(135deg, #0a1628 0%, #1a5276 60%, #0e1f3d 100%);color:#ffffff;page-break-before:always;position:relative;overflow:hidden">
         <div class="chapter-number" style="font-size:72pt;font-weight:300;color:rgba(255,255,255,0.3);line-height:1;position:relative;z-index:1">{{ num }}</div>
         <div class="chapter-accent-line" style="width:60px;height:3px;background:#2e86c1;margin:16px auto;border-radius:2px;position:relative;z-index:1"></div>
         <div class="chapter-title" style="font-size:24pt;font-weight:700;color:#ffffff;position:relative;z-index:1">{{ title }}</div>


### PR DESCRIPTION
## Summary
This PR fixes a critical bug in readiness score calculation where stale stored values could override correct live calculations, and enhances prompt consistency by adding formatting markers across all strategy sections.

## Key Changes

### Score Calculation Fix (FIX-Iv4b)
- **Root cause**: The previous logic used `max(live, stored)` which could cause post-bonus stored scores from older formulas to override correct live calculations due to int(float()) rounding artifacts
- **Solution**: Implemented dimension-aware logic that prefers live calculation when dimension data exists, falling back to stored values only for legacy data without dimensions
- **Applied to**: Both `strategy_pipeline.py` and `strategy_renderer.py`
- **Logging**: Enhanced logs now include `live_preferred` flag to track which calculation path was used

### Reifegrad Label Fallback
- Added on-demand computation of `reifegrad_label` (maturity rating) via `get_score_context()` when the stored value is missing but a valid readiness score exists
- Prevents empty maturity labels in reports when stored data is incomplete
- Includes error handling to gracefully degrade if computation fails

### Bundesland Label Mapping
- Added `_bundesland_label()` helper function to map raw state codes (e.g., "bw", "by") to readable German state names (e.g., "Baden-Württemberg", "Bayern")
- Improves prompt context by providing human-readable state information instead of abbreviations

### Prompt Enhancements
- Added consistent **FORMATIERUNGS-MARKER** section to all strategy generation prompts:
  - `<strong>Auf einen Blick:</strong>` for section summaries (max 1× per section)
  - `<strong>Tipp:</strong>` for practical tips
  - `<strong>Wichtig:</strong>` for warnings/risks
  - `<strong>Empfehlung:</strong>` for strategic recommendations
  - "Quick Win" for quick-win actions
- Updated main strategy prompt with additional style rules to avoid placeholder text ("Ohne Angaben")
- Applied to: `gc_implementation_plan.md`, `gc_risk_assessment.md`, `gc_strategic_analysis.md`, `gc_next_steps.md`

### Minor Template Fix
- Added `background-color` fallback to chapter separator gradient for better Puppeteer PDF rendering compatibility

## Implementation Details
- Score logic now checks `any(_dim_vals)` or `any(_dim_scores)` to determine if dimension data is present
- Fallback computation uses existing `get_score_context()` service with company size context
- All changes maintain backward compatibility with legacy data
- Formatting markers are optional guidance for LLM prompts (not enforced)

https://claude.ai/code/session_0193P3rSdbsJ5NWafsVQAbvA