### PR TITLE
Add conversational AI questionnaire (PoC Block 1)

### DIFF
--- a/core/migrate.py
+++ b/core/migrate.py
@@ -134,6 +134,30 @@ DDL = [
         created_at TIMESTAMP DEFAULT NOW()
     )"""),
     text("CREATE INDEX IF NOT EXISTS idx_appetizer_analytics_branche ON appetizer_analytics(branche)"),
+    # chat_sessions (Konversationeller KI-Fragebogen)
+    text("""    CREATE TABLE IF NOT EXISTS chat_sessions (
+        id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+        report_type VARCHAR(20) NOT NULL DEFAULT 'r1',
+        lang VARCHAR(5) DEFAULT 'de',
+        user_id INTEGER REFERENCES users(id) ON DELETE SET NULL,
+        briefing_id INTEGER REFERENCES briefings(id) ON DELETE SET NULL,
+        consent_report BOOLEAN DEFAULT FALSE,
+        consent_at TIMESTAMPTZ,
+        collected_fields JSONB DEFAULT '{}'::jsonb,
+        field_meta JSONB DEFAULT '{}'::jsonb,
+        current_section INTEGER DEFAULT 0,
+        status VARCHAR(20) DEFAULT 'active',
+        created_at TIMESTAMPTZ DEFAULT NOW(),
+        updated_at TIMESTAMPTZ DEFAULT NOW(),
+        last_activity_at TIMESTAMPTZ DEFAULT NOW(),
+        completed_at TIMESTAMPTZ,
+        messages JSONB DEFAULT '[]'::jsonb,
+        turn_count INTEGER DEFAULT 0,
+        conversation_summary TEXT
+    )"""),
+    text("CREATE INDEX IF NOT EXISTS idx_chat_sessions_status ON chat_sessions(status)"),
+    text("CREATE INDEX IF NOT EXISTS idx_chat_sessions_user ON chat_sessions(user_id)"),
+    text("CREATE INDEX IF NOT EXISTS idx_chat_sessions_activity ON chat_sessions(last_activity_at)"),
 ]
 
 def migrate_all(engine: Engine) -> None:

--- a/main.py
+++ b/main.py
@@ -236,6 +236,9 @@ def _build_router_config() -> List[Tuple[str, str, str]]:
     # Report 3: KI-Strategiebericht
     cfg.append(("routes.strategy", "/api", "strategy"))
 
+    # Conversational AI Questionnaire (Chat PoC)
+    cfg.append(("routes.chat", "/api", "chat"))
+
     # KI-Potenzial-Check Appetizer
     cfg.append(("routes.appetizer", "/api/appetizer", "generate"))
 

--- a/migrations/2026-04-09_add_chat_sessions_postgres.sql
+++ b/migrations/2026-04-09_add_chat_sessions_postgres.sql
@@ -1,0 +1,37 @@
+-- Chat Sessions: Konversationeller KI-Fragebogen (PoC Block 1)
+-- Neue Tabelle, keine bestehenden Tabellen geaendert.
+
+CREATE TABLE IF NOT EXISTS chat_sessions (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+
+    -- Zuordnung
+    report_type VARCHAR(20) NOT NULL DEFAULT 'r1',
+    lang VARCHAR(5) DEFAULT 'de',
+    user_id INTEGER REFERENCES users(id) ON DELETE SET NULL,
+    briefing_id INTEGER REFERENCES briefings(id) ON DELETE SET NULL,
+
+    -- Consent
+    consent_report BOOLEAN DEFAULT FALSE,
+    consent_at TIMESTAMPTZ,
+
+    -- State
+    collected_fields JSONB DEFAULT '{}'::jsonb,
+    field_meta JSONB DEFAULT '{}'::jsonb,
+    current_section INTEGER DEFAULT 0,
+    status VARCHAR(20) DEFAULT 'active',
+
+    -- Timestamps
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    updated_at TIMESTAMPTZ DEFAULT NOW(),
+    last_activity_at TIMESTAMPTZ DEFAULT NOW(),
+    completed_at TIMESTAMPTZ,
+
+    -- Konversation
+    messages JSONB DEFAULT '[]'::jsonb,
+    turn_count INTEGER DEFAULT 0,
+    conversation_summary TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_chat_sessions_status ON chat_sessions(status);
+CREATE INDEX IF NOT EXISTS idx_chat_sessions_user ON chat_sessions(user_id);
+CREATE INDEX IF NOT EXISTS idx_chat_sessions_activity ON chat_sessions(last_activity_at);

--- a/models.py
+++ b/models.py
@@ -8,10 +8,11 @@ Warum: Dev/CI ohne Postgres soll nicht brechen.
 
 from datetime import datetime, timezone
 from typing import Any, Optional
+from uuid import uuid4, UUID
 
 from sqlalchemy import (
     Boolean, DateTime, ForeignKey, Integer, String, Text,
-    UniqueConstraint, Index
+    UniqueConstraint, Index, Uuid
 )
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
@@ -442,3 +443,65 @@ class StrategyReport(Base):
             "created_at": self.created_at.isoformat() if self.created_at else None,
             "updated_at": self.updated_at.isoformat() if self.updated_at else None,
         }
+
+
+# =============================================================================
+# KONVERSATIONELLER KI-FRAGEBOGEN (Chat Sessions)
+# =============================================================================
+
+class ChatSession(Base):
+    """
+    Chat session for conversational AI questionnaire.
+    Stores conversation state, collected fields, and message history.
+    """
+    __tablename__ = "chat_sessions"
+
+    id: Mapped[UUID] = mapped_column(
+        Uuid, primary_key=True, default=uuid4
+    )
+    report_type: Mapped[str] = mapped_column(String(20), default="r1", nullable=False)
+    lang: Mapped[str] = mapped_column(String(5), default="de", nullable=False)
+    user_id: Mapped[Optional[int]] = mapped_column(
+        Integer, ForeignKey("users.id", ondelete="SET NULL"), nullable=True, index=True
+    )
+    briefing_id: Mapped[Optional[int]] = mapped_column(
+        Integer, ForeignKey("briefings.id", ondelete="SET NULL"), nullable=True
+    )
+
+    # Consent
+    consent_report: Mapped[bool] = mapped_column(Boolean, default=False, nullable=False)
+    consent_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), nullable=True)
+
+    # State
+    collected_fields: Mapped[dict] = mapped_column(JSONType, default=dict, nullable=False)
+    field_meta: Mapped[dict] = mapped_column(JSONType, default=dict, nullable=False)
+    current_section: Mapped[int] = mapped_column(Integer, default=0, nullable=False)
+    status: Mapped[str] = mapped_column(String(20), default="active", nullable=False)
+
+    # Timestamps
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+        nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+        nullable=False
+    )
+    last_activity_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+        nullable=False
+    )
+    completed_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), nullable=True)
+
+    # Conversation
+    messages: Mapped[list] = mapped_column(JSONType, default=list, nullable=False)
+    turn_count: Mapped[int] = mapped_column(Integer, default=0, nullable=False)
+    conversation_summary: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+
+    user = relationship("User", lazy="joined")
+
+    def __repr__(self) -> str:  # pragma: no cover
+        return f"<ChatSession id={self.id} status={self.status!r} turn={self.turn_count}>"

--- a/routes/chat.py
+++ b/routes/chat.py
@@ -363,12 +363,14 @@ def _build_session_state(session: ChatSession) -> ChatSessionState:
     total = len(FIELD_REGISTRY)
     collected_count = len(collected)
 
+    section_name: str = section["name"]  # type: ignore[assignment]
+
     return ChatSessionState(
         session_id=session.id,
         report_type=session.report_type,
         status=session.status,
         current_section=section_idx,
-        current_section_name=section["name"],
+        current_section_name=section_name,
         total_sections=len(SECTIONS),
         progress_percent=calculate_progress(collected),
         collected_fields=collected,

--- a/routes/chat.py
+++ b/routes/chat.py
@@ -1,0 +1,464 @@
+# -*- coding: utf-8 -*-
+"""
+routes/chat.py — Conversational AI Questionnaire (PoC Block 1)
+
+Endpoints:
+  POST /api/chat/start      — Start new chat session
+  POST /api/chat/message     — Process user message + stream AI response (SSE)
+  GET  /api/chat/session/{id} — Get session state (for resume / frontend init)
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from datetime import datetime, timezone
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException
+from fastapi.responses import StreamingResponse
+from sqlalchemy.orm import Session
+
+from models import ChatSession
+from routes._bootstrap import get_db
+from schemas.chat import (
+    ChatMessage,
+    ChatMessageRequest,
+    ChatSessionResponse,
+    ChatSessionState,
+    ChatStartRequest,
+    ChatStartResponse,
+    QuickReply,
+    QuickReplyOption,
+)
+from services.chat_normalizer import (
+    BUNDESLAND_LABELS,
+    BUNDESLAND_VALUES,
+    ENUM_VALUES,
+    FIELD_REGISTRY,
+    SECTIONS,
+    calculate_progress,
+    get_missing_fields,
+    get_next_fields,
+    is_field_visible,
+    is_section_complete,
+    normalize_field,
+)
+
+router = APIRouter(prefix="/chat", tags=["chat"])
+log = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+POC_SECTION = 0  # Only section 0 in PoC
+
+WELCOME_MESSAGE = (
+    "Willkommen bei ki-sicherheit.jetzt! Ich bin ein KI-Assistent und "
+    "führe Sie durch eine kurze Bestandsaufnahme Ihres Unternehmens.\n\n"
+    "Lassen Sie uns mit den Grundlagen beginnen: "
+    "In welcher Branche ist Ihr Unternehmen tätig?"
+)
+
+
+# ===========================================================================
+# POST /api/chat/start
+# ===========================================================================
+
+@router.post("/start", response_model=ChatStartResponse)
+async def chat_start(req: ChatStartRequest, db: Session = Depends(get_db)):
+    """Start a new chat conversation."""
+    if not req.consent_report:
+        raise HTTPException(status_code=400, detail="consent_report must be true")
+
+    now = datetime.now(timezone.utc)
+
+    session = ChatSession(
+        report_type=req.report_type,
+        lang=req.lang,
+        consent_report=True,
+        consent_at=now,
+        collected_fields=req.prefill or {},
+        field_meta={},
+        current_section=POC_SECTION,
+        status="active",
+        messages=[],
+        turn_count=0,
+    )
+    db.add(session)
+    db.commit()
+    db.refresh(session)
+
+    # Build initial state
+    state = _build_session_state(session)
+
+    # Build welcome quick replies (branche)
+    welcome_qr = _build_quick_replies(["branche"])
+    state.quick_replies = welcome_qr
+
+    # Save welcome message
+    welcome_msg = {
+        "role": "assistant",
+        "content": WELCOME_MESSAGE,
+        "timestamp": now.isoformat(),
+        "turn": 0,
+        "fields_extracted": None,
+        "section_index": POC_SECTION,
+        "quick_replies": [qr.model_dump() for qr in welcome_qr] if welcome_qr else None,
+    }
+    session.messages = [welcome_msg]
+    db.commit()
+
+    log.info("[CHAT] Session started: %s (report_type=%s)", session.id, session.report_type)
+
+    return ChatStartResponse(
+        session_id=session.id,
+        state=state,
+        welcome_message=WELCOME_MESSAGE,
+    )
+
+
+# ===========================================================================
+# POST /api/chat/message
+# ===========================================================================
+
+@router.post("/message")
+async def chat_message(req: ChatMessageRequest, db: Session = Depends(get_db)):
+    """Process user message, extract fields, stream AI response via SSE."""
+    session = db.query(ChatSession).filter(ChatSession.id == req.session_id).first()
+    if not session:
+        raise HTTPException(status_code=404, detail="Session nicht gefunden")
+    if session.status != "active":
+        raise HTTPException(status_code=400, detail="Session ist nicht aktiv")
+
+    now = datetime.now(timezone.utc)
+    session.turn_count += 1
+    turn = session.turn_count
+
+    # Save user message
+    user_msg = {
+        "role": "user",
+        "content": req.message,
+        "timestamp": now.isoformat(),
+        "turn": turn,
+    }
+    messages = list(session.messages or [])
+    messages.append(user_msg)
+    session.messages = messages
+    session.last_activity_at = now
+    session.updated_at = now
+    db.commit()
+
+    # Handle quick reply shortcut
+    if req.quick_reply_field and req.quick_reply_value:
+        raw_extracted = {req.quick_reply_field: req.quick_reply_value}
+    else:
+        # Phase 1: Extraction (Claude Haiku)
+        from services.chat_extractor import extract_fields
+
+        missing_req, missing_opt = get_missing_fields(
+            session.collected_fields, session.current_section
+        )
+        all_missing = missing_req + missing_opt
+
+        try:
+            raw_extracted = await asyncio.wait_for(
+                extract_fields(
+                    req.message,
+                    messages[-6:],
+                    all_missing,
+                    session.collected_fields,
+                ),
+                timeout=30,
+            )
+        except asyncio.TimeoutError:
+            log.warning("[CHAT] Extraction timeout, retrying once...")
+            try:
+                raw_extracted = await asyncio.wait_for(
+                    extract_fields(
+                        req.message,
+                        messages[-6:],
+                        all_missing,
+                        session.collected_fields,
+                    ),
+                    timeout=30,
+                )
+            except asyncio.TimeoutError:
+                raw_extracted = {}
+                log.error("[CHAT] Extraction timeout on retry")
+
+    # Phase 1b: Normalize extracted fields
+    normalized = {}
+    field_meta = dict(session.field_meta or {})
+    collected = dict(session.collected_fields or {})
+
+    for field_name, raw_value in raw_extracted.items():
+        if field_name not in FIELD_REGISTRY:
+            continue
+        # Skip fields not visible due to conditionals
+        if not is_field_visible(field_name, collected):
+            continue
+
+        result = normalize_field(field_name, raw_value, collected)
+
+        if result.confidence == "low":
+            log.info("[CHAT] Field %s: low confidence, skipping", field_name)
+            continue
+
+        # Store in collected_fields
+        collected[field_name] = result.value
+        normalized[field_name] = result.value
+
+        # Store metadata
+        field_meta[field_name] = {
+            "confidence": result.confidence,
+            "source_turn": turn,
+            "raw_input": str(raw_value),
+            "normalized": True,
+            "confirmed": False,
+        }
+
+    # Update session state
+    session.collected_fields = collected
+    session.field_meta = field_meta
+    session.updated_at = now
+
+    # Evaluate conditionals: remove hidden fields
+    for cond_field in ["selbststaendig", "bundesland"]:
+        if cond_field in collected and not is_field_visible(cond_field, collected):
+            del collected[cond_field]
+            if cond_field in field_meta:
+                del field_meta[cond_field]
+            session.collected_fields = collected
+            session.field_meta = field_meta
+
+    db.commit()
+
+    # Determine next fields
+    missing_req, missing_opt = get_missing_fields(collected, session.current_section)
+    all_missing = missing_req + missing_opt
+    next_fields = get_next_fields(collected, session.current_section)
+    current_section = SECTIONS[session.current_section]
+
+    # Phase 2: Conversation (Claude Sonnet streaming)
+    from services.chat_conversation import generate_response
+
+    async def event_stream():
+        # Heartbeat while processing
+        yield f"event: heartbeat\ndata: {{}}\n\n"
+
+        # Stream tokens
+        full_response = ""
+        try:
+            async for token in generate_response(
+                session_messages=list(session.messages),
+                collected_fields=collected,
+                missing_fields=all_missing,
+                next_fields=next_fields,
+                section=current_section,
+            ):
+                full_response += token
+                yield f"event: token\ndata: {json.dumps({'text': token})}\n\n"
+        except Exception as exc:
+            log.error("[CHAT] Streaming error: %s", exc, exc_info=True)
+            error_msg = "Entschuldigung, es gab einen Fehler. Bitte versuchen Sie es nochmal."
+            yield f"event: error\ndata: {json.dumps({'code': 'stream_error', 'message': error_msg})}\n\n"
+            return
+
+        # Save assistant message
+        quick_replies = _build_quick_replies(next_fields)
+        assistant_msg = {
+            "role": "assistant",
+            "content": full_response,
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "turn": turn,
+            "fields_extracted": normalized if normalized else None,
+            "section_index": session.current_section,
+            "quick_replies": [qr.model_dump() for qr in quick_replies] if quick_replies else None,
+        }
+        msgs = list(session.messages)
+        msgs.append(assistant_msg)
+        session.messages = msgs
+        session.updated_at = datetime.now(timezone.utc)
+        db.commit()
+
+        # Send state update
+        state = _build_session_state(session)
+        state.quick_replies = quick_replies
+        yield f"event: state_update\ndata: {state.model_dump_json()}\n\n"
+
+        # Send quick replies
+        if quick_replies:
+            qr_data = [qr.model_dump() for qr in quick_replies]
+            yield f"event: quick_replies\ndata: {json.dumps(qr_data)}\n\n"
+
+        # Done signal
+        yield f"event: done\ndata: {json.dumps({'turn': turn})}\n\n"
+
+    return StreamingResponse(
+        event_stream(),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "Connection": "keep-alive",
+            "X-Accel-Buffering": "no",
+        },
+    )
+
+
+# ===========================================================================
+# GET /api/chat/session/{session_id}
+# ===========================================================================
+
+@router.get("/session/{session_id}", response_model=ChatSessionResponse)
+async def chat_session_get(session_id: UUID, db: Session = Depends(get_db)):
+    """Get session state and recent messages (for resume / frontend init)."""
+    session = db.query(ChatSession).filter(ChatSession.id == session_id).first()
+    if not session:
+        raise HTTPException(status_code=404, detail="Session nicht gefunden")
+
+    state = _build_session_state(session)
+    next_fields = get_next_fields(session.collected_fields, session.current_section)
+    state.quick_replies = _build_quick_replies(next_fields)
+
+    # Last 10 messages
+    all_msgs = session.messages or []
+    recent_msgs = all_msgs[-10:]
+    chat_messages = []
+    for m in recent_msgs:
+        chat_messages.append(ChatMessage(
+            role=m["role"],
+            content=m["content"],
+            timestamp=m.get("timestamp", session.created_at.isoformat()),
+            turn=m.get("turn", 0),
+            fields_extracted=m.get("fields_extracted"),
+            section_index=m.get("section_index"),
+            quick_replies=m.get("quick_replies"),
+        ))
+
+    resumable = session.status == "active"
+
+    return ChatSessionResponse(
+        state=state,
+        messages=chat_messages,
+        resumable=resumable,
+        last_activity=session.last_activity_at,
+    )
+
+
+# ===========================================================================
+# Helpers
+# ===========================================================================
+
+def _build_session_state(session: ChatSession) -> ChatSessionState:
+    """Build ChatSessionState from a ChatSession DB model."""
+    collected = session.collected_fields or {}
+    section_idx = session.current_section
+    section = SECTIONS[section_idx]
+
+    missing_req, missing_opt = get_missing_fields(collected, section_idx)
+    next_fields = get_next_fields(collected, section_idx)
+
+    # Count total fields (across all sections)
+    total = len(FIELD_REGISTRY)
+    collected_count = len(collected)
+
+    return ChatSessionState(
+        session_id=session.id,
+        report_type=session.report_type,
+        status=session.status,
+        current_section=section_idx,
+        current_section_name=section["name"],
+        total_sections=len(SECTIONS),
+        progress_percent=calculate_progress(collected),
+        collected_fields=collected,
+        collected_count=collected_count,
+        missing_required=missing_req,
+        missing_optional=missing_opt,
+        total_fields=total,
+        next_fields=next_fields,
+        is_completable=len(missing_req) == 0,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Quick Reply Builder
+# ---------------------------------------------------------------------------
+
+# Maps field → quick reply options (for enum fields in PoC)
+_QR_OPTIONS: dict[str, list[dict]] = {
+    "branche": [
+        {"value": "marketing", "label": "Marketing & Werbung"},
+        {"value": "beratung", "label": "Beratung & Dienstleistungen"},
+        {"value": "it", "label": "IT & Software"},
+        {"value": "finanzen", "label": "Finanzen & Versicherungen"},
+        {"value": "handel", "label": "Handel & E-Commerce"},
+        {"value": "bildung", "label": "Bildung"},
+        {"value": "verwaltung", "label": "Verwaltung"},
+        {"value": "gesundheit", "label": "Gesundheit & Pflege"},
+        {"value": "bau", "label": "Bauwesen & Architektur"},
+        {"value": "medien", "label": "Medien & Kreativwirtschaft"},
+        {"value": "industrie", "label": "Industrie & Produktion"},
+        {"value": "logistik", "label": "Transport & Logistik"},
+        {"value": "gastronomie", "label": "Gastronomie & Tourismus"},
+    ],
+    "unternehmensgroesse": [
+        {"value": "1", "label": "1 (Solo/Freiberuflich)"},
+        {"value": "2–10", "label": "2–10 (Kleines Team)"},
+        {"value": "11–100", "label": "11–100 (KMU)"},
+    ],
+    "selbststaendig": [
+        {"value": "freiberufler", "label": "Freiberuflich/Selbstständig"},
+        {"value": "kapitalgesellschaft", "label": "1-Personen-GmbH/UG"},
+        {"value": "einzelunternehmer", "label": "Einzelunternehmer (Gewerbe)"},
+        {"value": "sonstiges", "label": "Sonstiges"},
+    ],
+    "country": [
+        {"value": "DE", "label": "Deutschland"},
+        {"value": "AT", "label": "Österreich"},
+        {"value": "CH", "label": "Schweiz"},
+        {"value": "GB", "label": "Vereinigtes Königreich"},
+    ],
+    "jahresumsatz": [
+        {"value": "unter_100k", "label": "Bis 100.000 €"},
+        {"value": "100k_500k", "label": "100.000–500.000 €"},
+        {"value": "500k_2m", "label": "500.000–2 Mio. €"},
+        {"value": "2m_10m", "label": "2–10 Mio. €"},
+        {"value": "ueber_10m", "label": "Über 10 Mio. €"},
+        {"value": "keine_angabe", "label": "Keine Angabe"},
+    ],
+}
+
+# Field labels for quick replies
+_QR_LABELS: dict[str, str] = {
+    "branche": "Branche",
+    "unternehmensgroesse": "Unternehmensgröße",
+    "selbststaendig": "Unternehmensform",
+    "country": "Land",
+    "bundesland": "Bundesland / Region",
+    "hauptleistung": "Hauptleistung",
+    "jahresumsatz": "Jahresumsatz",
+}
+
+
+def _build_quick_replies(next_fields: list[str]) -> list[QuickReply]:
+    """Build quick reply buttons for the next enum fields."""
+    replies = []
+    for field_name in next_fields:
+        reg = FIELD_REGISTRY.get(field_name, {})
+        # Only build QR for enum fields with known options
+        if reg.get("chat_mode") != "QR":
+            continue
+
+        options_data = _QR_OPTIONS.get(field_name)
+        if not options_data:
+            continue
+
+        options = [
+            QuickReplyOption(value=o["value"], label=o["label"], description=o.get("description"))
+            for o in options_data
+        ]
+        label = _QR_LABELS.get(field_name, field_name)
+        replies.append(QuickReply(field=field_name, label=label, options=options))
+
+    return replies

--- a/schemas/chat.py
+++ b/schemas/chat.py
@@ -1,0 +1,139 @@
+# -*- coding: utf-8 -*-
+"""Pydantic schemas for the conversational AI questionnaire (Chat)."""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Literal, Optional
+from uuid import UUID
+
+from pydantic import BaseModel
+
+
+# ---------------------------------------------------------------------------
+# Chat Message
+# ---------------------------------------------------------------------------
+
+class ChatMessage(BaseModel):
+    role: Literal["user", "assistant", "system"]
+    content: str
+    timestamp: datetime
+    turn: int
+    fields_extracted: Optional[dict] = None
+    section_index: Optional[int] = None
+    quick_replies: Optional[list] = None
+
+
+# ---------------------------------------------------------------------------
+# Quick Replies
+# ---------------------------------------------------------------------------
+
+class QuickReplyOption(BaseModel):
+    value: str
+    label: str
+    description: Optional[str] = None
+
+
+class QuickReply(BaseModel):
+    field: str
+    label: str
+    options: list[QuickReplyOption]
+
+
+# ---------------------------------------------------------------------------
+# Session State (returned with every turn)
+# ---------------------------------------------------------------------------
+
+class ChatSessionState(BaseModel):
+    session_id: UUID
+    report_type: str
+    status: str
+
+    # Progress
+    current_section: int
+    current_section_name: str
+    total_sections: int = 8
+    progress_percent: int
+
+    # Fields
+    collected_fields: dict
+    collected_count: int
+    missing_required: list[str]
+    missing_optional: list[str]
+    total_fields: int
+
+    # Next steps
+    next_fields: list[str]
+    is_completable: bool
+
+    # Quick Replies
+    quick_replies: Optional[list[QuickReply]] = None
+
+
+# ---------------------------------------------------------------------------
+# POST /api/chat/start
+# ---------------------------------------------------------------------------
+
+class ChatStartRequest(BaseModel):
+    report_type: Literal["r1", "strategy", "kpa"] = "r1"
+    lang: str = "de"
+    consent_report: bool
+    prefill: Optional[dict[str, Any]] = None
+
+
+class ChatStartResponse(BaseModel):
+    session_id: UUID
+    state: ChatSessionState
+    welcome_message: str
+
+
+# ---------------------------------------------------------------------------
+# POST /api/chat/message
+# ---------------------------------------------------------------------------
+
+class ChatMessageRequest(BaseModel):
+    session_id: UUID
+    message: str
+    quick_reply_field: Optional[str] = None
+    quick_reply_value: Optional[str] = None
+
+
+# ---------------------------------------------------------------------------
+# GET /api/chat/session/{session_id}
+# ---------------------------------------------------------------------------
+
+class ChatSessionResponse(BaseModel):
+    state: ChatSessionState
+    messages: list[ChatMessage]
+    resumable: bool
+    last_activity: datetime
+
+
+# ---------------------------------------------------------------------------
+# POST /api/chat/complete  (not in PoC)
+# ---------------------------------------------------------------------------
+
+class ChatCompleteRequest(BaseModel):
+    session_id: UUID
+    confirmed: bool = True
+
+
+class ChatCompleteResponse(BaseModel):
+    success: bool
+    briefing_id: int
+    report_type: str
+    redirect_url: str
+
+
+# ---------------------------------------------------------------------------
+# POST /api/chat/fallback  (not in PoC)
+# ---------------------------------------------------------------------------
+
+class ChatFallbackRequest(BaseModel):
+    session_id: UUID
+
+
+class ChatFallbackResponse(BaseModel):
+    prefill_answers: dict
+    missing_fields: list[str]
+    current_section: int
+    form_url: str

--- a/services/chat_conversation.py
+++ b/services/chat_conversation.py
@@ -1,0 +1,221 @@
+# -*- coding: utf-8 -*-
+"""
+Phase 2: Conversational response generation via Claude Sonnet with streaming.
+
+Generates the next AI response based on current session state.
+Streams tokens via an async generator for SSE delivery.
+"""
+from __future__ import annotations
+
+import logging
+import os
+from typing import AsyncGenerator
+
+from services.chat_normalizer import (
+    FIELD_REGISTRY,
+    SECTIONS,
+    BUNDESLAND_LABELS,
+    ENUM_VALUES,
+)
+
+log = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Model Config
+# ---------------------------------------------------------------------------
+CONVERSATION_MODEL = os.getenv(
+    "CHAT_CONVERSATION_MODEL", "claude-sonnet-4-20250514"
+)
+
+# ---------------------------------------------------------------------------
+# System Prompt
+# ---------------------------------------------------------------------------
+CONVERSATION_SYSTEM_PROMPT = """\
+Sie sind ein KI-Assistent von ki-sicherheit.jetzt und führen
+Nutzerinnen und Nutzer in deutscher Sprache durch eine professionelle
+Bestandsaufnahme zur KI-Readiness ihres Unternehmens.
+
+IHRE ROLLE:
+Sie sind ein kompetenter, freundlicher Berater — kein Chatbot.
+Sie siezen durchgehend. Sie erklären Fachbegriffe proaktiv.
+Sie bleiben effizient und respektieren die Zeit des Nutzers.
+
+TRANSPARENZ:
+Sie sind ein KI-Assistent. Machen Sie das zu Gesprächsbeginn
+transparent und weisen Sie darauf hin, dass die Angaben zur
+Erstellung eines individuellen KI-Reports verarbeitet werden.
+
+REGELN:
+1. Bestätigen Sie zuerst, was Sie verstanden haben.
+2. Stellen Sie dann maximal 2–3 thematisch zusammenhängende Fragen.
+3. Bei Auswahlfeldern nennen Sie die Optionen als nummerierte Liste.
+4. Bei Fachbegriffen geben Sie in 1–2 Sätzen eine verständliche \
+Erklärung mit einem konkreten Beispiel aus der Branche des Nutzers.
+5. Erfinden Sie keine Angaben.
+6. Keine unnötig langen Antworten.
+7. Keine juristischen Zusicherungen.
+8. Keine technischen Interna erwähnen.
+
+AKTUELLER STAND:
+- Abschnitt: {section_name} (Schritt {section_number} von {total_sections})
+- Bereits erfasst: {collected_fields_summary}
+- In diesem Abschnitt noch offen: {missing_in_section}
+
+ALS NÄCHSTES ERFRAGEN:
+{next_fields_with_descriptions}
+
+ABSCHLUSS DIESES ABSCHNITTS:
+Wenn alle Felder dieses Abschnitts erfasst sind, fassen Sie die \
+Angaben kurz zusammen und fragen: "Ist das so korrekt?"
+"""
+
+# ---------------------------------------------------------------------------
+# Async Anthropic Client (shares singleton with extractor)
+# ---------------------------------------------------------------------------
+_async_client = None
+
+
+def _get_async_client():
+    """Lazy-initialize async Anthropic client."""
+    global _async_client
+    if _async_client is not None:
+        return _async_client
+
+    try:
+        import anthropic
+    except ImportError:
+        log.error("[CHAT-CONV] anthropic SDK not installed")
+        return None
+
+    api_key = os.getenv("ANTHROPIC_API_KEY")
+    if not api_key:
+        log.error("[CHAT-CONV] ANTHROPIC_API_KEY not set")
+        return None
+
+    timeout = float(os.getenv("ANTHROPIC_TIMEOUT", "120"))
+    _async_client = anthropic.AsyncAnthropic(
+        api_key=api_key,
+        timeout=timeout,
+    )
+    log.info("[CHAT-CONV] AsyncAnthropic client initialized (model=%s)", CONVERSATION_MODEL)
+    return _async_client
+
+
+# ---------------------------------------------------------------------------
+# Context Building
+# ---------------------------------------------------------------------------
+
+def build_conversation_messages(messages: list[dict]) -> list[dict]:
+    """
+    Build messages for the conversation model.
+    Uses last 6 messages (3 turns). If more exist, prepends a summary stub.
+    """
+    result: list[dict] = []
+
+    if len(messages) > 6:
+        # Compact summary for earlier messages
+        result.append({
+            "role": "user",
+            "content": "[Bisheriger Gesprächsverlauf: Die Bestandsaufnahme hat bereits begonnen. "
+                       "Einige Felder wurden bereits erfasst — siehe AKTUELLER STAND im System-Prompt.]",
+        })
+        result.append({
+            "role": "assistant",
+            "content": "Verstanden, ich setze die Bestandsaufnahme fort.",
+        })
+
+    # Last 6 messages (3 turns)
+    recent = messages[-6:] if len(messages) > 6 else messages
+    for msg in recent:
+        result.append({"role": msg["role"], "content": msg["content"]})
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Field Descriptions for Prompt
+# ---------------------------------------------------------------------------
+
+FIELD_DESCRIPTIONS: dict[str, str] = {
+    "branche": "Branche des Unternehmens (13 Optionen: Marketing, Beratung, IT, Finanzen, Handel, Bildung, Verwaltung, Gesundheit, Bau, Medien, Industrie, Logistik, Gastronomie)",
+    "unternehmensgroesse": "Unternehmensgröße (1 Person / 2–10 / 11–100 Mitarbeiter)",
+    "selbststaendig": "Unternehmensform bei Einzelperson (Freiberufler, Kapitalgesellschaft, Einzelunternehmer, Sonstiges)",
+    "country": "Land des Unternehmens (Deutschland, Österreich, Schweiz, UK oder anderes)",
+    "bundesland": "Bundesland / Kanton / Region (für regionale Fördermöglichkeiten)",
+    "hauptleistung": "Hauptdienstleistung oder wichtigstes Produkt (Freitext, 2–3 Sätze)",
+    "jahresumsatz": "Geschätzter Jahresumsatz (bis 100T€ / 100–500T€ / 500T€–2Mio / 2–10Mio / >10Mio / keine Angabe)",
+}
+
+
+def _format_next_fields(field_names: list[str]) -> str:
+    """Format field descriptions for the system prompt."""
+    if not field_names:
+        return "Alle Felder dieses Abschnitts sind erfasst."
+    lines = []
+    for name in field_names:
+        desc = FIELD_DESCRIPTIONS.get(name, name)
+        reg = FIELD_REGISTRY.get(name, {})
+        pflicht = "Pflicht" if reg.get("required") else "Optional"
+        lines.append(f"- {name} ({pflicht}): {desc}")
+    return "\n".join(lines)
+
+
+def _format_collected_summary(collected: dict) -> str:
+    """Format collected fields for display in the system prompt."""
+    if not collected:
+        return "noch keine Angaben"
+    parts = []
+    for k, v in collected.items():
+        # Make bundesland human-readable
+        if k == "bundesland" and isinstance(v, str):
+            label = BUNDESLAND_LABELS.get(v, v)
+            parts.append(f"{k}: {label}")
+        else:
+            parts.append(f"{k}: {v}")
+    return ", ".join(parts)
+
+
+# ---------------------------------------------------------------------------
+# Streaming Response Generator
+# ---------------------------------------------------------------------------
+
+async def generate_response(
+    session_messages: list[dict],
+    collected_fields: dict,
+    missing_fields: list[str],
+    next_fields: list[str],
+    section: dict,
+) -> AsyncGenerator[str, None]:
+    """
+    Generate streaming AI response.
+
+    Yields text tokens as they arrive from Claude Sonnet.
+    """
+    client = _get_async_client()
+    if client is None:
+        yield "Entschuldigung, ich bin gerade nicht erreichbar. Bitte versuchen Sie es gleich nochmal."
+        return
+
+    system_prompt = CONVERSATION_SYSTEM_PROMPT.format(
+        section_name=section["name"],
+        section_number=section["index"] + 1,
+        total_sections=8,
+        collected_fields_summary=_format_collected_summary(collected_fields),
+        missing_in_section=", ".join(missing_fields) if missing_fields else "alle erfasst",
+        next_fields_with_descriptions=_format_next_fields(next_fields),
+    )
+
+    messages = build_conversation_messages(session_messages)
+
+    try:
+        async with client.messages.stream(
+            model=CONVERSATION_MODEL,
+            max_tokens=800,
+            system=system_prompt,
+            messages=messages,
+        ) as stream:
+            async for text in stream.text_stream:
+                yield text
+    except Exception as exc:
+        log.error("[CHAT-CONV] Streaming failed: %s", exc, exc_info=True)
+        yield "Entschuldigung, es gab einen Verbindungsfehler. Könnten Sie das bitte nochmal versuchen?"

--- a/services/chat_extractor.py
+++ b/services/chat_extractor.py
@@ -176,7 +176,7 @@ async def extract_fields(
         # Extract tool result
         for block in response.content:
             if block.type == "tool_use" and block.name == "update_intake_fields":
-                extracted: dict = block.input  # type: ignore[assignment]
+                extracted: dict = block.input
                 log.info(
                     "[CHAT-EXTRACT] Extracted %d fields: %s",
                     len(extracted),

--- a/services/chat_extractor.py
+++ b/services/chat_extractor.py
@@ -176,7 +176,7 @@ async def extract_fields(
         # Extract tool result
         for block in response.content:
             if block.type == "tool_use" and block.name == "update_intake_fields":
-                extracted = block.input
+                extracted: dict = block.input  # type: ignore[assignment]
                 log.info(
                     "[CHAT-EXTRACT] Extracted %d fields: %s",
                     len(extracted),

--- a/services/chat_extractor.py
+++ b/services/chat_extractor.py
@@ -1,0 +1,203 @@
+# -*- coding: utf-8 -*-
+"""
+Phase 1: Field extraction via Claude Haiku with tool_use.
+
+The extractor receives the user message + recent conversation context
+and returns structured fields using a tool call. It never writes to DB
+directly — results go through the normalizer first.
+"""
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any
+
+log = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Model Config
+# ---------------------------------------------------------------------------
+EXTRACTOR_MODEL = os.getenv(
+    "CHAT_EXTRACTOR_MODEL", "claude-haiku-4-5-20251001"
+)
+
+# ---------------------------------------------------------------------------
+# System Prompt
+# ---------------------------------------------------------------------------
+EXTRACTOR_SYSTEM_PROMPT = """\
+Du bist ein Daten-Extractor für einen KI-Readiness-Fragebogen.
+Analysiere die Nutzerantwort und extrahiere strukturierte Felder
+mit dem Tool update_intake_fields.
+
+REGELN:
+1. Setze NUR Felder, die der Nutzer tatsächlich genannt hat.
+2. Erfinde NIEMALS Werte.
+3. Wenn unsicher, setze das Feld NICHT.
+4. Extrahiere auch implizite Informationen:
+   - "in München" → bundesland: "München" (wird extern normalisiert)
+   - "8 Mitarbeiter" → unternehmensgroesse: "8" (wird extern normalisiert)
+   - "Handwerksbetrieb" → branche: "Handwerk" (wird extern normalisiert)
+5. Bei Freitextfeldern (hauptleistung): den Kern der Aussage
+   in 1–3 Sätzen zusammenfassen.
+6. Wenn der Nutzer eine Rückfrage stellt statt zu antworten,
+   rufe das Tool NICHT auf.
+
+Aktuell fehlende Felder: {missing_fields}
+Bereits erfasst: {collected_fields}"""
+
+# ---------------------------------------------------------------------------
+# Tool Definition — PoC Block 1 (Section 0, 7 fields)
+# ---------------------------------------------------------------------------
+EXTRACTOR_TOOL_POC: dict[str, Any] = {
+    "name": "update_intake_fields",
+    "description": (
+        "Extrahiert strukturierte Felder aus der User-Nachricht. "
+        "Nur Felder setzen, die der User tatsächlich genannt hat. "
+        "Niemals Werte erfinden oder raten."
+    ),
+    "input_schema": {
+        "type": "object",
+        "properties": {
+            "branche": {
+                "type": "string",
+                "description": "Branche des Unternehmens (z.B. bau, it, marketing, beratung, handel, gastronomie)",
+            },
+            "unternehmensgroesse": {
+                "type": "string",
+                "description": "Anzahl Mitarbeiter als Zahl oder Kategorie (z.B. '1', '8', '2-10', 'solo')",
+            },
+            "selbststaendig": {
+                "type": "string",
+                "description": "Unternehmensform bei Einzelperson: freiberufler, kapitalgesellschaft, einzelunternehmer, sonstiges",
+            },
+            "country": {
+                "type": "string",
+                "description": "Land als ISO-Code oder Name (z.B. DE, AT, CH, Deutschland, Österreich)",
+            },
+            "bundesland": {
+                "type": "string",
+                "description": "Bundesland, Kanton, Region oder Stadt (wird zu Bundesland-Code normalisiert)",
+            },
+            "hauptleistung": {
+                "type": "string",
+                "description": "Haupttätigkeit/Kernleistung des Unternehmens in 1–3 Sätzen",
+            },
+            "jahresumsatz": {
+                "type": "string",
+                "description": "Ungefährer Jahresumsatz (z.B. unter_100k, 100k_500k, 500k_2m, 2m_10m, ueber_10m)",
+            },
+        },
+        "required": [],  # CRITICAL: extractor only sets actually mentioned fields
+    },
+}
+
+
+# ---------------------------------------------------------------------------
+# Async Anthropic Client (singleton)
+# ---------------------------------------------------------------------------
+_async_client = None
+
+
+def _get_async_client():
+    """Lazy-initialize async Anthropic client."""
+    global _async_client
+    if _async_client is not None:
+        return _async_client
+
+    try:
+        import anthropic
+    except ImportError:
+        log.error("[CHAT-EXTRACT] anthropic SDK not installed")
+        return None
+
+    api_key = os.getenv("ANTHROPIC_API_KEY")
+    if not api_key:
+        log.error("[CHAT-EXTRACT] ANTHROPIC_API_KEY not set")
+        return None
+
+    timeout = float(os.getenv("ANTHROPIC_TIMEOUT", "60"))
+    _async_client = anthropic.AsyncAnthropic(
+        api_key=api_key,
+        timeout=timeout,
+    )
+    log.info("[CHAT-EXTRACT] AsyncAnthropic client initialized (model=%s)", EXTRACTOR_MODEL)
+    return _async_client
+
+
+# ---------------------------------------------------------------------------
+# Main Extraction Function
+# ---------------------------------------------------------------------------
+
+async def extract_fields(
+    user_message: str,
+    conversation_context: list[dict],
+    missing_fields: list[str],
+    collected_fields: dict,
+) -> dict:
+    """
+    Call Claude Haiku with tool_use to extract structured fields.
+
+    Args:
+        user_message: The current user message
+        conversation_context: Last 6 messages (3 turns) for context
+        missing_fields: Fields still needed
+        collected_fields: Already collected field values
+
+    Returns:
+        Dict of extracted fields (may be empty if user asked a question).
+    """
+    client = _get_async_client()
+    if client is None:
+        log.error("[CHAT-EXTRACT] No async client available")
+        return {}
+
+    # Build messages: recent context + current message
+    messages: list[dict] = []
+    for turn in conversation_context[-6:]:
+        messages.append({"role": turn["role"], "content": turn["content"]})
+    messages.append({"role": "user", "content": user_message})
+
+    # Format system prompt with current state
+    system = EXTRACTOR_SYSTEM_PROMPT.format(
+        missing_fields=", ".join(missing_fields) if missing_fields else "keine",
+        collected_fields=_format_collected(collected_fields),
+    )
+
+    try:
+        response = await client.messages.create(
+            model=EXTRACTOR_MODEL,
+            max_tokens=500,
+            system=system,
+            messages=messages,
+            tools=[EXTRACTOR_TOOL_POC],
+            tool_choice={"type": "auto"},  # auto: no tool call if user asks question
+        )
+
+        # Extract tool result
+        for block in response.content:
+            if block.type == "tool_use" and block.name == "update_intake_fields":
+                extracted = block.input
+                log.info(
+                    "[CHAT-EXTRACT] Extracted %d fields: %s",
+                    len(extracted),
+                    list(extracted.keys()),
+                )
+                return extracted
+
+        # No tool call — user probably asked a question
+        log.info("[CHAT-EXTRACT] No fields extracted (user question or off-topic)")
+        return {}
+
+    except Exception as exc:
+        log.error("[CHAT-EXTRACT] Extraction failed: %s", exc, exc_info=True)
+        return {}
+
+
+def _format_collected(collected: dict) -> str:
+    """Format collected fields for the system prompt."""
+    if not collected:
+        return "keine"
+    parts = []
+    for k, v in collected.items():
+        parts.append(f"{k}={v!r}")
+    return ", ".join(parts)

--- a/services/chat_normalizer.py
+++ b/services/chat_normalizer.py
@@ -1,0 +1,660 @@
+# -*- coding: utf-8 -*-
+"""
+Deterministic field normalizer for the conversational AI questionnaire.
+
+Rules:
+- LLM never writes directly to DB — always through this normalizer
+- Enums/normalization run deterministically, not LLM-based
+- Fields with confidence "low" are NOT stored in collected_fields
+"""
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass
+from typing import Any, Optional
+
+log = logging.getLogger(__name__)
+
+
+# ===========================================================================
+# Normalization Result
+# ===========================================================================
+
+@dataclass
+class NormResult:
+    value: Any
+    confidence: str          # "high" | "medium" | "low"
+    needs_confirmation: bool
+
+
+# ===========================================================================
+# Field Registry — PoC Block 1 (Section 0) + full structure for later
+# ===========================================================================
+
+FIELD_REGISTRY: dict[str, dict] = {
+    # --- Section 0: Ihr Unternehmen (PoC) ---
+    "branche":              {"type": "enum",  "required": True,  "section": 0, "chat_mode": "QR"},
+    "unternehmensgroesse":  {"type": "enum",  "required": True,  "section": 0, "chat_mode": "QR"},
+    "selbststaendig":       {"type": "enum",  "required": False, "section": 0, "chat_mode": "QR"},
+    "country":              {"type": "enum",  "required": True,  "section": 0, "chat_mode": "QR"},
+    "bundesland":           {"type": "enum",  "required": True,  "section": 0, "chat_mode": "QR"},
+    "hauptleistung":        {"type": "text",  "required": True,  "section": 0, "chat_mode": "FT"},
+    "jahresumsatz":         {"type": "enum",  "required": False, "section": 0, "chat_mode": "QR"},
+    # --- Section 1: Organisation & Datenlage ---
+    "zielgruppen":          {"type": "multi", "required": False, "section": 1, "chat_mode": "QR"},
+    "it_infrastruktur":     {"type": "enum",  "required": False, "section": 1, "chat_mode": "QR"},
+    "interne_ki_kompetenzen": {"type": "enum", "required": False, "section": 1, "chat_mode": "QR"},
+    "datenquellen":         {"type": "multi", "required": False, "section": 1, "chat_mode": "QR"},
+    # --- Section 2: Digitalisierung & KI-Status ---
+    "digitalisierungsgrad": {"type": "slider", "required": True,  "section": 2, "chat_mode": "SC", "min": 1, "max": 10},
+    "prozesse_papierlos":   {"type": "enum",  "required": False, "section": 2, "chat_mode": "QR"},
+    "automatisierungsgrad": {"type": "enum",  "required": False, "section": 2, "chat_mode": "QR"},
+    "ki_einsatz":           {"type": "multi", "required": False, "section": 2, "chat_mode": "QR"},
+    "ki_kompetenz":         {"type": "enum",  "required": False, "section": 2, "chat_mode": "QR"},
+    # --- Section 3: Ziele & Use Cases ---
+    "ki_ziele":             {"type": "multi", "required": True,  "section": 3, "chat_mode": "QR"},
+    "anwendungsfaelle":     {"type": "multi", "required": False, "section": 3, "chat_mode": "QR"},
+    "ki_projekte":          {"type": "text",  "required": False, "section": 3, "chat_mode": "FT"},
+    "pilot_bereich":        {"type": "enum",  "required": False, "section": 3, "chat_mode": "QR"},
+    "zeitersparnis_prioritaet": {"type": "text", "required": True, "section": 3, "chat_mode": "FT"},
+    "geschaeftsmodell_evolution": {"type": "text", "required": False, "section": 3, "chat_mode": "FT"},
+    # --- Section 4: Strategie & Governance ---
+    "vision_3_jahre":       {"type": "text",  "required": True,  "section": 4, "chat_mode": "FT"},
+    "strategische_ziele":   {"type": "text",  "required": True,  "section": 4, "chat_mode": "FT"},
+    "ki_guardrails":        {"type": "text",  "required": False, "section": 4, "chat_mode": "FT"},
+    "roadmap_vorhanden":    {"type": "enum",  "required": False, "section": 4, "chat_mode": "QR"},
+    "change_management":    {"type": "enum",  "required": False, "section": 4, "chat_mode": "QR"},
+    "massnahmen_komplexitaet": {"type": "enum", "required": False, "section": 4, "chat_mode": "QR"},
+    "governance_richtlinien": {"type": "enum", "required": False, "section": 4, "chat_mode": "QR"},
+    # --- Section 5: Ressourcen & Umsetzung ---
+    "zeitbudget":           {"type": "enum",  "required": False, "section": 5, "chat_mode": "QR"},
+    "vorhandene_tools":     {"type": "multi", "required": False, "section": 5, "chat_mode": "QR"},
+    "trainings_interessen": {"type": "multi", "required": False, "section": 5, "chat_mode": "QR"},
+    "vision_prioritaet":    {"type": "enum",  "required": False, "section": 5, "chat_mode": "QR"},
+    "innovationsprozess":   {"type": "enum",  "required": False, "section": 5, "chat_mode": "QR"},
+    # --- Section 6: Recht & Datenschutz ---
+    "datenschutz":          {"type": "bool",  "required": True,  "section": 6, "chat_mode": "QR"},
+    "datenschutzbeauftragter": {"type": "enum", "required": False, "section": 6, "chat_mode": "QR"},
+    "technische_massnahmen": {"type": "enum", "required": False, "section": 6, "chat_mode": "QR"},
+    "folgenabschaetzung":   {"type": "enum",  "required": False, "section": 6, "chat_mode": "QR"},
+    "meldewege":            {"type": "enum",  "required": False, "section": 6, "chat_mode": "QR"},
+    "loeschregeln":         {"type": "enum",  "required": False, "section": 6, "chat_mode": "QR"},
+    "ai_act_kenntnis":      {"type": "enum",  "required": False, "section": 6, "chat_mode": "QR"},
+    "regulierte_branche":   {"type": "multi", "required": False, "section": 6, "chat_mode": "QR"},
+    "ki_hemmnisse":         {"type": "multi", "required": False, "section": 6, "chat_mode": "QR"},
+    # --- Section 7: Förderung & Investition ---
+    "bisherige_foerdermittel": {"type": "enum", "required": False, "section": 7, "chat_mode": "QR"},
+    "interesse_foerderung": {"type": "enum",  "required": False, "section": 7, "chat_mode": "QR"},
+    "erfahrung_beratung":   {"type": "enum",  "required": False, "section": 7, "chat_mode": "QR"},
+    "investitionsbudget":   {"type": "enum",  "required": True,  "section": 7, "chat_mode": "QR"},
+    "marktposition":        {"type": "enum",  "required": False, "section": 7, "chat_mode": "QR"},
+    "benchmark_wettbewerb": {"type": "enum",  "required": False, "section": 7, "chat_mode": "QR"},
+    "risikofreude":         {"type": "slider", "required": False, "section": 7, "chat_mode": "SC", "min": 1, "max": 5},
+}
+
+
+# ===========================================================================
+# Sections (8 conversation sections)
+# ===========================================================================
+
+SECTIONS = [
+    {
+        "index": 0,
+        "name": "Ihr Unternehmen",
+        "fields": ["branche", "unternehmensgroesse", "selbststaendig",
+                    "country", "bundesland", "hauptleistung", "jahresumsatz"],
+        "intro": "Lassen Sie uns mit den Grundlagen beginnen — erzählen Sie mir von Ihrem Unternehmen.",
+    },
+    {
+        "index": 1,
+        "name": "Organisation & Datenlage",
+        "fields": ["zielgruppen", "it_infrastruktur", "interne_ki_kompetenzen", "datenquellen"],
+        "intro": "Wie sieht es mit Ihrer IT-Infrastruktur und Ihren Daten aus?",
+    },
+    {
+        "index": 2,
+        "name": "Digitalisierung & KI-Status",
+        "fields": ["digitalisierungsgrad", "prozesse_papierlos", "automatisierungsgrad",
+                    "ki_einsatz", "ki_kompetenz"],
+        "intro": "Wie digital arbeiten Sie heute — und nutzen Sie bereits KI?",
+    },
+    {
+        "index": 3,
+        "name": "Ziele & Use Cases",
+        "fields": ["ki_ziele", "anwendungsfaelle", "ki_projekte", "pilot_bereich",
+                    "zeitersparnis_prioritaet", "geschaeftsmodell_evolution"],
+        "intro": "Was erhoffen Sie sich konkret vom KI-Einsatz?",
+    },
+    {
+        "index": 4,
+        "name": "Strategie & Governance",
+        "fields": ["vision_3_jahre", "strategische_ziele", "ki_guardrails",
+                    "roadmap_vorhanden", "change_management", "massnahmen_komplexitaet",
+                    "governance_richtlinien"],
+        "intro": "Sprechen wir über Ihre strategische Ausrichtung und Leitplanken.",
+    },
+    {
+        "index": 5,
+        "name": "Ressourcen & Umsetzung",
+        "fields": ["zeitbudget", "vorhandene_tools", "trainings_interessen",
+                    "vision_prioritaet", "innovationsprozess"],
+        "intro": "Welche Ressourcen und Werkzeuge stehen Ihnen zur Verfügung?",
+    },
+    {
+        "index": 6,
+        "name": "Recht & Datenschutz",
+        "fields": ["datenschutz", "datenschutzbeauftragter", "technische_massnahmen",
+                    "folgenabschaetzung", "meldewege", "loeschregeln", "ai_act_kenntnis",
+                    "regulierte_branche", "ki_hemmnisse"],
+        "intro": "Klären wir den Stand bei Datenschutz, Compliance und möglichen Hürden.",
+    },
+    {
+        "index": 7,
+        "name": "Förderung & Investition",
+        "fields": ["bisherige_foerdermittel", "interesse_foerderung", "erfahrung_beratung",
+                    "investitionsbudget", "marktposition", "benchmark_wettbewerb",
+                    "risikofreude"],
+        "intro": "Zum Abschluss: Budget, Fördermittel und Ihre Marktposition.",
+    },
+]
+
+
+# ===========================================================================
+# Conditional Logic
+# ===========================================================================
+
+CONDITIONALS: dict[str, dict] = {
+    "selbststaendig": {
+        "show_if": {"unternehmensgroesse": "1"},
+        "hide_action": "delete",
+    },
+    "bundesland": {
+        "show_if": {"country": ["DE", "AT", "CH", "GB"]},
+        "hide_action": "delete",
+    },
+}
+
+
+def is_field_visible(field_name: str, collected: dict) -> bool:
+    """Check if a conditional field should be shown given current collected data."""
+    cond = CONDITIONALS.get(field_name)
+    if not cond:
+        return True
+    show_if = cond["show_if"]
+    for dep_field, dep_value in show_if.items():
+        current = collected.get(dep_field)
+        if current is None:
+            return False
+        if isinstance(dep_value, list):
+            if current not in dep_value:
+                return False
+        elif current != dep_value:
+            return False
+    return True
+
+
+# ===========================================================================
+# Verified Enum Values (from Frontend formbuilder_de_SINGLE_FULL.js)
+# ===========================================================================
+
+ENUM_VALUES: dict[str, list[str]] = {
+    "branche": [
+        "marketing", "beratung", "it", "finanzen", "handel", "bildung",
+        "verwaltung", "gesundheit", "bau", "medien", "industrie",
+        "logistik", "gastronomie",
+    ],
+    "unternehmensgroesse": ["1", "2–10", "11–100"],
+    "selbststaendig": [
+        "freiberufler", "kapitalgesellschaft", "einzelunternehmer", "sonstiges",
+    ],
+    "country": [
+        "DE", "AT", "FR", "IT", "ES", "NL", "BE", "IE", "PL", "SE", "DK",
+        "FI", "PT", "CZ", "GR", "HU", "RO", "other_eu",
+        "GB", "CH", "NO", "IS", "LI", "other_europe",
+        "other",
+    ],
+    "jahresumsatz": [
+        "unter_100k", "100k_500k", "500k_2m", "2m_10m", "ueber_10m", "keine_angabe",
+    ],
+}
+
+# Bundesland codes per country (from frontend REGION_OPTIONS)
+BUNDESLAND_VALUES: dict[str, list[str]] = {
+    "DE": ["bw", "by", "be", "bb", "hb", "hh", "he", "mv", "ni", "nw", "rp", "sl", "sn", "st", "sh", "th"],
+    "CH": ["zh", "be_ch", "lu", "ur", "sz", "ow", "nw_ch", "gl", "zg", "fr", "so", "bs", "bl", "sh_ch", "ar", "ai", "sg", "gr", "ag", "tg", "ti", "vd", "vs", "ne", "ge", "ju"],
+    "AT": ["wi", "noe", "ooe", "sbg", "tir", "vbg", "ktn", "stm", "bgl"],
+    "GB": ["eng", "sco", "wal", "nir"],
+}
+
+# All valid bundesland codes (flat set for quick lookup)
+ALL_BUNDESLAND_CODES: set[str] = set()
+for _codes in BUNDESLAND_VALUES.values():
+    ALL_BUNDESLAND_CODES.update(_codes)
+
+# Bundesland labels (code -> display name)
+BUNDESLAND_LABELS: dict[str, str] = {
+    # DE
+    "bw": "Baden-Württemberg", "by": "Bayern", "be": "Berlin", "bb": "Brandenburg",
+    "hb": "Bremen", "hh": "Hamburg", "he": "Hessen", "mv": "Mecklenburg-Vorpommern",
+    "ni": "Niedersachsen", "nw": "Nordrhein-Westfalen", "rp": "Rheinland-Pfalz",
+    "sl": "Saarland", "sn": "Sachsen", "st": "Sachsen-Anhalt",
+    "sh": "Schleswig-Holstein", "th": "Thüringen",
+    # CH
+    "zh": "Zürich", "be_ch": "Bern", "lu": "Luzern", "ur": "Uri", "sz": "Schwyz",
+    "ow": "Obwalden", "nw_ch": "Nidwalden", "gl": "Glarus", "zg": "Zug",
+    "fr": "Freiburg", "so": "Solothurn", "bs": "Basel-Stadt", "bl": "Basel-Landschaft",
+    "sh_ch": "Schaffhausen", "ar": "Appenzell Ausserrhoden", "ai": "Appenzell Innerrhoden",
+    "sg": "St. Gallen", "gr": "Graubünden", "ag": "Aargau", "tg": "Thurgau",
+    "ti": "Tessin", "vd": "Waadt", "vs": "Wallis", "ne": "Neuenburg",
+    "ge": "Genf", "ju": "Jura",
+    # AT
+    "wi": "Wien", "noe": "Niederösterreich", "ooe": "Oberösterreich",
+    "sbg": "Salzburg", "tir": "Tirol", "vbg": "Vorarlberg",
+    "ktn": "Kärnten", "stm": "Steiermark", "bgl": "Burgenland",
+    # GB
+    "eng": "England", "sco": "Scotland", "wal": "Wales", "nir": "Northern Ireland",
+}
+
+
+# ===========================================================================
+# Branch Aliases (chat free-text → canonical enum value)
+# ===========================================================================
+
+BRANCH_ALIASES: dict[str, str] = {
+    # Canonical values (1:1)
+    "marketing": "marketing", "beratung": "beratung", "it": "it",
+    "finanzen": "finanzen", "handel": "handel", "bildung": "bildung",
+    "verwaltung": "verwaltung", "gesundheit": "gesundheit", "bau": "bau",
+    "medien": "medien", "industrie": "industrie", "logistik": "logistik",
+    "gastronomie": "gastronomie",
+    # Handwerk / Bau
+    "handwerk": "bau", "bauwesen": "bau", "schreinerei": "bau",
+    "tischlerei": "bau", "malerbetrieb": "bau", "elektrik": "bau",
+    "sanitär": "bau", "architektur": "bau", "ingenieurbüro": "bau",
+    "dachdecker": "bau", "zimmerer": "bau", "installateur": "bau",
+    # Marketing
+    "werbung": "marketing", "kommunikation": "marketing", "pr": "marketing",
+    "public relations": "marketing", "agentur": "marketing",
+    "werbeagentur": "marketing", "medienagentur": "marketing",
+    # Beratung
+    "consulting": "beratung", "unternehmensberatung": "beratung",
+    "managementberatung": "beratung", "steuerberatung": "beratung",
+    "coaching": "beratung", "dienstleistung": "beratung",
+    "dienstleistungen": "beratung",
+    # IT
+    "software": "it", "tech": "it", "informatik": "it",
+    "webentwicklung": "it", "saas": "it", "systemhaus": "it",
+    "webdesign": "it", "programmierung": "it", "softwareentwicklung": "it",
+    # Finanzen
+    "bank": "finanzen", "versicherung": "finanzen",
+    "finanzberatung": "finanzen", "wirtschaftsprüfung": "finanzen",
+    "vermögensverwaltung": "finanzen", "versicherungsmakler": "finanzen",
+    # Handel
+    "einzelhandel": "handel", "e-commerce": "handel",
+    "online-handel": "handel", "großhandel": "handel", "onlineshop": "handel",
+    # Bildung
+    "schule": "bildung", "universität": "bildung",
+    "weiterbildung": "bildung", "sprachschule": "bildung", "nachhilfe": "bildung",
+    # Verwaltung
+    "behörde": "verwaltung", "öffentlicher dienst": "verwaltung",
+    "kommune": "verwaltung", "verband": "verwaltung", "stiftung": "verwaltung",
+    # Gesundheit
+    "arztpraxis": "gesundheit", "klinik": "gesundheit",
+    "pflege": "gesundheit", "apotheke": "gesundheit",
+    "pflegedienst": "gesundheit", "therapie": "gesundheit",
+    # Medien
+    "verlag": "medien", "film": "medien", "fernsehen": "medien",
+    "journalismus": "medien", "designstudio": "medien",
+    "filmproduktion": "medien", "kreativwirtschaft": "medien",
+    # Industrie
+    "produktion": "industrie", "fertigung": "industrie",
+    "maschinenbau": "industrie", "automotive": "industrie",
+    "zulieferer": "industrie",
+    # Logistik
+    "spedition": "logistik", "transport": "logistik",
+    "lager": "logistik", "kurierdienst": "logistik", "lagerhaltung": "logistik",
+    # Gastronomie
+    "restaurant": "gastronomie", "hotel": "gastronomie",
+    "catering": "gastronomie", "café": "gastronomie",
+    "tourismus": "gastronomie", "hotellerie": "gastronomie",
+}
+
+
+# ===========================================================================
+# Company Size Aliases
+# ===========================================================================
+
+SIZE_ALIASES: dict[str, str] = {
+    "1": "1", "2–10": "2–10", "2-10": "2–10",
+    "11–100": "11–100", "11-100": "11–100",
+    # German free-text
+    "solo": "1", "allein": "1", "selbstständig": "1",
+    "freelancer": "1", "einzelunternehmer": "1", "freiberufler": "1",
+    "klein": "2–10", "kleines team": "2–10",
+    "mittelständisch": "11–100", "mittelstand": "11–100", "kmu": "11–100",
+}
+
+
+def _normalize_size_from_number(n: int) -> str:
+    if n == 1:
+        return "1"
+    if 2 <= n <= 10:
+        return "2–10"
+    # 11+ → cap at KMU maximum
+    return "11–100"
+
+
+# ===========================================================================
+# City → Bundesland Code Mapping
+# ===========================================================================
+
+CITY_TO_BUNDESLAND: dict[str, str] = {
+    # DE
+    "münchen": "by", "nürnberg": "by", "augsburg": "by", "regensburg": "by",
+    "würzburg": "by", "ingolstadt": "by",
+    "stuttgart": "bw", "karlsruhe": "bw", "freiburg": "bw",
+    "mannheim": "bw", "heidelberg": "bw", "ulm": "bw",
+    "berlin": "be",
+    "hamburg": "hh",
+    "bremen": "hb",
+    "frankfurt": "he", "wiesbaden": "he", "darmstadt": "he", "kassel": "he",
+    "köln": "nw", "düsseldorf": "nw", "dortmund": "nw", "essen": "nw",
+    "bonn": "nw", "münster": "nw", "bielefeld": "nw", "aachen": "nw",
+    "hannover": "ni", "braunschweig": "ni", "osnabrück": "ni",
+    "oldenburg": "ni", "göttingen": "ni",
+    "dresden": "sn", "leipzig": "sn", "chemnitz": "sn",
+    "kiel": "sh", "lübeck": "sh", "flensburg": "sh",
+    "mainz": "rp", "koblenz": "rp", "trier": "rp",
+    "saarbrücken": "sl",
+    "potsdam": "bb", "cottbus": "bb",
+    "schwerin": "mv", "rostock": "mv",
+    "erfurt": "th", "jena": "th", "weimar": "th",
+    "magdeburg": "st", "halle": "st",
+    # AT
+    "wien": "wi", "graz": "stm", "linz": "ooe", "salzburg": "sbg",
+    "innsbruck": "tir", "klagenfurt": "ktn", "bregenz": "vbg",
+    "st. pölten": "noe", "eisenstadt": "bgl",
+    # CH
+    "zürich": "zh", "bern": "be_ch", "basel": "bs", "genf": "ge",
+    "lausanne": "vd", "luzern": "lu", "st. gallen": "sg",
+    "winterthur": "zh", "lugano": "ti",
+    # GB
+    "london": "eng", "manchester": "eng", "birmingham": "eng",
+    "liverpool": "eng", "bristol": "eng", "leeds": "eng",
+    "edinburgh": "sco", "glasgow": "sco",
+    "cardiff": "wal", "swansea": "wal",
+    "belfast": "nir",
+}
+
+# Also map full Bundesland names → codes
+_BUNDESLAND_NAME_TO_CODE: dict[str, str] = {
+    v.lower(): k for k, v in BUNDESLAND_LABELS.items()
+}
+
+
+# ===========================================================================
+# Country Aliases (chat free-text → ISO code)
+# ===========================================================================
+
+COUNTRY_ALIASES: dict[str, str] = {
+    "deutschland": "DE", "germany": "DE", "de": "DE", "deutsch": "DE",
+    "österreich": "AT", "austria": "AT", "at": "AT",
+    "schweiz": "CH", "switzerland": "CH", "ch": "CH",
+    "uk": "GB", "england": "GB", "großbritannien": "GB",
+    "vereinigtes königreich": "GB", "united kingdom": "GB", "gb": "GB",
+    "frankreich": "FR", "france": "FR", "fr": "FR",
+    "italien": "IT", "italy": "IT", "it_country": "IT",
+    "spanien": "ES", "spain": "ES", "es": "ES",
+    "niederlande": "NL", "netherlands": "NL", "nl": "NL", "holland": "NL",
+    "belgien": "BE", "belgium": "BE",
+    "irland": "IE", "ireland": "IE",
+    "polen": "PL", "poland": "PL",
+    "schweden": "SE", "sweden": "SE",
+    "dänemark": "DK", "denmark": "DK",
+    "finnland": "FI", "finland": "FI",
+    "portugal": "PT",
+    "tschechien": "CZ", "czech republic": "CZ",
+    "griechenland": "GR", "greece": "GR",
+    "ungarn": "HU", "hungary": "HU",
+    "rumänien": "RO", "romania": "RO",
+    "norwegen": "NO", "norway": "NO",
+    "island": "IS", "iceland": "IS",
+    "liechtenstein": "LI",
+}
+
+
+# ===========================================================================
+# Normalizer Functions
+# ===========================================================================
+
+def normalize_field(field_name: str, raw_value: Any, collected: dict) -> NormResult:
+    """
+    Normalize a single extracted field value.
+
+    Returns NormResult with:
+    - confidence "high": value is correct, store immediately
+    - confidence "medium": plausible but ask for confirmation
+    - confidence "low": cannot determine, do NOT store
+    """
+    reg = FIELD_REGISTRY.get(field_name)
+    if not reg:
+        log.warning("[CHAT-NORM] Unknown field: %s", field_name)
+        return NormResult(None, "low", True)
+
+    # 1. Multi-fields: ensure list
+    if reg["type"] == "multi" and isinstance(raw_value, str):
+        raw_value = [raw_value]
+
+    # 2. Special normalizers
+    if field_name == "branche":
+        return _normalize_branche(raw_value)
+
+    if field_name == "unternehmensgroesse":
+        return _normalize_size(raw_value)
+
+    if field_name == "bundesland":
+        return _normalize_bundesland(raw_value, collected)
+
+    if field_name == "country":
+        return _normalize_country(raw_value)
+
+    if field_name == "selbststaendig":
+        return _normalize_selbststaendig(raw_value)
+
+    # 3. Generic enum check
+    if reg["type"] == "enum":
+        allowed = ENUM_VALUES.get(field_name, [])
+        val = str(raw_value).strip()
+        if val in allowed:
+            return NormResult(val, "high", False)
+        # Case-insensitive match
+        val_lower = val.lower()
+        for a in allowed:
+            if a.lower() == val_lower:
+                return NormResult(a, "high", False)
+        return NormResult(None, "low", True)
+
+    # 4. Free text
+    if reg["type"] == "text":
+        cleaned = str(raw_value).strip()
+        if len(cleaned) < 3:
+            return NormResult(None, "low", True)
+        return NormResult(cleaned, "high", False)
+
+    # 5. Bool
+    if reg["type"] == "bool":
+        return NormResult(bool(raw_value), "high", False)
+
+    # 6. Slider
+    if reg["type"] == "slider":
+        try:
+            val = int(raw_value)
+            mn = reg.get("min", 1)
+            mx = reg.get("max", 10)
+            val = max(mn, min(val, mx))
+            return NormResult(val, "high", False)
+        except (ValueError, TypeError):
+            return NormResult(None, "low", True)
+
+    # 7. Multi — validate each element
+    if reg["type"] == "multi":
+        if not isinstance(raw_value, list):
+            raw_value = [raw_value]
+        return NormResult(raw_value, "high", False)
+
+    return NormResult(raw_value, "medium", True)
+
+
+# ---------------------------------------------------------------------------
+# Specific normalizers
+# ---------------------------------------------------------------------------
+
+def _normalize_branche(raw: Any) -> NormResult:
+    key = str(raw).lower().strip()
+    # Direct alias match
+    if key in BRANCH_ALIASES:
+        return NormResult(BRANCH_ALIASES[key], "high", False)
+    # Partial match: check if alias is contained in input or vice versa
+    for alias, canonical in BRANCH_ALIASES.items():
+        if len(alias) >= 4 and (alias in key or key in alias):
+            return NormResult(canonical, "medium", True)
+    return NormResult(None, "low", True)
+
+
+def _normalize_size(raw: Any) -> NormResult:
+    key = str(raw).strip()
+    # Direct alias match
+    if key in SIZE_ALIASES:
+        return NormResult(SIZE_ALIASES[key], "high", False)
+    # Case-insensitive alias
+    key_lower = key.lower()
+    if key_lower in SIZE_ALIASES:
+        return NormResult(SIZE_ALIASES[key_lower], "high", False)
+    # Extract number
+    numbers = re.findall(r"\d+", str(raw))
+    if numbers:
+        return NormResult(_normalize_size_from_number(int(numbers[0])), "high", False)
+    return NormResult(None, "low", True)
+
+
+def _normalize_bundesland(raw: Any, collected: dict) -> NormResult:
+    val = str(raw).strip()
+    val_lower = val.lower()
+
+    # Direct code match
+    if val_lower in ALL_BUNDESLAND_CODES:
+        return NormResult(val_lower, "high", False)
+
+    # Full name → code
+    if val_lower in _BUNDESLAND_NAME_TO_CODE:
+        return NormResult(_BUNDESLAND_NAME_TO_CODE[val_lower], "high", False)
+
+    # City → code
+    if val_lower in CITY_TO_BUNDESLAND:
+        return NormResult(CITY_TO_BUNDESLAND[val_lower], "high", False)
+
+    # If country is known, validate against that country's codes
+    country = collected.get("country")
+    if country and country in BUNDESLAND_VALUES:
+        valid_codes = BUNDESLAND_VALUES[country]
+        if val_lower in valid_codes:
+            return NormResult(val_lower, "high", False)
+
+    return NormResult(None, "medium", True)
+
+
+def _normalize_country(raw: Any) -> NormResult:
+    val = str(raw).strip()
+    # Direct match (ISO code)
+    val_upper = val.upper()
+    all_countries = set(ENUM_VALUES.get("country", []))
+    if val_upper in all_countries:
+        return NormResult(val_upper, "high", False)
+    # Alias match
+    val_lower = val.lower()
+    if val_lower in COUNTRY_ALIASES:
+        return NormResult(COUNTRY_ALIASES[val_lower], "high", False)
+    return NormResult(None, "low", True)
+
+
+def _normalize_selbststaendig(raw: Any) -> NormResult:
+    val = str(raw).strip().lower()
+    allowed = ENUM_VALUES["selbststaendig"]
+    if val in allowed:
+        return NormResult(val, "high", False)
+    # Common aliases
+    aliases = {
+        "ja": "freiberufler", "yes": "freiberufler",
+        "freiberuflich": "freiberufler", "selbstständig": "freiberufler",
+        "freelancer": "freiberufler",
+        "gmbh": "kapitalgesellschaft", "ug": "kapitalgesellschaft",
+        "gewerbe": "einzelunternehmer",
+    }
+    if val in aliases:
+        return NormResult(aliases[val], "high", False)
+    return NormResult(None, "medium", True)
+
+
+# ===========================================================================
+# Helper: get missing / next fields
+# ===========================================================================
+
+def get_missing_fields(collected: dict, section_index: int) -> tuple[list[str], list[str]]:
+    """
+    Get missing required and optional fields for a given section.
+    Returns (missing_required, missing_optional).
+    Respects conditional logic.
+    """
+    section = SECTIONS[section_index]
+    missing_required = []
+    missing_optional = []
+
+    for field_name in section["fields"]:
+        if field_name in collected:
+            continue
+        if not is_field_visible(field_name, collected):
+            continue
+        reg = FIELD_REGISTRY.get(field_name)
+        if not reg:
+            continue
+        if reg["required"]:
+            missing_required.append(field_name)
+        else:
+            missing_optional.append(field_name)
+
+    return missing_required, missing_optional
+
+
+def get_next_fields(collected: dict, section_index: int, max_fields: int = 3) -> list[str]:
+    """Get the next fields to ask about (max 3 at a time)."""
+    missing_req, missing_opt = get_missing_fields(collected, section_index)
+    # Prioritize required fields
+    next_fields = missing_req[:max_fields]
+    remaining = max_fields - len(next_fields)
+    if remaining > 0:
+        next_fields.extend(missing_opt[:remaining])
+    return next_fields
+
+
+def is_section_complete(collected: dict, section_index: int) -> bool:
+    """Check if all required fields in a section are collected."""
+    missing_req, _ = get_missing_fields(collected, section_index)
+    return len(missing_req) == 0
+
+
+def calculate_progress(collected: dict) -> int:
+    """Calculate overall progress percentage (0-100)."""
+    total = 0
+    filled = 0
+    for field_name, reg in FIELD_REGISTRY.items():
+        if not reg["required"]:
+            continue
+        if not is_field_visible(field_name, collected):
+            continue
+        total += 1
+        if field_name in collected:
+            filled += 1
+    if total == 0:
+        return 0
+    return int(filled / total * 100)

--- a/services/chat_normalizer.py
+++ b/services/chat_normalizer.py
@@ -489,11 +489,11 @@ def normalize_field(field_name: str, raw_value: Any, collected: dict) -> NormRes
     # 6. Slider
     if reg["type"] == "slider":
         try:
-            val = int(raw_value)
-            mn = reg.get("min", 1)
-            mx = reg.get("max", 10)
-            val = max(mn, min(val, mx))
-            return NormResult(val, "high", False)
+            slider_val = int(raw_value)
+            mn = int(reg.get("min", 1))
+            mx = int(reg.get("max", 10))
+            slider_val = max(mn, min(slider_val, mx))
+            return NormResult(slider_val, "high", False)
         except (ValueError, TypeError):
             return NormResult(None, "low", True)
 
@@ -607,10 +607,11 @@ def get_missing_fields(collected: dict, section_index: int) -> tuple[list[str], 
     Respects conditional logic.
     """
     section = SECTIONS[section_index]
-    missing_required = []
-    missing_optional = []
+    missing_required: list[str] = []
+    missing_optional: list[str] = []
+    fields: list[str] = section["fields"]  # type: ignore[assignment]
 
-    for field_name in section["fields"]:
+    for field_name in fields:
         if field_name in collected:
             continue
         if not is_field_visible(field_name, collected):


### PR DESCRIPTION
## Summary
Implements the first phase of a conversational AI questionnaire system for the ki-sicherheit.jetzt platform. This PoC focuses on Section 0 ("Ihr Unternehmen") and establishes the foundational architecture for deterministic field normalization, LLM-based extraction, and conversational response generation.

## Key Changes

### Core Services
- **`services/chat_normalizer.py`** (660 lines): Deterministic field normalization engine
  - Field registry with 8 sections and 60+ fields (full structure defined, PoC uses Section 0)
  - Enum value mappings with aliases (e.g., branch names, company sizes, regions)
  - Conditional field logic (e.g., "bundesland" only shown if country is DE/AT/CH/GB)
  - City-to-Bundesland mapping for automatic region detection
  - Normalization functions that enforce confidence levels ("high"/"medium"/"low")
  - **Critical rule**: Fields with "low" confidence are NOT stored in collected_fields

- **`services/chat_extractor.py`** (203 lines): Phase 1 field extraction via Claude Haiku
  - Tool-use based extraction from user messages
  - Receives conversation context and missing fields
  - Returns raw extracted values (never writes to DB directly)
  - Respects "never invent values" principle

- **`services/chat_conversation.py`** (221 lines): Phase 2 response generation via Claude Sonnet
  - Streaming token generation for SSE delivery
  - Context-aware prompting with section state and field descriptions
  - Builds conversation messages with optional summary for long histories

### API Routes
- **`routes/chat.py`** (464 lines): Three main endpoints
  - `POST /api/chat/start`: Initialize new chat session with optional prefill
  - `POST /api/chat/message`: Process user message with SSE streaming response
    - Handles quick-reply shortcuts
    - Extracts fields via Haiku, normalizes via deterministic rules
    - Generates response via Sonnet with streaming
    - Evaluates conditionals and removes hidden fields
  - `GET /api/chat/session/{id}`: Resume session or fetch state

### Data Models & Schemas
- **`models.py`**: New `ChatSession` model
  - UUID primary key, JSONB fields for collected_fields and field_meta
  - Tracks consent, current section, status, message history
  - Timestamps for created/updated/last_activity/completed

- **`schemas/chat.py`** (139 lines): Pydantic schemas
  - `ChatSessionState`: Progress tracking, field counts, next steps
  - `ChatMessage`: Role, content, extracted fields, quick replies
  - `QuickReply`: Field options with labels and descriptions
  - Request/response models for all three endpoints

### Database
- **`migrations/2026-04-09_add_chat_sessions_postgres.sql`**: New chat_sessions table
- **`core/migrate.py`**: Integrated migration into startup sequence

### Integration
- **`main.py`**: Registered chat router at `/api/chat`
- **`schemas/__init__.py`**: Created (empty, for package structure)

## Notable Implementation Details

1. **Two-Phase Processing**: Extraction (Haiku) → Normalization (deterministic) → Conversation (Sonnet)
2. **Confidence-Based Storage**: Only "high" and "medium" confidence fields stored; "low" confidence fields logged but discarded
3. **Conditional Fields**: Dynamically shown/hidden based on collected values (e.g., "selbststaendig" only if company size is "1")
4. **Alias Resolution**: Free-text inputs (e.g., "Handwerk", "München") automatically mapped to canonical enum values
5. **SSE Streaming**: Response tokens streamed to frontend with state updates and quick replies
6. **Session Resumability**: Full conversation history and state persisted for session recovery
7. **PoC Scope**: Section 0 only (7 fields: branche, unternehmensgroesse, selbststaendig, country, bundesland,

https://claude.ai/code/session_01Er3mBQTHMKAWTJt5ctXiVr