### PR TITLE
Fix: Eliminate duplicate feedback notification — single email path

### DIFF
--- a/services/feedback.py
+++ b/services/feedback.py
@@ -8,15 +8,11 @@ optional forwarding to external webhook (Make/n8n), and email notification.
 from __future__ import annotations
 
 import asyncio
-import hashlib
-import hmac
 import json
 import logging
 import os
 from datetime import datetime, timezone
 from typing import Any, Dict, Optional
-
-import httpx
 
 log = logging.getLogger("services.feedback")
 
@@ -26,75 +22,7 @@ FEEDBACK_NOTIFY_EMAIL_DEFAULT = "kontakt@ki-sicherheit.jetzt"
 
 def _get_feedback_notify_email() -> str:
     """Returns FEEDBACK_NOTIFY_EMAIL or default (kontakt@ki-sicherheit.jetzt)."""
-    return (os.getenv("FEEDBACK_NOTIFY_EMAIL") or os.getenv("FEEDBACK_ADMIN_EMAIL") or "").strip() or FEEDBACK_NOTIFY_EMAIL_DEFAULT
-
-
-def _get_feedback_url() -> Optional[str]:
-    """Returns FEEDBACK_URL if configured."""
-    return (os.getenv("FEEDBACK_URL") or "").strip() or None
-
-
-def _get_feedback_secret() -> Optional[str]:
-    """Returns FEEDBACK_SECRET if configured."""
-    return (os.getenv("FEEDBACK_SECRET") or "").strip() or None
-
-
-def _compute_hmac(payload: Dict[str, Any], secret: str) -> str:
-    """Compute HMAC-SHA256 signature for payload."""
-    payload_str = json.dumps(payload, sort_keys=True, ensure_ascii=False)
-    return hmac.new(
-        secret.encode("utf-8"),
-        payload_str.encode("utf-8"),
-        hashlib.sha256
-    ).hexdigest()
-
-
-async def forward_to_webhook(payload: Dict[str, Any]) -> bool:
-    """
-    Forward feedback to external webhook (if FEEDBACK_URL is configured).
-
-    Returns True if successful or if no webhook is configured.
-    Returns False if forwarding failed (but doesn't raise - we log instead).
-    """
-    webhook_url = _get_feedback_url()
-    if not webhook_url:
-        log.debug("No FEEDBACK_URL configured - skipping webhook forwarding")
-        return True
-
-    secret = _get_feedback_secret()
-    headers = {"Content-Type": "application/json; charset=utf-8"}
-
-    if secret:
-        signature = _compute_hmac(payload, secret)
-        headers["X-Feedback-Secret"] = secret
-        headers["X-Feedback-Signature"] = signature
-        log.debug("Added HMAC signature to webhook request")
-
-    try:
-        async with httpx.AsyncClient(timeout=10.0) as client:
-            response = await client.post(
-                webhook_url,
-                json=payload,
-                headers=headers
-            )
-
-            if response.status_code in (200, 201, 202, 204):
-                log.info("✓ Feedback forwarded to webhook: status=%d", response.status_code)
-                return True
-            else:
-                log.warning(
-                    "⚠️ Webhook returned non-success status: %d - %s",
-                    response.status_code,
-                    response.text[:200] if response.text else "(empty)"
-                )
-                return False
-
-    except httpx.TimeoutException:
-        log.error("✗ Webhook timeout after 10s: %s", webhook_url)
-        return False
-    except Exception as exc:
-        log.error("✗ Webhook forwarding failed: %s - %s", type(exc).__name__, str(exc))
-        return False
+    return (os.getenv("FEEDBACK_NOTIFY_EMAIL") or "").strip() or FEEDBACK_NOTIFY_EMAIL_DEFAULT
 
 
 def _build_notification_body(payload: Dict[str, Any], feedback_type: str, timestamp: str) -> str:
@@ -222,16 +150,18 @@ async def process_feedback(
     source: str = "feedback_form_v1"
 ) -> Dict[str, Any]:
     """
-    Process incoming feedback: log, save to DB, forward to webhook, send email.
+    Process incoming feedback: log, save to DB, send email notification.
 
     This is the main entry point for the feedback service.
+    Single notification path: email via Resend/SMTP to kontakt@ki-sicherheit.jetzt.
+    Webhook forwarding was removed to prevent duplicate emails (external
+    Make/n8n scenarios sent their own notifications).
 
     Returns a result dict with status and optional details.
     """
     result: Dict[str, Any] = {
         "logged": False,
         "saved_to_db": False,
-        "forwarded_to_webhook": False,
         "email_sent": False,
         "feedback_id": None,
     }
@@ -247,11 +177,8 @@ async def process_feedback(
             result["saved_to_db"] = True
             result["feedback_id"] = feedback_id
 
-    # 3. Forward to webhook if configured
-    webhook_success = await forward_to_webhook(payload)
-    result["forwarded_to_webhook"] = webhook_success
-
-    # 4. Send email notification to admin (fire-and-forget, non-blocking)
+    # 3. Send email notification to admin (fire-and-forget, non-blocking)
+    #    Single path for ALL feedback types — no webhook, no duplicate.
     asyncio.ensure_future(_safe_send_notification(payload))
     result["email_sent"] = True  # optimistic; errors are logged
 


### PR DESCRIPTION
Root cause: forward_to_webhook() in process_feedback() posted every feedback payload to FEEDBACK_URL (Make.com/n8n), which triggered its own email notification (old format: "Neues KI-Readiness Feedback" to bewertung@). Combined with our new code-level email, this caused two emails per feedback submission.

Changes:
- Remove webhook forwarding (forward_to_webhook, _compute_hmac, _get_feedback_url, _get_feedback_secret) from process_feedback flow
- Remove FEEDBACK_ADMIN_EMAIL fallback from _get_feedback_notify_email() to prevent env var override routing to bewertung@ instead of kontakt@
- Clean up unused imports (hashlib, hmac, httpx)
- Single notification path: code-level email via Resend/SMTP to kontakt@ki-sicherheit.jetzt for ALL feedback types

Result: exactly 1 email per feedback, always to kontakt@, always with
subject [KI-Sicherheit] Neues Feedback: {type}.

https://claude.ai/code/session_01VhrnghvSkR6XHTVqpDXkEN