### PR TITLE
Fix LLM hallucinations and truncation in strategy reports (S9)

### DIFF
--- a/gpt_analyze.py
+++ b/gpt_analyze.py
@@ -19832,12 +19832,15 @@ NUR HTML ausgeben. Keine Erklärungen, keine Markdown-Fences."""
     _b40_skipped = 0
 
     # FIX-B41-SKIP: Non-text keys that must NOT be modified by clean-ending pass
+    # FIX-B40-S9: Import B39 content-critical skip sections to prevent double-truncation
     _b40_skip_keys = {
         "LOGO_PRIMARY_SRC", "FOOTER_LEFT_LOGO_SRC", "FOOTER_MID_LOGO_SRC",
         "FOOTER_RIGHT_LOGO_SRC", "FOOTER_BRANDS_HTML", "FEEDBACK_URL",
         "THEME_CSS_VARS", "BUILD_ID", "CONTACT_EMAIL", "OWNER_NAME",
         "TRANSITION_EXEC_TO_ACTION", "TRANSITION_QUICKWINS_TO_ROADMAP",
         "TRANSITION_RISK_TO_FUNDING",
+        # B39 content-critical sections — already handled by report_healer.py B39 pass
+        "SOFORT_START_HTML", "CHALLENGE_30_TAGE_HTML", "STARTER_KIT_HTML",
     }
 
     for _b40_key in list(sections.keys()):

--- a/services/final_sanitizer.py
+++ b/services/final_sanitizer.py
@@ -144,6 +144,34 @@ def final_sanitize(sections: dict) -> dict:
             sections[key] = val
             fixes_applied.append(f"F4:hours-fix-in-{key[:30]}")
 
+    # ─── FIX-F4b-S9: Zeitersparnis-Fließtext mit falschem Monatswert korrigieren ───
+    # LLM halluziniert manchmal falsche Stundenzahlen (z.B. 18 statt 36) im Fließtext.
+    # Nur Monatswerte zwischen 1-100 patchen, die != canon_hours sind.
+    _canon_h_str = str(canon_hours)
+    _f4b_patterns = [
+        (r'Zeitersparnis\s+von\s+(\d{1,3})\s+Stunden', f'Zeitersparnis von {_canon_h_str} Stunden'),
+        (r'Einsparung\s+von\s+(\d{1,3})\s+Stunden', f'Einsparung von {_canon_h_str} Stunden'),
+        (r'(\d{1,3})\s+Stunden\s+monatlich', f'{_canon_h_str} Stunden monatlich'),
+        (r'(\d{1,3})\s+Stunden\s+pro\s+Monat', f'{_canon_h_str} Stunden pro Monat'),
+        (r'(\d{1,3})\s+Stunden/Monat', f'{_canon_h_str} Stunden/Monat'),
+    ]
+    for key in list(sections.keys()):
+        val = sections.get(key)
+        if not isinstance(val, str) or len(val) < 50:
+            continue
+        original = val
+        for _pat, _repl in _f4b_patterns:
+            def _f4b_replace(m, repl=_repl, canon=_canon_h_str):
+                # Extract the number from the match
+                num = m.group(1) if m.lastindex and m.group(1).isdigit() else None
+                if num and num != canon and 1 <= int(num) <= 100:
+                    return repl
+                return m.group(0)  # no change if already correct or out of range
+            val = re.sub(_pat, _f4b_replace, val)
+        if val != original:
+            sections[key] = val
+            fixes_applied.append(f"F4b:hours-prose-fix-{key[:30]}")
+
     # ─── FIX-F5: Prompt-Leak-Patterns entfernen ───
     LEAK_PATTERNS = [
         r'Ihr Ziel\s*\(z\.?\s*B\.[^)]*\)',

--- a/services/strategy_pipeline.py
+++ b/services/strategy_pipeline.py
@@ -398,13 +398,22 @@ async def _generate_section(
         use_claude, prompt_len, prompt_words,
     )
 
-    # Longer sections (S8 Risiken, EXEC) get more output tokens
-    max_out_tokens = 6000 if section_key in ("S8", "EXEC", "S5") else 5000
+    # Longer sections get more output tokens — S4 (Tool-Landschaft) has large prompts
+    # FIX-S9-B2: Increased token budget for S4 to prevent truncation
+    max_out_tokens = 8000 if section_key in ("S4", "S8", "EXEC", "S5") else 5000
 
     if route_to_anthropic:
         result = await _call_anthropic(prompt, SYSTEM_PROMPT_STRATEGY_REPORT, section_key, max_tokens=max_out_tokens)
     else:
         result = await _call_openai(prompt, SYSTEM_PROMPT_STRATEGY_REPORT, section_key, max_tokens=max_out_tokens)
+
+        # FIX-S9-B2: If OpenAI truncated (returned empty/very short), retry with Claude
+        if not result or len(result.split()) < 20:
+            logger.warning(
+                "[Strategy] Section %s: OpenAI returned empty/truncated (%d words), retrying with Claude",
+                section_key, len((result or "").split()),
+            )
+            result = await _call_anthropic(prompt, SYSTEM_PROMPT_STRATEGY_REPORT, section_key, max_tokens=max_out_tokens)
 
     duration = time.time() - start
     word_count = len((result or "").split())
@@ -413,7 +422,14 @@ async def _generate_section(
         section_key, word_count, duration, route_to_anthropic,
     )
 
-    return result or f"<p><em>Section {section_key} konnte nicht generiert werden.</em></p>"
+    # FIX-S9-B2: Customer-friendly fallback instead of technical error message
+    if not result or len(result.split()) < 10:
+        return (
+            "<p><em>Die Tool-Landschaft und Empfehlungen werden in einem Update nachgeliefert. "
+            "Kontaktieren Sie uns unter kontakt@ki-sicherheit.jetzt für Details.</em></p>"
+        )
+
+    return result
 
 
 async def _call_openai(prompt: str, system_prompt: str, section: str, max_tokens: int = 5000) -> Optional[str]:
@@ -457,6 +473,8 @@ async def _call_openai(prompt: str, system_prompt: str, section: str, max_tokens
         )
         if finish_reason == "length":
             logger.warning("[Strategy] OpenAI response TRUNCATED for %s (hit token limit)", section)
+            # FIX-S9-B2: Return None on truncation so retry logic in _generate_section triggers
+            return None
 
         return content
     except Exception as exc:


### PR DESCRIPTION
## Summary
This PR addresses multiple content quality issues in strategy report generation, focusing on correcting LLM hallucinations in hour values and preventing truncation of longer sections like the tool landscape (S4).

## Key Changes

- **FIX-F4b (final_sanitizer.py)**: Added prose-level correction for hallucinated hour values in free-text descriptions. The fix detects and replaces incorrect hour counts (e.g., "18 Stunden" → "36 Stunden") in common German phrases like "Zeitersparnis von X Stunden" and "X Stunden monatlich", but only when the detected value differs from the canonical value and falls within 1-100 range.

- **FIX-S9-B2 (strategy_pipeline.py)**: 
  - Increased max output tokens from 5000 to 8000 for S4 (Tool-Landschaft), S8, EXEC, and S5 sections to prevent truncation of longer content
  - Added fallback retry logic: if OpenAI returns empty or very short results (<20 words), automatically retry with Claude
  - Improved truncation detection: OpenAI now returns `None` when hitting token limits (finish_reason="length") to trigger retry
  - Replaced generic error message with customer-friendly fallback text directing users to contact support

- **FIX-B40-S9 (gpt_analyze.py)**: Added content-critical sections (SOFORT_START_HTML, CHALLENGE_30_TAGE_HTML, STARTER_KIT_HTML) to the B40 skip list to prevent double-truncation by the clean-ending pass, since these are already handled by report_healer.py's B39 pass.

## Implementation Details

- The F4b fix uses regex patterns with a custom replacement function that validates extracted numbers before substitution
- The S9-B2 retry logic gracefully degrades: if both OpenAI and Claude fail, returns a professional fallback message instead of a technical error
- Token budget increase for S4 reflects the larger prompt size for tool landscape analysis

https://claude.ai/code/session_01MuVfuj4iHC88MjtCmNt1id