### PR TITLE
fix(KIS-1091 #3): fix duplicate text in GF-Vorlage regex replacement

### DIFF
--- a/gpt_analyze.py
+++ b/gpt_analyze.py
@@ -20833,12 +20833,14 @@ NUR HTML ausgeben. Keine Erklärungen, keine Markdown-Fences."""
             if _l3_hours <= 0:
                 _l3_hours = {"solo": 15, "team": 25, "kmu": 50}.get(_l3_size, 25)
             _l3_brutto = int(_l3_hours) * int(_l3_rate) * 12
-            _l3_fmt = f"{_l3_brutto:,}".replace(",", ".")
-            # Negative lookahead: match "ca." NOT followed by a digit
-            # This catches ALL broken occurrences regardless of trailing content
+            _l3_fmt = f"{_l3_brutto:,.0f}€".replace(",", ".")
+            # Negative lookahead (?!\s*\d) checks past whitespace for digits,
+            # preventing backtracking false-positives on already-correct values.
+            # Trailing \s* consumes leftover whitespace only when lookahead passes.
+            # Replacement: \1 keeps "Brutto-Zeitersparnis: ca." then appends " 28.500€"
             _l3_html, _l3_count = re.subn(
-                r'(Brutto-Zeitersparnis:\s*ca\.)\s*(?!\d)',
-                rf'\1 {_l3_fmt}\u20ac',
+                r'(Brutto-Zeitersparnis:\s*ca\.)(?!\s*\d)\s*',
+                rf'\1 {_l3_fmt}',
                 _l3_html,
             )
             result["html"] = _l3_html


### PR DESCRIPTION
Two bugs in the Commit #1 regex:

1. \s*(?!\d) backtracking: when "ca. 28.500€" was already correct, \s* would match 0 chars, lookahead saw space (not digit) → matched → injected duplicate value "ca. 28.500€ 28.500€"

2. \u20ac in rf-string: raw strings don't interpret \u escapes, producing literal "\u20ac" instead of "€" in the HTML.

Fix: Change to (?!\s*\d)\s* — lookahead checks past whitespace for digits BEFORE \s* consumes anything, preventing backtracking false positives. Use f-string "€" literal instead of \u20ac.

https://claude.ai/code/session_01AbFBRF7aa5zuSYwoMFoxEJ