### PR TITLE
Add chat system status-quo analysis and draft-state implementation plan

### DIFF
--- a/chat-system-status-quo.md
+++ b/chat-system-status-quo.md
@@ -1,0 +1,269 @@
+# Chat-System Status Quo (Ist-Analyse)
+
+## 1) Session-State-Modell
+
+### Betroffene Dateien
+- `models.py` (`ChatSession` SQLAlchemy-Modell)
+- `migrations/2026-04-09_add_chat_sessions_postgres.sql` (Postgres DDL)
+- `schemas/chat.py` (`ChatSessionState`, API Request/Response-Schemas)
+- `routes/chat.py` (`_build_session_state`, Persistenz über Turns)
+
+### DB-Schema und State-Felder
+`chat_sessions` speichert den laufenden Chat-Zustand in relationalen Kernspalten + JSON-Spalten:
+- Kern: `id`, `report_type`, `lang`, `status`, `current_section`, Zeitstempel, `turn_count`
+- JSON-State: `collected_fields` (fachliche Antworten), `field_meta` (Confidence/Quelle), `messages` (Konversationshistorie)
+- Abschluss/Verknüpfung: `briefing_id`, `conversation_summary` (optional) [derzeit kaum genutzt].
+
+Wichtige Beobachtung: Es gibt **kein** separates Feld für `current_field`, `pending_value`, `pending_field`, `dialog_mode` oder ähnliches. Der aktive Fokus wird zur Laufzeit aus `get_next_fields(...)` berechnet, nicht persistiert.
+
+### Persistenz zwischen Requests
+1. `/chat/start` legt Session mit Initialwerten an (`collected_fields={}`, `field_meta={}`, `current_section=0`, `messages=[welcome]`).
+2. `/chat/message`:
+   - schreibt User-Message in `messages`
+   - extrahiert/normalisiert Werte
+   - schreibt Werte **direkt** in `session.collected_fields`
+   - aktualisiert `session.field_meta`
+   - berechnet ggf. Section-Transition
+   - streamt Antwort und hängt Assistant-Message an `messages`.
+
+### Typischer Session-State nach ~10 beantworteten Feldern (Beispiel)
+```json
+{
+  "session_id": "6f1f57f2-9e1d-4f28-9c8c-15f5d39fd331",
+  "report_type": "r1",
+  "status": "active",
+  "current_section": 2,
+  "current_section_name": "Digitalisierung & KI-Status",
+  "progress_percent": 47,
+  "collected_fields": {
+    "branche": "beratung",
+    "unternehmensgroesse": "2–10",
+    "country": "DE",
+    "bundesland": "be",
+    "hauptleistung": "KI-Strategieberatung für KMU mit Fokus auf Prozesse.",
+    "jahresumsatz": "100k_500k",
+    "zielgruppen": ["kmu", "b2b"],
+    "it_infrastruktur": "cloud",
+    "interne_ki_kompetenzen": "in_planung",
+    "datenquellen": ["kundendaten", "marketingdaten"]
+  },
+  "collected_count": 10,
+  "missing_required": ["digitalisierungsgrad"],
+  "missing_optional": ["prozesse_papierlos", "automatisierungsgrad", "ki_einsatz", "ki_kompetenz"],
+  "next_fields": ["digitalisierungsgrad"],
+  "is_completable": false
+}
+```
+
+### Implikationen für Draft-Pattern
+- Der Ist-Zustand kennt nur „gesammelt“ vs. „nicht gesammelt“.
+- Jede Extraktion wird sofort finalisiert (`collected_fields`), daher keine explizite User-Bestätigungsschicht.
+
+---
+
+## 2) Message-Flow (eine User-Nachricht)
+
+### Betroffene Dateien
+- `routes/chat.py` (`POST /chat/message`, SSE-`event_stream`)
+- `services/chat_extractor.py` (Haiku-Extraktion)
+- `services/chat_conversation.py` (Sonnet-Streaming)
+- `services/chat_normalizer.py` (Normalisierung/Progression)
+
+### Schritt-für-Schritt von `/api/chat/message` bis SSE
+1. Session laden + Statuscheck.
+2. User-Message in `session.messages` persistieren.
+3. Pfadentscheidung:
+   - **Quick-Reply-Pfad**: wenn `quick_reply_field` + `quick_reply_value` gesetzt.
+   - **Extractor-Pfad**: sonst `extract_fields(...)` via Haiku.
+4. Normalisierung via `normalize_field(...)`; bei `confidence != low` direkter Write in `collected_fields`.
+5. Optional-Skip-Heuristik (`weiter`, `skip`, ...), nur wenn nichts extrahiert wurde.
+6. Session speichern, conditionals bereinigen (`selbststaendig`, `bundesland` ggf. löschen).
+7. Section-Transition prüfen (`_check_section_transition`): nur wenn required+optional leer.
+8. Sonnet-Streaming starten (`generate_response(...)`) und `token`-Events senden.
+9. Nach Streaming: Quick-Replies neu berechnen, Assistant-Message speichern.
+10. SSE finalisieren: `state_update`, optional `quick_replies`, dann `done`.
+
+### Reihenfolge (Ist)
+**Extractor/QR-Norm → State-Update/DB-Commit → Conversation-LLM → QR-Generierung → SSE-Events**.
+
+### Aktuelle SSE-Event-Typen
+- `heartbeat`
+- `token`
+- `error`
+- `state_update`
+- `quick_replies`
+- `done`
+
+### Race-Conditions?
+- Es gibt keinen parallelen Async-Write zwischen Extractor und QR-Generierung; Ablauf ist sequentiell.
+- Potenzielles Risiko liegt eher in Session-Expiry nach Commit (im Code bewusst mitigiert durch `collected`-Closure + `collected_override`), nicht in echter Konkurrenz.
+
+### Implikationen für Draft-Pattern
+- Draft lässt sich sauber zwischen Schritt 4 und 7 einziehen (statt direkt final zu schreiben).
+- Neue SSE-Events können am Ende des Streams ergänzt werden (z. B. `draft_value`).
+
+---
+
+## 3) Extractor (Haiku)
+
+### Betroffene Dateien
+- `services/chat_extractor.py` (`EXTRACTOR_SYSTEM_PROMPT`, `extract_fields`)
+- Aufrufer: `routes/chat.py`
+
+### System-Prompt (Quelle)
+Vollständig in `EXTRACTOR_SYSTEM_PROMPT` in `services/chat_extractor.py`.
+Kernregeln:
+- nur genannte Felder setzen
+- nichts erfinden
+- Rückfragen → **kein** Tool-Call
+- Skip/„keine Ahnung“ auf optionalen Feldern als `keine_angabe` fürs aktuelle Feld
+- Fokus auf `current_field` + fehlende Felder + bereits erfasste Felder
+
+### Input in den Extractor
+`extract_fields(...)` bekommt:
+- `user_message`
+- `conversation_context` (letzte bis zu 6 Messages)
+- `missing_fields`
+- `collected_fields`
+- `current_field` + `current_field_description`
+- `report_type` (R1 vs Strategy Tool-Schema)
+
+### Output-Format
+- Erwartet Tool-Use `update_intake_fields` mit JSON-Objekt (Feldname → Rohwert).
+- Kein Tool-Call => `{}`.
+
+### Schreiben in `collected_fields`
+- Extractor schreibt **nicht** in DB.
+- `routes/chat.py` normalisiert Resultat und schreibt danach **sofort** in `collected_fields` (bei confidence high/medium).
+
+### Quick-Reply-Bypass
+- Bei explizitem Quick-Reply (`quick_reply_field/value`) wird Haiku übersprungen.
+- Wert wird direkt normalisiert und bei Erfolg in `collected_fields` persistiert (`confirmed=True` in `field_meta`).
+
+### Kritisch: Trennung „extrahiert“ vs „bestätigt“?
+- **Nein, nicht wirklich.**
+- Es gibt zwar `field_meta.confirmed`, aber für Freitext-Extraktion wird trotzdem sofort final gespeichert (nur Meta-Flag `confirmed=False`).
+- Es existiert **kein** Workflow, der vor Persistierung eine explizite Bestätigung fordert.
+
+### Implikationen für Draft-Pattern
+- Technische Anschlussstelle ist klar: Nach Extractor/Normalizer zunächst in `pending_value` statt `collected_fields`.
+- Zusätzlich braucht der Extractor einen Modus „confirm vs correction vs question“.
+
+---
+
+## 4) Conversation-LLM (Sonnet)
+
+### Betroffene Dateien
+- `services/chat_conversation.py` (`CONVERSATION_SYSTEM_PROMPT`, `STRATEGY_CONVERSATION_PROMPT`, `generate_response`)
+- Aufrufer: `routes/chat.py`
+
+### System-Prompt (Quelle)
+- R1: `CONVERSATION_SYSTEM_PROMPT`
+- Strategy: `STRATEGY_CONVERSATION_PROMPT`
+
+### Input für Sonnet
+`generate_response(...)` erhält:
+- `session_messages` (kompakt: letzte 6 + optional Stub)
+- `collected_fields`
+- `missing_fields`
+- `next_fields`
+- `section`
+- `report_type`
+
+Prompt enthält u. a.:
+- Abschnitt/Schritt
+- bereits erfasste Felder (als Summary-String)
+- fehlende Felder
+- „als nächstes erfragen“ inkl. Feldbeschreibungen + Pflicht/Optional
+
+### Entscheidungslogik „nächste Frage vs Kommentar“
+- Der Code entscheidet es nicht deterministisch; Sonnet bekommt Instruktionen („genau eine Frage“, „kurz reagieren, dann nächste Frage“).
+- Harte Logik „bleib im Feld bis bestätigt“ gibt es derzeit nicht.
+
+### Rückfragen-Erkennung
+- Prompt fordert Rückfragen zu beantworten.
+- Zusätzlich im Extractor: kein Tool-Call bei Rückfrage.
+- Aber es gibt keine persistente `dialog_mode`-State-Maschine, d. h. Verhalten bleibt promptgetrieben.
+
+### Historienlänge
+- `build_conversation_messages(...)`: effektiv letzte 6 Messages; bei mehr wird ein kurzer Stub vorangestellt.
+
+### Implikationen für Draft-Pattern
+- Sonnet-Prompt muss zustandsabhängig erweitert werden (Dialog-Modus / Draft-Bestätigung).
+- Aktuell fehlt struktureller Guardrail, der Fortschritt vor Confirm blockiert.
+
+---
+
+## 5) Quick-Reply-Generierung
+
+### Betroffene Dateien
+- `routes/chat.py` (`_build_quick_replies`, `_QR_OPTIONS`, `FREETEXT_SUGGESTIONS`)
+
+### Wann getriggert?
+- Nach Abschluss des Sonnet-Streams im SSE-Callback (`event_stream`), basierend auf neu berechneten `next_fields`.
+- Zusätzlich bei `/chat/start` (Welcome-QR) und `/chat/session/{id}` (Resume-State).
+
+### Woher kommen Optionen?
+- Statisch aus `_QR_OPTIONS` (feldspezifisch)
+- Sonderfall dynamisch: `bundesland` aus `country` via `_build_bundesland_options`
+- Freitextvorschläge aus `FREETEXT_SUGGESTIONS` für ausgewählte Textfelder
+
+### Verhalten bei Freitext trotz QR-Feld
+- User kann Freitext senden; dann läuft Extractor-Pfad.
+- Wenn normalisierbar, wird Wert wie üblich in `collected_fields` geschrieben.
+- QR ist also Hilfe, kein Zwang.
+
+### Implikationen für Draft-Pattern
+- QR-Single-Select kann weiter direkt final sein.
+- Für FT/MS sollte QR-Ausgabe ggf. unterdrückt/angepasst werden, solange `pending_value` offen ist.
+
+---
+
+## 6) Field-Progression
+
+### Betroffene Dateien
+- `services/chat_normalizer.py` (`get_missing_fields`, `get_next_fields`, `is_section_complete`, `is_field_visible`)
+- `routes/chat.py` (`_check_section_transition`)
+
+### Logik der nächsten Felder
+- `get_missing_fields`: pro Abschnitt fehlende required/optional, inklusive Conditional-Logik.
+- `get_next_fields`: zuerst required, dann optional (Standard `max_fields=1`).
+
+### Pflicht vs. Optional
+- Unterscheidung aus Registry-Feld `required`.
+- `skip_in_chat` blendet Felder im Chatfluss aus (z. B. `datenschutz`).
+
+### Section-Transition
+- `_check_section_transition(...)` wechselt Abschnitt erst, wenn **required und optional** leer sind.
+- Dadurch bleiben optionale Felder Teil des Flows (außer Nutzer skippt sie).
+
+### Wenn Extractor nichts extrahiert
+- Feld bleibt offen.
+- Optional kann über Skip-Wörter übersprungen werden (Sentinel `""` oder `None`).
+- Sonnet antwortet dennoch weiter; keine harte Retry-/Clarification-State-Maschine.
+
+### Implikationen für Draft-Pattern
+- Progression muss um „pending blockiert next field“ erweitert werden.
+- Section-Transition darf erst nach Confirm offener Drafts passieren.
+
+---
+
+## 7) Frontend-Chat-Widget (Überblick)
+
+### Befund in diesem Backend-Repo
+- Es gibt hier keinen konkreten Chat-Widget-Clientcode (kein EventSource-Handling, keine Button-Komponenten im gefundenen Codebestand).
+- Vorhanden sind nur Backend-Schemas/Events und serverseitige QR-Datenstruktur.
+
+### Ableitbarer Vertragsstatus (Backend-seitig)
+- SSE liefert `token`, `state_update`, `quick_replies`, `done`, `error`, `heartbeat`.
+- Quick-Replies enthalten:
+  - `field`, `label`, `options[]`
+  - `multi_select`, `max_select`
+- Daraus folgt: Frontend muss Multi-Select + Confirm bereits clientseitig lösen, aber Implementierungsdetails liegen nicht in diesem Repository.
+
+### Bestätigungs-UI vorhanden?
+- In diesem Repo: **nein** (kein Draft-/Confirm-Event, kein dediziertes API-Pattern).
+
+### Implikationen für Draft-Pattern
+- API-Vertrag muss erweitert werden (neue Events und/oder Endpoint).
+- Frontend-Umsetzung ist extern abzustimmen, da Quellcode im vorliegenden Repo nicht enthalten ist.

