### PR TITLE
Add unified customer-facing report display IDs (KIS-XXXX)

### DIFF
--- a/gpt_analyze.py
+++ b/gpt_analyze.py
@@ -15276,6 +15276,9 @@ Gib NUR das angeforderte HTML-Fragment aus - keine Fragen, keine Hilfsangebote, 
     sections["report_id"] = report_id
     sections["report_version"] = version_mm
     sections["WATERMARK_TEXT"] = _build_watermark_text(report_id, version_mm)
+    # Unified customer-facing report number (KIS-XXXX) for all three PDFs
+    from utils.report_display_id import get_report_display_id
+    sections["REPORT_DISPLAY_ID"] = get_report_display_id(briefing_id)
     
     # Build stamp & Feedback box
     sections["BUILD_STAMP"] = f"{datetime.now(timezone.utc).strftime('%Y-%m-%d %H:%M UTC')} · {report_id} · v{version_mm}"
@@ -20722,9 +20725,12 @@ def _send_emails(db: Session, rep: Report, br: Briefing, pdf_url: Optional[str],
         
         if user_email:
             user_attachments = [] if pdf_url else attachments_admin[:1]
+            # Unified display number for customer-facing emails
+            from utils.report_display_id import get_report_display_id as _disp_id
+            _display = _disp_id(br.id)
             ok, err = _send_email_via_resend(
                 user_email,
-                "Ihr KI‑Status‑Report ist fertig",
+                f"Ihr KI\u2011Status\u2011Report ({_display})",
                 render_report_ready_email(recipient="user", pdf_url=pdf_url, user_email=user_email, briefing_id=getattr(br, "id", None)),
                 attachments=user_attachments
             )

--- a/routes/report.py
+++ b/routes/report.py
@@ -993,7 +993,9 @@ def _send_deep_dive_email(
             "content": pdf_bytes,
             "mimetype": "application/pdf",
         }
-        subject = "Ihre KI-Potenzial-Analyse"
+        from utils.report_display_id import get_report_display_id
+        _display = get_report_display_id(briefing_id)
+        subject = f"Ihre KI-Potenzial-Analyse ({_display})"
 
         # --- User email ---
         if user_email:

--- a/services/gamechanger_deep_dive.py
+++ b/services/gamechanger_deep_dive.py
@@ -813,6 +813,9 @@ def generate_gamechanger_report(briefing_id: int) -> Dict[str, Any]:
         context.get('kundencode', ''), context.get('UNTERNEHMENSGROESSE_LABEL', ''),
     )
 
+    # 3b. Inject briefing_id into context for display-ID generation
+    context['briefing_id'] = briefing_id
+
     # 4. Generate sections
     sections = generate_deep_dive_sections(context)
 
@@ -877,6 +880,10 @@ def render_deep_dive_html(sections: Dict[str, str],
             or context.get('HAUPTLEISTUNG')
             or 'Ihr Unternehmen'
         )
+        # Unified customer-facing report number (KIS-XXXX)
+        from utils.report_display_id import get_report_display_id
+        _bid = context.get('briefing_id', 0)
+        template_vars['REPORT_DISPLAY_ID'] = get_report_display_id(int(_bid)) if _bid else ''
 
         return str(template.render(**template_vars))
 

--- a/services/strategy_pipeline.py
+++ b/services/strategy_pipeline.py
@@ -753,7 +753,9 @@ def _send_strategy_email(briefing_id: int, pdf_bytes: bytes, db_session: Any) ->
         "content": pdf_bytes,
         "mimetype": "application/pdf",
     }
-    subject = "Ihr KI-Strategiebericht"
+    from utils.report_display_id import get_report_display_id
+    _display = get_report_display_id(briefing_id)
+    subject = f"Ihr KI-Strategiebericht ({_display})"
 
     # --- User email ---
     if user_email:

--- a/services/strategy_renderer.py
+++ b/services/strategy_renderer.py
@@ -16,6 +16,8 @@ from typing import Any, Dict, Optional
 
 from jinja2 import Environment, FileSystemLoader
 
+from utils.report_display_id import get_report_display_id as _get_display_id
+
 logger = logging.getLogger(__name__)
 
 
@@ -298,6 +300,8 @@ def render_strategy_html(sr: Any, db_session: Any) -> str:
         "research_date": research_date,
         "report_id": f"STR-{sr.briefing_id}",
         "build_id": os.getenv("BUILD_ID", ""),
+        # Unified customer-facing report number (KIS-XXXX)
+        "REPORT_DISPLAY_ID": _get_display_id(sr.briefing_id),
         # Sections
         "exec_summary": _exec_body,
         "section_s1": _strip_prompt_leaks(sections.get("S1", "")),

