### PR TITLE
Add BAFA amount enforcer and compound noun grammar fix (Session 28)

### DIFF
--- a/services/content_quality_enforcer.py
+++ b/services/content_quality_enforcer.py
@@ -2054,6 +2054,99 @@ def apply_grammar_fixer(sections: dict) -> dict:
 
 
 # =============================================================================
+# NEU-1 (Session 28): BAFA Amount Enforcer
+# Prevents LLM from hallucinating wrong BAFA max amounts (e.g. 2.800€ for Bayern).
+# Uses config/bafa.py as single source of truth for regional values.
+# =============================================================================
+
+def apply_bafa_amount_enforcer(sections: dict, bundesland: str) -> dict:
+    """
+    Replace incorrect BAFA max funding amounts in foerderpotenzial section
+    with the correct regional value from config/bafa.py.
+
+    The LLM prompt already contains deterministic BAFA data, but LLMs can
+    hallucinate wrong amounts. This post-processor is a safety net.
+    """
+    if not bundesland:
+        return sections
+
+    # Only enforce in the foerderpotenzial section (where BAFA is discussed)
+    target_keys = [k for k in sections if "foerder" in k.lower() or "funding" in k.lower()]
+    if not target_keys:
+        return sections
+
+    try:
+        from config.bafa import get_bafa_foerderung_max_display, get_bafa_foerderquote
+        correct_max = get_bafa_foerderung_max_display(bundesland)  # e.g. "1.750 €"
+        correct_quote = get_bafa_foerderquote(bundesland)  # e.g. 50
+    except ImportError:
+        log.warning("[BAFA-ENFORCER] config.bafa not available, skipping")
+        return sections
+
+    # Known wrong BAFA amounts that the LLM might hallucinate
+    # Correct values: Alte BL = 1.750€/50%, Neue BL = 2.800€/80%, Berlin = 2.100€/60%
+    all_bafa_amounts = ["1.750", "2.800", "2.100"]
+    # Remove the correct amount from the "wrong" list
+    correct_amount_str = correct_max.replace(" €", "").replace("\xa0€", "").strip()
+    wrong_amounts = [a for a in all_bafa_amounts if a != correct_amount_str]
+
+    total_fixes = 0
+    for key in target_keys:
+        value = sections.get(key, "")
+        if not isinstance(value, str) or not value:
+            continue
+
+        original = value
+        for wrong in wrong_amounts:
+            # Pattern: wrong BAFA amount near BAFA context
+            # Match "maximal X.XXX €" or "X.XXX €" or "X.XXX€" patterns
+            # Only replace when in BAFA context (within ~200 chars of "BAFA" mention)
+            # Use a function-based replacement to check BAFA proximity
+            def _bafa_context_replace(m, _wrong=wrong, _correct_max=correct_max, _full=value):
+                start = max(0, m.start() - 200)
+                end = min(len(_full), m.end() + 200)
+                context = _full[start:end].lower()
+                if "bafa" in context or "beratungsförderung" in context or "unternehmensberatung" in context:
+                    return m.group(0).replace(_wrong, correct_amount_str)
+                return m.group(0)  # Not in BAFA context, leave unchanged
+
+            # Match the wrong amount with optional € sign and optional "netto"
+            pattern = re.compile(
+                rf'(?:maximal\s+)?{re.escape(wrong)}\s*(?:€|&euro;|Euro)',
+                re.IGNORECASE
+            )
+            value = pattern.sub(_bafa_context_replace, value)
+
+            # Also catch "Zuschuss von X%" with wrong percentage near BAFA
+            if correct_quote == 50 and "80" in value:
+                # For Alte Bundesländer: 80% is wrong
+                pct_pattern = re.compile(r'(?:Zuschuss\s+von\s+)80\s*(?:%|Prozent)', re.IGNORECASE)
+                value = pct_pattern.sub(
+                    lambda m, _v=value: m.group(0).replace("80", str(correct_quote))
+                    if "bafa" in _v[max(0, m.start()-200):m.end()+200].lower() else m.group(0),
+                    value
+                )
+            elif correct_quote == 80 and "50" in value:
+                # For Neue Bundesländer: 50% is wrong
+                pct_pattern = re.compile(r'(?:Zuschuss\s+von\s+)50\s*(?:%|Prozent)', re.IGNORECASE)
+                value = pct_pattern.sub(
+                    lambda m, _v=value: m.group(0).replace("50", str(correct_quote))
+                    if "bafa" in _v[max(0, m.start()-200):m.end()+200].lower() else m.group(0),
+                    value
+                )
+
+        if value != original:
+            sections[key] = value
+            total_fixes += 1
+            log.info("[BAFA-ENFORCER] Fixed BAFA amounts in section '%s' (bundesland=%s, correct=%s/%s%%)",
+                     key, bundesland, correct_max, correct_quote)
+
+    if total_fixes:
+        log.info("[BAFA-ENFORCER] Complete: %d sections corrected", total_fixes)
+    return sections
+
+
+# =============================================================================
 # MASTER FUNCTION: Apply All Quality Enforcers
 # =============================================================================
 
