### PR TITLE
fix: B724 Nuclear Sweep excludes BUSINESS_CASE_ENGINE_HTML to prevent…

### DIFF
--- a/gpt_analyze.py
+++ b/gpt_analyze.py
@@ -17678,7 +17678,9 @@ Digitalisierungs- und KI-Vorhaben relevant sein
                             _b724r = str(sections.get("CANON_RATE_EUR", "") or "")
                             if _b724r and _b724r.strip().replace(".", "").isdigit():
                                 _b724_rate = int(float(_b724r.strip()))
+                                _b724_skip = {"BUSINESS_CASE_ENGINE_HTML"}
                                 _b724_keys = [k for k in sections if isinstance(sections.get(k), str)
+                                              and k not in _b724_skip
                                               and any(t in k.upper() for t in ("BUSINESS_CASE", "BC_", "STUNDENSATZ",
                                                       "ROI_HTML", "COSTS_OVERVIEW", "SENSITIVITY"))]
                                 _b724_fixed = []


### PR DESCRIPTION
… currency corruption

The B724 rate-enforcement regex (\d{2,3})(\s*€) was matching the thousands-group "200" in German-formatted "19.200 €" (=19,200€) and replacing it with the canonical hourly rate "95", producing "19.95 €".

Only affected Team-segment optimistic scenario (CAPEX 24000 × 0.8 = 19200) because "200" is the only thousands-group in the 50-300 range that B724 treats as a rate candidate. Solo (600), KMU (400), and all other values have thousands-groups outside this range.

Fix: Add BUSINESS_CASE_ENGINE_HTML to B724 skip set, matching the existing ROI sanitizer exclusion at line 16969.

Audit-Finding: KIS-1073 MINOR (Run 1, Briefing 956)

https://claude.ai/code/session_012z47jiseonV79p5amk6RbG