### PR TITLE
fix: ROI-Herleitung uses segment hours from briefing (not DEFAULT_EFF…

### DIFF
--- a/services/business_case_engine_v2.py
+++ b/services/business_case_engine_v2.py
@@ -1673,8 +1673,38 @@ def extract_baseline_from_sections(
     }
 
     if briefing:
-        # Extract from briefing
-        result["effort_hours"] = float(briefing.get("EINSPARUNG_STUNDEN_MONAT", DEFAULT_EFFORT_HOURS))
+        # Extract hours from multiple sources (priority order)
+        # FIX-911b: briefing may have qw_hours_total from calc_business_case
+        # but NOT EINSPARUNG_STUNDEN_MONAT (which is set in sections, not answers)
+        _hours_candidates = [
+            briefing.get("EINSPARUNG_STUNDEN_MONAT"),
+            briefing.get("qw_hours_total"),
+            briefing.get("monatsersparnis_stunden"),
+            briefing.get("TIME_SAVINGS_MONTH_HOURS_CAPPED"),
+        ]
+        effort_h = None
+        for _cand in _hours_candidates:
+            if _cand is not None:
+                try:
+                    _v = float(_cand)
+                    if _v > 0:
+                        effort_h = _v
+                        break
+                except (ValueError, TypeError):
+                    continue
+        # Also check sections if passed (they may have canonical hours)
+        if effort_h is None and sections:
+            for _sk in ("qw_hours_total", "EINSPARUNG_STUNDEN_MONAT", "CANON_HOURS_MONTH"):
+                _sv = sections.get(_sk)
+                if _sv is not None:
+                    try:
+                        _v = float(_sv)
+                        if _v > 0:
+                            effort_h = _v
+                            break
+                    except (ValueError, TypeError):
+                        continue
+        result["effort_hours"] = effort_h if effort_h is not None else DEFAULT_EFFORT_HOURS
         result["monthly_cost"] = float(briefing.get("EINSPARUNG_MONAT_EUR", 0.0))
 
         # Check for existing KPI values


### PR DESCRIPTION
…ORT_HOURS)

Root cause: generate_business_case_report() called extract_baseline_from_sections() which read effort_hours from briefing["EINSPARUNG_STUNDEN_MONAT"]. That key was never set in the answers dict (only in sections), so it fell back to DEFAULT_EFFORT_HOURS=25 for all segments.

Fix: extract_baseline_from_sections() now checks multiple hour sources in priority order: EINSPARUNG_STUNDEN_MONAT, qw_hours_total, monatsersparnis_stunden, TIME_SAVINGS_MONTH_HOURS_CAPPED from briefing, plus sections fallback for CANON_HOURS_MONTH.

KMU ROI-Herleitung now correctly shows:
  50h/Monat × 110€/h × 12 = 66.000€ → ROI = +22.5%
instead of:
  25h/Monat × 110€/h × 12 = 33.000€ → ROI = -46%

356 tests passing.

https://claude.ai/code/session_01D5bf9S7SEKadPu32NzWrBy