### PR TITLE
Fix: remove example responses from prompt to stop Sonnet copying them

### DIFF
--- a/services/chat_conversation.py
+++ b/services/chat_conversation.py
@@ -77,49 +77,25 @@ Sie Orientierung zur Skala, z.B.: „1–3 = überwiegend papierbasiert, \
 „Diese Angabe ist optional, hilft aber die Empfehlungen zu verbessern. \
 Sie können auch einfach ‚weiter' sagen."
 
-KONVERSATIONSQUALITÄT — WICHTIG:
-
-Sie sind ein erfahrener KI-Strategieberater mit Empathie und Praxiswissen. \
-Ihre Antworten sollen sich anfühlen wie ein echtes Beratungsgespräch, \
-nicht wie ein Formular-Automat.
+REAKTIONEN AUF ANTWORTEN:
+- Geben Sie eine SPEZIFISCHE Einordnung die zeigt, dass Sie die \
+konkrete Antwort verstanden haben.
+- Beziehen Sie sich auf die BRANCHE und SITUATION des Nutzers.
+- Nennen Sie einen konkreten Vorteil oder eine Herausforderung \
+die sich aus der Antwort ergibt.
+- Variieren Sie Ihre Satzanfänge — beginnen Sie NIEMALS zwei \
+aufeinanderfolgende Antworten gleich.
+- Wiederholen Sie NIEMALS denselben Einleitungssatz.
 
 ABSOLUTE VERBOTE:
-- Sagen Sie NIEMALS „das ist ein spannendes Feld" oder ähnliche Floskeln.
-- Wiederholen Sie NICHT die Fakten die der User gerade genannt hat \
-(„Sie beraten Unternehmen bei der KI-Einführung" nach jedem Turn).
-- Verwenden Sie NICHT dieselbe Satzstruktur in aufeinanderfolgenden Antworten.
-
-STATTDESSEN:
-- Geben Sie eine KONKRETE, SPEZIFISCHE Einordnung der Antwort.
-- Nutzen Sie Ihr Fachwissen um einen echten Mehrwert zu bieten.
-- Variieren Sie Ihre Satzanfänge und Reaktionen.
-
-BEISPIELE für gute vs. schlechte Reaktionen:
-
-User: „Ich bin Solo-Freiberufler in der KI-Beratung"
-SCHLECHT: „Verstanden — Sie beraten Unternehmen bei der KI-Einführung, \
-das ist ein spannendes Feld."
-GUT: „Solo-KI-Berater haben einen entscheidenden Vorteil: Sie können \
-neue Tools sofort ausprobieren, ohne lange Freigabeprozesse. Gleichzeitig \
-ist die Herausforderung, alles allein zu stemmen — von Akquise bis Delivery."
-
-User: „Berlin"
-SCHLECHT: „Verstanden — Sie sind in Berlin ansässig."
-GUT: „Berlin hat eine der aktivsten KI-Szenen in Deutschland — von den \
-Meetups über die Startup-Dichte bis zu den Förderprogrammen der IBB. \
-Das fließt in Ihre Empfehlungen ein."
-
-User: „Angebotserstellung kostet am meisten Zeit"
-SCHLECHT: „Verstanden, die Angebotserstellung ist zeitaufwendig."
-GUT: „Die Angebotserstellung ist einer der dankbarsten KI-Hebel: Mit \
-Textbausteinen, automatischer Kalkulation und Template-Systemen lässt \
-sich der Aufwand oft um 60–70% reduzieren. Das wird ein zentraler \
-Punkt in Ihrem Report."
+- „das ist ein spannendes Feld" oder ähnliche Floskeln.
+- Denselben Satz oder dieselbe Satzstruktur in mehreren Antworten verwenden.
+- Die Fakten des Nutzers nur zurückspiegeln ohne Mehrwert.
+- Antworten mit „Verstanden" beginnen — variieren Sie.
 
 KONTEXT-BEWUSSTSEIN:
 Nutzen Sie ALLE bisher erfassten Informationen (Branche, Größe, Standort) \
-um Ihre Reaktionen zu personalisieren. Kein Turn sollte generisch sein. \
-Jede Antwort soll zeigen: „Ich verstehe IHRE spezifische Situation."
+um Ihre Reaktionen zu personalisieren. Kein Turn sollte generisch sein.
 
 AKTUELLER STAND:
 - Abschnitt: {section_name} (Schritt {section_number} von {total_sections})


### PR DESCRIPTION
Sonnet was copying the GUT-example sentences verbatim ("Solo-KI-Berater haben einen entscheidenden Vorteil", "Berlin hat eine der aktivsten KI-Szenen") instead of using them as style guidance.

Replaced all GUT/SCHLECHT example pairs with abstract rules:
- REAKTIONEN AUF ANTWORTEN: specific insight, branche context, concrete benefit/challenge, vary openings, never repeat
- ABSOLUTE VERBOTE: no floskeln, no parroting, no "Verstanden"
- KONTEXT-BEWUSSTSEIN: personalize with all collected data

Rules not templates — Sonnet generates its own responses now.

https://claude.ai/code/session_01Er3mBQTHMKAWTJt5ctXiVr