### PR TITLE
fix(R1): ProFIT Berlin missing from funding table (KIS-1104)

### DIFF
--- a/gpt_analyze.py
+++ b/gpt_analyze.py
@@ -18759,6 +18759,49 @@ Digitalisierungs- und KI-Vorhaben relevant sein
         log.warning(f"[{run_id}] [QUALITY-ENFORCER-RENDER] Failed: {e}")
 
     # =========================================================================
+    # FIX-KIS-1104: RE-INJECT PROGRAMMATIC FUNDING TABLE AFTER QUALITY ENFORCER
+    # The LOCATION-VALIDATOR (inside apply_all_quality_enforcers) removes <tr>
+    # rows that mention wrong Bundesländer and replaces remaining names with
+    # "Ihr Bundesland".  This damages the funding table — even the programmatic
+    # table injected at line ~15517 can be affected after 3 enforcer passes.
+    # Solution: rebuild the programmatic table from scratch AFTER the final
+    # enforcer pass and inject it as the primary funding display.
+    # =========================================================================
+    try:
+        from services.extra_sections import build_core_funding_table_html
+        import re as _re_kis1104
+        _core_html = build_core_funding_table_html(sections)
+        if _core_html and '<table' in _core_html.lower():
+            # --- FOERDERPOTENZIAL_HTML (rendered by PDF template) ---
+            _fp_html = sections.get("FOERDERPOTENZIAL_HTML", "") or ""
+            # Strip ALL existing <table>…</table> from the section (damaged tables)
+            _fp_prose = _re_kis1104.sub(
+                r'<table[^>]*>.*?</table>', '', _fp_html, flags=_re_kis1104.DOTALL,
+            )
+            # Strip orphaned funding headings left over from table removal
+            _fp_prose = _re_kis1104.sub(
+                r'<h3[^>]*>[^<]*(?:Kernprogramme|Förder(?:programm|mittel)|Programmüberblick)[^<]*</h3>\s*',
+                '', _fp_prose, flags=_re_kis1104.IGNORECASE,
+            )
+            _fp_prose = _fp_prose.strip()
+            _heading = '<h3>Kernprogramme für Ihr Profil (2025/2026)</h3>\n'
+            if _fp_prose:
+                sections["FOERDERPOTENZIAL_HTML"] = (
+                    f"{_heading}{_core_html}\n\n{_fp_prose}"
+                )
+            else:
+                sections["FOERDERPOTENZIAL_HTML"] = f"{_heading}{_core_html}"
+            # --- FOERDERPROGRAMME_HTML + FUNDING_HTML ---
+            sections["FOERDERPROGRAMME_HTML"] = (
+                f"<h3>Kernprogramme für Ihr Profil (2025/2026)</h3>\n"
+                f"{_core_html}"
+            )
+            sections["FUNDING_HTML"] = sections["FOERDERPROGRAMME_HTML"]
+            log.info(f"[{run_id}] [FIX-KIS-1104] Re-injected programmatic funding table after final enforcer")
+    except Exception as e:
+        log.warning(f"[{run_id}] [FIX-KIS-1104] Failed to re-inject funding table: {e}")
+
+    # =========================================================================
     # FIX-R3-5B: QUICK-WINS RECONCILIATION (replaces R2-3)
     # QUICK_WINS_HTML may have been shortened by enforcer passes, losing the
     # premium-rendered PROBLEM/WIRKUNG/UMSETZUNG blocks.  _QUICK_WINS_PRISTINE

--- a/services/extra_sections.py
+++ b/services/extra_sections.py
@@ -703,12 +703,18 @@ def build_core_funding_table_html(briefing: Dict[str, Any]) -> str:
     country = (briefing.get("country") or briefing.get("COUNTRY") or "DE").upper()
 
     # Size-Erkennung
