### PR TITLE
fix: KIS-1081 — canonical monthly savings, deterministic hours, fundi…

### DIFF
--- a/gpt_analyze.py
+++ b/gpt_analyze.py
@@ -9181,16 +9181,14 @@ def _build_prompt_vars(briefing: Dict[str, Any], scores: Dict[str, Any]) -> Dict
     qw1_h = int(os.getenv("DEFAULT_QW1_H", "20"))
     qw2_h = int(os.getenv("DEFAULT_QW2_H", "15"))
 
-    # Calculate monthly and yearly savings with SIZE-BASED CAP
-    # Cap must match services/extra_sections.py get_size_constraints()
-    max_hours_by_size = {
-        "solo": 20,
-        "team": 80,
-        "kmu": 200,
-    }
-    max_hours = max_hours_by_size.get(company_size, 80)
-    raw_hours = qw1_h + qw2_h
-    monatsersparnis_stunden = min(raw_hours, max_hours)
+    # FIX-KIS-1081: Use CANONICAL segment hours, not QW defaults.
+    # QW defaults (20+15=35) don't match canonical (Solo=15, Team=25, KMU=50).
+    # The old value leaked into ROI_STUNDEN_MONAT, causing LLM to hallucinate
+    # wrong hour values in prose (e.g. "18 Stunden" instead of "25 Stunden").
+    _CANONICAL_HOURS = {"solo": 15, "team": 25, "kmu": 50}
+    monatsersparnis_stunden = _CANONICAL_HOURS.get(company_size, 25)
+    log.info("[PROMPT-VARS] FIX-KIS-1081: Using canonical hours for %s: %d h/Mo",
+             company_size, monatsersparnis_stunden)
 
     if monatsersparnis_stunden < raw_hours:
         log.info(
@@ -14410,6 +14408,19 @@ Gib den erweiterten HTML-Inhalt aus (mindestens {_heal_target_words} Wörter):
     log.info(f"[CI-DESIGN] Förderpotenzial HTML input: {len(foerderpotenzial_html) if foerderpotenzial_html else 0} chars")
 
     if foerderpotenzial_html and len(foerderpotenzial_html) > 100:
+        # FIX-KIS-1081: Strip LLM-generated funding tables from FOERDERPOTENZIAL.
+        # The deterministic funding table is in FOERDERPROGRAMME_HTML (separate section).
+        # LLM-generated tables often have broken rendering (e.g. "3× Baden-Württemberg").
+        import re as _re_fp
+        _fp_table_count = foerderpotenzial_html.count("<table")
+        if _fp_table_count > 0:
+            foerderpotenzial_html = _re_fp.sub(
+                r'<table[^>]*>.*?</table>',
+                '<p class="muted small"><em>→ Detaillierte Programmübersicht siehe Förderprogramme-Tabelle unten.</em></p>',
+                foerderpotenzial_html,
+                flags=_re_fp.DOTALL,
+            )
+            log.info("[FIX-KIS-1081] Stripped %d LLM-generated table(s) from FOERDERPOTENZIAL", _fp_table_count)
         try:
             if use_compact_design:
                 # FIX-620: Get min_words for current segment

--- a/prompts/de/foerderpotenzial.md
+++ b/prompts/de/foerderpotenzial.md
@@ -150,6 +150,13 @@ ANTI-REDUNDANZ:
 - Business-Case-Zahlen EINMAL nennen, nicht wiederholen
 - KEINE Wiederholung der Zahlen aus business_case.md – nur Förder-Kontext
 
+TABELLEN-VERBOT (FIX-KIS-1081 — KRITISCH!):
+- Erstelle KEINE Tabelle mit Förderprogrammen (kein <table> mit Programmnamen, Eignung, Max. Förderung etc.)
+- Die konkrete Programmübersicht wird AUTOMATISCH als separate Tabelle eingefügt
+- In DIESEM Abschnitt nur PROSA über Förderstrategie, Förderschwerpunkte und nächste Schritte
+- BAFA-Daten ({{BAFA_FOERDERQUOTE}}%, max. {{BAFA_MAX_FOERDERUNG}}) dürfen im Fließtext erwähnt werden
+- VERBOTEN: <table>-Tags mit Programmlisten, Eignungsbewertungen oder Förderbeträgen
+
 CROSS-SECTION-ZAHLEN IN DIESER SECTION (VERBINDLICH):
 - Nenne NIE eine konkrete Förder-Summe, die du nicht direkt aus den dir übergebenen Daten ablesen kannst.
 - Berechne KEINE abgeleiteten Werte wie „ROI nach Förderung", „Netto-Investition nach Abzug" oder „Eigenkapital-Reduktion um X €".

--- a/prompts/de/ki_stack_summary.md
+++ b/prompts/de/ki_stack_summary.md
@@ -83,6 +83,7 @@ INHALTLICHE STRUKTUR (5 feste Bausteine)
    - Kurz kommentieren, was diese KPIs für die Entscheidungsebene bedeuten.
    - KEINE eigenen KPI-Werte erfinden oder berechnen!
    - WICHTIG: ROI bezieht sich IMMER auf 12 Monate. Schreibe "nach 12 Monaten", NIEMALS "24 Monate" oder andere Zeiträume.
+   - WICHTIG: Wenn du Zeitersparnis, Stunden oder Entlastung in Fließtext erwähnst, verwende EXAKT {{ROI_STUNDEN_MONAT}} Stunden — NIEMALS andere Zahlen erfinden!
 
 5) Branch Badge + Risikoindikator
    - Branch-Label: {{BRANCH_SHORT_LABEL}}.

