### PR TITLE
fix: remove stale raw_hours reference from KIS-1081 canonical hours p…

### DIFF
--- a/gpt_analyze.py
+++ b/gpt_analyze.py
@@ -9190,12 +9190,6 @@ def _build_prompt_vars(briefing: Dict[str, Any], scores: Dict[str, Any]) -> Dict
     log.info("[PROMPT-VARS] FIX-KIS-1081: Using canonical hours for %s: %d h/Mo",
              company_size, monatsersparnis_stunden)
 
-    if monatsersparnis_stunden < raw_hours:
-        log.info(
-            "[gpt_analyze] Capped monatsersparnis_stunden from %d to %d for size '%s'",
-            raw_hours, monatsersparnis_stunden, company_size
-        )
-
     monatsersparnis_eur = monatsersparnis_stunden * stundensatz_eur
     jahresersparnis_stunden = monatsersparnis_stunden * 12
     jahresersparnis_eur = monatsersparnis_eur * 12


### PR DESCRIPTION
…atch

The old capping log block referenced `raw_hours` which no longer exists after switching to canonical segment hours. The comparison was dead code since canonical values are already the final values — nothing to cap.

https://claude.ai/code/session_01MUCFX29bMWPMDBnhoB9e11