-    if "solo" in size_label or "freiberuf" in size_label or "1" in size_label:
-        size_group = "solo"
-    elif "2" in size_label or "team" in size_label or "klein" in size_label:
-        size_group = "team"
-    else:
-        size_group = "kmu"
+    # FIX-KIS-1104: Use company_size_normalizer for robust size detection.
+    # Previous logic ("1" in size_label) matched "1" inside "11-100" → mis-classified KMU as solo.
+    try:
+        from services.company_size_normalizer import get_segment
+        size_group = get_segment(size_label)
+    except Exception:
+        if "solo" in size_label or "freiberuf" in size_label or size_label in ("1", "einzelunternehmer"):
+            size_group = "solo"
+        elif any(x in size_label for x in ("2-10", "2 bis 10", "team", "klein")):
+            size_group = "team"
+        else:
+            size_group = "kmu"
 
     # FIX-KIS-1098-R1-FUNDING: Filter by country AND size AND status
     # DE companies see DE + EU programs only; AT sees AT + EU; etc.
@@ -720,20 +726,45 @@ def build_core_funding_table_html(briefing: Dict[str, Any]) -> str:
         and p.get("country_code", "DE").upper() in allowed_countries
     ]
 
-    # Regionaler Filter (optional - zeige alle, aber markiere passende)
+    # FIX-KIS-1104: Regional filter — exclude state-specific programs from OTHER states.
+    # Keep: bundesweit, EU, Länderprogramme (generic), and the user's own state.
     _bl = bundesland.lower()
+    _BUNDESLAND_REGIONS = {
+        "berlin": "Berlin", "be": "Berlin",
+        "bayern": "Bayern", "by": "Bayern",
+        "baden-württemberg": "Baden-Württemberg", "bw": "Baden-Württemberg",
+        "hamburg": "Hamburg", "hh": "Hamburg",
+        "hessen": "Hessen", "he": "Hessen",
+        "niedersachsen": "Niedersachsen", "ni": "Niedersachsen",
+        "nordrhein-westfalen": "Nordrhein-Westfalen", "nrw": "Nordrhein-Westfalen",
+        "sachsen": "Sachsen", "sn": "Sachsen",
+        "brandenburg": "Brandenburg", "bb": "Brandenburg",
+        "bremen": "Bremen", "hb": "Bremen",
+        "mecklenburg-vorpommern": "Mecklenburg-Vorpommern", "mv": "Mecklenburg-Vorpommern",
+        "rheinland-pfalz": "Rheinland-Pfalz", "rp": "Rheinland-Pfalz",
+        "saarland": "Saarland", "sl": "Saarland",
+        "sachsen-anhalt": "Sachsen-Anhalt", "st": "Sachsen-Anhalt",
+        "schleswig-holstein": "Schleswig-Holstein", "sh": "Schleswig-Holstein",
+        "thüringen": "Thüringen", "th": "Thüringen",
+    }
+    _user_region = _BUNDESLAND_REGIONS.get(_bl, bundesland)
+    _safe_regions = {"bundesweit", "Länderprogramme", "Europa"}
+    filtered = [
+        p for p in filtered
+        if _user_region in p.get("region", "")
+        or any(sr in p.get("region", "") for sr in _safe_regions)
+    ]
+
+    # Prioritize the user's own state program
     if "berlin" in _bl or _bl == "be":
-        # ProFIT höher priorisieren
         for p in filtered:
             if p["id"] == "profit_berlin":
-                p["priority"] = 0  # höchste Prio
+                p["priority"] = 0
     elif "baden" in _bl or "württemberg" in _bl or _bl == "bw":
-        # Invest BW höher priorisieren
         for p in filtered:
             if p["id"] == "invest_bw_digital_ki":
                 p["priority"] = 0
     elif "bayern" in _bl or _bl == "by":
-        # Digitalbonus Bayern höher priorisieren
         for p in filtered:
             if p["id"] == "digitalbonus_bayern":
                 p["priority"] = 0


### PR DESCRIPTION
Two root causes fixed:

1. Size detection bug in build_core_funding_table_html(): "1" in "KMU (11-100)" matched True, mis-classifying KMU customers as "solo". ProFIT (suitable_for: [team, kmu]) was filtered out. Fixed by using company_size_normalizer.

2. No regional filter: Berlin customers saw programs from Bayern, Hamburg, Hessen, Niedersachsen. Added filter to exclude state-specific programs from other Bundesländer while keeping bundesweit/EU/Länderprogramme.

3. Re-inject programmatic funding table AFTER the final quality enforcer pass (LOCATION-VALIDATOR) to ensure clean data survives all 3 enforcer passes.

https://claude.ai/code/session_01VUpDxYrYiTnhY4mPZmg7Fg