### PR TITLE
[FIX-S25] Sprint 2.5 Runde 2: 4 Bug-Fixes (1 Blocker + 3 Medium)

### DIFF
--- a/gpt_analyze.py
+++ b/gpt_analyze.py
@@ -13253,16 +13253,25 @@ def _generate_content_sections(briefing: Dict[str, Any], scores: Dict[str, Any])
         
         # PLATIN+++ FIX 1.1: Pass canonical rate to sofort_start_generator
         _sofort_rate = 0  # 0 = use canonical rate from single source of truth
-        _sofort_hours_month = float(sections.get("CANON_HOURS_MONTH") or sections.get("monatsersparnis_stunden") or 36)
+        # FIX-S25-B4: Use BC canonical hours, not QW-derived defaults.
+        # Previous default of 36h/month was too high for solo (capped to 20 → 5h/week).
+        # Size-aware defaults match typical BC outputs when CANON_HOURS_MONTH is not yet set.
+        _SIZE_DEFAULTS_HOURS = {"solo": 15, "team": 25, "kmu": 50}
+        _sofort_hours_month = float(sections.get("CANON_HOURS_MONTH") or sections.get("monatsersparnis_stunden") or 0)
         try:
             from services.business_case_engine_v2 import get_hourly_rate, normalize_company_size, cap_time_savings
             _sofort_size_norm = normalize_company_size(sofort_size)
             _sofort_rate, _ = get_hourly_rate(_sofort_size_norm)
+            # FIX-S25-B4: Use size-aware default if no canonical hours available
+            if _sofort_hours_month <= 0:
+                _sofort_hours_month = float(_SIZE_DEFAULTS_HOURS.get(_sofort_size_norm, 25))
             # FIX-v720-F2-HOURS: Apply size cap BEFORE sofort-start generation
-            # Without this, solo gets 36h/month (9h/week) instead of capped 20h/month (5h/week)
             _sofort_hours_month, _ = cap_time_savings(_sofort_hours_month, _sofort_size_norm)
         except Exception:
             pass