--- a/templates/gamechanger_deep_dive_v1.html
+++ b/templates/gamechanger_deep_dive_v1.html
@@ -753,7 +753,7 @@ h1, h2, h3, h4 {
 </div>
 
 <p class="small" style="text-align: center; color: var(--c-text-3); margin-top: var(--sp-lg);">
-    KI-Potenzial-Analyse v1.0 · Design: Clean Corporate Plus · Generiert am {{ report_date_display }}
+    KI-Potenzial-Analyse v1.0 · Design: Clean Corporate Plus · Generiert am {{ report_date_display }}{% if REPORT_DISPLAY_ID %} · {{ REPORT_DISPLAY_ID }}{% endif %}
 </p>
 
 </body>

--- a/templates/pdf_template_v7.html
+++ b/templates/pdf_template_v7.html
@@ -1009,7 +1009,7 @@ h1, h2, h3, h4 {
     <div class="cover-eyebrow">
         KI-Status-Report · {{ report_date }}
         <span class="muted"> · </span>
-        Report-ID: {{ report_id }}{% if BUILD_ID %} · Build: {{ BUILD_ID }}{% endif %}
+        {% if REPORT_DISPLAY_ID %}Report-Nr: {{ REPORT_DISPLAY_ID }}{% else %}Report-ID: {{ report_id }}{% endif %}{% if BUILD_ID %} · Build: {{ BUILD_ID }}{% endif %}
     </div>
     <div style="margin-bottom: var(--sp-xl); max-width: 600px;">
         <h1>KI-Readiness Report</h1>
@@ -1949,7 +1949,7 @@ h1, h2, h3, h4 {
 </div>
 
 <p class="small" style="text-align: center; color: var(--c-text-3); margin-top: var(--sp-lg);">
-    Report v7.1 · Template v7.1.0 "Clean Corporate Plus" · Generiert am {{ report_date }} · {{ report_id }}
+    Report v7.1 · Template v7.1.0 "Clean Corporate Plus" · Generiert am {{ report_date }} · {% if REPORT_DISPLAY_ID %}{{ REPORT_DISPLAY_ID }}{% else %}{{ report_id }}{% endif %}
     {% if BUILD_ID %} · Build: {{ BUILD_ID }}{% endif %}
 </p>
 

--- a/templates/strategy_report.html
+++ b/templates/strategy_report.html
@@ -22,7 +22,7 @@
     size: A4;
     margin: 20mm 20mm 25mm 23mm; /* links 3mm extra für Akzentlinie */
     @bottom-center {
-        content: "Seite " counter(page) " von " counter(pages) "  ·  {{ report_id }}  ·  {{ datum }}";
+        content: "Seite " counter(page) " von " counter(pages) "  ·  {% if REPORT_DISPLAY_ID %}{{ REPORT_DISPLAY_ID }}{% else %}{{ report_id }}{% endif %}  ·  {{ datum }}";
         font-size: 7pt;
         color: #9CA3AF;
         font-family: 'Inter', system-ui, sans-serif;
@@ -1219,7 +1219,7 @@ sup.src-ref {
         </div>
 
         <p class="small" style="text-align: center; color: var(--c-text-3); margin-top: var(--sp-lg);">
-            KI-Strategiebericht v1.0 · Template: Strategy Blue · Generiert am {{ datum }} · {{ report_id }}
+            KI-Strategiebericht v1.0 · Template: Strategy Blue · Generiert am {{ datum }} · {% if REPORT_DISPLAY_ID %}{{ REPORT_DISPLAY_ID }}{% else %}{{ report_id }}{% endif %}
             {% if build_id %} · Build: {{ build_id }}{% endif %}
         </p>
     </div>

--- a/utils/report_display_id.py
+++ b/utils/report_display_id.py
@@ -1,0 +1,14 @@
+"""Unified customer-facing report number (KIS-XXXX) for all three report types."""
+
+import os
+
+
+def get_report_display_id(briefing_id: int) -> str:
+    """Compute the customer-friendly report number.
+
+    Uses ENV ``REPORT_DISPLAY_OFFSET`` (default 0) so that e.g.
+    briefing 883 + offset 117 → KIS-1000.
+    """
+    offset = int(os.getenv("REPORT_DISPLAY_OFFSET", "0"))
+    display_number = briefing_id + offset
+    return f"KIS-{display_number:04d}"


### PR DESCRIPTION
## Summary
Introduces a unified customer-facing report numbering system across all three report types (KI-Status-Report, KI-Strategiebericht, and KI-Potenzial-Analyse). All reports now display a consistent `KIS-XXXX` format instead of internal report IDs, with configurable offset support via environment variable.

## Key Changes

- **New utility module** (`utils/report_display_id.py`): Centralized function to generate customer-friendly report numbers from briefing IDs with optional `REPORT_DISPLAY_OFFSET` environment variable support
  
- **KI-Status-Report integration** (`gpt_analyze.py`): 
  - Injects `REPORT_DISPLAY_ID` into PDF template context
  - Updates email subject line to include display ID

- **KI-Strategiebericht integration** (`services/strategy_pipeline.py`, `services/strategy_renderer.py`):
  - Passes display ID to email subject and template context
  - Updates footer and page numbering to show `KIS-XXXX` format

- **KI-Potenzial-Analyse integration** (`routes/report.py`, `services/gamechanger_deep_dive.py`):
  - Injects briefing_id into context for display ID generation
  - Updates email subject and template rendering

- **Template updates** (all three report templates):
  - Conditionally displays `REPORT_DISPLAY_ID` when available, falls back to internal `report_id`
  - Updates cover pages, footers, and page headers to use new format

## Implementation Details

- Display ID format: `KIS-{briefing_id + offset:04d}` (e.g., KIS-1000)
- Offset is configurable via `REPORT_DISPLAY_OFFSET` environment variable (defaults to 0)
- Graceful fallback: templates show internal report ID if display ID is not provided
- Consistent across all customer-facing touchpoints (PDFs, emails, headers, footers)

https://claude.ai/code/session_016uRMF9ZdaUzGSLsudxi6Zz