### PR TITLE
Enforce minimum 1h time savings per lever in appetizer scoring

### DIFF
--- a/services/appetizer_score.py
+++ b/services/appetizer_score.py
@@ -62,6 +62,10 @@ def enforce_zeitersparnis_caps(hebel: list, mitarbeiter: str) -> list:
     Skaliert proportional, wenn Summe > Cap.
     Architektur-Regel: LLMs rechnen nie — Enforcement im Backend.
     """
+    # Minimum 1h pro Hebel — ein Hebel mit 0h Zeitersparnis ist sinnlos
+    for h in hebel:
+        h["zeitersparnis_pro_woche_stunden"] = max(1, h["zeitersparnis_pro_woche_stunden"])
+
     caps = {
         "1": 15,
         "2-10": 25,


### PR DESCRIPTION
## Summary
Added validation to ensure each lever has a minimum of 1 hour per week time savings before cap enforcement is applied in the appetizer scoring system.

## Key Changes
- Added minimum time savings validation in `enforce_zeitersparnis_caps()` function
- Each lever's `zeitersparnis_pro_woche_stunden` is now clamped to a minimum of 1 hour
- Validation occurs before cap scaling logic is applied

## Implementation Details
The change prevents levers with zero or negative time savings values from being processed, as these are considered meaningless for the scoring system. This aligns with the backend enforcement architecture principle that validation should occur server-side rather than relying on LLM calculations.

https://claude.ai/code/session_01AxE1vtH41mL4NsHmvELcHh