### PR TITLE
Add QR buttons for risikofreude (1-5) to fix extraction

### DIFF
--- a/routes/chat.py
+++ b/routes/chat.py
@@ -1096,6 +1096,13 @@ _QR_OPTIONS: dict[str, list[dict]] = {
         {"value": "nein", "label": "Nein"},
         {"value": "selten", "label": "Selten"},
     ],
+    "risikofreude": [
+        {"value": "1", "label": "1 (sehr vorsichtig)"},
+        {"value": "2", "label": "2"},
+        {"value": "3", "label": "3 (ausgewogen)"},
+        {"value": "4", "label": "4"},
+        {"value": "5", "label": "5 (experimentierfreudig)"},
+    ],
     # --- Strategy Fields ---
     "s1_budget": [
         {"value": "unter_2000", "label": "Unter 2.000 €"},

--- a/services/chat_normalizer.py
+++ b/services/chat_normalizer.py
@@ -90,7 +90,7 @@ FIELD_REGISTRY: dict[str, dict] = {
     "investitionsbudget":   {"type": "enum",  "required": True,  "section": 7, "chat_mode": "QR"},
     "marktposition":        {"type": "enum",  "required": False, "section": 7, "chat_mode": "QR"},
     "benchmark_wettbewerb": {"type": "enum",  "required": False, "section": 7, "chat_mode": "QR"},
-    "risikofreude":         {"type": "slider", "required": False, "section": 7, "chat_mode": "SC", "min": 1, "max": 5},
+    "risikofreude":         {"type": "slider", "required": False, "section": 7, "chat_mode": "QR", "min": 1, "max": 5},
 }
 
 


### PR DESCRIPTION
Same fix as digitalisierungsgrad: slider SC -> QR with individual buttons. 5 buttons matching formbuilder range (min=1, max=5). Labels on endpoints: "1 (sehr vorsichtig)", "3 (ausgewogen)", "5 (experimentierfreudig)".

All slider fields now use QR: digitalisierungsgrad (1-10), risikofreude (1-5). Field inventory 50/50 complete.

https://claude.ai/code/session_01Er3mBQTHMKAWTJt5ctXiVr