### PR TITLE
fix: Replay idempotency guard — prevent duplicate testruns [S31]

### DIFF
--- a/migrations/2026-03-20_add_replayed_from_postgres.sql
+++ b/migrations/2026-03-20_add_replayed_from_postgres.sql
@@ -1,0 +1,6 @@
+-- Migration: Add replayed_from column to briefings table (PostgreSQL)
+-- Purpose: Track source briefing ID for replay deduplication
+-- Date: 2026-03-20
+
+ALTER TABLE briefings ADD COLUMN IF NOT EXISTS replayed_from INTEGER;
+CREATE INDEX IF NOT EXISTS ix_briefings_replayed_from ON briefings (replayed_from);

--- a/models.py
+++ b/models.py
@@ -82,6 +82,7 @@ class Briefing(Base):
     )
     error: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
     worker_id: Mapped[Optional[str]] = mapped_column(String(64), nullable=True)
+    replayed_from: Mapped[Optional[int]] = mapped_column(Integer, nullable=True, index=True)
 
     user = relationship("User", lazy="joined")
 

--- a/routes/admin_testrun.py
+++ b/routes/admin_testrun.py
@@ -54,10 +54,14 @@ class ReplayRequest(BaseModel):
 
 # ---------- Endpoint ----------
 
+_REPLAY_DEDUP_WINDOW_MINUTES = 30
+
+
 @router.post("/replay/{briefing_id}")
 def replay_testrun(
     briefing_id: int,
     admin_key: str = Query(..., description="Admin API Key"),
+    force: bool = Query(False, description="Bypass duplicate guard"),
     body: Optional[ReplayRequest] = None,
     db: Session = Depends(get_db),
 ) -> Dict[str, Any]:
@@ -67,6 +71,7 @@ def replay_testrun(
 
     - Path: briefing_id — source briefing whose answers are copied
     - Query: admin_key — STRATEGY_ADMIN_KEY
+    - Query: force — bypass duplicate replay guard (default: false)
     - Body (optional): email_override, answer_overrides, trigger_kpa, trigger_strategy
 
     answer_overrides merges into the copied answers, e.g.:
@@ -87,6 +92,47 @@ def replay_testrun(
             status_code=422,
             detail=f"Briefing {briefing_id} has no replayable answers",
         )
+
+    # 1b. Duplicate replay guard
+    if not force:
+        from datetime import datetime, timezone, timedelta
+        from sqlalchemy import and_
+
+        cutoff = datetime.now(timezone.utc) - timedelta(minutes=_REPLAY_DEDUP_WINDOW_MINUTES)
+        existing = (
+            db.query(Briefing)
+            .filter(
+                and_(
+                    Briefing.replayed_from == briefing_id,
+                    Briefing.created_at >= cutoff,
+                    Briefing.status != "error",
+                )
+            )
+            .order_by(Briefing.created_at.desc())
+            .first()
+        )
+        if existing:
+            age_minutes = int(
+                (datetime.now(timezone.utc) - existing.created_at).total_seconds() / 60
+            )
+            log.warning(
+                "[REPLAY] Duplicate blocked: source=%d, existing=%d, age=%dmin",
+                briefing_id, existing.id, age_minutes,
+            )
+            raise HTTPException(
+                status_code=409,
+                detail={
+                    "error": "duplicate_replay",
+                    "detail": (
+                        f"Replay von Briefing {briefing_id} wurde vor {age_minutes} Minuten "
+                        f"bereits ausgeführt (→ Briefing {existing.id}, Status: {existing.status})"
+                    ),
+                    "existing_briefing_id": existing.id,
+                    "created_at": existing.created_at.isoformat(),
+                },
+            )
+    else:
+        log.info("[REPLAY] Force-override: duplicate guard bypassed for source=%d", briefing_id)
 
     # 2. Build diagnostics of source answers
     source_answers = source.answers
@@ -140,6 +186,7 @@ def replay_testrun(
         answers=cleaned_answers,
         status="accepted",
         accepted_at=now,
+        replayed_from=briefing_id,
     )
     db.add(new_briefing)
     db.commit()
@@ -147,8 +194,8 @@ def replay_testrun(
 
     new_id = new_briefing.id
     log.info(
-        "🔄 Testrun replay: source=%d → new=%d, email=%s, overrides=%s, kpa=%s, strategy=%s",
-        briefing_id, new_id, new_email, overrides_applied, trigger_kpa, trigger_strategy,
+        "[REPLAY] Created briefing %d from source %d (force=%s), email=%s, overrides=%s, kpa=%s, strategy=%s",
+        new_id, briefing_id, force, new_email, overrides_applied, trigger_kpa, trigger_strategy,
     )
 
     # 6. Return immediately — worker picks up the new briefing


### PR DESCRIPTION
Problem: POST /api/admin/testrun/replay/{id} had no dedup protection. Accidental double-calls created identical briefings with full pipeline execution (R1 + KPA + Strategy), wasting $3-6 in API fees each time.

Changes:
- Add `replayed_from` INTEGER NULL column to briefings table (model + migration)
- Set replayed_from = source briefing ID on every replay
- Before creating a new replay, check for existing replays of same source within 30-minute window (status != 'error')
- Return HTTP 409 Conflict with details if duplicate detected
- Add `force=true` query parameter to bypass the guard
- Structured logging: [REPLAY] Created/Blocked messages

Normal briefing submission (POST /api/briefings/submit) is not affected.

https://claude.ai/code/session_018Hd3DXW2nnoaKFJezuKWRv