### PR TITLE
Add QR buttons for digitalisierungsgrad (1-10) to fix extraction

### DIFF
--- a/routes/chat.py
+++ b/routes/chat.py
@@ -878,6 +878,18 @@ _QR_OPTIONS: dict[str, list[dict]] = {
         {"value": "sonstige", "label": "Sonstige Datenquellen"},
     ],
     # --- Sektion 2 ---
+    "digitalisierungsgrad": [
+        {"value": "1", "label": "1 (kaum digital)"},
+        {"value": "2", "label": "2"},
+        {"value": "3", "label": "3"},
+        {"value": "4", "label": "4"},
+        {"value": "5", "label": "5 (halb-halb)"},
+        {"value": "6", "label": "6"},
+        {"value": "7", "label": "7"},
+        {"value": "8", "label": "8"},
+        {"value": "9", "label": "9"},
+        {"value": "10", "label": "10 (voll digital)"},
+    ],
     "prozesse_papierlos": [
         {"value": "0-20", "label": "0–20 %"},
         {"value": "21-50", "label": "21–50 %"},

--- a/services/chat_normalizer.py
+++ b/services/chat_normalizer.py
@@ -47,7 +47,7 @@ FIELD_REGISTRY: dict[str, dict] = {
     "interne_ki_kompetenzen": {"type": "enum", "required": False, "section": 1, "chat_mode": "QR"},
     "datenquellen":         {"type": "multi", "required": False, "section": 1, "chat_mode": "QR"},
     # --- Section 2: Digitalisierung & KI-Status ---
-    "digitalisierungsgrad": {"type": "slider", "required": True,  "section": 2, "chat_mode": "SC", "min": 1, "max": 10},
+    "digitalisierungsgrad": {"type": "slider", "required": True,  "section": 2, "chat_mode": "QR", "min": 1, "max": 10},
     "prozesse_papierlos":   {"type": "enum",  "required": False, "section": 2, "chat_mode": "QR"},
     "automatisierungsgrad": {"type": "enum",  "required": False, "section": 2, "chat_mode": "QR"},
     "ki_einsatz":           {"type": "multi", "required": False, "section": 2, "chat_mode": "QR"},


### PR DESCRIPTION
Haiku extractor couldn't map naked numbers ("8") to the slider field, causing repeated questions. Fix: digitalisierungsgrad changed from chat_mode SC (slider) to QR with 10 individual buttons (values "1"-"10"). Uses single integers for pipeline compatibility with the static form's slider output.

prozesse_papierlos and automatisierungsgrad already had QR options.

https://claude.ai/code/session_01Er3mBQTHMKAWTJt5ctXiVr