### PR TITLE
KIS-1116: Remove strategy upsell from KPA email and improve prompt context

### DIFF
--- a/services/email_templates.py
+++ b/services/email_templates.py
@@ -116,19 +116,8 @@ def render_deep_dive_email(recipient: str = "user", briefing_id: Optional[int] =
     )
     cta = "Bei Fragen stehen wir Ihnen gerne zur Verf\u00fcgung."
 
-    # CTA to Strategy form (user emails only)
+    # KIS-1116: Strategy-Upsell removed from KPA-Email (belongs in R1-Email only)
     strategy_cta_html = ""
-    if recipient != "admin" and briefing_id:
-        _strategy_url = f"https://make.ki-sicherheit.jetzt/strategy.html?briefing_id={briefing_id}"
-        strategy_cta_html = (
-            '<hr style="border:none;border-top:1px solid #e6edf3;margin:24px 0">'
-            '<p style="font-size:15px;margin:0 0 8px"><strong>Noch mehr Tiefe?</strong></p>'
-            '<p style="margin:0 0 12px">Ihr ma\u00dfgeschneiderter <strong>KI\u2011Strategiebericht</strong> '
-            '\u2014 10 Fragen, 3 Minuten, und Sie erhalten einen individuellen 90\u2011Tage\u2011Implementierungsplan.</p>'
-            f'<p><a href="{escape(_strategy_url)}" style="display:inline-block;background:#0D7377;color:#fff;'
-            'padding:10px 20px;border-radius:8px;text-decoration:none;font-weight:600">'
-            'Strategiebericht anfordern \u2192</a></p>'
-        )
 
     return f"""<!doctype html>
 <html lang="de">

--- a/services/sofort_start_generator.py
+++ b/services/sofort_start_generator.py
@@ -1544,9 +1544,14 @@ def generate_sofort_start_html(
 '''
 
     # Prompts hinzufügen
+    # KIS-1116 Fix 2: Inject hauptleistung context so prompts are sub-sector-specific
+    _hl_context_prefix = ""
+    if _hl_clean:
+        _hl_context_prefix = f"Kontext: Mein Unternehmen ist spezialisiert auf {_hl_clean}.\n\n"
     prompts_list: List[Dict[str, Any]] = cast(List[Dict[str, Any]], branche_data["prompts"])
     for i, prompt_data in enumerate(prompts_list, 1):
-        prompt_text = prompt_data["prompt"][:400] + "..." if len(prompt_data["prompt"]) > 400 else prompt_data["prompt"]
+        _raw_prompt = _hl_context_prefix + prompt_data["prompt"] if _hl_context_prefix else prompt_data["prompt"]
+        prompt_text = _raw_prompt[:400] + "..." if len(_raw_prompt) > 400 else _raw_prompt
         # FIX-B17: Close the avoid-break wrapper after first prompt box
         close_wrapper = "</div>" if i == 1 else ""
         html += f'''
@@ -1570,7 +1575,8 @@ def generate_sofort_start_html(
     _lern_raw = branche_data.get("lern_prompt")
     lern_prompt: Dict[str, str] | None = cast(Dict[str, str], _lern_raw) if isinstance(_lern_raw, dict) else None
     if lern_prompt:
-        lern_text = lern_prompt["prompt"][:400] + "..." if len(lern_prompt["prompt"]) > 400 else lern_prompt["prompt"]
+        _raw_lern = _hl_context_prefix + lern_prompt["prompt"] if _hl_context_prefix else lern_prompt["prompt"]
+        lern_text = _raw_lern[:400] + "..." if len(_raw_lern) > 400 else _raw_lern
         html += f'''
         <div style="background: #fffbeb; border: 1px solid #f59e0b; border-radius: 8px; padding: 16px; margin-bottom: 12px; page-break-inside: avoid;">
             <div style="display: flex; justify-content: space-between; align-items: flex-start; margin-bottom: 8px;">

--- a/services/strategy_renderer.py
+++ b/services/strategy_renderer.py
@@ -16,6 +16,7 @@ from typing import Any, Dict, Optional
 
 from jinja2 import Environment, FileSystemLoader
 
+from services.answers_normalizer import BRANCHEN_LABELS
 from utils.report_display_id import get_report_display_id as _get_display_id
 
 logger = logging.getLogger(__name__)
@@ -193,9 +194,9 @@ def render_strategy_html(sr: Any, db_session: Any) -> str:
         except Exception:
             pass
 
-    # Branche: capitalize for display
+    # Branche: use canonical display label (KIS-1116 Fix 1)
     branche_raw = briefing_data.get("branche", "")
-    branche_label = branche_raw.title() if branche_raw else ""
+    branche_label = BRANCHEN_LABELS.get(branche_raw.lower(), branche_raw.title()) if branche_raw else ""
 
     # Research date from report1 or generation date (always German DD.MM.YYYY format)
     research_date = report1_meta.get("research_last_updated", "")


### PR DESCRIPTION
## Summary
This PR addresses KIS-1116 by removing the strategy form upsell from the KPA email (which should only appear in R1 emails) and improving prompt specificity by injecting hauptleistung (main service) context into generated prompts.

## Key Changes

- **Email template cleanup** (`email_templates.py`): Removed the strategy upsell CTA section from the deep dive email renderer. The strategy form promotion is now exclusive to R1 emails as intended.

- **Prompt context injection** (`sofort_start_generator.py`): Enhanced prompt generation to include hauptleistung context when available. Prompts now prepend "Kontext: Mein Unternehmen ist spezialisiert auf [hauptleistung]." to make them more sector-specific and relevant. This applies to both regular prompts and learning prompts.

- **Branche label standardization** (`strategy_renderer.py`): Updated branche display to use canonical labels from `BRANCHEN_LABELS` mapping instead of simple title-casing. This ensures consistent, properly formatted industry names across the strategy report.

## Implementation Details

- The strategy CTA removal is a straightforward deletion of conditional HTML generation logic
- Prompt context injection preserves the original prompt text while prepending context, with proper handling of truncation to 400 characters
- The branche label lookup falls back to title-casing if no mapping exists, maintaining backward compatibility

https://claude.ai/code/session_01BqhbSnym3DTk5noEyEPJcB