+        # Final fallback if everything above failed
+        if _sofort_hours_month <= 0:
+            _sofort_hours_month = 15.0
         # FIX-GRAMMAR-T1: Pass canonical OPEX for consistent net savings
         _sofort_opex_monthly = float(sections.get("OPEX_REALISTISCH_EUR") or briefing.get("OPEX_REALISTISCH_EUR") or 0)
         sections["SOFORT_START_HTML"] = generate_sofort_start_html(

--- a/services/business_case_engine_v2.py
+++ b/services/business_case_engine_v2.py
@@ -1283,10 +1283,14 @@ def heal_scenario_consistency(scenarios: List[ScenarioKPIs]) -> List[ScenarioKPI
         return scenarios
 
     # PLATIN+++ v5.4: CRITICAL errors that persist after recalculation cannot be healed
+    # FIX-S25-B3: Skip CRITICAL raise if C4 recalc ran — negative ROI is a valid outcome,
+    # not broken data. Only raise if no recalc happened (truly 0% with no savings).
     critical_errors = [e for e in errors if "CRITICAL" in e]
-    if critical_errors:
+    if critical_errors and not needs_recalc:
         log.error("[BC_001] CRITICAL errors remain after recalculation - cannot heal: %s", critical_errors)
         raise ValueError(f"Business case has unhealable CRITICAL errors: {critical_errors}")
+    elif critical_errors:
+        log.info("[BC_001] Negative ROI after C4 recalc — valid outcome, continuing: %s", critical_errors)
 
     log.info("[BC_001] Healing scenario consistency issues: %s", errors)
 

--- a/services/business_case_engine_v2.py
+++ b/services/business_case_engine_v2.py
@@ -1261,7 +1261,7 @@ def heal_scenario_consistency(scenarios: List[ScenarioKPIs]) -> List[ScenarioKPI
             )
             recalculated_scenarios.append(ScenarioKPIs(
                 name=scenario.name,
-                roi_12m=max(new_roi, 10.0),  # Minimum 10% ROI if savings exist
+                roi_12m=new_roi,  # FIX-S25-B3: Allow negative ROI (was floored at 10%)
                 payback_months=scenario.payback_months,
                 monthly_savings=scenario.monthly_savings,
                 annual_savings=annual,

--- a/services/sofort_start_generator.py
+++ b/services/sofort_start_generator.py
@@ -148,6 +148,82 @@ Zusätzlich: Gib mir 3 häufige Missverständnisse zu diesem Thema.""",
     },
     
     # -------------------------------------------------------------------------
+    # 1b. HANDWERK & GEWERBE (FIX-S25-B1: Separate from bauwesen)
+    # -------------------------------------------------------------------------
+    "handwerk": {
+        "name": "Handwerk & Gewerbe",
+        "erster_schritt": "Lassen Sie ChatGPT ein Angebot für eine Standardleistung formulieren",
+        "zeitersparnis_pro_woche": 5,
+        "typische_aufgaben": ["Angebote", "Wartungsprotokolle", "Kundenkommunikation"],
+        "prompts": [
+            {
+                "titel": "Angebotsbeschreibung für Standardleistungen erstellen",
+                "prompt": """Erstellen Sie ein professionelles Angebot:
+
+Leistung: [z.B. Heizungswartung, Bad-Sanierung, Elektroinstallation]
+Kunde: [Privat/Gewerbe]
+Umfang: [BESCHREIBUNG]
+
+Struktur:
+1. Leistungsbeschreibung (verständlich für Laien)
+2. Einzelpositionen mit Erläuterung
+3. Material- und Arbeitskosten (getrennt)
+4. Zeitrahmen
+5. Gewährleistungshinweise
+6. Gültigkeitsdauer""",
+                "zeitersparnis": "30-45 Min pro Angebot"
+            },
+            {
+                "titel": "Wartungsbericht/Protokoll formulieren",
+                "prompt": """Erstellen Sie einen Wartungsbericht:
+
+Anlage/Gerät: [BESCHREIBUNG]
+Kunde: [NAME/ADRESSE]
+Durchgeführte Arbeiten: [STICHPUNKTE]
+
+Struktur:
+- Anlagendaten und Zustand
+- Durchgeführte Wartungsarbeiten
+- Festgestellte Mängel
+- Empfohlene Maßnahmen
+- Nächster Wartungstermin
+- Unterschriftsfeld""",
+                "zeitersparnis": "15-20 Min pro Bericht"
+            },
+            {
+                "titel": "Kundenerinnerung für Wartungstermin schreiben",
+                "prompt": """Schreiben Sie eine freundliche Wartungserinnerung:
+
+Kunde: [NAME]
+Anlage/Gerät: [z.B. Heizung, Klimaanlage]
+Letzte Wartung: [DATUM]
+Empfohlener Termin: [ZEITRAUM]
+
+Die Erinnerung soll:
+- Freundlich und nicht aufdringlich sein
+- Den Nutzen der Wartung erklären
+- Konkrete Terminvorschläge machen
+- Kontaktmöglichkeit nennen""",
+                "zeitersparnis": "5-10 Min pro Erinnerung"
+            }
+        ],
+        "lern_prompt": {
+            "titel": "Qualitätsmanagement verstehen & erklären",
+            "thema": "wie digitales Qualitätsmanagement und Checklisten-Apps die Arbeit im Handwerk verbessern",
+            "zielgruppe": "Mitarbeitenden",
+            "prompt": """Erkläre mir, wie digitales Qualitätsmanagement und Checklisten-Apps die Arbeit im Handwerk verbessern, so dass ich es einem Mitarbeitenden ohne technischen Hintergrund in 3 Sätzen erklären kann.
+
+Strukturiere deine Antwort als:
+1. Kernaussage (1 Satz)
+2. Warum das wichtig ist (1 Satz)
+3. Was sich dadurch ändert (1 Satz)
+
+Zusätzlich: Gib mir 3 häufige Missverständnisse zu diesem Thema.""",
+            "zeitersparnis": "15-20 Min"
+        }
+    },
+
+    # -------------------------------------------------------------------------
     # 2. BERATUNG & DIENSTLEISTUNGEN
     # -------------------------------------------------------------------------
     "beratung": {
@@ -1019,6 +1095,80 @@ Zusätzlich: Gib mir 3 häufige Missverständnisse zu diesem Thema.""",
     },
 
     # -------------------------------------------------------------------------
+    # 14. RECHT & KANZLEI (FIX-S25-B1: New branch)
+    # -------------------------------------------------------------------------
+    "recht": {
+        "name": "Recht & Kanzlei",
+        "erster_schritt": "Lassen Sie ChatGPT einen Textbaustein für ein Standardschreiben formulieren",
+        "zeitersparnis_pro_woche": 6,
+        "typische_aufgaben": ["Textbausteine", "Recherche-Zusammenfassungen", "Mandantenkommunikation"],
+        "prompts": [
+            {
+                "titel": "Textbaustein formulieren",
+                "prompt": """Formulieren Sie einen juristischen Textbaustein:
+
+Schreibentyp: [z.B. Abmahnung, Vertragsentwurf, Widerspruch]
+Sachverhalt: [KURZBESCHREIBUNG]
+Tonalität: [sachlich/bestimmt/kooperativ]
+
+Der Textbaustein soll:
+- Juristisch präzise formuliert sein
+- Den Sachverhalt klar darstellen
+- Rechtsgrundlagen referenzieren
+- Handlungsaufforderung/Frist enthalten
+- Als Vorlage wiederverwendbar sein""",
+                "zeitersparnis": "30-45 Min pro Baustein"
+            },
+            {
+                "titel": "Recherche-Zusammenfassung erstellen",
+                "prompt": """Fassen Sie diese juristische Recherche zusammen:
+
+Thema: [RECHTSFRAGE]
+Gefundene Quellen: [STICHPUNKTE/URTEILE]
+Relevanter Sachverhalt: [KONTEXT]
+
+Liefern Sie:
+1. Kernaussage in 2-3 Sätzen
+2. Relevante Rechtsprechung (Aktenzeichen)
+3. Pro/Contra-Argumente
+4. Handlungsempfehlung
+5. Offene Fragen""",
+                "zeitersparnis": "1-2 Std pro Recherche"
+            },
+            {
+                "titel": "Mandanten-Update schreiben",
+                "prompt": """Schreiben Sie ein Mandanten-Update:
+
+Mandant: [NAME/ROLLE]
+Verfahren/Sache: [KURZBESCHREIBUNG]
+Aktueller Stand: [STICHPUNKTE]
+Nächste Schritte: [GEPLANT]
+
+Das Update soll:
+- Für juristische Laien verständlich sein
+- Den aktuellen Stand klar darstellen
+- Nächste Schritte und Fristen nennen
+- Professionell aber nahbar formuliert sein""",
+                "zeitersparnis": "15-20 Min pro Update"
+            }
+        ],
+        "lern_prompt": {
+            "titel": "Fristenmanagement verstehen & erklären",
+            "thema": "wie KI-gestütztes Fristenmanagement Haftungsrisiken in der Kanzlei reduziert",
+            "zielgruppe": "Mandanten",
+            "prompt": """Erkläre mir, wie KI-gestütztes Fristenmanagement Haftungsrisiken in der Kanzlei reduziert, so dass ich es einem Mandanten ohne Fachwissen in 3 Sätzen erklären kann.
+
+Strukturiere deine Antwort als:
+1. Kernaussage (1 Satz)
+2. Warum das wichtig ist (1 Satz)
+3. Was sich dadurch ändert (1 Satz)
+
+Zusätzlich: Gib mir 3 häufige Missverständnisse zu diesem Thema.""",
+            "zeitersparnis": "15-20 Min"
+        }
+    },
+
+    # -------------------------------------------------------------------------
     # DEFAULT (Fallback für alle anderen)
     # -------------------------------------------------------------------------
     "default": {
@@ -1193,11 +1343,13 @@ def get_branche_key(branche: str) -> str:
         "bildung": ["bildung", "schul", "training", "akadem", "lehr"],
         "verwaltung": ["verwalt", "behörd", "öffentlich", "amt"],
         "gesundheit": ["gesundheit", "pflege", "medizin", "arzt", "klinik", "praxis"],
-        "bauwesen": ["bau", "architekt", "immobil", "handwerk"],
+        "handwerk": ["handwerk", "shk", "heizung", "sanitär", "elektro", "maler", "tischler", "schreiner", "dachdecker", "klempner", "schlosser", "kfz", "werkstatt", "meister", "gewerk"],
+        "bauwesen": ["bau", "architekt", "immobil"],
         "medien": ["medien", "kreativ", "agentur", "design", "film", "foto"],
         "industrie": ["industrie", "produktion", "fertigung", "maschin", "herstellung"],
         "transport": ["transport", "logistik", "spedition", "versand", "lieferung"],
         "gastronomie": ["gastro", "hotel", "restaurant", "touris", "reise", "catering"],
+        "recht": ["recht", "anwalt", "kanzlei", "jurist", "notar", "rechtsanwalt"],
     }
     
     for key, keywords in mappings.items():

--- a/services/sofort_start_generator.py
+++ b/services/sofort_start_generator.py
@@ -2263,6 +2263,17 @@ _FALLSTUDIE_UNTERNEHMEN: Dict[str, Dict[str, str]] = {
         "team": "Praxis mit 3 Therapeuten",
         "kmu": "Gesundheitszentrum mit 15 Mitarbeitenden",
     },
+    # FIX-S25-B2: Handwerk & Recht segment overrides
+    "handwerk": {
+        "solo": "Selbstständiger Handwerksmeister, SHK",
+        "team": "SHK-Betrieb mit 5 Mitarbeitern",
+        "kmu": "Handwerksbetrieb mit 25 Mitarbeitern",
+    },
+    "recht": {
+        "solo": "Einzelanwalt, Zivilrecht",
+        "team": "Kanzlei mit 4 Anwälten",
+        "kmu": "Wirtschaftskanzlei mit 20 Mitarbeitenden",
+    },
 }
 
 FALLSTUDIEN: Dict[str, Dict[str, Any]] = {
@@ -2434,6 +2445,34 @@ FALLSTUDIEN: Dict[str, Dict[str, Any]] = {
         },
         "zitat": "Jede Bewertung bekommt jetzt eine persönliche Antwort. Das macht den Unterschied.",
         "dauer_bis_roi": "3 Wochen"
+    },
+    # FIX-S25-B2: Handwerk-specific Fallstudie
+    "handwerk": {
+        "titel": "SHK-Betrieb halbiert Dispositionszeit",
+        "unternehmen": "SHK-Betrieb mit 5 Mitarbeitern",
+        "ausgangslage": "Tägliche Disposition bindet Meister 1-2h, Angebote dauern zu lange, Wartungstermine werden vergessen",
+        "loesung": "Craftboxx Tourenplanung + ChatGPT Angebotsbausteine",
+        "ergebnis": {
+            "zeitersparnis": "25 Stunden/Monat (Team)",
+            "kosteneinsparung": "~2.375 €/Monat",
+            "qualitaet": "Kein vergessener Wartungstermin mehr"
+        },
+        "zitat": "Die KI schreibt jetzt unsere Angebote vor – der Meister prüft nur noch. Beste Entscheidung.",
+        "dauer_bis_roi": "3 Wochen"
+    },
+    # FIX-S25-B2: Recht-specific Fallstudie
+    "recht": {
+        "titel": "Einzelanwalt verdoppelt Mandantenkapazität",
+        "unternehmen": "Einzelanwalt, Zivilrecht",
+        "ausgangslage": "Zeitintensive Schriftsatzformulierung, aufwändige Recherche-Zusammenfassungen, viele Mandanten-Updates per Hand",
+        "loesung": "ChatGPT Plus für Textbausteine, Recherche und Mandantenkommunikation",
+        "ergebnis": {
+            "zeitersparnis": "10 Stunden/Woche",
+            "kosteneinsparung": "~4.000 €/Monat",
+            "qualitaet": "Schnellere Reaktionszeit, konsistentere Schriftsätze"
+        },
+        "zitat": "Meine Mandanten bekommen jetzt am gleichen Tag Antwort statt nach einer Woche.",
+        "dauer_bis_roi": "2 Wochen"
     },
     "default": {
         "titel": "Selbstständiger spart 8 Stunden pro Woche",


### PR DESCRIPTION
## Summary

Sprint 2.5 Runde 2 fixes for 4 remaining bugs found after Runde 1 re-test.

- **[FIX-S25-B1] BLOCKER: Branch-specific prompts for Handwerk & Recht** — "Handwerk" mapped to "bauwesen" (architecture prompts), now has own key with SHK/trades-specific prompts (Angebotsbeschreibung, Wartungsbericht, Kundenerinnerung, QM). Added "recht" branch (Textbaustein, Recherche, Mandanten-Update, Fristen).
- **[FIX-S25-B2] Fallstudien for Handwerk & Recht** — Added "SHK-Betrieb halbiert Dispositionszeit" and "Einzelanwalt verdoppelt Mandantenkapazität" case studies with segment-aware company descriptions.
- **[FIX-S25-B3/B3b] Scenario cards ROI floor removed** — `heal_scenario_consistency()` floored all recalculated ROIs at `max(new_roi, 10.0)`, causing all 3 cards to show "10%" when actual ROIs were negative. Removed floor and updated CRITICAL validation to allow legitimate negative ROIs after C4 recalculation.
- **[FIX-S25-B4] Sofort-Start hours from BC canonical** — Default 36h/month fallback (when CANON_HOURS_MONTH not yet set) caused solo=5h/wk instead of ~4h/wk. Replaced with size-aware defaults (solo=15h, team=25h, kmu=50h).

## Test plan

- [ ] Testrun A re-run (Solo/Marketing/Berlin): Marketing prompts + Marketing Fallstudie
- [ ] Testrun B re-run (Team/Handwerk/NRW): Handwerk prompts + SHK Fallstudie
- [ ] Scenario cards show 3 different ROI values (including negative when applicable)
- [ ] Sofort-Start box: Solo ≈ 3-4h/Woche, Team ≈ 6h/Woche
- [ ] No regression: CAPEX, StBerG, Fördermittel, Branchenkontext intact
- [ ] 5588 existing tests pass (92 pre-existing failures from missing sqlalchemy/fastapi deps)

https://claude.ai/code/session_0116nkRMQqGCMo9udML1bHXP