### PR TITLE
Update TÜV certification badge labels across templates

### DIFF
--- a/templates/gamechanger_deep_dive_v1.html
+++ b/templates/gamechanger_deep_dive_v1.html
@@ -568,7 +568,7 @@ h1, h2, h3, h4 {
 
     <!-- Trust Badges -->
     <div class="trust-badges">
-        <img src="tuev-logo-transparent.png" alt="TÜV-geprüft">
+        <img src="tuev-logo-transparent.png" alt="TÜV Austria zertifiziert">
         <img src="KI-READY-2025-badge.png" alt="KI-Ready 2025">
         <img src="dsgvo.svg" alt="DSGVO-konform">
         <img src="eu-ai.svg" alt="EU AI Act">

--- a/templates/pdf_template_v7.html
+++ b/templates/pdf_template_v7.html
@@ -1096,7 +1096,7 @@ h1, h2, h3, h4 {
 
     <!-- Trust Badges -->
     <div class="trust-badges">
-        <img src="tuev-logo-transparent.png" alt="TÜV-geprüft">
+        <img src="tuev-logo-transparent.png" alt="TÜV Austria zertifiziert">
         <img src="KI-READY-2025-badge.png" alt="KI-Ready 2025">
         <img src="dsgvo.svg" alt="DSGVO-konform">
         <img src="eu-ai.svg" alt="EU AI Act">

--- a/templates/strategy_report.html
+++ b/templates/strategy_report.html
@@ -1005,7 +1005,7 @@ sup.src-ref {
                 <path d="M12 18l4 4 8-8" stroke="#27ae60" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
             </svg>
             <div class="tuev-badge-text">
-                <div class="tuev-badge-title">TÜV Austria zertifizierte Methodik</div>
+                <div class="tuev-badge-title">Erstellt durch TÜV Austria zertifizierten KI-Manager</div>
                 <div class="tuev-badge-sub">Qualitätsgesicherte KI-Readiness-Analyse</div>
             </div>
         </div>


### PR DESCRIPTION
## Summary
Updated alt text and display labels for TÜV certification badges across multiple report templates to reflect more accurate certification descriptions.

## Key Changes
- Updated TÜV badge alt text from "TÜV-geprüft" to "TÜV Austria zertifiziert" in:
  - `templates/gamechanger_deep_dive_v1.html`
  - `templates/pdf_template_v7.html`
- Enhanced TÜV badge title in `templates/strategy_report.html` from "TÜV Austria zertifizierte Methodik" to "Erstellt durch TÜV Austria zertifizierten KI-Manager" for more specific context about the certification scope

## Implementation Details
These changes improve clarity around the TÜV Austria certification by:
- Using more precise terminology ("zertifiziert" vs "geprüft") for accessibility and SEO purposes
- Clarifying that the certification applies to the KI-Manager conducting the analysis, not just the methodology
- Maintaining consistency in certification messaging across all report templates

https://claude.ai/code/session_01JjdGzQHhS2rkCwFyCXB81q