### PR TITLE
fix(KIS-1098): strategy funding uses normalized size instead of raw D…

### DIFF
--- a/services/funding_recommender.py
+++ b/services/funding_recommender.py
@@ -466,7 +466,7 @@ def calculate_relevance_score(
         return -1.0
 
     # --- SEGMENT MATCH (required) ---
-    size_lower = size.lower() if size else "team"
+    size_lower = size.lower().replace("\u2013", "-").replace("\u2014", "-") if size else "team"
     # Normalize verbose size labels: "KMU (11-250)" → "kmu", "Solo" → "solo"
     if "solo" in size_lower or "1 " in size_lower or size_lower == "1":
         size_norm = "solo"

--- a/services/strategy_pipeline.py
+++ b/services/strategy_pipeline.py
@@ -370,10 +370,14 @@ async def generate_strategy_report(
                 get_filtered_funding_programs,
                 format_funding_programs_for_prompt,
             )
+            # KIS-1098: Normalize size before passing — DB stores "11–100" (en-dash)
+            # but funding_recommender's inline normalization only checks hyphen "11-".
+            from services.business_case_engine_v2 import normalize_company_size as _norm_size
+            _funding_size = _norm_size(briefing_data.get("unternehmensgroesse", "team"))
             _filtered_programs = get_filtered_funding_programs(
                 bundesland=briefing_data.get("bundesland", ""),
                 country=_country_code,
-                size=briefing_data.get("unternehmensgroesse", "team"),
+                size=_funding_size,
                 branch=briefing_data.get("branche", ""),
                 limit=8,
             )


### PR DESCRIPTION
…B value

Root cause: DB stores unternehmensgroesse as "11–100" (en-dash) but the funding recommender's inline size normalization only checked for hyphen "11-", so KMU values fell through to raw string "11–100" which matched no program's size_match list. All programs scored -1.0 and were filtered out, leaving only the BAFA fallback.

Fix: (1) normalize size via business_case_engine_v2.normalize_company_size() before calling get_filtered_funding_programs(), (2) add en-dash/em-dash normalization to the inline size check in calculate_relevance_score() as defense in depth.

https://claude.ai/code/session_01HCkNGdM1zDSHa7nLD9S32L