### PR TITLE
Fix: recompute next_fields for QR inside streaming callback

### DIFF
--- a/routes/chat.py
+++ b/routes/chat.py
@@ -316,8 +316,11 @@ async def chat_message(req: ChatMessageRequest, db: Session = Depends(get_db)):
             yield f"event: error\ndata: {json.dumps({'code': 'stream_error', 'message': error_msg})}\n\n"
             return
 
-        # Save assistant message
-        quick_replies = _build_quick_replies(next_fields, rt, collected)
+        # Save assistant message — recompute next fields from current state
+        # to ensure QR matches what was actually collected this turn
+        current_collected = dict(session.collected_fields or {})
+        updated_next = get_next_fields(current_collected, session.current_section, report_type=rt)
+        quick_replies = _build_quick_replies(updated_next, rt, current_collected)
         assistant_msg = {
             "role": "assistant",
             "content": full_response,


### PR DESCRIPTION
Quick replies in the SSE callback were using pre-computed next_fields from before streaming. Now recomputes from session.collected_fields at QR generation time to ensure buttons match the actual post-extraction state.

https://claude.ai/code/session_01Er3mBQTHMKAWTJt5ctXiVr