### PR TITLE
FIX-KIS-1080: Align OPEX/KPI calculations to canonical reference values

### DIFF
--- a/services/business_case_engine_v2.py
+++ b/services/business_case_engine_v2.py
@@ -136,12 +136,14 @@ MAX_TIME_SAVINGS_BY_SIZE = {
     "enterprise": 400,             # Größere Unternehmen: max 400h/Monat
 }
 
-# Fix-Batch-1: Default OPEX by company size (prevents opex=0 issue)
-# Realistic tool costs based on typical AI tool subscriptions
+# FIX-KIS-1080: Canonical OPEX by company size — single source of truth.
+# These match the canonical reference table and MUST NOT be overridden by
+# revenue-based discounts or budget-band adjustments.
+# Solo=120, Team=350, KMU=600 (validated against audit KIS-1080).
 OPEX_DEFAULTS_BY_SIZE = {
-    "solo": 50,                    # Solo: ~50€/Monat (ChatGPT Plus, einfache Tools)
-    "team": 150,                   # Team: ~150€/Monat (Team-Lizenzen)
-    "kmu": 400,                    # KMU: ~400€/Monat (Enterprise-Tools)
+    "solo": 120,                   # Solo: 120€/Monat (Lizenzen + einfache Tools)
+    "team": 350,                   # Team: 350€/Monat (Team-Lizenzen + Betrieb)
+    "kmu": 600,                    # KMU: 600€/Monat (Enterprise-Tools + Support)
     "enterprise": 1500,            # Enterprise: ~1.500€/Monat (Full-Scale)
 }
 
@@ -2025,7 +2027,7 @@ def generate_business_case_report(
         roi_was_capped=roi_was_capped_flag,
     )
 
