### PR TITLE
Fix hauptleistung mutation in parallel content generation

### DIFF
--- a/gpt_analyze.py
+++ b/gpt_analyze.py
@@ -12865,6 +12865,10 @@ def _generate_content_sections(briefing: Dict[str, Any], scores: Dict[str, Any])
     """
     sections: Dict[str, Any] = {}
 
+    # KIS-1117: Save original hauptleistung BEFORE parallel threads can mutate
+    # briefing dict via _build_prompt_vars() (FIX-B726 cleanup + truncation).
+    _raw_hauptleistung = str(briefing.get("hauptleistung", "") or "")
+
     # Alle GPT-Sektionen, die parallel erzeugt werden
     parallel_sections = [
         ("executive_summary", "EXECUTIVE_SUMMARY_HTML"),
@@ -13176,7 +13180,7 @@ def _generate_content_sections(briefing: Dict[str, Any], scores: Dict[str, Any])
     
     # ========== v14.10: SOFORT-START-SEITE (Gamechanger Feature) ==========
     try:
-        sofort_hauptleistung = briefing.get("hauptleistung", "")
+        sofort_hauptleistung = _raw_hauptleistung or briefing.get("hauptleistung", "")
         sofort_branche = briefing.get("BRANCHE_LABEL", "") or briefing.get("branche", "") or ""
         sofort_size = briefing.get("UNTERNEHMENSGROESSE_LABEL", "") or briefing.get("unternehmensgroesse", "solo")
         sofort_zeit = briefing.get("ZEITERSPARNIS_PRIORITAET", "") or briefing.get("zeitersparnis_prioritaet", "")


### PR DESCRIPTION
## Summary
Fixes a race condition where the `hauptleistung` field in the briefing dictionary could be mutated by parallel threads during content section generation, causing the SOFORT-START-SEITE feature to use stale or modified data.

## Changes
- **Preserve original hauptleistung value**: Capture the original `hauptleistung` value before parallel threads execute, preventing mutations from `_build_prompt_vars()` (which performs cleanup and truncation per FIX-B726) from affecting downstream usage
- **Use cached value in SOFORT-START-SEITE**: Updated the sofort_hauptleistung assignment to use the preserved `_raw_hauptleistung` value with a fallback to the current briefing value

## Implementation Details
- The original `hauptleistung` is saved as `_raw_hauptleistung` at the start of `_generate_content_sections()`, before any parallel processing begins
- This ensures the SOFORT-START-SEITE feature receives the unmodified original value while allowing other sections to use cleaned/truncated versions as needed
- Addresses KIS-1117 and relates to FIX-B726 cleanup operations

https://claude.ai/code/session_01D8VqA1oVRxcRyraAX2jrvY