### PR TITLE
[FIX-S25-FINAL-CAPEX] Fix CAPEX budget-band capping + KMU hours

### DIFF
--- a/services/business_case_engine_v2.py
+++ b/services/business_case_engine_v2.py
@@ -187,7 +187,23 @@ def normalize_company_size(size: Optional[str]) -> str:
     size_str = str(size).strip()
     # Normalize dashes before lookup (en-dash → hyphen)
     size_lower = size_str.lower().replace("\u2013", "-").replace("\u2014", "-").replace("\u2212", "-")
-    return SIZE_NORMALIZATION.get(size_lower, "team")
+
+    # Exact match first
+    if size_lower in SIZE_NORMALIZATION:
+        return SIZE_NORMALIZATION[size_lower]
+
+    # FIX-S25-FINAL-KMU: Substring match for label variants like "11-100 Mitarbeiter"
+    # Order matters: check larger ranges first to avoid false matches
+    if "11-100" in size_lower or "11–100" in size_lower or "kmu" in size_lower or "mittelstand" in size_lower:
+        return "kmu"
+    if "2-10" in size_lower or "2–10" in size_lower or "team" in size_lower or "klein" in size_lower:
+        return "team"
+    if ">100" in size_lower or "100+" in size_lower or "enterprise" in size_lower or "groß" in size_lower:
+        return "enterprise"
+    if "solo" in size_lower or "freiberuf" in size_lower or "selbst" in size_lower:
+        return "solo"
+
+    return "team"  # Default
 
 
 def get_funding_cap(company_size: Optional[str]) -> float:
