### PR TITLE
Add email notifications for Appetizer (Schnell-Check) results

### DIFF
--- a/routes/appetizer.py
+++ b/routes/appetizer.py
@@ -5,17 +5,20 @@ Registered via _build_router_config in main.py.
 
 import json
 import logging
+import os
+import time
 from enum import Enum
 from typing import Optional
 
 import anthropic
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, BackgroundTasks, HTTPException
 from pydantic import BaseModel, Field, field_validator
 from sqlalchemy import text
 
 from core.db import SessionLocal
 from prompts.appetizer_prompts import APPETIZER_SYSTEM_PROMPT, build_user_prompt
 from services.appetizer_score import calculate_appetizer_score, enforce_zeitersparnis_caps
+from services.email_templates import render_appetizer_result_email
 
 logger = logging.getLogger(__name__)
 
@@ -200,11 +203,64 @@ def save_appetizer_analytics(branche: str, mitarbeiter: str, score: dict):
 
 
 # ---------------------------------------------------------------------------
+# Email helper (runs as BackgroundTask)
+# ---------------------------------------------------------------------------
+
+def _send_appetizer_emails(email: str, request_data: dict, result: dict):
+    """Send Schnell-Check result to user + admin. Fire-and-forget."""
+    if os.getenv("DISABLE_EMAILS", "") in ("1", "true", "TRUE"):
+        logger.info("DISABLE_EMAILS is set — skipping appetizer emails for %s", email)
+        return
+
+    from gpt_analyze import _send_email_via_resend, _admin_recipients, _mask_email
+
+    score_wert = result.get("score", {}).get("wert", 0)
+    branche = request_data.get("branche", "")
+
+    # --- User email ---
+    try:
+        user_html = render_appetizer_result_email(
+            recipient="user", request_data=request_data, result=result,
+        )
+        ok, err = _send_email_via_resend(
+            email,
+            f"Ihr KI\u2011Schnell\u2011Check Ergebnis \u2014 {score_wert}/100",
+            user_html,
+        )
+        if ok:
+            logger.info("Appetizer email sent to user %s", _mask_email(email))
+        else:
+            logger.warning("Appetizer email to user %s failed: %s", _mask_email(email), err)
+    except Exception as exc:
+        logger.warning("Appetizer user email failed: %s", exc)
+
+    # --- Admin email ---
+    try:
+        if os.getenv("ENABLE_ADMIN_NOTIFY", "1") in ("1", "true", "TRUE", "yes", "YES"):
+            admin_html = render_appetizer_result_email(
+                recipient="admin", request_data=request_data, result=result,
+            )
+            for addr in _admin_recipients():
+                time.sleep(0.6)  # Resend rate limit: max 2 req/sec
+                ok, err = _send_email_via_resend(
+                    addr,
+                    f"[Schnell-Check Lead] {score_wert}/100 \u2014 {branche} \u2014 {email}",
+                    admin_html,
+                )
+                if ok:
+                    logger.info("Appetizer admin email sent to %s", _mask_email(addr))
+                else:
+                    logger.warning("Appetizer admin email to %s failed: %s", _mask_email(addr), err)
+    except Exception as exc:
+        logger.warning("Appetizer admin email failed: %s", exc)
+
+
+# ---------------------------------------------------------------------------
 # Endpoint (sync — FastAPI runs it in threadpool automatically)
 # ---------------------------------------------------------------------------
 
 @router.post("/generate")
-def generate_appetizer(request: AppetizerRequest):
+def generate_appetizer(request: AppetizerRequest, background: BackgroundTasks):
     # 1. Score berechnen (deterministic, no LLM)
     score = calculate_appetizer_score(
         ki_erfahrung=request.ki_erfahrung.value,
@@ -248,9 +304,25 @@ def generate_appetizer(request: AppetizerRequest):
         result["hebel"], request.mitarbeiter.value
     )
 
