### PR TITLE
feat: S-Moat Backend-Erweiterung (KI-gestützter Wettbewerbsvorteil)

### DIFF
--- a/migrations/2026-04-04_add_s_moat_fields_postgres.sql
+++ b/migrations/2026-04-04_add_s_moat_fields_postgres.sql
@@ -1,0 +1,17 @@
+-- Migration: Add S-Moat fields to strategy_questions table
+-- Date: 2026-04-04
+-- Purpose: Three new optional fields for the "KI-gestützter Wettbewerbsvorteil" section
+-- NOTE: DO NOT auto-apply. Wolf applies this manually after review.
+
+BEGIN;
+
+ALTER TABLE strategy_questions
+    ADD COLUMN IF NOT EXISTS wettbewerber_anzahl VARCHAR(50),
+    ADD COLUMN IF NOT EXISTS kundenbindung_typ VARCHAR(50),
+    ADD COLUMN IF NOT EXISTS datenreife VARCHAR(50);
+
+COMMENT ON COLUMN strategy_questions.wettbewerber_anzahl IS 'wenige | mehrere | viele | unklar | NULL';
+COMMENT ON COLUMN strategy_questions.kundenbindung_typ IS 'einmalig | wiederkehrend | gemischt | NULL';
+COMMENT ON COLUMN strategy_questions.datenreife IS 'keine | basis | umfangreich | unklar | NULL';
+
+COMMIT;

--- a/models.py
+++ b/models.py
@@ -334,6 +334,11 @@ class StrategyQuestion(Base):
     s9_ansatz: Mapped[Optional[str]] = mapped_column(String(50), nullable=True)
     s10_datenschutz: Mapped[Optional[str]] = mapped_column(String(50), nullable=True)
 
+    # S-Moat Felder (optional, für Wettbewerbsvorteil-Section)
+    wettbewerber_anzahl: Mapped[Optional[str]] = mapped_column(String(50), nullable=True)
+    kundenbindung_typ: Mapped[Optional[str]] = mapped_column(String(50), nullable=True)
+    datenreife: Mapped[Optional[str]] = mapped_column(String(50), nullable=True)
+
     # Metadaten
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
@@ -360,6 +365,9 @@ class StrategyQuestion(Base):
             "s8_erfahrung": self.s8_erfahrung,
             "s9_ansatz": self.s9_ansatz,
             "s10_datenschutz": self.s10_datenschutz,
+            "wettbewerber_anzahl": self.wettbewerber_anzahl,
+            "kundenbindung_typ": self.kundenbindung_typ,
+            "datenreife": self.datenreife,
             "created_at": self.created_at.isoformat() if self.created_at else None,
         }
 

