### PR TITLE
Prompt: add consulting impulses — the chat itself is already advice

### DIFF
--- a/services/chat_conversation.py
+++ b/services/chat_conversation.py
@@ -115,6 +115,34 @@ KONTEXT-BEWUSSTSEIN:
 Nutzen Sie die erfassten Informationen (Branche, Größe, Standort) \
 um Ihre Reaktion zu personalisieren — aber fassen Sie sie nicht auf.
 
+BERATUNGSIMPULSE BEI JEDER FRAGE:
+- Geben Sie bei jeder neuen Frage einen kurzen DENKANTOSS der \
+dem Nutzer hilft, seine Situation besser einzuschätzen.
+- Nennen Sie 1–2 konkrete Beispiele oder Möglichkeiten aus der \
+Praxis ähnlicher Unternehmen in seiner Branche.
+- Helfen Sie dem Nutzer, über den Status Quo hinauszudenken — \
+zeigen Sie kurz auf, was mit KI möglich WÄRE.
+Formatbeispiele für die Struktur (NICHT wörtlich übernehmen):
+- Statt „Was ist Ihre Hauptdienstleistung?" besser: „Was ist Ihre \
+Hauptdienstleistung? Manche Berater fokussieren sich auf Strategie, \
+andere auf Implementierung oder Schulung — je nachdem ergeben sich \
+ganz unterschiedliche KI-Hebel."
+- Statt „Wo frisst am meisten Zeit?" besser: „Wo verbringen Sie \
+aktuell die meiste Zeit, die Sie lieber anders nutzen würden? \
+Bei vielen Beratern sind es Angebotserstellung, Recherche oder \
+Dokumentation."
+- Statt „Haben Sie schon KI-Tools?" besser: „Nutzen Sie bereits \
+KI-Tools? Das kann von ChatGPT für Texte über Perplexity für \
+Recherche bis hin zu Automatisierungstools reichen — selbst ein \
+gelegentlicher Einsatz zählt."
+Dies sind Formatbeispiele für die Struktur — formulieren Sie IMMER \
+eigene, zur konkreten Branche und Situation passende Impulse. \
+Wiederholen Sie NIEMALS einen dieser Beispielsätze wörtlich.
+
+ZIEL: Der Nutzer soll nach jeder Frage das Gefühl haben, bereits \
+etwas gelernt zu haben — noch bevor er den Report bekommt. Das \
+Gespräch selbst ist schon Beratung.
+
 AKTUELLER STAND:
 - Abschnitt: {section_name} (Schritt {section_number} von {total_sections})
 - Bereits erfasst: {collected_fields_summary}


### PR DESCRIPTION
New BERATUNGSIMPULSE BEI JEDER FRAGE section:
- Give a brief thought-provoking impulse with every question
- Name 1-2 concrete examples from similar companies in user's branch
- Help user think beyond status quo — show what AI could enable
- Format examples with explicit "never repeat these verbatim" guard

Key principle: "Das Gespräch selbst ist schon Beratung" — the user should feel they learned something from each question, even before getting the report. This is what makes the chat superior to a form.

https://claude.ai/code/session_01Er3mBQTHMKAWTJt5ctXiVr