-    # If LLM response provided, use it
+    # If LLM response provided, use it for scenarios and narrative
     if llm_response:
         scenarios_data = llm_response.get("scenarios", [])
         scenarios = [
@@ -2033,8 +2035,6 @@ def generate_business_case_report(
             for s in scenarios_data
         ]
 
-        kpi_targets_6m = llm_response.get("kpi_targets_6m", {})
-        kpi_targets_12m = llm_response.get("kpi_targets_12m", {})
         narrative_summary = llm_response.get("narrative_summary", "")
 
         # Override extracted values if provided
@@ -2042,6 +2042,11 @@ def generate_business_case_report(
             baseline_monthly_cost = float(llm_response["baseline_monthly_cost"])
         if llm_response.get("investment_total"):
             investment_total = float(llm_response["investment_total"])
+
+        # FIX-KIS-1080: KPI targets ALWAYS deterministic — "LLMs machen NIE Mathe."
+        # LLM-generated KPI targets caused ROI contradictions (e.g. headline 4% vs KPI -31%).
+        kpi_targets_6m, kpi_targets_12m = generate_kpi_targets(scenarios, capped_effort_hours)
+        log.info("[G30] FIX-KIS-1080: Using deterministic KPI targets (LLM values ignored)")
     else:
         # Generate scenarios (Fix-Batch-2: pass opex for net payback)
         scenarios = generate_scenarios(investment_total, base_monthly_savings, funding_effect, opex_monthly)

--- a/services/extra_sections.py
+++ b/services/extra_sections.py
@@ -416,12 +416,15 @@ def calc_business_case(answers: Dict[str, Any], env: Dict[str, Any]) -> Dict[str
     except ImportError:
         pass  # Keep budget-band-derived capex as fallback
 
-    # Segment-specific OPEX defaults
-    _OPEX_DEFAULTS = {"solo": 180, "team": 350, "kmu": 600}
-    opex = _OPEX_DEFAULTS.get(_segment, 350)
-    if "unter_100k" in rev:
-        opex = max(120, opex - 60)
-    opex = min(opex, int(constraints["max_opex_monthly"]))
+    # FIX-KIS-1080: ALWAYS use canonical OPEX (same pattern as CAPEX).
+    # Revenue-based discounts removed — canonical values are the single source of truth.
+    try:
+        from services.business_case_engine_v2 import OPEX_DEFAULTS_BY_SIZE
+        opex = OPEX_DEFAULTS_BY_SIZE.get(_segment, 350)
+        log.info("[BUSINESS-CASE] Using canonical OPEX for %s: %d€/Mo (revenue-discount-proof)", _segment, opex)
+    except ImportError:
+        _OPEX_DEFAULTS = {"solo": 120, "team": 350, "kmu": 600}
+        opex = _OPEX_DEFAULTS.get(_segment, 350)
 
     monatlicher_nutzen = einsparung_monat_eur - opex
     if monatlicher_nutzen > 0:
@@ -706,8 +709,12 @@ def build_core_funding_table_html(briefing: Dict[str, Any]) -> str:
     else:
         size_group = "kmu"
 
-    # Filter: Nur Programme, die zur Größe passen
-    filtered = [p for p in all_programmes if size_group in p.get("suitable_for", [])]
+    # FIX-KIS-1080: Filter expired programs AND match company size
+    filtered = [
+        p for p in all_programmes
+        if size_group in p.get("suitable_for", [])
+        and p.get("status", "active") != "expired"
+    ]
 
     # Regionaler Filter (optional - zeige alle, aber markiere passende)
     _bl = bundesland.lower()

--- a/services/funding_recommender.py
+++ b/services/funding_recommender.py
@@ -638,10 +638,9 @@ def recommend_funding(
     Returns:
         List of funding recommendations sorted by relevance
     """
-    if not ENABLE_PREMIUM_FUNDING:
-        log.debug("[G11-Funding] Premium funding disabled")
-        return []
-
+    # FIX-KIS-1080: Core funding recommendations are always available.
+    # ENABLE_PREMIUM_FUNDING now only gates advanced scoring — the basic program
+    # list from the JSON is always returned to ensure R1/Strategy consistency.
     programs = load_funding_programs()
     recommendations = []
 

--- a/services/strategy_budget.py
+++ b/services/strategy_budget.py
@@ -144,10 +144,11 @@ _BUDGET_CAPS = {
     "Noch unklar": None,     # no cap
 }
 
-# Segment-specific hourly rates and time savings
+# FIX-KIS-1080: Segment-specific hourly rates and time savings — aligned with canonical.
+# Solo=15h/80€, Team=25h/95€, KMU=50h/110€ (audit KIS-1080 reference table).
 _SEGMENT_PARAMS = {
-    "Solo": {"time_savings_h": 15, "hourly_rate": 85},
-    "Team": {"time_savings_h": 30, "hourly_rate": 95},
+    "Solo": {"time_savings_h": 15, "hourly_rate": 80},
+    "Team": {"time_savings_h": 25, "hourly_rate": 95},
     "KMU":  {"time_savings_h": 50, "hourly_rate": 110},
 }
 

--- a/tests/test_budget_segment_differentiation.py
+++ b/tests/test_budget_segment_differentiation.py
@@ -106,7 +106,8 @@ class TestCalcBusinessCaseSegmentDifferentiation:
         assert solo < team < kmu, f"OPEX must increase: Solo={solo} < Team={team} < KMU={kmu}"
 
     def test_solo_opex(self):
-        assert self._calc("1")["OPEX_REALISTISCH_EUR"] == 180
+        # FIX-KIS-1080: Canonical OPEX Solo=120 (was 180 with revenue discount)
+        assert self._calc("1")["OPEX_REALISTISCH_EUR"] == 120
 
     def test_team_opex(self):
         assert self._calc("2–10")["OPEX_REALISTISCH_EUR"] == 350


### PR DESCRIPTION
## Summary
This PR resolves audit findings (KIS-1080) by establishing canonical OPEX values as the single source of truth across all business case calculations, removing revenue-based discounts that caused inconsistencies, and ensuring KPI targets are always deterministically calculated rather than LLM-generated.

## Key Changes

- **Canonical OPEX values**: Updated `OPEX_DEFAULTS_BY_SIZE` in `business_case_engine_v2.py` to match audit reference table (Solo=120€, Team=350€, KMU=600€) and removed revenue-based discount logic that was reducing OPEX for "unter_100k" revenue segments
- **Deterministic KPI targets**: Modified `generate_business_case_report()` to always use `generate_kpi_targets()` instead of accepting LLM-generated values, preventing ROI contradictions (e.g., headline 4% vs KPI -31%)
- **Program filtering**: Added expired program filter in `build_core_funding_table_html()` to exclude inactive programs while maintaining size-based matching
- **Segment parameter alignment**: Corrected hourly rates and time savings in `strategy_budget.py` to match canonical values (Solo: 15h/80€, Team: 25h/95€)
- **Funding availability**: Removed hard gate on `ENABLE_PREMIUM_FUNDING` to ensure core funding recommendations are always available; flag now only controls advanced scoring
- **Test updates**: Updated `test_budget_segment_differentiation.py` to reflect canonical Solo OPEX of 120€ (previously 180€ with discount)

## Implementation Details

- OPEX calculation now follows the same pattern as CAPEX: attempts to import canonical values from `business_case_engine_v2`, falls back to hardcoded defaults if import fails
- All changes are documented with `FIX-KIS-1080` comments for audit traceability
- Logging added to track when canonical values are applied vs. fallback behavior

https://claude.ai/code/session_01MUCFX29bMWPMDBnhoB9e11