--- a/prompts/strategy_prompts.py
+++ b/prompts/strategy_prompts.py
@@ -896,6 +896,97 @@ CROSS-SECTION-ZAHLEN IN DIESER SECTION (VERBINDLICH):
 
 FORMAT: HTML-Fragment (<p> Tags). Keine Überschrift (wird vom Template gesetzt).
 Maximal 300 Wörter. Kein Markdown. KEINE Quellenangaben.""",
+
+    # =========================================================================
+    # s_moat: KI-gestützter Wettbewerbsvorteil
+    # =========================================================================
+    "s_moat": """<role>
+Du bist ein strategischer KI-Berater für deutsche KMU. Du analysierst, wie KI-Maßnahmen nicht nur Effizienz steigern, sondern nachhaltige Wettbewerbsvorteile ("Moats") aufbauen können. Du schreibst auf Deutsch, klar und ohne Buzzwords, für Geschäftsführer:innen ohne technischen Hintergrund.
+</role>
+
+<context>
+Du erstellst die Section "KI-gestützter Wettbewerbsvorteil" innerhalb eines KI-Strategieberichts.
+Der Kunde hat bereits einen Readiness-Report (R1) und eine KI-Potenzial-Analyse (KPA) erhalten.
+Du baust auf deren Ergebnissen auf.
+
+Branche: {branche}
+Unternehmensgr��ße: {groesse}
+Hauptleistung: {hauptleistung}
+Geschäftsmodell-Entwicklung: {geschaeftsmodell_evolution}
+3-Jahres-Vision: {vision_3_jahre}
+Strategische Ziele: {strategische_ziele}
+Bestehende/geplante KI-Projekte: {ki_projekte}
+R1-Readiness-Score: {r1_readiness_score}
+KPA-Top-Use-Cases: {kpa_top_use_cases}
+Wettbewerbssituation: {wettbewerber_anzahl}
+Kundenbindungstyp: {kundenbindung_typ}
+Datenreife: {datenreife}
+</context>
+
+<constraints>
+- Schreibe auf Deutsch, Zielgruppe: KMU-Geschäftsführer:in.
+- Maximal 800–1.000 Wörter für die gesamte Section.
+- Vermeide englische Fachbegriffe wo möglich; wenn nötig, erkläre sie in Klammern.
+- Beziehe dich konkret auf die KPA-Use-Cases – keine generischen Ratschläge.
+- Nenne keine konkreten Produkt- oder Toolnamen (diese kommen aus anderen Sections).
+- Erfinde KEINE Zahlen, Statistiken oder Marktstudien.
+- Wenn die Datenreife "keine" oder "unklar" ist, empfehle keine Datenstrategie als Priorität.
+- Passe die Empfehlungen an die Unternehmensgröße an:
+  - Solo (1 MA): Fokus auf Nischen-Expertise und persönliche Marke
+  - Team (2–10 MA): Fokus auf Prozessvorsprung und Kundenbeziehungen
+  - KMU (11–100 MA): Volles Moat-Spektrum möglich
+- Verwende "Sie" (Höflichkeitsform), niemals "du".
+- Alle Ausgaben sind HTML-Fragmente (kein vollständiges HTML-Dokument).
+- Verwende semantische HTML-Tags: <h3>, <p>, <ul>, <li>, <table>, <strong>, <em>.
+- KEINE Markdown-Syntax (kein ```, kein #, kein *). Nur HTML.
+- Schreibe NIEMALS "Ohne Angaben" oder "keine Angaben" — wenn ein Wert fehlt, formuliere den Satz um oder lasse ihn weg.
+</constraints>
+
+<output_structure>
+Erstelle die Section mit exakt dieser Struktur:
+
+<h3>1. Wettbewerbslage-Einschätzung</h3>
+(ca. 150 Wörter)
+Kurze Analyse: Wie exponiert ist das Unternehmen gegenüber KI-getriebener Disruption durch Wettbewerber? Basierend auf Branche, Wettbewerbssituation und aktuellem Readiness-Score.
+Bewertung: "niedrig", "mittel" oder "hoch" – mit Begründung.
+
+<h3>2. Moat-Potenzial-Matrix</h3>
+(ca. 200 Wörter)
+Bewerte die fünf Moat-Kategorien für dieses spezifische Unternehmen als HTML-Tabelle:
+
+<table>
+<thead><tr><th>Moat-Typ</th><th>Relevanz</th><th>Aktueller Stand</th><th>Potenzial</th></tr></thead>
+<tbody>
+Zeilen für: Markenvertrauen, Produkt-/Leistungsvorteil, Datenvorsprung, Prozesseffizienz, Kundenbeziehung
+Relevanz/Stand/Potenzial jeweils: niedrig/mittel/hoch
+</tbody>
+</table>
+
+Für jede Kategorie: 1–2 Sätze Erläuterung mit konkretem Bezug zum Unternehmen.
+
+<h3>3. Priorisierte Moat-Maßnahmen</h3>
+(ca. 400 Wörter)
+Wähle die 2–3 relevantesten Moat-Strategien und beschreibe für jede:
+- <strong>Was:</strong> Konkrete Maßnahme, bezogen auf die KPA-Use-Cases
+- <strong>Warum:</strong> Welchen Wettbewerbsvorteil baut sie auf?
+- <strong>Zeithorizont:</strong> Sofort (dieses Quartal) / Mittelfristig (6–12 Monate) / Langfristig (1–3 Jahre)
+- <strong>Erfolgsmessung:</strong> Wie lässt sich der Fortschritt messen?
+
+<h3>4. Risiken &amp; Gegenmaßnahmen</h3>
+(ca. 150 Wörter)
+2–3 Szenarien: Was passiert, wenn Wettbewerber schneller sind oder der Moat erodiert?
+Für jedes Szenario: eine konkrete Gegenmaßnahme.
+
+<h3>5. Fazit</h3>
+(ca. 100 Wörter)
+Ein konkreter, motivierender Absatz: Was ist der wichtigste nächste Schritt für dieses Unternehmen, um KI nicht nur als Werkzeug, sondern als strategischen Vorteil zu nutzen?
+</output_structure>
+
+UMGANG MIT LÜCKENHAFTEN EINGABEN: Wenn ein Input fehlt oder unkonkret ist: - nichts erfinden, - die Aussage auf den belastbaren Kern reduzieren, - und nur den Teil formulieren, der fachlich tragfähig bleibt. Nutze keine Meta-Sätze über fehlende Datenquellen. Lieber präzise knapp als breit spekulativ.
+
+ANTI-SCHEINPRÄZISION (VERBINDLICH): Keine exakten Zahlen, Fristen, Marktanteile, Prozentsätze, Tool-Preise oder Förderbeträge nennen, wenn sie nicht ausdrücklich im Input oder in der Recherche stehen. Bei fehlender Exaktheit lieber Spannbreite, Einordnung oder qualitative Formulierung nutzen. VERBOTEN: erfundene Prozentwerte, Monatszahlen, Eurobeträge, Rankings oder scheinbar exakte Benchmarks.
+
+FORMAT: HTML-Fragment. Keine Markdown-Syntax. Keine Quellenangaben.""",
 }
 
 

--- a/routes/strategy.py
+++ b/routes/strategy.py
@@ -54,6 +54,10 @@ class StrategyQuestionsCreate(BaseModel):
     s8_erfahrung: Optional[str] = None
     s9_ansatz: Optional[str] = None
     s10_datenschutz: Optional[str] = None
+    # S-Moat Felder (optional)
+    wettbewerber_anzahl: Optional[str] = None
+    kundenbindung_typ: Optional[str] = None
+    datenreife: Optional[str] = None
 
 
 class StrategyQuestionsResponse(BaseModel):
@@ -139,6 +143,10 @@ VALID_DATENSCHUTZ = [
     "Niedrig",
 ]
 
+VALID_WETTBEWERBER_ANZAHL = ["wenige", "mehrere", "viele", "unklar"]
+VALID_KUNDENBINDUNG_TYP = ["einmalig", "wiederkehrend", "gemischt"]
+VALID_DATENREIFE = ["keine", "basis", "umfangreich", "unklar"]
+
 
 def _validate_questions(q: StrategyQuestionsCreate) -> Optional[str]:
     """Validate question values against allowed lists. Returns error message or None."""
@@ -164,6 +172,13 @@ def _validate_questions(q: StrategyQuestionsCreate) -> Optional[str]:
         return f"Ungültiger Wert für s9_ansatz: {q.s9_ansatz}"
     if q.s10_datenschutz is not None and q.s10_datenschutz not in VALID_DATENSCHUTZ:
         return f"Ungültiger Wert für s10_datenschutz: {q.s10_datenschutz}"
+    # S-Moat fields (optional)
+    if q.wettbewerber_anzahl is not None and q.wettbewerber_anzahl not in VALID_WETTBEWERBER_ANZAHL:
+        return f"Ungültiger Wert für wettbewerber_anzahl: {q.wettbewerber_anzahl}"
+    if q.kundenbindung_typ is not None and q.kundenbindung_typ not in VALID_KUNDENBINDUNG_TYP:
+        return f"Ungültiger Wert für kundenbindung_typ: {q.kundenbindung_typ}"
+    if q.datenreife is not None and q.datenreife not in VALID_DATENREIFE:
+        return f"Ungültiger Wert für datenreife: {q.datenreife}"
     return None
 
 
@@ -215,6 +230,9 @@ async def save_strategy_questions(
         existing.s8_erfahrung = questions.s8_erfahrung
         existing.s9_ansatz = questions.s9_ansatz
         existing.s10_datenschutz = questions.s10_datenschutz
+        existing.wettbewerber_anzahl = questions.wettbewerber_anzahl
+        existing.kundenbindung_typ = questions.kundenbindung_typ
+        existing.datenreife = questions.datenreife
         log.info("[Strategy] Updated questions for briefing_id=%d", briefing_id)
     else:
         # Insert
@@ -230,6 +248,9 @@ async def save_strategy_questions(
             s8_erfahrung=questions.s8_erfahrung,
             s9_ansatz=questions.s9_ansatz,
             s10_datenschutz=questions.s10_datenschutz,
+            wettbewerber_anzahl=questions.wettbewerber_anzahl,
+            kundenbindung_typ=questions.kundenbindung_typ,
+            datenreife=questions.datenreife,
         )
         db.add(sq)
         log.info("[Strategy] Saved new questions for briefing_id=%d", briefing_id)

--- a/services/strategy_pipeline.py
+++ b/services/strategy_pipeline.py
@@ -12,7 +12,7 @@ Pipeline order:
 4. S3b + S4 (parallel; S3b independent, S4 needs S3)
 5. S5 (needs S3, S4)
 6. S6 (needs S3-S5)
-7. S7 + S8 (parallel)
+7. S7 + S8 + s_moat (parallel)
 8. Executive Summary (needs all sections, via Claude)
 """
 from __future__ import annotations
@@ -439,7 +439,7 @@ async def generate_strategy_report(
                 briefing_id, _bafa_quote, _bafa_max,
             )
 
-        # S7 + S8 parallel
+        # S7 + S8 + s_moat parallel (s_moat is independent of S7/S8)
         s7_task = _generate_section("S7", base_context, {
             "foerder_matches": str(report1_data.get("foerder_matches", "")),
             "research_foerdermittel": research_context.get("foerdermittel", {}).get("results", ""),
@@ -453,7 +453,33 @@ async def generate_strategy_report(
             "s4_tools_summary": _extract_summary(sections["S4"]),
         })
 
-        sections["S7"], sections["S8"] = await asyncio.gather(s7_task, s8_task)
+        # S-Moat: KI-gestützter Wettbewerbsvorteil
+        # Build KPA top use cases from R1 analysis data
+        _kpa_top_use_cases = (
+            str(report1_sections.get("ANWENDUNGSFAELLE_LABELS", "")
+                or briefing_data.get("anwendungsfaelle", ""))
+        )
+        # Fallback: derive from report2 potenziale if available
+        if not _kpa_top_use_cases.strip():
+            _r2_potenziale = report2_data.get("potenziale", "")
+            _kpa_top_use_cases = str(_r2_potenziale) if _r2_potenziale else "keine Angabe"
+
+        s_moat_task = _generate_section("s_moat", base_context, {
+            "groesse": _segment_label(briefing_data.get("unternehmensgroesse", "")),
+            "geschaeftsmodell_evolution": briefing_data.get("geschaeftsmodell_evolution", "") or "",
+            "vision_3_jahre": briefing_data.get("vision_3_jahre", "") or "",
+            "strategische_ziele": briefing_data.get("strategische_ziele", "") or "",
+            "ki_projekte": briefing_data.get("ki_projekte", "") or "",
+            "r1_readiness_score": str(_score),
+            "kpa_top_use_cases": _kpa_top_use_cases,
+            "wettbewerber_anzahl": strategy_questions.get("wettbewerber_anzahl") or "keine Angabe",
+            "kundenbindung_typ": strategy_questions.get("kundenbindung_typ") or "keine Angabe",
+            "datenreife": strategy_questions.get("datenreife") or "keine Angabe",
+        })
+
+        sections["S7"], sections["S8"], sections["s_moat"] = await asyncio.gather(
+            s7_task, s8_task, s_moat_task,
+        )
         _heartbeat(db_session, briefing_id)
 
         # Executive Summary LAST (via Claude, not GPT)

--- a/services/strategy_renderer.py
+++ b/services/strategy_renderer.py
@@ -376,6 +376,7 @@ def render_strategy_html(sr: Any, db_session: Any) -> str:
         "section_s6": _strip_prompt_leaks(sections.get("S6", "")),
         "section_s7": _strip_prompt_leaks(_strip_funding_total(sections.get("S7", ""))),
         "section_s8": _strip_prompt_leaks(sections.get("S8", "")),
+        "section_s_moat": _strip_prompt_leaks(sections.get("s_moat", "")),
         "naechste_schritte": naechste_schritte,
     }
 

--- a/templates/strategy_report.html
+++ b/templates/strategy_report.html
@@ -1186,6 +1186,15 @@ sup.src-ref {
         {{ section_s8 | safe }}
     </div>
 
+    <!-- ====== S-MOAT: KI-GESTÜTZTER WETTBEWERBSVORTEIL ====== -->
+    {% if section_s_moat %}
+    {{ chapter_sep("9", "KI-gestützter Wettbewerbsvorteil", "Nachhaltige Vorteile durch strategischen KI-Einsatz") }}
+
+    <div class="section-content">
+        {{ section_s_moat | safe }}
+    </div>
+    {% endif %}
+
     <!-- ====== NÄCHSTE SCHRITTE ====== -->
     <div class="naechste-schritte page-break">
         <div class="section-header">


### PR DESCRIPTION
## Summary
- **Neue Strategy-Section `s_moat`** (Kapitel 9: KI-gestützter Wettbewerbsvorteil) mit 5 Sub-Sections: Wettbewerbslage, Moat-Matrix, Maßnahmen, Risiken, Fazit
- **3 neue optionale Felder** im StrategyQuestion-Model: `wettbewerber_anzahl`, `kundenbindung_typ`, `datenreife` — inkl. Validation, Pydantic-Schema, DB-Migration
- Section generiert parallel mit S7+S8, rendert als Kapitel 9 vor "Nächste Schritte"
- Fallback `"keine Angabe"` bei fehlenden Moat-Feldern — Prompt kommt damit zurecht

## Migration erforderlich
`migrations/2026-04-04_add_s_moat_fields_postgres.sql` muss VOR Deploy auf Railway-Postgres ausgeführt werden (idempotent, IF NOT EXISTS).

https://claude.ai/code/session_01VCLpYXm1HpbPvFHSFpbu6b