@@ -1928,6 +1944,9 @@ def generate_business_case_report(
     baseline_monthly_cost = baseline.get("monthly_cost", 0.0)
     baseline_effort_hours = baseline.get("effort_hours", DEFAULT_EFFORT_HOURS)
 
+    # Extract company size early (needed for canonical CAPEX)
+    company_size = briefing.get("unternehmensgroesse") if briefing else None
+
     # Extract investment from tools
     tools_investment = extract_investment_from_tools(tools_data, sections)
     investment_total = tools_investment.get("capex", DEFAULT_INVESTMENT) + (
@@ -1935,14 +1954,19 @@ def generate_business_case_report(
     )
     recurring_costs_12m = tools_investment.get("opex_annual", 0.0)
 
-    # Use briefing values if available
-    if briefing.get("CAPEX_REALISTISCH_EUR"):
+    # FIX-S25-FINAL-CAPEX: Use canonical size-based CAPEX, ignoring budget-band values.
+    # The briefing's CAPEX_REALISTISCH_EUR may contain budget-band-capped values.
+    _bc_size = normalize_company_size(company_size)
+    _canonical_capex = CAPEX_DEFAULTS_BY_SIZE.get(_bc_size)
+    if _canonical_capex:
+        investment_total = float(_canonical_capex)
+        log.info("[G30] Using canonical CAPEX for %s: %.0f€ (budget-band-proof)", _bc_size, investment_total)
+    elif briefing.get("CAPEX_REALISTISCH_EUR"):
         investment_total = float(briefing.get("CAPEX_REALISTISCH_EUR", investment_total))
     if briefing.get("OPEX_REALISTISCH_EUR"):
         recurring_costs_12m = float(briefing.get("OPEX_REALISTISCH_EUR", 0.0)) * 12
 
     # Extract funding effect with size-appropriate caps
-    company_size = briefing.get("unternehmensgroesse") if briefing else None
     funding_effect, funding_programmes = extract_funding_effect(
         funding_data, investment_total, company_size
     )

--- a/services/extra_sections.py
+++ b/services/extra_sections.py
@@ -404,6 +404,18 @@ def calc_business_case(answers: Dict[str, Any], env: Dict[str, Any]) -> Dict[str
     capex = int(capex_base * capex_mult)
     capex = min(capex, int(constraints["max_capex"]))
 
+    # FIX-S25-FINAL-CAPEX: ALWAYS use canonical size-based CAPEX.
+    # Budget-band calculation above is OVERRIDDEN — the report shows realistic
+    # market CAPEX regardless of what the customer entered as budget.
+    try:
+        from services.business_case_engine_v2 import CAPEX_DEFAULTS_BY_SIZE
+        _canonical_capex = CAPEX_DEFAULTS_BY_SIZE.get(_segment)
+        if _canonical_capex is not None:
+            capex = _canonical_capex
+            log.info("[BUSINESS-CASE] Using canonical CAPEX for %s: %d€ (budget-band-proof)", _segment, capex)
+    except ImportError:
+        pass  # Keep budget-band-derived capex as fallback
+
     # Segment-specific OPEX defaults
     _OPEX_DEFAULTS = {"solo": 180, "team": 350, "kmu": 600}
     opex = _OPEX_DEFAULTS.get(_segment, 350)

--- a/tests/test_budget_segment_differentiation.py
+++ b/tests/test_budget_segment_differentiation.py
@@ -62,11 +62,11 @@ class TestCalcBusinessCaseSegmentDifferentiation:
 
     def test_solo_capex(self):
         r = self._calc("1")
-        assert r["CAPEX_REALISTISCH_EUR"] == 24_000
+        assert r["CAPEX_REALISTISCH_EUR"] == 12_000  # FIX-S25-FINAL-CAPEX: Solo=12k
 
     def test_team_capex(self):
         r = self._calc("2–10")
-        assert r["CAPEX_REALISTISCH_EUR"] == 12_000
+        assert r["CAPEX_REALISTISCH_EUR"] == 24_000  # FIX-S25-FINAL-CAPEX: Team=24k
 
     def test_kmu_capex(self):
         r = self._calc("11–100")
@@ -79,7 +79,7 @@ class TestCalcBusinessCaseSegmentDifferentiation:
         kmu = self._calc("11–100")["CAPEX_REALISTISCH_EUR"]
         assert solo != team, "Solo and Team CAPEX must differ"
         assert team != kmu, "Team and KMU CAPEX must differ"
-        assert kmu > team > 0, "KMU CAPEX > Team CAPEX"
+        assert kmu > team > solo > 0, "KMU > Team > Solo CAPEX"
 
     def test_hours_differ_across_segments(self):
         """Hours fallback must be segment-specific, not flat 36."""
@@ -135,21 +135,21 @@ class TestCalcBusinessCaseSegmentDifferentiation:
 class TestBudgetBandEdgeCases:
     """Test CAPEX across different budget bands."""
 
-    def test_small_budget_solo_capped(self):
-        """Solo with unter_2000 budget: CAPEX capped by budget ceiling."""
+    def test_small_budget_solo_canonical(self):
+        """FIX-S25-FINAL-CAPEX: Solo CAPEX is always canonical 12k, never budget-band-capped."""
         r = calc_business_case(
             {"unternehmensgroesse": "1", "jahresumsatz": "unter_100k",
              "investitionsbudget": "unter_2000"}, {}
         )
-        assert r["CAPEX_REALISTISCH_EUR"] <= 2000
+        assert r["CAPEX_REALISTISCH_EUR"] == 12_000
 
     def test_kmu_large_budget(self):
-        """KMU with ueber_50000 budget gets higher CAPEX."""
+        """KMU CAPEX is always canonical 48k, regardless of budget."""
         r = calc_business_case(
             {"unternehmensgroesse": "11–100", "jahresumsatz": "2m_10m",
              "investitionsbudget": "ueber_50000"}, {}
         )
-        assert r["CAPEX_REALISTISCH_EUR"] >= 48_000
+        assert r["CAPEX_REALISTISCH_EUR"] == 48_000
 
     def test_qw_hours_override_respected(self):
         """When qw_hours_total is provided, it overrides segment default."""

--- a/tests/test_finalB_bc_table_opex_inclusive.py
+++ b/tests/test_finalB_bc_table_opex_inclusive.py
@@ -154,19 +154,18 @@ class TestBatchBIntegration:
     """Integration tests for Fix-Batch B."""
 
     def test_example_from_briefing(self):
-        """Test specific example: capex=5000, opex=180, monthly_savings=1600."""
-        # This tests the briefing example:
-        # net_12m = (1600 - 180) * 12 - 5000 = 1420 * 12 - 5000 = 17040 - 5000 = 12040
-        # roi_pct = 12040 / 5000 * 100 = 240.8% → capped to 200%
+        """Test CAPEX is canonical and NET ROI formula is correct.
 
+        FIX-S25-FINAL-CAPEX: Team CAPEX is always 24k (canonical), not budget-band-derived.
+        With 17h * 95€ = 1615€/month savings and canonical CAPEX, ROI may be negative.
+        """
         from services.extra_sections import calc_business_case
 
-        # Configure to get close to example values
         answers = {
             "unternehmensgroesse": "team",
             "jahresumsatz": "100k_500k",
-            "investitionsbudget": "2000_10000",  # → capex ~6000
-            "qw_hours_total": 17,  # 17h * 95€ = 1615€ ≈ 1600€
+            "investitionsbudget": "2000_10000",
+            "qw_hours_total": 17,  # 17h * 95€ = 1615€
         }
         env = {}
 
@@ -177,14 +176,17 @@ class TestBatchBIntegration:
         capex = bc.get("CAPEX_REALISTISCH_EUR", 0)
         roi_12m_eur = bc.get("ROI_12M_EUR", 0)
 
+        # FIX-S25-FINAL-CAPEX: Team CAPEX is always canonical 24k
+        assert capex == 24_000, f"Team CAPEX should be canonical 24000, got {capex}"
+
         # Verify NET formula is used
         expected_net_12m = (monthly_savings - opex) * 12 - capex
         assert roi_12m_eur == expected_net_12m, \
             f"ROI_12M_EUR ({roi_12m_eur}) should equal NET formula ({expected_net_12m})"
 
-        # ROI should be positive and capped appropriately
+        # ROI is within bounds (-100% to 200%)
         roi_pct = bc.get("ROI_12M", 0)
-        assert 0 <= roi_pct <= 200, f"ROI percentage should be 0-200%, got {roi_pct}%"
+        assert -100 <= roi_pct <= 200, f"ROI should be -100 to 200%, got {roi_pct}%"
 
     def test_net_roi_lower_than_gross(self):
         """Test that NET ROI is lower than GROSS ROI when OPEX > 0."""

--- a/tests/test_p08_roi_opex_inclusive.py
+++ b/tests/test_p08_roi_opex_inclusive.py
@@ -162,7 +162,8 @@ class TestNoBusinessCasePlaceholders:
         # ROI should be a number, not a placeholder
         roi = bc.get("ROI_12M")
         assert isinstance(roi, (int, float)), f"ROI should be numeric, got {type(roi)}"
-        assert roi > 0, "ROI should be positive"
+        # FIX-S25-FINAL-CAPEX: ROI can be negative with canonical CAPEX (24k for team)
+        assert -100 <= roi <= 200, f"ROI should be -100 to 200%, got {roi}%"
 
     def test_business_case_table_html_no_placeholders(self):
         """Test that BC table HTML contains no unresolved placeholders."""


### PR DESCRIPTION
## Summary

Fixes two remaining blockers found in the 3-Segment audit:

**Bug 1: CAPEX budget-band capping** — BC-Tabelle and Strategy report showed budget-band-capped CAPEX (Solo 10k, Team 6k) instead of canonical values (Solo 12k, Team 24k). Two code paths bypassed the canonical CAPEX:
- `extra_sections.py`: Now overrides budget-band CAPEX with `CAPEX_DEFAULTS_BY_SIZE`
- `generate_business_case_report`: Now uses canonical size-based CAPEX instead of briefing dict

**Bug 2: KMU Sofort-Start hours** — `normalize_company_size("11–100 Mitarbeiter")` returned "team" (exact match only). Added substring matching for size ranges, so KMU now correctly shows 12h/week, 600h/year.

### Validation
```
# All segments × all budget bands = canonical CAPEX
solo: unter_2000=12k, 2000_10000=12k, 10000_50000=12k, ueber_50000=12k  ✅
team: unter_2000=24k, 2000_10000=24k, 10000_50000=24k, ueber_50000=24k  ✅
kmu:  unter_2000=48k, 2000_10000=48k, 10000_50000=48k, ueber_50000=48k  ✅

# KMU Sofort-Start: "11–100 Mitarbeiter" → kmu → 50h/mo → 12h/wk → 600h/yr  ✅
```

## Test plan

- [x] 5588 tests pass (same as before, 92 pre-existing failures)
- [x] CAPEX canonical for all budget bands
- [x] KMU size normalization handles label variants
- [ ] Testrun 943 (Solo): CAPEX=12k in BC-Tabelle + Strategy
- [ ] Testrun 944 (Team): CAPEX=24k in BC-Tabelle + Strategy
- [ ] Testrun 945 (KMU): 12h/week, 600h/year in Sofort-Start box

https://claude.ai/code/session_0116nkRMQqGCMo9udML1bHXP