### PR TITLE
Add briefing_id parameter to feedback link generation

### DIFF
--- a/services/email_templates.py
+++ b/services/email_templates.py
@@ -6,10 +6,13 @@ from typing import Optional
 from urllib.parse import quote
 
 
-def generate_feedback_link(email: str) -> str:
+def generate_feedback_link(email: str, briefing_id: int = None) -> str:
     """Generiert den Feedback-Link mit der E-Mail als URL-Parameter."""
     encoded_email = quote(email)
-    return f"https://make.ki-sicherheit.jetzt/feedback/feedback.html?email={encoded_email}"
+    url = f"https://make.ki-sicherheit.jetzt/feedback/feedback.html?email={encoded_email}"
+    if briefing_id:
+        url += f"&briefing_id={briefing_id}"
+    return url
 
 def render_report_ready_email(recipient: str, pdf_url: Optional[str], briefing_summary_html: Optional[str] = None, user_email: Optional[str] = None, briefing_id: Optional[int] = None) -> str:
     if recipient == "admin":
@@ -52,7 +55,7 @@ def render_report_ready_email(recipient: str, pdf_url: Optional[str], briefing_s
     # Add feedback section for user emails only
     feedback_section = ""
     if recipient != "admin" and user_email:
-        feedback_link = generate_feedback_link(user_email)
+        feedback_link = generate_feedback_link(user_email, briefing_id=briefing_id)
         feedback_section = f"""
         <hr style="border:none;border-top:1px solid #e6edf3;margin:24px 0">
         <p style="font-size:15px;margin:0 0 8px">💬 <strong>Ihr Feedback hilft!</strong></p>


### PR DESCRIPTION
## Summary
Enhanced the feedback link generation to include an optional `briefing_id` parameter, allowing feedback to be associated with specific briefings.

## Changes
- Modified `generate_feedback_link()` function to accept an optional `briefing_id` parameter
- Updated the function to append `briefing_id` as a query parameter when provided
- Updated the call to `generate_feedback_link()` in `render_report_ready_email()` to pass the `briefing_id` when available

## Implementation Details
- The `briefing_id` parameter is optional (defaults to `None`) to maintain backward compatibility
- The query parameter is only appended to the URL if `briefing_id` is provided
- This enables tracking which briefing a user's feedback is associated with, improving feedback organization and analysis

https://claude.ai/code/session_01GegLbAjk87fRTCmznAzBRv