### PR TITLE
Add branche and unternehmensgroesse to briefing status response

### DIFF
--- a/routes/briefings.py
+++ b/routes/briefings.py
@@ -213,10 +213,13 @@ async def get_briefing_status(
             detail=f"Briefing {briefing_id} not found"
         )
 
+    answers = briefing.answers or {}
     response = {
         "briefing_id": briefing.id,
         "status": briefing.status,
         "lang": briefing.lang,
+        "branche": answers.get("branche", ""),
+        "unternehmensgroesse": answers.get("unternehmensgroesse", ""),
         "created_at": briefing.created_at.isoformat() if briefing.created_at else None,
         "accepted_at": briefing.accepted_at.isoformat() if briefing.accepted_at else None,
         "processing_at": briefing.processing_at.isoformat() if briefing.processing_at else None,


### PR DESCRIPTION
## Summary
Extended the briefing status endpoint to include additional company information fields in the response.

## Changes
- Added `branche` (industry/sector) field to the briefing status response
- Added `unternehmensgroesse` (company size) field to the briefing status response
- Both fields are extracted from the briefing's answers with empty string as default fallback
- Safely handles cases where answers may be null or missing these fields

## Implementation Details
- Introduced a local `answers` variable that defaults to an empty dictionary if `briefing.answers` is None
- Uses dictionary `.get()` method with empty string defaults to safely retrieve the new fields
- Maintains backward compatibility by providing sensible defaults for missing data

https://claude.ai/code/session_01M5S3YWYsThHKTeCBu38bNG