### PR TITLE
fix: correct quality bonus defaults and add score debug logging

### DIFF
--- a/services/report_renderer.py
+++ b/services/report_renderer.py
@@ -858,6 +858,15 @@ def render(briefing_obj: Any,
     log.info(f"🎨 Rendering report {run_id} with {len(sections)} sections (lang={lang})")
     log.debug(f"Sections available: {list(sections.keys())}")
 
+    # --- R1-SCORE-DEBUG (temporary, remove after verification) ---
+    _r1_gov = sections.get("score_governance", sections.get("CANONICAL_GOVERNANCE", "?"))
+    _r1_sec = sections.get("score_sicherheit", sections.get("CANONICAL_SECURITY", "?"))
+    _r1_val = sections.get("score_nutzen", sections.get("score_wertschoepfung", "?"))
+    _r1_ena = sections.get("score_befaehigung", "?")
+    _r1_gesamt = sections.get("score_gesamt", sections.get("CANONICAL_OVERALL", "?"))
+    log.warning("R1-SCORE-DEBUG: [%s] gov=%s, sec=%s, val=%s, ena=%s, score_gesamt=%s",
+                run_id, _r1_gov, _r1_sec, _r1_val, _r1_ena, _r1_gesamt)
+
     # FIX-503C: Debug logging for QUICK_WINS_HTML to trace rendering issues
     qw_html = sections.get("QUICK_WINS_HTML", "")
     qw_html_left = sections.get("QUICK_WINS_HTML_LEFT", "")

--- a/services/strategy_pipeline.py
+++ b/services/strategy_pipeline.py
@@ -99,6 +99,26 @@ async def generate_strategy_report(
         ]
         _base = round(sum(_dim_vals) / 4) if any(_dim_vals) else 0
 
+        # --- SCORE-DEBUG (temporary, remove after verification) ---
+        logger.warning("SCORE-DEBUG-1: [Strategy %d] meta.scores = %r", briefing_id, _r1_scores)
+        logger.warning("SCORE-DEBUG-2: [Strategy %d] dimension scores = gov=%s, sec=%s, val=%s, ena=%s",
+                        briefing_id, _dim_vals[0], _dim_vals[1], _dim_vals[2], _dim_vals[3])
+        logger.warning("SCORE-DEBUG-3: [Strategy %d] calculated = %s, rounded = %d",
+                        briefing_id, sum(_dim_vals) / 4 if any(_dim_vals) else 0, _base)
+        logger.warning("SCORE-DEBUG-KEYS: [Strategy %d] N43_DOD_PASSED=%r, _n43_dod_passed=%r, "
+                        "CONSISTENCY_GRADE=%r, _CONSISTENCY_GRADE=%r, _CONSISTENCY_SCORE=%r, "
+                        "QUALITY_BONUS=%r, score_gesamt=%r, CANONICAL_OVERALL=%r, scores.overall=%r",
+                        briefing_id,
+                        report1_sections.get("N43_DOD_PASSED", "MISSING"),
+                        report1_sections.get("_n43_dod_passed", "MISSING"),
+                        report1_sections.get("CONSISTENCY_GRADE", "MISSING"),
+                        report1_sections.get("_CONSISTENCY_GRADE", "MISSING"),
+                        report1_sections.get("_CONSISTENCY_SCORE", "MISSING"),
+                        report1_sections.get("QUALITY_BONUS", "MISSING"),
+                        report1_sections.get("score_gesamt", "MISSING"),
+                        report1_sections.get("CANONICAL_OVERALL", "MISSING"),
+                        _r1_scores.get("overall", "MISSING"))
+
         # FIX-HOTFIX3: Prefer stored QUALITY_BONUS (exact value from gpt_analyze)
         # over re-deriving from N43_DOD_PASSED/_CONSISTENCY_GRADE which may be
         # filtered from serializable_sections (underscore-prefixed keys).
@@ -109,12 +129,18 @@ async def generate_strategy_report(
         else:
             # Fallback: re-derive quality bonus (for older analyses without QUALITY_BONUS)
             _dod_ok = report1_sections.get("N43_DOD_PASSED", False) or report1_sections.get("_n43_dod_passed", False)
-            _cg = str(report1_sections.get("_CONSISTENCY_GRADE", "A"))
-            _cs = report1_sections.get("_CONSISTENCY_SCORE", 100)
+            # FIX-HOTFIX3b: Read CONSISTENCY_GRADE (without underscore, survives
+            # serialization at gpt_analyze.py:18084) and default to 'F'/0 to match
+            # calc_quality_bonus defaults (gpt_analyze.py:2099-2100).
+            # Previous code used _CONSISTENCY_GRADE (filtered) with default 'A'/100,
+            # which OVER-estimated the bonus vs what calc_quality_bonus actually gave.
+            _cg = str(report1_sections.get("CONSISTENCY_GRADE",
+                       report1_sections.get("_CONSISTENCY_GRADE", "F")))
+            _cs = report1_sections.get("_CONSISTENCY_SCORE", 0)
             _qb = 0
             if _dod_ok:
                 _qb = 2 if (_cg in ("A", "B") or (isinstance(_cs, (int, float)) and _cs >= 80)) else 1
-            logger.info("[Strategy %d] Re-derived QUALITY_BONUS=%d (dod=%s, grade=%s)", briefing_id, _qb, _dod_ok, _cg)
+            logger.info("[Strategy %d] Re-derived QUALITY_BONUS=%d (dod=%s, grade=%s, score=%s)", briefing_id, _qb, _dod_ok, _cg, _cs)
         _live = min(_base + _qb, 98)
 
         # Fallback: stored values (for older analyses)
@@ -145,6 +171,9 @@ async def generate_strategy_report(
             _score = _stored_max  # Legacy data without dimensions → use stored
         logger.info("[Strategy %d] Score: R1-formula dims=%r base=%d bonus=%d live=%d stored_max=%d → using %d (live_preferred=%s)",
                     briefing_id, _dim_vals, _base, _qb, _live, _stored_max, _score, any(_dim_vals))
+        # --- SCORE-DEBUG (temporary, remove after verification) ---
+        logger.warning("SCORE-DEBUG-4: [Strategy %d] score passed to template = %d", briefing_id, _score)
+        logger.warning("SCORE-DEBUG-5: [Strategy %d] stored_candidates = %r", briefing_id, _stored)
 
         # Reifegrad label: fallback to live calculation if not stored
         _reifegrad_label = report1_sections.get("score_rating", "")

--- a/services/strategy_renderer.py
+++ b/services/strategy_renderer.py
@@ -128,10 +128,10 @@ def render_strategy_html(sr: Any, db_session: Any) -> str:
         "[Strategy-Score] briefing_id=%s R1-formula dims=%r base=%d bonus=%d live=%d stored_max=%d → using %d (live_preferred=%s)",
         sr.briefing_id, _dim_scores, _base_score, _quality_bonus, _live_score, _stored_max, readiness_score, any(_dim_scores),
     )
+    reifegrad_label = report1_sections.get("score_rating", "")
     # --- SCORE-DEBUG (temporary, remove after verification) ---
     logger.warning("SCORE-DEBUG-4: [Renderer %s] score passed to template = %d", sr.briefing_id, readiness_score)
     logger.warning("SCORE-DEBUG-5: [Renderer %s] score_label = %s", sr.briefing_id, reifegrad_label)
-    reifegrad_label = report1_sections.get("score_rating", "")
 
     # Reifegrad label: fallback to live calculation if not stored
     if not reifegrad_label and readiness_score > 0:

--- a/services/strategy_renderer.py
+++ b/services/strategy_renderer.py
@@ -54,6 +54,26 @@ def render_strategy_html(sr: Any, db_session: Any) -> str:
     ]
     _base_score = round(sum(_dim_scores) / 4) if any(_dim_scores) else 0
 
+    # --- SCORE-DEBUG (temporary, remove after verification) ---
+    logger.warning("SCORE-DEBUG-1: [Renderer %s] meta.scores = %r", sr.briefing_id, _scores)
+    logger.warning("SCORE-DEBUG-2: [Renderer %s] dimension scores = gov=%s, sec=%s, val=%s, ena=%s",
+                    sr.briefing_id, _dim_scores[0], _dim_scores[1], _dim_scores[2], _dim_scores[3])
+    logger.warning("SCORE-DEBUG-3: [Renderer %s] calculated = %s, rounded = %d",
+                    sr.briefing_id, sum(_dim_scores) / 4 if any(_dim_scores) else 0, _base_score)
+    logger.warning("SCORE-DEBUG-KEYS: [Renderer %s] N43_DOD_PASSED=%r, _n43_dod_passed=%r, "
+                    "CONSISTENCY_GRADE=%r, _CONSISTENCY_GRADE=%r, _CONSISTENCY_SCORE=%r, "
+                    "QUALITY_BONUS=%r, score_gesamt=%r, CANONICAL_OVERALL=%r, scores.overall=%r",
+                    sr.briefing_id,
+                    report1_sections.get("N43_DOD_PASSED", "MISSING"),
+                    report1_sections.get("_n43_dod_passed", "MISSING"),
+                    report1_sections.get("CONSISTENCY_GRADE", "MISSING"),
+                    report1_sections.get("_CONSISTENCY_GRADE", "MISSING"),
+                    report1_sections.get("_CONSISTENCY_SCORE", "MISSING"),
+                    report1_sections.get("QUALITY_BONUS", "MISSING"),
+                    report1_sections.get("score_gesamt", "MISSING"),
+                    report1_sections.get("CANONICAL_OVERALL", "MISSING"),
+                    _scores.get("overall", "MISSING"))
+
     # FIX-HOTFIX3: Prefer stored QUALITY_BONUS (exact value from gpt_analyze)
     # over re-deriving from N43_DOD_PASSED/_CONSISTENCY_GRADE which may be
     # filtered from serializable_sections (underscore-prefixed keys).
@@ -64,15 +84,19 @@ def render_strategy_html(sr: Any, db_session: Any) -> str:
     else:
         # Fallback: re-derive quality bonus (for older analyses without QUALITY_BONUS)
         _dod_passed = report1_sections.get("N43_DOD_PASSED", False) or report1_sections.get("_n43_dod_passed", False)
-        _consistency_grade = str(report1_sections.get("_CONSISTENCY_GRADE", "A"))
-        _consistency_score = report1_sections.get("_CONSISTENCY_SCORE", 100)
+        # FIX-HOTFIX3b: Read CONSISTENCY_GRADE (without underscore, survives
+        # serialization at gpt_analyze.py:18084) and default to 'F'/0 to match
+        # calc_quality_bonus defaults (gpt_analyze.py:2099-2100).
+        _consistency_grade = str(report1_sections.get("CONSISTENCY_GRADE",
+                                  report1_sections.get("_CONSISTENCY_GRADE", "F")))
+        _consistency_score = report1_sections.get("_CONSISTENCY_SCORE", 0)
         _quality_bonus = 0
         if _dod_passed:
             if _consistency_grade in ("A", "B") or (isinstance(_consistency_score, (int, float)) and _consistency_score >= 80):
                 _quality_bonus = 2
             else:
                 _quality_bonus = 1
-        logger.info("[Strategy-Score] Re-derived QUALITY_BONUS=%d (dod=%s, grade=%s)", _quality_bonus, _dod_passed, _consistency_grade)
+        logger.info("[Strategy-Score] Re-derived QUALITY_BONUS=%d (dod=%s, grade=%s, score=%s)", _quality_bonus, _dod_passed, _consistency_grade, _consistency_score)
     _live_score = min(_base_score + _quality_bonus, 98)
 
     # Fallback: also check stored values (for older analyses without dimension scores)
@@ -104,6 +128,9 @@ def render_strategy_html(sr: Any, db_session: Any) -> str:
         "[Strategy-Score] briefing_id=%s R1-formula dims=%r base=%d bonus=%d live=%d stored_max=%d → using %d (live_preferred=%s)",
         sr.briefing_id, _dim_scores, _base_score, _quality_bonus, _live_score, _stored_max, readiness_score, any(_dim_scores),
     )
