### PR TITLE
Clarify vendor audit status terminology in strategy prompts

### DIFF
--- a/prompts/strategy_prompts.py
+++ b/prompts/strategy_prompts.py
@@ -186,6 +186,8 @@ UMGANG MIT LÜCKENHAFTEN EINGABEN: Wenn ein Input fehlt oder unkonkret ist: - ni
 
 ANTI-SCHEINPRÄZISION (VERBINDLICH): Keine exakten Zahlen, Fristen, Marktanteile, Prozentsätze, Tool-Preise oder Förderbeträge nennen, wenn sie nicht ausdrücklich im Input oder in der Recherche stehen. Bei fehlender Exaktheit lieber Spannbreite, Einordnung oder qualitative Formulierung nutzen. VERBOTEN: erfundene Prozentwerte, Monatszahlen, Eurobeträge, Rankings oder scheinbar exakte Benchmarks.
 
+QUELLENNUMMERN-REGEL (VERBINDLICH): Publikations- und Studiennummern (z.B. 'Fokus Nr. 533', 'Report Nr. 47', 'Working Paper 2024/15', 'Studie Nr. 12') sind Quellenbezeichner, KEINE Datenwerte. Sie dürfen NIEMALS als Prozentzahlen, Euro-Beträge oder sonstige Kennzahlen in Tabellen oder Fließtext erscheinen. Nutze sie ausschließlich in Quellenangaben und Fußnoten. Wenn eine Recherchequelle eine Nummer im Titel trägt (z.B. 'KfW Fokus Nr. 533'), verwende NUR den inhaltlichen Datenwert (z.B. '8% KI-Nutzung'), nicht die Publikationsnummer.
+
 AUFGABE:
 1. Analysiere den aktuellen Stand der KI-Adoption in der Branche {branche}.
 2. Zeige Benchmark-Daten: Wie weit sind Wettbewerber mit KI?

--- a/prompts/strategy_prompts.py
+++ b/prompts/strategy_prompts.py
@@ -91,7 +91,8 @@ NICHT als Fußnote danach. Verwende eine verständliche, nicht-technische Sprach
 VENDOR-KONSISTENZ (PFLICHT bei Tool-Empfehlungen in S4 und S8):
 Der KI-Readiness Report hat {vendor_audit_red_count} Tools als nicht EU-konform
 (RED) bewertet und {vendor_audit_green_count} als konform (GREEN).
-Gesamtstatus: {vendor_audit_status}.
+Vendor-Audit Compliance-Status (genutzter KI-Tools): {vendor_audit_status}.
+WICHTIG: Der Wert '{vendor_audit_status}' bezieht sich ausschließlich auf den Vendor-Audit-Compliance-Status der genutzten KI-Tools (z.B. 0 von N Tools EU-konform), NICHT auf den Gesamt-KI-Readiness-Score des Unternehmens. Formuliere dies IMMER als 'Vendor-Audit-Status', 'Tool-Compliance-Status' oder 'Konformitätsstatus der genutzten Tools'. Verwende NIEMALS 'Gesamtstatus' in Verbindung mit 'fail' — der KI-Readiness-Score des Unternehmens kann gleichzeitig hoch sein (z.B. 89/100), obwohl der Vendor-Audit-Status 'fail' ist.
 Wenn ein Tool im Report 1 als RED bewertet wurde (z.B. ChatGPT),
 weise bei Erwähnung auf die DSGVO-Einschränkung hin und priorisiere
 EU-konforme Alternativen. Empfehle kein RED-bewertetes Tool als Hauptempfehlung."""
@@ -341,7 +342,8 @@ DIVERSITÄTS-REGELN:
 
 VENDOR-AUDIT AUS REPORT 1 (PFLICHT bei Tool-Empfehlungen):
 Der KI-Readiness Report hat {vendor_audit_red_count} Tools als nicht EU-konform bewertet
-und {vendor_audit_green_count} als konform. Gesamtstatus: {vendor_audit_status}.
+und {vendor_audit_green_count} als konform. Vendor-Audit Compliance-Status (genutzter KI-Tools): {vendor_audit_status}.
+WICHTIG: '{vendor_audit_status}' bezieht sich NUR auf die EU-Konformität der genutzten KI-Tools, NICHT auf den Gesamt-KI-Readiness-Score. Schreibe NIEMALS 'Gesamtstatus fail' — formuliere stattdessen 'Vendor-Audit-Status: fail' oder 'Tool-Compliance-Status: fail'.
 Wenn ein Tool (z.B. ChatGPT) im Report 1 als RED/nicht konform bewertet wurde:
 - Erwähne bei jeder Nennung den DSGVO-Vorbehalt.
 - Empfehle es NICHT als Hauptempfehlung.


### PR DESCRIPTION
## Summary
Updated strategy prompts to eliminate ambiguity between vendor audit compliance status and overall company KI-Readiness scores. Added explicit guidance to prevent misrepresentation of tool compliance failures as company-wide readiness failures.

## Key Changes
- **Terminology clarification**: Replaced generic "Gesamtstatus" (overall status) with specific "Vendor-Audit Compliance-Status (genutzter KI-Tools)" to clearly indicate the metric refers only to tool compliance, not company-wide KI readiness
- **Critical distinction note**: Added mandatory clarification that vendor audit status values (e.g., "fail") reflect only EU-compliance of used AI tools, NOT the company's overall KI-Readiness Score
- **Forbidden phrasing**: Explicitly prohibited combining "Gesamtstatus" with "fail" to prevent misleading statements that a company's KI readiness is poor when only specific tools lack EU compliance
- **New source numbering rule**: Added binding rule (QUELLENNUMMERN-REGEL) to prevent publication/study numbers (e.g., "Fokus Nr. 533") from being misused as data values in tables or text—they must appear only in source citations
- **Applied to multiple prompts**: Changes made consistently across both S4/S8 vendor consistency section and general vendor audit section

## Implementation Details
The changes enforce semantic precision by:
1. Using qualified terminology ("Tool-Compliance-Status", "Vendor-Audit-Status") instead of ambiguous "Gesamtstatus"
2. Providing concrete examples (e.g., "89/100 KI-Readiness Score with fail vendor-audit status")
3. Establishing clear rules for source citation formatting to prevent data integrity issues

https://claude.ai/code/session_012z47jiseonV79p5amk6RbG