### PR TITLE
fix: Scenario ROI ordering — 3-layer defense (KIS-1040 Fix-Zyklus 4)

### DIFF
--- a/gpt_analyze.py
+++ b/gpt_analyze.py
@@ -17433,64 +17433,21 @@ Digitalisierungs- und KI-Vorhaben relevant sein
         log.warning(f"[{run_id}] ⚠️ G22 consistency check failed: {exc}")
     # === END G22 CONSISTENCY CHECK ===
 
-    # === G22-POST: Ensure scenario ROI ordering in rendered HTML ===
-    # Regardless of which healer ran (BCv2 or G22), extract current ROIs from
-    # the rendered HTML and fix if Conservative > Realistic.
+    # === G22-POST: Re-render BUSINESS_CASE_ENGINE_HTML to pick up any healed values ===
+    # The BC engine and N3.4-BC normalizer may have adjusted scenario ROI values
+    # AFTER the initial HTML was rendered. Re-render from the stored bc_report
+    # to ensure the HTML always reflects the current (healed) scenario data.
+    # The render function itself enforces ordering as a last defense line.
     try:
-        import re as _re_bc
-        _bc_html = sections.get("BUSINESS_CASE_ENGINE_HTML", "")
-        if _bc_html and "scenario-card" in _bc_html:
-            # Extract current ROIs from rendered HTML (including negative values)
-            _scenario_labels_de = ["Konservativ", "Realistisch", "Optimistisch"]
-            _scenario_labels_en = ["Conservative", "Realistic", "Optimistic"]
-            _roi_pattern = r'font-weight:600;color:[^"]*;">({label})</span>.*?font-size:24pt[^>]*>(-?\d+(?:\.\d+)?)%'
-
-            _extracted: dict = {}
-            _labels_used = _scenario_labels_de  # Try German first
-            for label in _scenario_labels_de:
-                m = _re_bc.search(_roi_pattern.replace("{label}", _re_bc.escape(label)), _bc_html, _re_bc.DOTALL)
-                if m:
-                    _extracted[label] = float(m.group(2))
-            if len(_extracted) < 3:
-                _extracted = {}
-                _labels_used = _scenario_labels_en
-                for label in _scenario_labels_en:
-                    m = _re_bc.search(_roi_pattern.replace("{label}", _re_bc.escape(label)), _bc_html, _re_bc.DOTALL)
-                    if m:
-                        _extracted[label] = float(m.group(2))
-
-            if len(_extracted) == 3:
-                cons_label, real_label, opt_label = _labels_used
-                cons_roi = _extracted[cons_label]
-                real_roi = _extracted[real_label]
-                opt_roi = _extracted[opt_label]
-
-                if cons_roi > real_roi:
-                    # Ordering violation: fix by setting Realistic = Conservative * 1.1
-                    new_real = round(cons_roi * 1.1, 1)
-                    log.info(
-                        f"[{run_id}] [G22-POST] Ordering violation: {cons_label}={cons_roi}%% > {real_label}={real_roi}%%. "
-                        f"Patching {real_label} to {new_real}%%"
-                    )
-
-                    # Patch the Realistic ROI value in the HTML
-                    _patch_pattern = (
-                        r'(font-weight:600;color:[^"]*;">' + _re_bc.escape(real_label) + r'</span>'
-                        r'.*?<p[^>]*font-size:24pt[^>]*>)'
-                        r'-?\d+(?:\.\d+)?'
-                        r'(%)'
-                    )
-                    _bc_html = _re_bc.sub(
-                        _patch_pattern,
-                        lambda m: str(m.group(1)) + f"{new_real:.0f}" + str(m.group(2)),
-                        _bc_html, count=1, flags=_re_bc.DOTALL
-                    )
-                    sections["BUSINESS_CASE_ENGINE_HTML"] = _bc_html
-                    log.info(f"[{run_id}] [G22-POST] Patched: {cons_label}={cons_roi:.0f}%% <= {real_label}={new_real:.0f}%% <= {opt_label}={opt_roi:.0f}%%")
-                else:
-                    log.debug(f"[{run_id}] [G22-POST] Scenario ordering OK: {cons_label}={cons_roi}%% <= {real_label}={real_roi}%% <= {opt_label}={opt_roi}%%")
-    except Exception as _bc_patch_exc:
-        log.warning(f"[{run_id}] [G22-POST] Scenario ROI patch failed (non-fatal): {_bc_patch_exc}")
+        _bc_report_obj = sections.get("_bc_report")
+        if _bc_report_obj and hasattr(_bc_report_obj, "scenarios"):
+            from services.business_case_engine_v2 import business_case_report_to_html as _bc_rerender
+            _bc_html_new = _bc_rerender(_bc_report_obj, lang=sections.get("LANG", "de"))
+            if _bc_html_new and "scenario-card" in _bc_html_new:
+                sections["BUSINESS_CASE_ENGINE_HTML"] = _bc_html_new
+                log.info(f"[{run_id}] [G22-POST] Re-rendered BUSINESS_CASE_ENGINE_HTML after G22 consistency check")
+    except Exception as _bc_rerender_exc:
+        log.warning(f"[{run_id}] [G22-POST] BC re-render failed (non-fatal): {_bc_rerender_exc}")
     # === END G22-POST ===
 
     # === FIX-B30: Strip canonical blocks AFTER G22 but BEFORE PDF render ===

