### PR TITLE
Improve funding recommendations and admin briefing with country and label resolution

### DIFF
--- a/routes/funding.py
+++ b/routes/funding.py
@@ -55,11 +55,9 @@ async def recommend_funding(
     try:
         from services.funding_recommender import recommend_funding as get_recommendations
 
-        # Resolve aliases: bundesland → region, segment → size, country → region
+        # Resolve aliases: bundesland → region, segment → size
         if bundesland and (not region or region == "DE"):
             region = bundesland
-        if country and (not region or region == "DE") and not bundesland:
-            region = country
         if segment and (not size or size == "team"):
             size = segment
 
@@ -92,6 +90,7 @@ async def recommend_funding(
             lang=lang,
             limit=limit,
             budget=budget or "",
+            country=country or "",
         )
 
         return {
@@ -101,6 +100,7 @@ async def recommend_funding(
             "parameters": {
                 "branch": branch,
                 "region": region,
+                "country": country,
                 "size": size_norm,
                 "ai_act_risk": ai_act_risk,
             },

--- a/services/email_templates.py
+++ b/services/email_templates.py
@@ -346,10 +346,14 @@ def render_admin_briefing_email(
     region = escape(str(meta.get("region", "\u2014")))
     score = escape(str(meta.get("score", "\u2014")))
     timestamp = escape(str(meta.get("timestamp", "\u2014")))
+    kis_number = escape(str(meta.get("kis_number", "")))
+
+    kis_line = f'<p style="margin:4px 0"><strong>KIS-Nummer:</strong> {kis_number}</p>' if kis_number else ""
 
     meta_html = (
         '<div style="background:#f0f4ff;border-radius:8px;padding:12px 16px;margin-bottom:16px">'
         f'<p style="margin:4px 0"><strong>Briefing-ID:</strong> #{briefing_id}</p>'
+        f'{kis_line}'
         f'<p style="margin:4px 0"><strong>Segment:</strong> {segment}</p>'
         f'<p style="margin:4px 0"><strong>Branche:</strong> {branche}</p>'
         f'<p style="margin:4px 0"><strong>Region:</strong> {region}</p>'

--- a/services/funding_recommender.py
+++ b/services/funding_recommender.py
@@ -431,6 +431,7 @@ def calculate_relevance_score(
     ai_act_risk: str,
     roi: float,
     budget: str = "",
+    country: str = "",
 ) -> float:
     """
     Calculate relevance score for a funding program.
@@ -441,7 +442,13 @@ def calculate_relevance_score(
     Returns score from 0.0 to 1.0, or -1.0 to signal "filter out".
     """
     user_region = _resolve_user_region(region)
-    user_country = user_region["country"]
+    # If explicit country parameter provided, it takes precedence over
+    # the country derived from region (fixes CH/AT/GB being ignored when
+    # region is also provided, e.g. country=CH&region=be).
+    if country and country.upper() in ("DE", "AT", "CH", "GB"):
+        user_country = country.upper()
+    else:
+        user_country = user_region["country"]
     user_bundesland = user_region["bundesland"]
 
     program_country = program.get("country_code", "DE")
@@ -456,9 +463,6 @@ def calculate_relevance_score(
     if program_country == "GB" and user_country != "GB":
         return -1.0
     if program_country == "DE" and user_country not in ("DE", "EU"):
-        return -1.0
-    # EU programs: not for CH or GB (not EU members)
-    if program_country == "EU" and user_country in ("CH", "GB"):
         return -1.0
 
     # --- SEGMENT MATCH (required) ---
@@ -488,6 +492,10 @@ def calculate_relevance_score(
         # EU program — baseline, no boost
         score *= 1.0
     elif program_country == "AT" and user_country == "AT":
+        score *= 1.5
+    elif program_country == "CH" and user_country == "CH":
+        score *= 1.5
+    elif program_country == "GB" and user_country == "GB":
         score *= 1.5
     elif user_bundesland and user_bundesland not in program_regions and len(program_regions) > 1:
         # Regional program but NOT for user's Bundesland → penalize
@@ -610,6 +618,7 @@ def recommend_funding(
     lang: str = "de",
     limit: int = 5,
     budget: str = "",
+    country: str = "",
 ) -> List[FundingRecommendation]:
     """
     Get personalized funding recommendations.
@@ -639,7 +648,8 @@ def recommend_funding(
     for program in programs:
         # Calculate relevance (returns -1.0 for filtered-out programs)
         score = calculate_relevance_score(
-            program, branch, region, size, maturity, ai_act_risk, roi, budget
+            program, branch, region, size, maturity, ai_act_risk, roi, budget,
+            country=country,
         )
 
         if score < 0.0:  # Filtered out by country/segment

--- a/services/strategy_pipeline.py
+++ b/services/strategy_pipeline.py
@@ -926,14 +926,40 @@ def _send_admin_briefing_email(briefing_id: int, db_session: Any) -> None:
     scores = analysis_meta.get("scores", {}) if isinstance(analysis_meta, dict) else {}
 
     # Derive segment label
-    size_raw = r1_answers.get("unternehmensgroesse", "")
-    segment_map = {"solo": "Solo", "team": "Team", "kmu": "KMU"}
-    segment = segment_map.get(str(size_raw).lower(), str(size_raw))
+    from services.answers_normalizer import (
+        BRANCHEN_LABELS, BUNDESLAENDER_LABELS, UNTERNEHMENSGROESSEN_LABELS,
+    )
+    from utils.report_display_id import get_report_display_id
 
-    # Derive branche label (prefer enriched label)
-    branche = r1_answers.get("BRANCHE_LABEL") or r1_answers.get("branche", "\u2014")
-    region = r1_answers.get("BUNDESLAND_LABEL") or r1_answers.get("bundesland", "\u2014")
+    size_raw = r1_answers.get("unternehmensgroesse", "")
+    segment = UNTERNEHMENSGROESSEN_LABELS.get(
+        str(size_raw).lower(),
+        str(size_raw) if size_raw else "\u2014",
+    )
+
+    # Derive branche label (prefer enriched label, then resolve raw key)
+    branche_raw = r1_answers.get("branche", "")
+    branche = (
+        r1_answers.get("BRANCHE_LABEL")
+        or BRANCHEN_LABELS.get(str(branche_raw).lower(), str(branche_raw) if branche_raw else "\u2014")
+    )
+
+    # Derive region label (prefer enriched label, then resolve raw key)
+    bundesland_raw = r1_answers.get("bundesland", "")
+    region = (
+        r1_answers.get("BUNDESLAND_LABEL")
+        or BUNDESLAENDER_LABELS.get(str(bundesland_raw).lower(), str(bundesland_raw) if bundesland_raw else "\u2014")
+    )
+
+    # Country label (show when not DE)
+    country_raw = r1_answers.get("country", r1_answers.get("land", ""))
+    country_labels = {"AT": "Österreich", "CH": "Schweiz", "GB": "Vereinigtes Königreich"}
+    country_label = country_labels.get(str(country_raw).upper(), "")
+    if country_label:
+        region = f"{region} / {country_label}" if region and region != "\u2014" else country_label
+
     score = scores.get("overall", "\u2014")
+    kis_number = get_report_display_id(briefing_id)
 
     meta = {
         "segment": segment,
@@ -941,10 +967,11 @@ def _send_admin_briefing_email(briefing_id: int, db_session: Any) -> None:
         "region": region,
         "score": score,
         "timestamp": datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC"),
+        "kis_number": kis_number,
     }
 
     # --- Build subject ---
-    subject = f"[KIS-Admin] Briefing #{briefing_id} \u2014 {branche} / {segment} / {region}"
+    subject = f"[KIS-Admin] Briefing #{briefing_id} / {kis_number} \u2014 {branche} / {segment} / {region}"
 
     # --- Render HTML ---
     html_body = render_admin_briefing_email(


### PR DESCRIPTION
## Summary
This PR enhances the funding recommendation system and admin briefing emails by improving country-level filtering, standardizing label resolution across segments/branches/regions, and adding KIS number tracking to briefing metadata.

## Key Changes

### Funding Recommender (`services/funding_recommender.py`)
- **Country parameter precedence**: Added explicit `country` parameter to `calculate_relevance_score()` and `recommend_funding()` that takes precedence over country derived from region. This fixes cases where country parameters (e.g., `country=CH&region=be`) were being ignored.
- **Removed EU program restriction**: Deleted the filter that prevented CH and GB users from accessing EU programs, allowing more flexibility for non-EU countries.
- **Country-specific scoring**: Added 1.5x multiplier for CH and GB programs when user is in the same country (matching existing AT behavior).

### Funding Routes (`routes/funding.py`)
- **Simplified country handling**: Removed automatic region aliasing for country parameter. Country is now passed explicitly to the recommender instead of being converted to region.
- **Response transparency**: Added `country` parameter to the returned response metadata for better API transparency.

### Admin Briefing Email (`services/strategy_pipeline.py`)
- **Standardized label resolution**: Replaced hardcoded segment map with `UNTERNEHMENSGROESSEN_LABELS` from `answers_normalizer` for consistent label handling across the application.
- **Improved branche/region resolution**: Enhanced label derivation to:
  - Prefer enriched labels (`BRANCHE_LABEL`, `BUNDESLAND_LABEL`) when available
  - Fall back to normalized label lookups using imported label dictionaries
  - Use em-dash (`\u2014`) as default for missing values
- **Country-aware region display**: Added logic to append country label to region when country is not DE (e.g., "Bern / Schweiz").
- **KIS number tracking**: Integrated `get_report_display_id()` to generate and include KIS number in briefing metadata and email subject line.

### Email Templates (`services/email_templates.py`)
- **KIS number display**: Added KIS number field to admin briefing email metadata section with conditional rendering (only shown when present).

## Implementation Details
- All label lookups use `.lower()` for case-insensitive matching and provide sensible defaults
- Country codes are validated against a whitelist ("DE", "AT", "CH", "GB")
- The KIS number is generated once and reused in both subject line and email body for consistency

https://claude.ai/code/session_01Y3mrJ9JYFqMYdbUeghwhZk