@@ -2961,9 +3054,13 @@ def apply_all_quality_enforcers(sections: dict, hauptleistung: str = "", bundesl
     
     
     # 5. Location-Validator
-    
+
+    # 5.5 NEU-1 (Session 28): BAFA Amount Enforcer — fix hallucinated BAFA max amounts
+    if bundesland:
+        sections = apply_bafa_amount_enforcer(sections, bundesland)
+
     # 6. Grammar-Fixer
-    
+
     # 7. AI-Act Konsistenz (v14.19)
     sections = apply_ai_act_consistency(sections)
     sections = apply_grammar_fixer(sections)

--- a/services/content_quality_enforcer.py
+++ b/services/content_quality_enforcer.py
@@ -2008,6 +2008,14 @@ GRAMMAR_FIX_PATTERNS = [
     (r'\b(Ihr|Der|Die|Das|Ein) (Team|Kollege|Mitarbeiter|Chef|Geschäftsführer) nutzen\b',
      r'\1 \2 nutzt'),
 
+    # NEU-2 (Session 28, KIS-1012): Compound-noun singular subjects + "nutzen" → "nutzt"
+    # Covers: "Ihr Motion-Design-Team nutzen", "Das Pilotteam nutzen", "Ihr Kernteam nutzen"
+    # The N1/N2 rule above only matches simple "Ihr Team nutzen" — this catches
+    # compound nouns (hyphenated) ending in singular nouns like -Team, -System, etc.
+    # "Teams nutzen" / "Sie nutzen" remain correct (plural subjects not matched).
+    (r'\b((?:Ihr|Das|Ein)\s+\S*(?:Team|Unternehmen|System|Management|Pilotteam|Kernteam))\s+nutzen\b',
+     lambda m: f'{m.group(1)} nutzt'),
+
     # KIS-1011-B1: "Ich haben" → "Ich habe" (defensive grammar fix)
     # Negative lookbehind prevents false positives like "die ich haben möchte"
     (r'(?<![a-zäöü])\bIch haben\b', 'Ich habe'),

--- a/services/content_quality_enforcer.py
+++ b/services/content_quality_enforcer.py
@@ -2129,19 +2129,19 @@ def apply_bafa_amount_enforcer(sections: dict, bundesland: str) -> dict:
             if correct_quote == 50 and "80" in value:
                 # For Alte Bundesländer: 80% is wrong
                 pct_pattern = re.compile(r'(?:Zuschuss\s+von\s+)80\s*(?:%|Prozent)', re.IGNORECASE)
-                value = pct_pattern.sub(
-                    lambda m, _v=value: m.group(0).replace("80", str(correct_quote))
-                    if "bafa" in _v[max(0, m.start()-200):m.end()+200].lower() else m.group(0),
-                    value
-                )
+                def _fix_pct_80(m: re.Match[str], _v: str = value) -> str:
+                    if "bafa" in _v[max(0, m.start()-200):m.end()+200].lower():
+                        return m.group(0).replace("80", str(correct_quote))
+                    return m.group(0)
+                value = pct_pattern.sub(_fix_pct_80, value)
             elif correct_quote == 80 and "50" in value:
                 # For Neue Bundesländer: 50% is wrong
                 pct_pattern = re.compile(r'(?:Zuschuss\s+von\s+)50\s*(?:%|Prozent)', re.IGNORECASE)
-                value = pct_pattern.sub(
-                    lambda m, _v=value: m.group(0).replace("50", str(correct_quote))
-                    if "bafa" in _v[max(0, m.start()-200):m.end()+200].lower() else m.group(0),
-                    value
-                )
+                def _fix_pct_50(m: re.Match[str], _v: str = value) -> str:
+                    if "bafa" in _v[max(0, m.start()-200):m.end()+200].lower():
+                        return m.group(0).replace("50", str(correct_quote))
+                    return m.group(0)
+                value = pct_pattern.sub(_fix_pct_50, value)
 
         if value != original:
             sections[key] = value


### PR DESCRIPTION
## Summary
This PR adds two quality enforcement features to prevent LLM hallucinations and improve German grammar handling:

1. **BAFA Amount Enforcer** — A new post-processor that corrects hallucinated BAFA funding amounts in the foerderpotenzial section
2. **Compound Noun Grammar Fix** — Extended siezen guard rule for compound nouns with singular subjects

## Key Changes

- **New `apply_bafa_amount_enforcer()` function** (NEU-1, Session 28):
  - Validates BAFA max funding amounts against regional values from `config/bafa.py`
  - Prevents LLM from hallucinating incorrect amounts (e.g., 2.800€ for Bayern when it should be 1.750€)
  - Uses context-aware pattern matching to only replace amounts within BAFA-related sections
  - Handles both amount corrections (e.g., "1.750 €") and percentage corrections (e.g., "50%")
  - Includes safety checks for missing config and non-string section values

- **Extended siezen guard rule** (NEU-2, Session 28):
  - Added pattern to handle compound nouns with singular subjects: `"Ihr Motion-Design-Team nutzen"` → `"Ihr Motion-Design-Team nutzt"`
  - Covers hyphenated compound nouns ending in -Team, -System, -Unternehmen, etc.
  - Complements existing simple noun rule without creating false positives for plural subjects

- **Integration into master enforcer**:
  - `apply_bafa_amount_enforcer()` is called in `apply_all_quality_enforcers()` when bundesland is provided
  - Positioned after Location-Validator and before Grammar-Fixer in the enforcement pipeline

## Implementation Details

- BAFA enforcer uses regex patterns with context windows (±200 chars) to avoid replacing amounts outside BAFA discussions
- Supports multiple BAFA amount formats: "1.750 €", "1.750€", "1.750 Euro", etc.
- Gracefully handles missing `config/bafa.py` with warning log
- Compound noun pattern uses non-capturing groups and word boundaries for precision
- All changes include detailed inline comments referencing Session 28 and ticket numbers (KIS-1012, NEU-1, NEU-2)

https://claude.ai/code/session_01D6g2VjSTkhX9kH5w6nbesR