-    # 5. Save lead if email provided
+    # 5. Save lead if email provided + schedule email
     if request.email:
         save_appetizer_lead(request, result, score)
+        background.add_task(
+            _send_appetizer_emails,
+            email=request.email,
+            request_data={
+                "firma": request.firma,
+                "branche": request.branche.value,
+                "mitarbeiter": request.mitarbeiter.value,
+                "hauptleistung": request.hauptleistung,
+                "zeitaufwand_repetitiv": request.zeitaufwand_repetitiv.value,
+                "ki_erfahrung": request.ki_erfahrung.value,
+                "groesste_herausforderung": request.groesste_herausforderung,
+                "email": request.email,
+                "newsletter_optin": request.newsletter_optin,
+            },
+            result=result,
+        )
 
     # 6. Always save anonymous analytics
     save_appetizer_analytics(request.branche.value, request.mitarbeiter.value, score)

--- a/services/email_templates.py
+++ b/services/email_templates.py
@@ -206,6 +206,183 @@ def render_strategy_email(recipient: str = "user") -> str:
 
 
 # =============================================================================
+# APPETIZER (Schnell-Check) EMAIL
+# =============================================================================
+
+_ZEITAUFWAND_LABELS = {
+    "unter_25": "unter 25 %",
+    "25_50": "25–50 %",
+    "ueber_50": "über 50 %",
+}
+
+_KI_ERFAHRUNG_LABELS = {
+    "keine": "Keine",
+    "erste_versuche": "Erste Versuche",
+    "regelmaessig": "Regelmäßig",
+}
+
+_MITARBEITER_LABELS = {
+    "1": "Solo (1)",
+    "2-10": "Team (2–10)",
+    "11-100": "KMU (11–100)",
+}
+
+
+def render_appetizer_result_email(
+    recipient: str,
+    request_data: dict,
+    result: dict,
+) -> str:
+    """Render email HTML for KI-Schnell-Check result.
+
+    Args:
+        recipient: "user" or "admin".
+        request_data: Dict with all AppetizerRequest fields.
+        result: The full appetizer result dict (score, hebel, monetarisierung, etc.).
+    """
+    score = result.get("score", {})
+    score_wert = score.get("wert", 0)
+    einordnung = score.get("einordnung", "")
+    einordnung_text = score.get("einordnung_text", "")
+
+    if recipient == "admin":
+        return _render_appetizer_admin_email(request_data, result)
+
+    # --- USER EMAIL ---
+    hebel = result.get("hebel", [])
+    hebel_html = ""
+    for h in hebel:
+        hebel_html += (
+            f'<tr><td style="padding:6px 8px;border-bottom:1px solid #e6edf3">'
+            f'<strong>{escape(h.get("titel", ""))}</strong><br>'
+            f'<span style="color:#64748b;font-size:13px">{escape(h.get("beschreibung", ""))}</span></td>'
+            f'<td style="padding:6px 8px;border-bottom:1px solid #e6edf3;white-space:nowrap;text-align:right;vertical-align:top">'
+            f'<strong>{h.get("zeitersparnis_pro_woche_stunden", 0)} h/Wo</strong></td></tr>'
+        )
+
+    monet = result.get("monetarisierung", [])
+    monet_html = ""
+    for m in monet:
+        monet_html += (
+            f'<tr><td style="padding:6px 8px;border-bottom:1px solid #e6edf3">'
+            f'<strong>{escape(m.get("titel", ""))}</strong></td>'
+            f'<td style="padding:6px 8px;border-bottom:1px solid #e6edf3;white-space:nowrap;text-align:right">'
+            f'{m.get("umsatzpotenzial_monat_eur", 0):,}\u202f\u20ac/Mon</td></tr>'.replace(",", ".")
+        )
+
+    positionierung = escape(result.get("positionierung", ""))
+    cta = result.get("cta", {})
+    cta_headline = escape(cta.get("headline", "Vollständigen Report anfordern"))
+
+    return f"""<!doctype html>
+<html lang="de">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Ihr KI\u2011Schnell\u2011Check Ergebnis</title>
+    <style>
+      body{{font-family:-apple-system,Segoe UI,Roboto,Arial,sans-serif;color:#0f172a;line-height:1.5;margin:0;padding:0;background:#f6f9ff}}
+      .wrap{{max-width:640px;margin:0 auto;padding:24px}}
+      .card{{background:#fff;border:1px solid #e6edf3;border-radius:12px;padding:18px;box-shadow:0 6px 30px #18324a16;border-top:4px solid #2B6CB0}}
+      h1{{color:#2B6CB0;font-size:20px;margin:0 0 8px}}
+      h2{{color:#2B6CB0;font-size:16px;margin:16px 0 6px}}
+      p{{margin:8px 0;font-size:14px}}
+      .muted{{color:#64748b}}
+      .score-box{{background:#f0f7ff;border:1px solid #b8d4f0;border-radius:8px;padding:12px 16px;text-align:center;margin:12px 0}}
+      .score-val{{font-size:32px;font-weight:700;color:#2B6CB0}}
+      table{{width:100%;border-collapse:collapse;font-size:14px}}
+    </style>
+  </head>
+  <body>
+    <div class="wrap">
+      <div class="card">
+        <h1>Ihr KI\u2011Schnell\u2011Check Ergebnis</h1>
+        <p>Guten Tag,</p>
+        <p>vielen Dank f\u00fcr Ihren KI\u2011Schnell\u2011Check. Hier ist Ihr Ergebnis:</p>
+
+        <div class="score-box">
+          <div class="score-val">{score_wert}/100</div>
+          <div style="font-weight:600">{escape(einordnung)}</div>
+          <div class="muted" style="font-size:13px">{escape(einordnung_text)}</div>
+        </div>
+
+        <h2>Top\u20113 KI\u2011Hebel</h2>
+        <table>{hebel_html}</table>
+
+        <h2>Monetarisierungs\u2011Potenzial</h2>
+        <table>{monet_html}</table>
+
+        <p style="margin-top:14px"><em>{positionierung}</em></p>
+
+        <hr style="border:none;border-top:1px solid #e6edf3;margin:20px 0">
+        <p style="text-align:center">
+          <a href="https://make.ki-sicherheit.jetzt" style="display:inline-block;background:#2B6CB0;color:#fff;padding:10px 24px;border-radius:8px;text-decoration:none;font-weight:600">
+            {cta_headline} \u2192
+          </a>
+        </p>
+        <p class="muted" style="text-align:center;font-size:13px">{escape(cta.get("subline", ""))}</p>
+
+        <hr style="border:none;border-top:1px solid #e6edf3;margin:20px 0">
+        <p class="muted">Wolf Hohl \u2014 KI\u2011Sicherheit.jetzt</p>
+        <p class="muted">Hinweis: Diese E\u2011Mail wurde automatisch erzeugt.</p>
+      </div>
+    </div>
+  </body>
+</html>"""
+
+
+def _render_appetizer_admin_email(request_data: dict, result: dict) -> str:
+    """Internal: admin lead-notification for Schnell-Check."""
+    score = result.get("score", {})
+    rows = [
+        ("Firma", request_data.get("firma", "")),
+        ("Branche", request_data.get("branche", "")),
+        ("Mitarbeiter", _MITARBEITER_LABELS.get(request_data.get("mitarbeiter", ""), request_data.get("mitarbeiter", ""))),
+        ("Hauptleistung", request_data.get("hauptleistung", "")),
+        ("Zeitaufwand repetitiv", _ZEITAUFWAND_LABELS.get(request_data.get("zeitaufwand_repetitiv", ""), request_data.get("zeitaufwand_repetitiv", ""))),
+        ("KI-Erfahrung", _KI_ERFAHRUNG_LABELS.get(request_data.get("ki_erfahrung", ""), request_data.get("ki_erfahrung", ""))),
+        ("Größte Herausforderung", request_data.get("groesste_herausforderung", "")),
+        ("Email", request_data.get("email", "")),
+        ("Newsletter Opt-in", "Ja" if request_data.get("newsletter_optin") else "Nein"),
+        ("Score", f'{score.get("wert", 0)}/100 — {score.get("einordnung", "")}'),
+    ]
+    rows_html = ""
+    for label, value in rows:
+        rows_html += (
+            f'<tr><td style="padding:6px 8px;border-bottom:1px solid #e6edf3;font-weight:600;white-space:nowrap;vertical-align:top">'
+            f'{escape(label)}</td>'
+            f'<td style="padding:6px 8px;border-bottom:1px solid #e6edf3">{escape(str(value))}</td></tr>'
+        )
+
+    return f"""<!doctype html>
+<html lang="de">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Schnell-Check Lead</title>
+    <style>
+      body{{font-family:-apple-system,Segoe UI,Roboto,Arial,sans-serif;color:#0f172a;line-height:1.5;margin:0;padding:0;background:#f6f9ff}}
+      .wrap{{max-width:640px;margin:0 auto;padding:24px}}
+      .card{{background:#fff;border:1px solid #e6edf3;border-radius:12px;padding:18px;box-shadow:0 6px 30px #18324a16;border-top:4px solid #2B6CB0}}
+      h1{{color:#2B6CB0;font-size:18px;margin:0 0 12px}}
+      p{{margin:8px 0;font-size:14px}}
+      .muted{{color:#64748b}}
+      table{{width:100%;border-collapse:collapse;font-size:14px}}
+    </style>
+  </head>
+  <body>
+    <div class="wrap">
+      <div class="card">
+        <h1>Schnell-Check Lead</h1>
+        <table>{rows_html}</table>
+        <p class="muted" style="margin-top:12px">Hinweis: Diese E\u2011Mail wurde automatisch erzeugt.</p>
+      </div>
+    </div>
+  </body>
+</html>"""
+
+
+# =============================================================================
 # ADMIN BRIEFING EMAIL (Fragebogen-Daten bei Strategy-Generierung)
 # =============================================================================
 


