### PR TITLE
Add region-specific BAFA funding rate and subsidy overrides

### DIFF
--- a/data/funding_programmes_core_2025.json
+++ b/data/funding_programmes_core_2025.json
@@ -253,8 +253,8 @@
     "country_code": "DE",
     "status": "active",
     "funding_type": "Zuschuss",
-    "funding_rate": "50% (neue BL) / 80% (alte BL)",
-    "max_amount": "3.500 € pro Beratung",
+    "funding_rate": "80% (neue BL) / 50% (alte BL)",
+    "max_amount": "bis 2.800 € (neue BL) / bis 1.750 € (alte BL)",
     "focus": "Unternehmensberatung, KI-Strategie, Digitalisierung",
     "suitable_for": ["solo", "team", "kmu"],
     "notes": "Max. 5 Beratungen pro Unternehmen, max. 2 pro Jahr. Laufzeit bis 31.12.2026.",
@@ -263,7 +263,7 @@
     "url": "https://www.bafa.de/DE/Wirtschaft/Beratung_Finanzierung/Unternehmensberatung/unternehmensberatung_node.html",
     "provider": "BAFA (Bundesamt für Wirtschaft und Ausfuhrkontrolle)",
     "deadline": "31.12.2026",
-    "deadline_notes": "Max 5 Beratungen pro Unternehmen, max 2 pro Jahr. Förderquote: 50% West / 80% Ost. Max förderfähig: 2.800€ pro Beratung."
+    "deadline_notes": "Max 5 Beratungen pro Unternehmen, max 2 pro Jahr. Förderquote: 80% Ost (neue BL) / 50% West (alte BL). Max Zuschuss: 2.800 € (neue BL) / 1.750 € (alte BL)."
   },
   {
     "id": "zim",

--- a/services/extra_sections.py
+++ b/services/extra_sections.py
@@ -790,15 +790,32 @@ def build_core_funding_table_html(briefing: Dict[str, Any]) -> str:
     html_parts.append('    </thead>')
     html_parts.append('    <tbody>')
 
+    # BAFA override: show region-specific rate and max subsidy
+    try:
+        from config.bafa import get_bafa_foerderquote, get_bafa_max_foerderung
+        _bafa_quote = get_bafa_foerderquote(bundesland)
+        _bafa_max = get_bafa_max_foerderung(bundesland)
+        _bafa_override = True
+    except ImportError:
+        _bafa_override = False
+
     for prog in top_programmes:
         relevance_class = prog.get("relevance_ki", "Mittel").split()[0].lower()
+        display_rate = prog["funding_rate"]
+        display_amount = prog["max_amount"]
+
+        # Override BAFA with deterministic regional values
+        if _bafa_override and prog.get("id") == "bafa_beratung":
+            display_rate = f"{_bafa_quote}%"
+            display_amount = f"bis {_bafa_max:,} €".replace(",", ".")
+
         html_parts.append('      <tr>')
         html_parts.append(f'        <td><strong>{prog["title"]}</strong><br>')
         html_parts.append(f'          <span class="small muted">{prog["focus"]}</span>')
         html_parts.append('        </td>')
         html_parts.append(f'        <td>{prog["region"]}</td>')
-        html_parts.append(f'        <td>{prog["funding_rate"]}</td>')
-        html_parts.append(f'        <td>{prog["max_amount"]}</td>')
+        html_parts.append(f'        <td>{display_rate}</td>')
+        html_parts.append(f'        <td>{display_amount}</td>')
         html_parts.append(f'        <td><span class="relevance-badge relevance-{relevance_class}">{prog.get("relevance_ki", "Mittel")}</span></td>')
         html_parts.append('      </tr>')
 

--- a/services/funding_recommender.py
+++ b/services/funding_recommender.py
@@ -2175,12 +2175,26 @@ def get_branch_funding_hits(
                 reasons = get_match_reasons(program, branch, region, size, "minimal", lang)
                 match_reason = reasons[0] if reasons else ""
 
+            hit_funding_rate = program.get("funding_rate", "")
+            hit_max_funding = program.get("max_funding") or program.get("max_amount", "")
+
+            # Override BAFA values with deterministic regional values
+            if program_id == "bafa_beratung" or "bafa" in (program.get("name") or program.get("title", "")).lower():
+                try:
+                    from config.bafa import get_bafa_foerderquote, get_bafa_max_foerderung
+                    bafa_quote = get_bafa_foerderquote(region)
+                    bafa_max = get_bafa_max_foerderung(region)
+                    hit_funding_rate = f"{bafa_quote}%"
+                    hit_max_funding = f"{bafa_max:,} €".replace(",", ".")
+                except ImportError:
+                    pass
+
             hits.append(BranchFundingHit(
                 program_id=program_id,
                 program_name=program.get("name") or program.get("title", ""),
                 provider=program.get("provider") or program.get("region", ""),
-                max_funding=program.get("max_funding") or program.get("max_amount", ""),
-                funding_rate=program.get("funding_rate", ""),
+                max_funding=hit_max_funding,
+                funding_rate=hit_funding_rate,
                 branch_boost=branch_boost,
                 match_reason=match_reason,
                 relevance_score=round(boosted_score, 2),


### PR DESCRIPTION
## Summary
This PR implements deterministic region-specific funding rates and maximum subsidy amounts for BAFA consultation programs by introducing a configuration-driven override system that replaces generic static values with state-specific (Bundesland) values.

## Key Changes

- **Dynamic BAFA Configuration**: Added imports from `config.bafa` module to fetch region-specific funding quotes (`get_bafa_foerderquote`) and maximum subsidies (`get_bafa_max_foerderung`) based on Bundesland
  
- **Core Funding Table Override** (`services/extra_sections.py`):
  - Implemented try/except block to safely import BAFA configuration functions
  - Added logic to detect BAFA programs and override their `funding_rate` and `max_amount` with region-specific values
  - Gracefully falls back to static values if configuration module is unavailable

- **Branch Funding Recommender Override** (`services/funding_recommender.py`):
  - Applied same override pattern to `get_branch_funding_hits()` function
  - Detects BAFA programs by ID or name matching
  - Replaces generic funding rates and maximum amounts with deterministic regional values before creating `BranchFundingHit` objects

- **Data Updates** (`data/funding_programmes_core_2025.json`):
  - Corrected BAFA funding rate description (swapped old/new Bundesland percentages)
  - Updated max subsidy amounts to reflect regional differentiation
  - Clarified deadline notes with explicit regional breakdown

## Implementation Details

- Both overrides use identical logic: check if program is BAFA, import regional config, apply region-specific values
- Formatting is consistent: funding rates as percentages (e.g., "80%"), amounts with German number formatting (e.g., "bis 2.800 €")
- ImportError handling ensures backward compatibility if configuration module is missing
- The override system allows centralized management of regional BAFA parameters in a separate config module

https://claude.ai/code/session_01EFjN6eyMutjhzuGpFviuC6