--- a/draft-pattern-implementation-plan.md
+++ b/draft-pattern-implementation-plan.md
@@ -1,0 +1,252 @@
+# Implementierungsplan: Draft-State + Bestätigungs-Pattern
+
+> Ziel: Extrahierte Werte werden nicht mehr sofort final in `collected_fields` geschrieben, sondern zuerst als Draft geführt und explizit bestätigt.
+
+## A) Neuer Session-State
+
+### Betroffene Dateien
+- `models.py` (`ChatSession`)
+- `migrations/*` (neue Migration, falls eigene Spalten)
+- `schemas/chat.py` (`ChatSessionState` + ggf. neue Request-Schemas)
+- `routes/chat.py` (`_build_session_state`)
+
+### Konkrete Änderungen
+1. Neue State-Felder:
+   - `pending_field: str | null`
+   - `pending_value: any | null`
+   - `dialog_mode: bool`
+2. **Empfehlung Speicherung:** zunächst in bestehendem JSON-State (`field_meta` oder neues JSON-Feld `runtime_state`) statt sofort neue DB-Spalten.
+   - Vorteil: schnell, rückwärtskompatibel, einfache Migration.
+   - Später bei Bedarf in dedizierte Spalten überführbar.
+3. `ChatSessionState` API um diese drei Felder erweitern.
+
+### Aufwand
+- **klein–mittel**
+
+### Abhängigkeiten
+- Basis für alle weiteren Schritte (B–H).
+
+### Risiken
+- JSON-State kann uneinheitlich werden, wenn nicht zentral validiert.
+- Alte Sessions enthalten die Felder nicht (muss default-sicher behandelt werden).
+
+---
+
+## B) Neuer Message-Flow
+
+### Betroffene Dateien
+- `routes/chat.py` (Hauptlogik `/chat/message`, SSE)
+- `services/chat_extractor.py` (Signalerkennung)
+- `services/chat_conversation.py` (zustandsabhängige Antwortführung)
+
+### Konkrete Änderungen
+1. **Rückfrage-Erkennung vor Extraktion**
+   - Heuristik +/oder Extractor-Signal: `is_question`.
+   - Bei Frage: kein Wert-Write, `dialog_mode=true`, current field bleibt.
+2. **Extraktion → Draft statt Final**
+   - Wenn inhaltliche Antwort: normalize, dann `pending_field/pending_value` setzen.
+   - `collected_fields` unverändert bis Confirm.
+   - SSE: `draft_value` senden.
+3. **Conversation-Verhalten**
+   - Bei offenem Draft: Sonnet soll nur bestätigen/korrigieren lassen, keine Progression.
+4. **Confirm-Pfad**
+   - Bei Confirm: pending → collected, pending leeren, `dialog_mode=false`, next field aktivieren.
+
+### Aufwand
+- **mittel–groß**
+
+### Abhängigkeiten
+- A zuerst; D/E parallel vorbereitbar.
+
+### Risiken
+- Edge Cases bei „Ja, aber ...“-Antworten.
+- Doppel-Events oder inkonsistenter State bei SSE-Abbruch.
+
+---
+
+## C) Quick-Reply-Felder: Ausnahme oder auch Draft?
+
+### Betroffene Dateien
+- `services/chat_normalizer.py` (Feldtyp/Chat-Mode)
+- `routes/chat.py` (`quick_reply_field`-Pfad, `_build_quick_replies`)
+
+### Konkrete Änderungen (empfohlen)
+- `QR` Single-Select: **kein Draft**, direkt final (explizite User-Aktion ist Bestätigung).
+- `MS` Multi-Select: **Draft optional**, abhängig vom UI:
+  - Wenn UI bereits „Auswahl bestätigen“ hat, kann final direkt beim Confirm-Click passieren.
+  - Falls Auswahl in Freitext/semantisch extrahiert wird, dann Draft anwenden.
+- `FT/SC` Freitext: **immer Draft**.
+
+### Aufwand
+- **mittel**
+
+### Abhängigkeiten
+- A/B und G (Frontend-Confirm-UX) abgestimmt.
+
+### Risiken
+- Inkonsistentes UX, wenn gleiche Feldart je nach Inputkanal anders behandelt wird.
+
+---
+
+## D) Conversation-Prompt-Änderungen
+
+### Betroffene Dateien
+- `services/chat_conversation.py` (`CONVERSATION_SYSTEM_PROMPT`, `STRATEGY_CONVERSATION_PROMPT`, `generate_response`)
+
+### Konkrete Änderungen
+1. Neuer Prompt-Block **DIALOG-MODUS**:
+   - Wenn `dialog_mode=true` und kein `pending_value`: Rückfrage beantworten, nicht vorwärts springen.
+2. Neuer Prompt-Block **DRAFT-BESTÄTIGUNG**:
+   - Wenn `pending_value` gesetzt: kurze Zusammenfassung + konkrete Confirm-Frage.
+3. Schärfere **FOKUS-REGEL**:
+   - Kein Feldwechsel ohne Confirm des aktuellen Drafts.
+4. Zustandsparameter in System-Prompt aufnehmen:
+   - `pending_field`, `pending_value`, `dialog_mode`.
+
+### Aufwand
+- **mittel**
+
+### Abhängigkeiten
+- A/B umgesetzt.
+
+### Risiken
+- Prompt-only Enforcement kann gelegentlich verletzt werden → serverseitige Guardrails nötig.
+
+---
+
+## E) Extractor-Änderungen
+
+### Betroffene Dateien
+- `services/chat_extractor.py`
+- ggf. `schemas/chat.py` (wenn strukturierter Extractor-Output typisiert werden soll)
+
+### Konkrete Änderungen
+Extractor-Output von reinem Feld-Dict auf signalfähiges Format erweitern, z. B.:
+```json
+{
+  "mode": "extract" | "confirm" | "question" | "none",
+  "fields": {"hauptleistung": "..."}
+}
+```
+1. **Confirm-Erkennung** bei offenem Pending (`ja`, `stimmt`, `passt`, `weiter`).
+2. **Rückfrage-Erkennung** (`?`, „was meinst du“, „warum“, ...).
+3. **Bestehende Extraktion** unverändert weiter nutzbar.
+
+### Aufwand
+- **mittel**
+
+### Abhängigkeiten
+- A/B; D für harmonisierte Interpretation.
+
+### Risiken
+- False Positives bei Confirm-Wörtern in anderen Kontexten.
+
+---
+
+## F) Neue SSE-Event-Typen
+
+### Betroffene Dateien
+- `routes/chat.py` (`event_stream`)
+- `schemas/chat.py` (optional Event-DTOs)
+- Frontend-Client (extern)
+
+### Konkrete Änderungen
+Neue Events:
+- `draft_value`: `{ field, value, label }`
+- `field_confirmed`: `{ field, value }`
+- `dialog_mode`: `{ active: true|false }`
+
+Erweiterte Reihenfolge (Soll):
+1. optional `dialog_mode`
+2. optional `draft_value`
+3. `token`-Stream
+4. optional `field_confirmed`
+5. `state_update`
+6. optional `quick_replies`
+7. `done`
+
+### Aufwand
+- **klein–mittel**
+
+### Abhängigkeiten
+- B und G.
+
+### Risiken
+- Event-Reihenfolge muss strikt dokumentiert werden, sonst Frontend-Rennen.
+
+---
+
+## G) Frontend-Änderungen (Überblick)
+
+### Betroffene Dateien
+- Frontend-Repo (in diesem Backend-Repo nicht vorhanden)
+
+### Konkrete Änderungen (UI-Vertrag)
+1. **Draft-Chip** unterhalb Chatverlauf mit Feldlabel + Wert.
+2. Buttons am Chip:
+   - `✓ Übernehmen` (confirm)
+   - `✏️ Ändern` (zurück in Eingabe/Rewrite)
+3. **Visual Feedback** nach Confirm (`field_confirmed`).
+4. **Dialog-Modus UI**:
+   - bei `dialog_mode.active=true` QR-Buttons ausblenden oder deaktivieren.
+5. Multi-Select:
+   - bestehendes „Auswahl bestätigen“ als Confirm-Hook verwenden.
+
+### Aufwand
+- **mittel** (abhängig von bestehender Widget-Architektur)
+
+### Abhängigkeiten
+- F (Event-Vertrag) + B/C (Flow-Entscheidung).
+
+### Risiken
+- Ohne saubere State-Machine im Client drohen inkonsistente Chips/Buttons.
+
+---
+
+## H) Migrationsstrategie
+
+### Betroffene Dateien
+- `routes/chat.py`
+- `schemas/chat.py`
+- `models.py` + ggf. neue Migration
+- Config/Env-Layer (Feature-Flag)
+
+### Konkrete Änderungen
+1. Feature-Flag einführen: `DRAFT_MODE_ENABLED=true|false`.
+2. Backward Compatibility:
+   - Fehlende Pending-Felder defaulten auf `null/false`.
+   - Alte Sessions laufen weiter im alten Verhalten, solange Flag aus.
+3. Rollout:
+   - Staging mit Flag an
+   - schrittweise Aktivierung in Produktion
+4. Rollback:
+   - Flag aus => alter Sofort-Write-Pfad aktiv.
+
+### Aufwand
+- **klein–mittel**
+
+### Abhängigkeiten
+- A/B/F zuerst, dann schrittweise D/E/G.
+
+### Risiken
+- Gemischte Sessions (alt/neu) brauchen robuste Default-Initialisierung.
+
+---
+
+## Entscheidung Confirm-Mechanismus (B.4)
+
+### Optionen
+- **A: Neuer Endpoint `POST /api/chat/confirm`**
+- B: Nur QR-Buttons „Übernehmen/Ändern“ als SSE-Signal
+- C: Freitext-Confirm („ja/stimmt/passt“) via Heuristik/Extractor
+
+### Empfehlung
+**Option A als Primärpfad**, ergänzt um C als Komfort-Fallback.
+
+**Begründung:**
+- Sauberste Trennung von „inhaltlicher Antwort“ vs. „State-Transition confirm“.
+- Bessere Wartbarkeit/Testbarkeit (idempotente Confirm-Operation).
+- Reduziert Ambiguität bei natürlicher Sprache.
+- Frontend kann weiterhin Buttons nutzen, aber technisch robust via explizitem Endpoint.
+
+B und C bleiben sinnvoll als UX-Schicht, sollten serverseitig auf denselben Confirm-Servicepfad gemappt werden.