### PR DESCRIPTION
## Summary
Implement email notifications for the KI-Schnell-Check (Appetizer) feature, sending personalized result emails to users and lead notifications to admins.

## Key Changes

- **New email template functions** in `services/email_templates.py`:
  - `render_appetizer_result_email()`: Generates user-facing result email with score, top 3 AI levers, and monetization potential
  - `_render_appetizer_admin_email()`: Generates admin lead notification with all form data and score
  - Added label mappings for time commitment, AI experience, and company size categories

- **Email sending infrastructure** in `routes/appetizer.py`:
  - `_send_appetizer_emails()`: Background task handler that sends both user and admin emails via Resend
  - Respects `DISABLE_EMAILS` and `ENABLE_ADMIN_NOTIFY` environment flags
  - Implements rate limiting (0.6s delay between admin emails) to comply with Resend's 2 req/sec limit
  - Includes error handling and logging with email masking for privacy

- **Endpoint integration**:
  - Modified `generate_appetizer()` to accept `BackgroundTasks` parameter
  - Schedules email sending as background task after lead is saved to database
  - Passes request data and result to email renderer

## Implementation Details

- User emails display score (0-100), classification, top 3 levers with weekly time savings, and monetization potential with monthly EUR values
- Admin emails receive structured lead data with form responses and score for CRM/sales follow-up
- Email sending is non-blocking (background task) to keep API response fast
- Graceful degradation: email failures are logged but don't affect API response
- HTML emails use consistent styling with the existing strategy email template

https://claude.ai/code/session_01UwQHmr3L8eqWyAXap75ZJK