### PR TITLE
Fix: no option lists in prompt, dynamic bundesland quick replies

### DIFF
--- a/routes/chat.py
+++ b/routes/chat.py
@@ -317,7 +317,7 @@ async def chat_message(req: ChatMessageRequest, db: Session = Depends(get_db)):
             return
 
         # Save assistant message
-        quick_replies = _build_quick_replies(next_fields, rt)
+        quick_replies = _build_quick_replies(next_fields, rt, collected)
         assistant_msg = {
             "role": "assistant",
             "content": full_response,
@@ -371,7 +371,7 @@ async def chat_session_get(session_id: UUID, db: Session = Depends(get_db)):
     rt = session.report_type
     state = _build_session_state(session)
     next_fields = get_next_fields(session.collected_fields, session.current_section, report_type=rt)
-    state.quick_replies = _build_quick_replies(next_fields, rt)
+    state.quick_replies = _build_quick_replies(next_fields, rt, session.collected_fields)
 
     # Last 10 messages
     all_msgs = session.messages or []
@@ -1020,9 +1020,14 @@ _QR_LABELS: dict[str, str] = {
 }
 
 
-def _build_quick_replies(next_fields: list[str], report_type: str = "r1") -> list[QuickReply]:
+def _build_quick_replies(
+    next_fields: list[str],
+    report_type: str = "r1",
+    collected_fields: dict | None = None,
+) -> list[QuickReply]:
     """Build quick reply buttons for the next enum fields."""
     registry = get_registry_for_report(report_type)
+    collected = collected_fields or {}
     replies = []
     for field_name in next_fields:
         reg = registry.get(field_name, {})
@@ -1030,7 +1035,12 @@ def _build_quick_replies(next_fields: list[str], report_type: str = "r1") -> lis
         if reg.get("chat_mode") not in ("QR", "qr"):
             continue
 
-        options_data = _QR_OPTIONS.get(field_name)
+        # Dynamic bundesland options based on collected country
+        if field_name == "bundesland":
+            options_data = _build_bundesland_options(collected.get("country", "DE"))
+        else:
+            options_data = _QR_OPTIONS.get(field_name)
+
         if not options_data:
             continue
 
@@ -1042,3 +1052,9 @@ def _build_quick_replies(next_fields: list[str], report_type: str = "r1") -> lis
         replies.append(QuickReply(field=field_name, label=label, options=options))
 
     return replies
+
+
+def _build_bundesland_options(country: str) -> list[dict]:
+    """Build bundesland/region QR options for the given country."""
+    codes = BUNDESLAND_VALUES.get(country, BUNDESLAND_VALUES.get("DE", []))
+    return [{"value": code, "label": BUNDESLAND_LABELS.get(code, code)} for code in codes]

--- a/services/chat_conversation.py
+++ b/services/chat_conversation.py
@@ -52,7 +52,11 @@ Erstellung eines individuellen KI-Reports verarbeitet werden.
 REGELN:
 1. Bestätigen Sie zuerst, was Sie verstanden haben.
 2. Stellen Sie dann maximal 2–3 thematisch zusammenhängende Fragen.
-3. Bei Auswahlfeldern nennen Sie die Optionen als nummerierte Liste.
+3. Für Auswahlfelder (Branche, Größe, Land, Bundesland, Umsatz etc.) \
+listen Sie NIEMALS alle Optionen als nummerierte Liste auf. \
+Der User sieht klickbare Buttons unter dem Chat. Fragen Sie \
+stattdessen kurz und direkt, z.B.: „In welchem Bundesland sind \
+Sie ansässig?" — OHNE die Optionen aufzuzählen.
 4. Bei Fachbegriffen geben Sie in 1–2 Sätzen eine verständliche \
 Erklärung mit einem konkreten Beispiel aus der Branche des Nutzers.
 5. Erfinden Sie keine Angaben.
@@ -276,6 +280,9 @@ in Ordnung — wählen Sie einfach die Option die am ehesten passt, oder \
 beschreiben Sie Ihre Situation in eigenen Worten."
 9. Fragen Sie NUR nach Feldern, die noch nicht erfasst sind. \
 Bereits erfasste Felder nicht erneut als Optionsliste anzeigen.
+10. Für Auswahlfelder listen Sie NIEMALS alle Optionen als \
+nummerierte Liste auf. Der User sieht klickbare Buttons unter \
+dem Chat. Fragen Sie kurz und direkt.
 
 AKTUELLER STAND:
 - Abschnitt: {section_name} (Schritt {section_number} von {total_sections})


### PR DESCRIPTION
Problem 1: AI listed all enum options as numbered lists (16 states, 6 revenue tiers) instead of relying on quick reply buttons. Fix: Replaced Rule 3 in R1 prompt from "list options as numbered list" to "NEVER enumerate options — the user sees clickable buttons." Added same rule (10) to strategy prompt.

Problem 2: Quick replies showed jahresumsatz buttons instead of bundesland because bundesland had no static entry in _QR_OPTIONS. Fix: _build_quick_replies now accepts collected_fields and dynamically builds bundesland options from the collected country (DE: 16 states, AT: 9, CH: 26 cantons, GB: 4 regions).

https://claude.ai/code/session_01Er3mBQTHMKAWTJt5ctXiVr