+    # --- SCORE-DEBUG (temporary, remove after verification) ---
+    logger.warning("SCORE-DEBUG-4: [Renderer %s] score passed to template = %d", sr.briefing_id, readiness_score)
+    logger.warning("SCORE-DEBUG-5: [Renderer %s] score_label = %s", sr.briefing_id, reifegrad_label)
     reifegrad_label = report1_sections.get("score_rating", "")
 
     # Reifegrad label: fallback to live calculation if not stored


### PR DESCRIPTION
FIX-HOTFIX3b: The fallback quality bonus re-derivation used wrong defaults:
- Read _CONSISTENCY_GRADE (underscore, filtered from serializable_sections) with default 'A' — but calc_quality_bonus uses default 'F'
- Read _CONSISTENCY_SCORE with default 100 — but calc_quality_bonus uses 0
- Now reads CONSISTENCY_GRADE (without underscore, stored at gpt_analyze:18084) and falls back to 'F'/0 to match calc_quality_bonus exactly

This caused strategy to either over-estimate bonus (+2 instead of +1) or under-estimate it (0 when DOD was only visible via filtered _n43_dod_passed).

Also adds SCORE-DEBUG WARNING-level logging to strategy_pipeline.py, strategy_renderer.py, and report_renderer.py for production diagnosis. Debug logs to be removed after verification.

https://claude.ai/code/session_01GT8LPW94m1P4ttKeWsS6U8