--- a/prompts/de/tools_empfehlungen.md
+++ b/prompts/de/tools_empfehlungen.md
@@ -89,6 +89,7 @@ STIL & REGELN:
 - Keine Platzhalter oder Developer-Sprache
 - Gesamtlänge: 180–250 Wörter, keine Bullet-Orgien, keine Tool-Listen
 - Fokus auf Funktionslogik statt Markennamen
+- ZAHLENREGEL: Wenn du Stunden, Zeitersparnis oder Entlastung erwähnst, verwende EXAKT {{ROI_STUNDEN_MONAT}} Stunden/Monat — NIEMALS andere Zahlen erfinden!
 
 SPRINT G6 - PERSONA HARD-GUARDS (STRIKT!):
 {% if COMPANY_SIZE == "solo" %}

--- a/services/business_case_engine_v2.py
+++ b/services/business_case_engine_v2.py
@@ -1987,11 +1987,13 @@ def generate_business_case_report(
     elif briefing and briefing.get("sum_quickwin_hours"):
         time_savings_source = "Summe aus Quick Wins"
 
-    # Calculate base monthly savings with size-appropriate rate
-    base_monthly_savings = baseline_monthly_cost
-    if base_monthly_savings <= 0:
-        # Estimate from effort hours using size-appropriate hourly rate
-        base_monthly_savings = calculate_monthly_savings(capped_effort_hours, hourly_rate=float(hourly_rate))
+    # FIX-KIS-1081: ALWAYS compute base_monthly_savings from canonical hours × rate.
+    # The briefing's EINSPARUNG_MONAT_EUR may be capped by revenue-based constraints
+    # (e.g. unter_100k → max_monthly_savings=1667 < canonical 2375 for Team).
+    # This caused scenarios to use wrong savings, producing ROI=-34% instead of +1%.
+    base_monthly_savings = float(capped_effort_hours * hourly_rate)
+    log.info("[G30] FIX-KIS-1081: Using canonical monthly savings: %.0f€ (%.0fh × %.0f€/h)",
+             base_monthly_savings, capped_effort_hours, hourly_rate)
 
     # Build ROI explanation for transparency
     # Fix-Batch-1: Use size-based default OPEX instead of 0.0

--- a/services/extra_sections.py
+++ b/services/extra_sections.py
@@ -379,10 +379,10 @@ def calc_business_case(answers: Dict[str, Any], env: Dict[str, Any]) -> Dict[str
             _segment,
         )
 
+    # FIX-KIS-1081: Monthly savings = canonical hours × rate, NOT capped by revenue.
+    # Revenue-based max_monthly_savings (e.g. 1667 for unter_100k) incorrectly
+    # reduced Team savings from 2375 to 1667, causing ROI=-34% in scenarios.
     einsparung_monat_eur = int(round(capped_hours * stundensatz))
-    einsparung_monat_eur = min(
-        einsparung_monat_eur, int(constraints["max_monthly_savings"])
-    )
 
     # Segment-specific CAPEX multipliers applied to budget-band base
     # Validated targets: Solo=24k, Team=12k, KMU=48k (for 10k-50k budget band)


### PR DESCRIPTION
…ng table isolation

- Fix base_monthly_savings in generate_business_case_report() to use canonical hours × rate instead of stale briefing values
- Remove revenue-based max_monthly_savings cap in calc_business_case() that was reducing savings below canonical (1667 < 2375)
- Fix ROI_STUNDEN_MONAT in base_vars to use canonical segment hours instead of QW defaults (was 35, now 25 for team)
- Add table-ban constraint in foerderpotenzial.md prompt to prevent LLM from generating duplicate funding tables
- Add post-processing table stripper in gpt_analyze.py for FOERDERPOTENZIAL_HTML to remove any LLM-generated <table> tags
- Add canonical hours constraints in ki_stack_summary.md and tools_empfehlungen.md prompts

Audit: KIS-1081 (Briefing #964), fixes bugs #1/#3/#4/#7 779 tests passed, 0 failed

https://claude.ai/code/session_01MUCFX29bMWPMDBnhoB9e11