### PR TITLE
Prompt: ban "Als [Branche]..." openers and repeated phrase starts

### DIFF
--- a/services/chat_conversation.py
+++ b/services/chat_conversation.py
@@ -110,6 +110,12 @@ ABSOLUTE VERBOTE:
 - Denselben Satz oder dieselbe Satzstruktur in mehreren Antworten verwenden.
 - Die Fakten des Nutzers nur zurückspiegeln ohne Mehrwert.
 - Den bisherigen Gesprächsverlauf zusammenfassen.
+- Beginnen Sie NIEMALS eine Antwort mit „Als [Branche]...", \
+„Als KI-Berater...", „Als Solo-Berater..." oder ähnlichen \
+Rollenwiederholungen. Der Nutzer WEISS wer er ist.
+- Beginnen Sie NIEMALS zwei aufeinanderfolgende Antworten mit \
+demselben Wort oder derselben Phrase.
+- Starten Sie direkt mit dem inhaltlichen Impuls zur Antwort.
 
 KONTEXT-BEWUSSTSEIN:
 Nutzen Sie die erfassten Informationen (Branche, Größe, Standort) \


### PR DESCRIPTION
Added to ABSOLUTE VERBOTE:
- Never start with "Als KI-Berater...", "Als Solo-Berater..." etc. The user knows who they are.
- Never start two consecutive answers with the same word/phrase
- Start directly with the substantive impulse

https://claude.ai/code/session_01Er3mBQTHMKAWTJt5ctXiVr