### PR TITLE
Enforce time savings caps per employee segment

### DIFF
--- a/routes/appetizer.py
+++ b/routes/appetizer.py
@@ -15,7 +15,7 @@ from sqlalchemy import text
 
 from core.db import SessionLocal
 from prompts.appetizer_prompts import APPETIZER_SYSTEM_PROMPT, build_user_prompt
-from services.appetizer_score import calculate_appetizer_score
+from services.appetizer_score import calculate_appetizer_score, enforce_zeitersparnis_caps
 
 logger = logging.getLogger(__name__)
 
@@ -243,11 +243,16 @@ def generate_appetizer(request: AppetizerRequest):
     result["score"]["wert"] = score["wert"]
     result["score"]["einordnung"] = score["einordnung"]
 
-    # 4. Save lead if email provided
+    # 4. Enforce Zeitersparnis-Caps (LLMs rechnen nie)
+    result["hebel"] = enforce_zeitersparnis_caps(
+        result["hebel"], request.mitarbeiter.value
+    )
+
+    # 5. Save lead if email provided
     if request.email:
         save_appetizer_lead(request, result, score)
 
-    # 5. Always save anonymous analytics
+    # 6. Always save anonymous analytics
     save_appetizer_analytics(request.branche.value, request.mitarbeiter.value, score)
 
     return {"status": "success", "result": result}

--- a/services/appetizer_score.py
+++ b/services/appetizer_score.py
@@ -54,3 +54,29 @@ def calculate_appetizer_score(
         einordnung = "ADVANCED"
 
     return {"wert": score, "einordnung": einordnung}
+
+
+def enforce_zeitersparnis_caps(hebel: list, mitarbeiter: str) -> list:
+    """
+    Erzwingt Zeitersparnis-Caps pro Segment.
+    Skaliert proportional, wenn Summe > Cap.
+    Architektur-Regel: LLMs rechnen nie — Enforcement im Backend.
+    """
+    caps = {
+        "1": 15,
+        "2-10": 25,
+        "11-100": 60,
+    }
+    max_hours = caps.get(mitarbeiter, 15)
+
+    total = sum(h["zeitersparnis_pro_woche_stunden"] for h in hebel)
+
+    if total > max_hours:
+        scale_factor = max_hours / total
+        for h in hebel:
+            h["zeitersparnis_pro_woche_stunden"] = max(
+                1,
+                round(h["zeitersparnis_pro_woche_stunden"] * scale_factor),
+            )
+
+    return hebel


### PR DESCRIPTION
## Summary
Added backend enforcement of time savings (Zeitersparnis) caps to prevent LLM-generated values from exceeding segment-specific limits. This ensures data integrity by scaling proportionally when total savings exceed the cap for an employee segment.

## Key Changes
- **New function `enforce_zeitersparnis_caps()`** in `services/appetizer_score.py`:
  - Defines segment-based caps: 15 hours (segment 1), 25 hours (segment 2-10), 60 hours (segment 11-100)
  - Implements proportional scaling when total savings exceed the cap
  - Ensures minimum value of 1 hour per lever after scaling
  
- **Integration in `routes/appetizer.py`**:
  - Imported the new enforcement function
  - Applied caps to `result["hebel"]` after score calculation (step 4)
  - Updated step numbering in comments (4→5→6)

## Implementation Details
- Caps are applied based on `mitarbeiter` (employee segment) value
- Scaling is proportional: if total is 2x the cap, all values are halved
- Uses `max(1, round(...))` to maintain minimum 1-hour values and avoid zero allocations
- Follows the architectural principle: "LLMs rechnen nie — Enforcement im Backend" (LLMs never calculate — enforcement in backend)

https://claude.ai/code/session_01ER253t4K85V5dBLbPUHY68