### PR TITLE
feat(KIS-1098-P3-3): process vertraulich_nda in scoring and prompt co…

### DIFF
--- a/gpt_analyze.py
+++ b/gpt_analyze.py
@@ -1230,6 +1230,20 @@ def build_strategic_context_block(answers: dict, lang: str = "de") -> str:
         if val and val != "—":
             lines.append(f"Vision für die nächsten 2–3 Jahre:\n{val}")
 
+    # FIX-KIS-1098-P3-3: Add NDA/confidentiality context when vertraulich_nda is set
+    regulierte = answers.get("regulierte_branche", [])
+    if isinstance(regulierte, str):
+        regulierte = [regulierte]
+    if "vertraulich_nda" in regulierte:
+        lines.append(
+            "Datenschutz-Kontext (NDA):\n"
+            "Das Unternehmen arbeitet mit vertraulichem Kundenmaterial unter NDA "
+            "(z.B. unveröffentlichte Produkte, geschützte Inhalte). Empfehlungen "
+            "sollten lokale/private KI-Verarbeitung bevorzugen, AVV-Prüfung als "
+            "Pflichtschritt betonen und Cloud-basierte Lösungen nur mit "
+            "entsprechenden Datenschutzgarantien empfehlen."
+        )
+
     # === Guardrails: Explizit angegeben + Auto-Detection v5 ===
     explicit_guardrails = answers.get("ki_guardrails", "")
     has_explicit = explicit_guardrails and explicit_guardrails != "—"

--- a/services/risk_engine_v2.py
+++ b/services/risk_engine_v2.py
@@ -499,6 +499,13 @@ def extract_dsgvo_risk_from_sections(
             if any(s in dtype_lower for s in sensitive_types):
                 risk_factors.append(f"Sensible Daten: {dtype}")
 
+        # FIX-KIS-1098-P3-3: Check regulierte_branche for vertraulich_nda
+        regulierte = briefing.get("regulierte_branche", [])
+        if isinstance(regulierte, str):
+            regulierte = [regulierte]
+        if "vertraulich_nda" in regulierte:
+            risk_factors.append("Vertrauliche Kundendaten / NDA-Material")
+
         # Check for automated decisions
         if briefing.get("automatisierte_entscheidungen") or briefing.get("automated_decisions"):
             risk_factors.append("Automatisierte Entscheidungsfindung")

--- a/services/risk_engine_v3.py
+++ b/services/risk_engine_v3.py
@@ -502,6 +502,13 @@ def _determine_dpia_required(
         if any(b in branch for b in ["gesundheit", "bildung", "kinder", "healthcare", "education"]):
             reasons.append("Verarbeitung von Daten schutzbedürftiger Gruppen")
 
+        # FIX-KIS-1098-P3-3: NDA/confidential data raises DPIA relevance
+        regulierte = briefing.get("regulierte_branche", [])
+        if isinstance(regulierte, str):
+            regulierte = [regulierte]
+        if "vertraulich_nda" in regulierte:
+            reasons.append("Vertrauliche Kundendaten unter NDA")
+
     dpia_required = len(reasons) >= 1
     reason_text = "; ".join(reasons) if reasons else "Keine DPIA-Anforderung identifiziert"
 


### PR DESCRIPTION
…ntext

When regulierte_branche contains "vertraulich_nda":
- DSGVO risk factor added in risk_engine_v2 (raises risk to mittel/hoch)
- DPIA trigger added in risk_engine_v3 (NDA data = DPIA-relevant)
- Prompt context in build_strategic_context_block emphasizes local processing and AVV requirements for NDA-sensitive material

https://claude.ai/code/session_01VUpDxYrYiTnhY4mPZmg7Fg