### PR TITLE
fix: normalize company_size to bucket for all downstream consumers

### DIFF
--- a/config/size_profiles.py
+++ b/config/size_profiles.py
@@ -304,6 +304,11 @@ _SIZE_TO_PROFILE_KEY = {
     "2\u201310": "team",  # En-dash
     "11-100": "kmu",
     "11\u2013100": "kmu",  # En-dash
+    # FIX-SIZE-BUCKET: Non-standard ranges (test data, edge cases)
+    "11-49": "kmu",
+    "11\u201349": "kmu",   # En-dash
+    "50-250": "kmu",
+    "50\u2013250": "kmu",  # En-dash
     # Normalized bucket names
     "solo": "solo",
     "small_team": "team",

--- a/gpt_analyze.py
+++ b/gpt_analyze.py
@@ -14802,6 +14802,25 @@ def analyze_briefing(
         pass
 
     # =========================================================================
+    # FIX-SIZE-BUCKET: Normalize unternehmensgroesse to canonical segment EARLY
+    # so ALL downstream consumers (score calibration, truncation, sofort_start,
+    # starter kits, branch profile) read "solo"/"team"/"kmu" instead of raw
+    # form values like "11–49" or "11–100" that cause fallback to solo.
+    # =========================================================================
+    try:
+        from services.company_size_normalizer import get_segment as _get_size_segment
+        _raw_ug = answers.get("unternehmensgroesse", "1")
+        _normalized_segment = _get_size_segment(str(_raw_ug))
+        if _normalized_segment != str(_raw_ug):
+            log.info(
+                "[%s] [FIX-SIZE-BUCKET] unternehmensgroesse normalized: '%s' → '%s'",
+                run_id, _raw_ug, _normalized_segment,
+            )
+        answers["unternehmensgroesse"] = _normalized_segment
+    except Exception as _size_err:
+        log.warning("[%s] [FIX-SIZE-BUCKET] Normalization failed: %s", run_id, _size_err)
+
+    # =========================================================================
     # FIX-529: AUTO-DETECT REPORT VARIANT BASED ON COMPANY SIZE
     # If report_variant is None or "auto", determine based on unternehmensgroesse
     # =========================================================================

--- a/services/answers_normalizer.py
+++ b/services/answers_normalizer.py
@@ -39,6 +39,11 @@ UNTERNEHMENSGROESSE_MAP = {
     "2-10": "team",                               # Hyphen fallback
     "11–100": "kmu",                              # En-dash (U+2013)
     "11-100": "kmu",                              # Hyphen fallback
+    # FIX-SIZE-BUCKET: Non-standard ranges that map to KMU
+    "11–49": "kmu",                               # En-dash (test data variant)
+    "11-49": "kmu",                               # Hyphen fallback
+    "50–250": "kmu",                              # En-dash (extended KMU range)
+    "50-250": "kmu",                              # Hyphen fallback
     # Frontend V2 with labels
     "1 (solo-selbstständig/freiberuflich)": "solo",
     "2–10 (kleines team)": "team",

--- a/services/branch_profile_engine.py
+++ b/services/branch_profile_engine.py
@@ -1275,7 +1275,8 @@ def _normalize_size(size: str) -> str:
     if not size:
         return "team"
 
-    size_lower = size.lower()
+    # FIX-SIZE-BUCKET: Normalize en-dash/em-dash to hyphen for consistent matching
+    size_lower = size.lower().replace("\u2013", "-").replace("\u2014", "-").replace("\u2212", "-")
     # Check team first to avoid "2-10" matching "1" in solo check
     if "team" in size_lower or "2-10" in size_lower or "klein" in size_lower:
         return "team"


### PR DESCRIPTION
Root cause: The pipeline had two separate size-resolution systems. company_size_normalizer correctly normalized raw values like "11–49" to "kmu", but 6+ downstream modules read the RAW unternehmensgroesse value from the briefing dict and defaulted to "solo" because they only recognized "solo"/"team"/"kmu" as keys.

Central fix (gpt_analyze.py):
- Write normalized segment ("solo"/"team"/"kmu") back to answers["unternehmensgroesse"] BEFORE score calibration, so ALL downstream consumers get the canonical value.

Defense-in-depth (3 additional layers):
- answers_normalizer.py: Add "11–49", "11-49", "50–250" mappings to UNTERNEHMENSGROESSE_MAP
- config/size_profiles.py: Add same mappings to _SIZE_TO_PROFILE_KEY
- branch_profile_engine.py: Normalize en-dash to hyphen in _normalize_size() for consistent substring matching

Fixes for Briefing 872 (KMU, "11–49"):
- Score calibration: size=kmu (was: solo, wrong factor 0.90)
- Global truncation: segment=kmu (was: solo, 87% content loss)
- Sofort-Start: size=kmu (was: solo, persona leaks)
- Starter Kit: size=kmu (was: solo, wrong kit)
- Branch Profile: size=kmu (was: team, inconsistent)
- COMPACT mode: consistent kmu (was: mixed solo/kmu)

https://claude.ai/code/session_01JjdGzQHhS2rkCwFyCXB81q