--- a/services/business_case_engine_v2.py
+++ b/services/business_case_engine_v2.py
@@ -1424,16 +1424,17 @@ def normalize_scenario_order(
 
     normalized = False
 
-    # Rule 1: If realistic < conservative → realistic = conservative * 1.1
-    if real_roi < cons_roi and cons_roi > 0:
-        new_real_roi = round(cons_roi * 1.1, 1)
+    # Rule 1: If conservative > realistic → reduce conservative (not raise realistic!)
+    # The conservative scenario should always have the lowest ROI.
+    if cons_roi > real_roi:
+        new_cons_roi = round(real_roi * 0.9, 1) if real_roi > 0 else round(real_roi - 10, 1)
         log.info(
-            "[N3.4-BC] Normalizing realistic ROI: %.1f%% → %.1f%% (was < conservative %.1f%%)",
-            real_roi, new_real_roi, cons_roi
+            "[N3.4-BC] Normalizing conservative ROI: %.1f%% → %.1f%% (was > realistic %.1f%%)",
+            cons_roi, new_cons_roi, real_roi
         )
-        if isinstance(realistic, dict):
-            realistic["roi_12m"] = new_real_roi
-        real_roi = new_real_roi
+        if isinstance(conservative, dict):
+            conservative["roi_12m"] = new_cons_roi
+        cons_roi = new_cons_roi
         normalized = True
 
     # Rule 2: If realistic > optimistic → realistic = optimistic * 0.9
@@ -2207,7 +2208,41 @@ def business_case_report_to_html(
             <div style="display:flex;gap:12px;flex-wrap:wrap;page-break-inside:avoid;break-inside:avoid;overflow:visible;">
     ''')
 
-    for scenario in report.scenarios:
+    # RENDER-TIME ORDERING ENFORCEMENT: Ensure cons <= real <= opt in HTML output.
+    # This is the last defense line — runs right before HTML generation.
+    _render_scenarios = list(report.scenarios)
+    _cons_r = next((s for s in _render_scenarios if s.name == "conservative"), None)
+    _real_r = next((s for s in _render_scenarios if s.name == "realistic"), None)
+    _opt_r = next((s for s in _render_scenarios if s.name == "optimistic"), None)
+    if _cons_r and _real_r and _cons_r.roi_12m > _real_r.roi_12m:
+        _fixed_cons_roi = round(_real_r.roi_12m * 0.9, 1) if _real_r.roi_12m > 0 else round(_real_r.roi_12m - 10, 1)
+        log.warning(
+            "[G30-RENDER] Scenario ordering violation at render time! "
+            "Conservative=%.1f%% > Realistic=%.1f%%. Fixing to %.1f%%",
+            _cons_r.roi_12m, _real_r.roi_12m, _fixed_cons_roi
+        )
+        _idx = next(i for i, s in enumerate(_render_scenarios) if s.name == "conservative")
+        _render_scenarios[_idx] = ScenarioKPIs(
+            name="conservative", roi_12m=_fixed_cons_roi,
+            payback_months=_cons_r.payback_months, monthly_savings=_cons_r.monthly_savings,
+            annual_savings=_cons_r.annual_savings, investment_total=_cons_r.investment_total,
+            notes=_cons_r.notes,
+        )
+    if _real_r and _opt_r and _real_r.roi_12m > _opt_r.roi_12m:
+        _fixed_real_roi = round(_opt_r.roi_12m * 0.9, 1)
+        log.warning(
+            "[G30-RENDER] Realistic=%.1f%% > Optimistic=%.1f%%. Fixing to %.1f%%",
+            _real_r.roi_12m, _opt_r.roi_12m, _fixed_real_roi
+        )
+        _idx = next(i for i, s in enumerate(_render_scenarios) if s.name == "realistic")
+        _render_scenarios[_idx] = ScenarioKPIs(
+            name="realistic", roi_12m=_fixed_real_roi,
+            payback_months=_real_r.payback_months, monthly_savings=_real_r.monthly_savings,
+            annual_savings=_real_r.annual_savings, investment_total=_real_r.investment_total,
+            notes=_real_r.notes,
+        )
+
+    for scenario in _render_scenarios:
         color = scenario_colors.get(scenario.name, "#6b7280")
         label = labels.get(scenario.name, scenario.name.capitalize())
 
@@ -2311,14 +2346,13 @@ def business_case_report_to_html(
         ''')
 
     # ROI Explanation (Problem #3 fix - transparency)
-    import logging
-    log = logging.getLogger(__name__)
-    log.info(f"[DEBUG] roi_explanation exists: {report.roi_explanation is not None}")
+    _bc_log = logging.getLogger(__name__)
+    _bc_log.info(f"[DEBUG] roi_explanation exists: {report.roi_explanation is not None}")
     if report.roi_explanation:
-        log.info(f"[DEBUG] Adding ROI explanation to HTML")
+        _bc_log.info(f"[DEBUG] Adding ROI explanation to HTML")
         html_parts.append(report.roi_explanation.to_html(lang))
     else:
-        log.warning(f"[DEBUG] ROI explanation is None - NOT adding to HTML!")
+        _bc_log.warning(f"[DEBUG] ROI explanation is None - NOT adding to HTML!")
 
     # Narrative Summary
     if report.narrative_summary:

--- a/tests/test_n34_bc_consistency.py
+++ b/tests/test_n34_bc_consistency.py
@@ -17,7 +17,7 @@ class TestNormalizeScenarioOrder:
         assert callable(normalize_scenario_order)
 
     def test_normalizes_realistic_below_conservative(self):
-        """If realistic < conservative, realistic should be set to conservative * 1.1."""
+        """If conservative > realistic, conservative should be reduced to realistic * 0.9."""
         from services.business_case_engine_v2 import normalize_scenario_order
 
         scenarios = {
@@ -28,8 +28,9 @@ class TestNormalizeScenarioOrder:
 
         result = normalize_scenario_order(scenarios)
 
-        # Realistic should now be 100 * 1.1 = 110
-        assert result["realistic"]["roi_12m"] == 110.0
+        # Conservative should now be 80 * 0.9 = 72.0
+        assert result["conservative"]["roi_12m"] == 72.0
+        assert result["realistic"]["roi_12m"] == 80.0  # Realistic unchanged
         assert result["_bc_consistency_normalized"] is True
 
     def test_normalizes_realistic_above_optimistic(self):


### PR DESCRIPTION
THREE simultaneous fixes to ensure Conservative <= Realistic <= Optimistic:

Fix A — N3.4-BC normalize_scenario_order(): REVERSED healing direction. Old: Conservative > Realistic → raise Realistic (WRONG — preserves the broken Conservative value). New: Conservative > Realistic → lower Conservative to Realistic * 0.9.

Fix B — business_case_report_to_html(): RENDER-TIME enforcement. Right before generating scenario card HTML, checks ordering and adjusts any violations. This is the LAST defense line, runs regardless of which upstream healer fired.

Fix C — G22-POST: Instead of fragile regex patching, now re-renders BUSINESS_CASE_ENGINE_HTML from the stored bc_report object after G22 consistency check. The re-render triggers Fix B's render-time enforcement automatically.

Also fixed UnboundLocalError: local `log` reassignment at line 2350 in business_case_report_to_html() shadowed the module-level logger, causing all prior `log.warning()` calls in the function to fail.

https://claude.ai/code/session_01DnEMa6ZV6VZF48qVaNuKX7