### PR TITLE
Add S3b section for AI revenue potential strategies

### DIFF
--- a/prompts/strategy_prompts.py
+++ b/prompts/strategy_prompts.py
@@ -322,6 +322,106 @@ FORMAT: HTML-Fragment. Verwende eine Tabelle für die Priorisierungsmatrix.
 Ampel-Farben als CSS-Klassen oder inline-styles.""",
 
     # =========================================================================
+    # S3b: KI-Umsatzpotenziale — Neue Erlösquellen durch KI
+    # =========================================================================
+    "S3b": """Erstelle die Section "KI-Umsatzpotenziale — Neue Erlösquellen durch KI" für den KI-Strategiebericht.
+
+UNTERNEHMENSDATEN:
+- Firmenname: {firmenname}
+- Branche: {branche}
+- Hauptleistung/Kerntätigkeit: {hauptleistung}
+- Segment/Größe: {segment}
+- Mitarbeiter: {mitarbeiter}
+- Bundesland: {bundesland}
+
+STRATEGISCHE EINGABEN:
+- Geschäftsmodell-Evolution: {geschaeftsmodell_evolution}
+- 3-Jahres-Vision: {vision_3_jahre}
+- Strategische Ziele: {strategische_ziele}
+- KI-Ziele: {ki_ziele_labels}
+- Zeitersparnis-Priorität: {zeitersparnis_prioritaet}
+- Laufende KI-Projekte: {ki_projekte}
+- KI-Kompetenz im Team: {ki_kompetenz}
+- Zielgruppen: {zielgruppen_labels}
+- Marktposition: {marktposition_label}
+- Anwendungsfälle: {anwendungsfaelle_labels}
+- Vorhandene Tools: {vorhandene_tools_labels}
+- Jahresumsatz: {jahresumsatz_label}
+
+AUS REPORT 1:
+- KI-Readiness-Score: {readiness_score}
+- Reifegrad: {reifegrad_label}
+- Zeitersparnis: {canon_hours_month} Stunden/Monat
+- Stundensatz: {canon_rate_eur} €
+- CAPEX: {canon_capex_eur} €
+
+STRATEGIE-FRAGEN (FB2):
+- Budget (12 Monate): {s1_budget}
+- Zeitrahmen: {s2_zeitrahmen}
+- Prioritäten: {s3_prioritaeten}
+- KI-Erfahrung: {s8_erfahrung}
+- Infrastruktur-Ansatz: {s9_ansatz}
+- Datenschutz-Priorität: {s10_datenschutz}
+- KI-Vision (Freitext): {s5_vision}
+
+EINSCHRÄNKUNGEN (BINDEND):
+- KI-Guardrails: {ki_guardrails}
+- Vorhandene Software: {s5_software}
+
+AUFGABE:
+Erstelle genau 3 KI-gestützte Umsatzstrategien, die über reine Kosteneinsparung hinausgehen und NEUEN Umsatz generieren.
+
+ANFORDERUNGEN AN DIE 3 STRATEGIEN:
+
+Strategie 1: Kurzfristiger Cashflow (1–3 Monate)
+- Schnell umsetzbar mit vorhandenen Ressourcen
+- Niedriger Investitionsaufwand
+- Sofort adressierbarer Käufermarkt
+
+Strategie 2: Systematisiertes Produkt oder Service (3–6 Monate)
+- Wiederholbares, standardisierbares Angebot
+- Klares Preismodell (Paket, Abo, Projekt)
+- Aufbauend auf Strategie 1
+
+Strategie 3: Langfristiger Vermögenswert (6–12 Monate)
+- Proprietäre Kompetenz oder Plattform
+- Wettbewerbsvorteil durch KI-Integration
+- Skalierbar über das bestehende Team hinaus
+
+STRUKTUR JE STRATEGIE (PFLICHT):
+Für JEDE der 3 Strategien liefere:
+1. Name — kurz, prägnant, kundenverständlich (als <h3>)
+2. Was genau — konkretes Angebot in 2–3 Sätzen
+3. Für wen — spezifischer Zielkäufer (nicht generisch)
+4. Preismodell — konkreter Preisvorschlag in € (Spanne oder Festpreis)
+5. KI-Hebel — welche KI-Tools/Prozesse ermöglichen das?
+6. Erster Validierungsschritt — 1 konkreter Test (maximal 2 Wochen, maximal 500 €)
+7. Umsatzprojektion — konservative Schätzung: Monatsumsatz nach 6 Monaten
+
+Gib abschließend eine Empfehlung: Welche Strategie zuerst, warum, und wie die drei aufeinander aufbauen.
+
+SEGMENTIERUNG (PFLICHT):
+Passe Preismodelle und Komplexität an die Unternehmensgröße ({segment}) an:
+- Einzelunternehmer: Persönliche Dienstleistungen, Stundensatz/Projektpakete, niedrige Fixkosten
+- Kleinunternehmen (2–10 MA): Kleine standardisierte Angebote, Team-Kapazität berücksichtigen
+- KMU (11–100 MA): Skalierbare Produkte/Services, Abteilungsstruktur nutzen
+
+ANTI-SCHEINPRÄZISION (VERBINDLICH): Keine exakten Zahlen, Fristen, Marktanteile, Prozentsätze, Tool-Preise oder Förderbeträge nennen, wenn sie nicht ausdrücklich im Input stehen. Umsatzprojektionen KONSERVATIV und BELASTBAR. Formuliere Projektionen als „voraussichtlich" oder „bei plausiblen Annahmen".
+
+REGELN:
+- DEUTSCH, KMU-gerecht, ohne Marketing-Jargon
+- Alle Strategien müssen ETHISCH, NACHHALTIG und REPUTATIONSSICHER sein
+- Strategien müssen zur BRANCHE und zum GESCHÄFTSMODELL passen
+- KEINE generischen Ideen (z.B. „verkaufen Sie KI-Beratung")
+- Stattdessen: BRANCHENSPEZIFISCHE Monetarisierung der KI-Fähigkeiten
+- Respektiere die KI-Guardrails des Kunden bei Tool-Empfehlungen
+- Wenn der Kunde „nur lokal" als Guardrail hat: KEINE Cloud-Tools als Hauptempfehlung
+
+ANNAHMEN-ABSATZ (PFLICHT AM SECTION-ENDE): Füge am Ende der Section genau einen kurzen Absatz ein: <p><strong>Annahmen:</strong> [1-3 zentrale fachliche Annahmen, auf denen die Umsatzprojektionen beruhen]</p> Maximal 2-3 Sätze.
+
+FORMAT: HTML-Fragment. Verwende für die Strategien jeweils eine eigene <h3>-Überschrift und strukturierte Absätze. Nutze eine abschließende Tabelle für die Übersicht aller 3 Strategien (Name, Zeithorizont, Preismodell, Umsatzprojektion).""",
+
+    # =========================================================================
     # S4: Tool-Landschaft & Empfehlungen
     # =========================================================================
     "S4": """Erstelle die Section "Tool-Landschaft & Empfehlungen" für den KI-Strategiebericht.

--- a/services/strategy_pipeline.py
+++ b/services/strategy_pipeline.py
@@ -9,7 +9,7 @@ Pipeline order:
 1. Research + Budget-Calc (parallel)
 2. S1 + S2 (parallel)
 3. S3 (needs S2)
-4. S4 (needs S3)
+4. S3b + S4 (parallel; S3b independent, S4 needs S3)
 5. S5 (needs S3, S4)
 6. S6 (needs S3-S5)
 7. S7 + S8 (parallel)
@@ -344,14 +344,34 @@ async def generate_strategy_report(
 
         _heartbeat(db_session, briefing_id)
 
-        # S4 (needs S3)
-        sections["S4"] = await _generate_section("S4", base_context, {
+        # S3b + S4 parallel (S3b is independent, S4 needs S3)
+        s3b_extra = {
+            "geschaeftsmodell_evolution": briefing_data.get("geschaeftsmodell_evolution", ""),
+            "vision_3_jahre": briefing_data.get("vision_3_jahre", ""),
+            "strategische_ziele": briefing_data.get("strategische_ziele", ""),
+            "ki_ziele_labels": str(report1_sections.get("KI_ZIELE_LABELS", "") or briefing_data.get("ki_ziele", "")),
+            "zeitersparnis_prioritaet": briefing_data.get("zeitersparnis_prioritaet", ""),
+            "ki_projekte": briefing_data.get("ki_projekte", ""),
+            "ki_kompetenz": briefing_data.get("ki_kompetenz", ""),
+            "zielgruppen_labels": str(report1_sections.get("ZIELGRUPPEN_LABELS", "") or briefing_data.get("zielgruppen", "")),
+            "marktposition_label": str(report1_sections.get("MARKTPOSITION_LABEL", "") or briefing_data.get("marktposition", "")),
+            "anwendungsfaelle_labels": str(report1_sections.get("ANWENDUNGSFAELLE_LABELS", "") or briefing_data.get("anwendungsfaelle", "")),
+            "vorhandene_tools_labels": str(report1_sections.get("VORHANDENE_TOOLS_LABELS", "") or briefing_data.get("vorhandene_tools", "")),
+            "jahresumsatz_label": str(report1_sections.get("JAHRESUMSATZ_LABEL", "") or briefing_data.get("jahresumsatz", "")),
+            "canon_hours_month": str(report1_sections.get("CANON_HOURS_MONTH", "") or ""),
+            "canon_rate_eur": str(report1_sections.get("CANON_RATE_EUR", "") or ""),
+            "canon_capex_eur": str(report1_sections.get("CANON_CAPEX_EUR", "") or ""),
+            "s5_vision": strategy_questions.get("s5_vision", ""),
+        }
+        s3b_task = _generate_section("S3b", base_context, s3b_extra)
+        s4_task = _generate_section("S4", base_context, {
             "s3_handlungsfelder": _extract_handlungsfelder(sections["S3"]),
             "research_tool_1": research_context.get("tool_vergleich_1", {}).get("results", ""),
             "research_tool_2": research_context.get("tool_vergleich_2", {}).get("results", ""),
             "research_integration": research_context.get("tool_integration", {}).get("results", ""),
         })
 
+        sections["S3b"], sections["S4"] = await asyncio.gather(s3b_task, s4_task)
         _heartbeat(db_session, briefing_id)
 
         # S5 (needs S3, S4 — budget values already in base_context)
@@ -606,7 +626,7 @@ async def _generate_section(
         prompt = prompt_template.format(**{k: str(v or "") for k, v in context.items()})
 
     # FIX-GUARDRAIL-STRATEGY: Inject local-only guardrail into S3/S4/S6 prompts
-    if section_key in ("S4", "S3", "S6"):
+    if section_key in ("S4", "S3", "S3b", "S6"):
         _is_local, _guardrail_text = _detect_local_only_guardrail(context)
         if _is_local:
             if section_key == "S4":

--- a/services/strategy_renderer.py
+++ b/services/strategy_renderer.py
@@ -365,6 +365,7 @@ def render_strategy_html(sr: Any, db_session: Any) -> str:
         "section_s1": _strip_prompt_leaks(sections.get("S1", "")),
         "section_s2": _strip_prompt_leaks(sections.get("S2", "")),
         "section_s3": _strip_prompt_leaks(sections.get("S3", "")),
+        "section_s3b": _strip_prompt_leaks(sections.get("S3b", "")),
         "section_s4": _strip_prompt_leaks(sections.get("S4", "")),
         "section_s5": _strip_prompt_leaks(sections.get("S5", "")),
         "section_s6": _strip_prompt_leaks(sections.get("S6", "")),

--- a/templates/strategy_report.html
+++ b/templates/strategy_report.html
@@ -1059,6 +1059,11 @@ sup.src-ref {
         </div>
 
         <div class="toc-entry">
+            <span class="toc-number">3b</span>
+            <span class="toc-title">KI-Umsatzpotenziale <span class="toc-subtitle">— Neue Erlösquellen durch KI</span></span>
+        </div>
+
+        <div class="toc-entry">
             <span class="toc-number">4</span>
             <span class="toc-title">Tool-Landschaft &amp; Empfehlungen <span class="toc-subtitle">— DSGVO-bewertete Lösungen</span></span>
         </div>
@@ -1122,6 +1127,14 @@ sup.src-ref {
     <!-- ====== S3: HANDLUNGSFELDER ====== -->
     <div class="section-content">
         {{ section_s3 | safe }}
+    </div>
+
+    <!-- ====== KAPITEL-TRENNER: 3b ====== -->
+    {{ chapter_sep("3b", "KI-Umsatzpotenziale", "Neue Erlösquellen durch KI") }}
+
+    <!-- ====== S3b: KI-UMSATZPOTENZIALE ====== -->
+    <div class="section-content">
+        {{ section_s3b | safe }}
     </div>
 
     <!-- ====== KAPITEL-TRENNER: 4 ====== -->


### PR DESCRIPTION
## Summary
This PR introduces a new section (S3b) to the KI-Strategiebericht that focuses on identifying and monetizing new revenue streams through AI, complementing the existing cost-optimization strategies in S3.

## Key Changes

- **New Strategy Prompt (S3b)**: Added comprehensive prompt template in `strategy_prompts.py` that generates three AI-driven revenue strategies tailored to company size and industry:
  - Strategie 1: Short-term cashflow (1–3 months)
  - Strategie 2: Systematized product/service (3–6 months)
  - Strategie 3: Long-term proprietary asset (6–12 months)
  
  Each strategy includes pricing model, AI leverage points, validation steps, and revenue projections with mandatory assumptions paragraph.

- **Updated Pipeline Execution**: Modified `strategy_pipeline.py` to run S3b and S4 in parallel (S3b is independent, S4 still depends on S3), improving report generation efficiency. S3b receives comprehensive context including business model evolution, 3-year vision, strategic goals, KI-readiness metrics, and guardrails.

- **Template Integration**: Updated `strategy_report.html` to include S3b in table of contents and render the new section between S3 and S4 with proper chapter separator.

- **Guardrail Handling**: Extended local-only guardrail detection in `strategy_renderer.py` to include S3b alongside S3, S4, and S6 to ensure compliance with customer data residency requirements.

## Implementation Details

- S3b prompt enforces anti-fake-precision rules (no exact numbers unless provided in input) and requires industry-specific, ethical monetization strategies
- Segmentation logic adapts pricing and complexity for Einzelunternehmer, Kleinunternehmen, and KMU
- Context mapping includes all necessary data from Report 1 (readiness scores, time savings, rates) and strategy questions (budget, timeline, priorities)
- HTML rendering includes proper section stripping to prevent prompt leakage

https://claude.ai/code/session_01Pn3V1bju891tK7pkVyowkC