### PR DESCRIPTION
### Motivation
- Provide a complete, actionable analysis of the current conversational chat system to make the existing state and gaps explicit for engineering work. 
- Define a concrete, low-risk implementation plan to introduce a draft/confirm pattern so extracted freetext values are reviewable before being persisted. 
- Align backend behaviour, prompts, extractor signals and SSE contract with frontend UX requirements and a safe rollout strategy.

### Description
- Added `chat-system-status-quo.md` which documents the current architecture across seven areas: session-state model (`ChatSession`, `collected_fields`, `field_meta`, `messages`), the full message flow (`/api/chat/message` → extractor → normalizer → conversation LLM → SSE), extractor (`services/chat_extractor.py`) behaviour and system prompt, conversation LLM (`services/chat_conversation.py`) prompt and context rules, quick-reply generation (`_build_quick_replies`), field progression (`services/chat_normalizer.py`) and frontend contract implications. 
- Added `draft-pattern-implementation-plan.md` containing a detailed A–H implementation plan that prescribes new runtime state (`pending_field`, `pending_value`, `dialog_mode`), modified message flow (question detection, extract→draft→confirm lifecycle), extractor output signals, conversation-prompt changes, new SSE events (`draft_value`, `field_confirmed`, `dialog_mode`), frontend UI expectations (draft chip + confirm/edit), and a feature-flagged migration/rollback strategy; it also recommends an explicit `POST /api/chat/confirm` as the primary confirm mechanism. 
- Both files are documentation-only and describe concrete code locations and minimal change sets required for implementation (files and functions cited for each change). 

### Testing
- No automated tests were executed for these documentation-only changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db5b310f808330b67ed38ade34b75f)