### PR TITLE
fix(A3b): read BUNDESLAND_LABEL from briefing dict, not sections

### DIFF
--- a/gpt_analyze.py
+++ b/gpt_analyze.py
@@ -14405,10 +14405,17 @@ Gib den erweiterten HTML-Inhalt aus (mindestens {_heal_target_words} Wörter):
                     pass
                 _fp_pre_compact = foerderpotenzial_html  # preserve for rollback
                 # NEU: Kompakte CI-Design v2.0 Darstellung
+                # FIX-A3b: Read BUNDESLAND_LABEL from briefing dict (enriched by
+                # _build_prompt_vars), NOT from sections which only has HTML outputs.
+                _bl_for_funding = (
+                    briefing.get("BUNDESLAND_LABEL", "")
+                    or BUNDESLAND_MAPPING.get(str(briefing.get("bundesland", "")).lower(), "")
+                    or briefing.get("bundesland", "")
+                )
                 foerderpotenzial_html = _generate_funding_compact_from_html(
                     raw_html=foerderpotenzial_html,
-                    bundesland=sections.get("BUNDESLAND_LABEL", "") or sections.get("bundesland", ""),
-                    company_size=sections.get("UNTERNEHMENSGROESSE", "1")
+                    bundesland=_bl_for_funding,
+                    company_size=briefing.get("unternehmensgroesse", "1")
                 )
                 # FIX-620: Post-compact word count check - revert if below min_words
                 _fp_text_after = re.sub(r"<[^>]+>", "", foerderpotenzial_html).strip()

--- a/services/content_quality_enforcer.py
+++ b/services/content_quality_enforcer.py
@@ -2003,8 +2003,10 @@ GRAMMAR_FIX_PATTERNS = [
     (r'ein\s+gutes\s+ROI', 'einen guten ROI'),
     (r'das\s+ROI', 'der ROI'),
 
-    # FIX-N1/N2 (KIS-1005): "Ihr Team nutzen" → "Ihr Team nutzt", "Ihr Kollege nutzen" → "Ihr Kollege nutzt"
-    (r'\bIhr (Team|Kollege) nutzen\b', r'Ihr \1 nutzt'),
+    # FIX-N1/N2 (KIS-1005): Singular subject + "nutzen" → "nutzt"
+    # Covers: "Ihr Team nutzen", "Der Kollege nutzen", "Ein Mitarbeiter nutzen", etc.
+    (r'\b(Ihr|Der|Die|Das|Ein) (Team|Kollege|Mitarbeiter|Chef|Geschäftsführer) nutzen\b',
+     r'\1 \2 nutzt'),
 ]
 
 def apply_grammar_fixes(html: str) -> tuple[str, int]:


### PR DESCRIPTION
Root cause: _generate_funding_compact_from_html() at line 14410 read BUNDESLAND_LABEL from `sections` dict, which only contains HTML outputs from parallel LLM calls. BUNDESLAND_LABEL lives on the `briefing` dict (enriched by _build_prompt_vars() inside each thread).

Fix: Read from briefing.get("BUNDESLAND_LABEL") with fallback chain:
1. briefing["BUNDESLAND_LABEL"] (set by _build_prompt_vars)
2. BUNDESLAND_MAPPING[briefing["bundesland"]] (direct code→name)
3. briefing["bundesland"] (raw code as last resort)

Also fixes company_size to read from briefing instead of sections.

Grammar regex (N1/N2): Extended pattern to cover "Der/Die/Das/Ein" articles in addition to "Ihr" (e.g. "Der Kollege nutzen" → "nutzt").

https://claude.ai/code/session_013fAVE2JRxjKqojU9kn5kbN