### PR TITLE
fix(R1): Solo-Segment Fördertabelle fehlte komplett (KIS-1108)

### DIFF
--- a/services/solo_compact_engine.py
+++ b/services/solo_compact_engine.py
@@ -158,7 +158,9 @@ SOLO_COMPACT_EXCLUDED = [
     "PROMPT_FRAMEWORK_HTML",
     "ROADMAP_12M_HTML",  # Use 90D instead
     "BUSINESS_CASE_HTML",  # Simplified in summary
-    "FOERDERPOTENZIAL_HTML",  # Minimal funding info in summary
+    # FIX-KIS-1108: FOERDERPOTENZIAL_HTML no longer excluded — Solo users
+    # need the programmatic funding table (Digitalbonus, BAFA, etc.)
+    # "FOERDERPOTENZIAL_HTML",
 ]
 
 # Max word counts for solo-compact sections


### PR DESCRIPTION
FOERDERPOTENZIAL_HTML was in SOLO_COMPACT_EXCLUDED, causing the entire funding table to be stripped for solo reports. The programmatic table (Digitalbonus, BAFA, etc.) was correctly built and injected but then removed by process_for_solo_compact() before rendering.

Root cause: solo_compact_engine.py line 161 excluded FOERDERPOTENZIAL_HTML with comment "Minimal funding info in summary" — but no alternative funding display existed for solo reports.

https://claude.ai/code/session_01VUpDxYrYiTnhY4mPZmg7Fg