### PR TITLE
Sprint 1: Draft-Pattern Infrastructure for Field Confirmation

### DIFF
--- a/migrations/2026-04-12_add_draft_state_to_chat_sessions.sql
+++ b/migrations/2026-04-12_add_draft_state_to_chat_sessions.sql
@@ -1,0 +1,5 @@
+-- Sprint 1: Draft-Pattern Infrastructure
+-- Adds draft_state JSONB column to chat_sessions for pending field tracking.
+-- Default empty object — backward compatible, no impact on existing sessions.
+
+ALTER TABLE chat_sessions ADD COLUMN IF NOT EXISTS draft_state JSONB DEFAULT '{}'::jsonb;

--- a/models.py
+++ b/models.py
@@ -496,6 +496,9 @@ class ChatSession(Base):
     )
     completed_at: Mapped[Optional[datetime]] = mapped_column(DateTime(timezone=True), nullable=True)
 
+    # Draft-Pattern State (Sprint 1: infra only, never written yet)
+    draft_state: Mapped[dict] = mapped_column(JSONType, default=dict, nullable=False)
+
     # Conversation
     messages: Mapped[list] = mapped_column(JSONType, default=list, nullable=False)
     turn_count: Mapped[int] = mapped_column(Integer, default=0, nullable=False)

--- a/routes/chat.py
+++ b/routes/chat.py
@@ -632,6 +632,28 @@ async def chat_complete(
 
 
 # ===========================================================================
+# SSE Event Helpers — Draft-Pattern (Sprint 1: defined, not yet called)
+# ===========================================================================
+
+def _sse_draft_value(field: str, value, label: str) -> str:
+    """SSE event: draft value extracted, awaiting user confirmation."""
+    data = json.dumps({"field": field, "value": value, "label": label})
+    return f"event: draft_value\ndata: {data}\n\n"
+
+
+def _sse_field_confirmed(field: str, value) -> str:
+    """SSE event: draft confirmed, value written to collected_fields."""
+    data = json.dumps({"field": field, "value": value})
+    return f"event: field_confirmed\ndata: {data}\n\n"
+
+
+def _sse_dialog_mode(active: bool) -> str:
+    """SSE event: dialog mode toggled (follow-up question vs. progression)."""
+    data = json.dumps({"active": active})
+    return f"event: dialog_mode\ndata: {data}\n\n"
+
+
+# ===========================================================================
 # Helpers
 # ===========================================================================
 

--- a/routes/chat.py
+++ b/routes/chat.py
@@ -447,7 +447,9 @@ async def chat_message(req: ChatMessageRequest, db: Session = Depends(get_db)):
 
         state = _build_session_state(session, collected_override=collected)
         state.quick_replies = quick_replies
-        yield f"event: state_update\ndata: {state.model_dump_json()}\n\n"
+        # Draft fields only included when DRAFT_MODE_ENABLED — otherwise identical to pre-draft output
+        _draft_exclude = None if DRAFT_MODE_ENABLED else {"pending_field", "pending_value", "dialog_mode"}
+        yield f"event: state_update\ndata: {state.model_dump_json(exclude=_draft_exclude)}\n\n"
 
         if quick_replies:
             qr_data = [qr.model_dump() for qr in quick_replies]

--- a/routes/chat.py
+++ b/routes/chat.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import os
 from datetime import datetime, timezone
 from uuid import UUID
 
@@ -57,6 +58,9 @@ from services.chat_normalizer import (
 
 router = APIRouter(prefix="/chat", tags=["chat"])
 log = logging.getLogger(__name__)
+
+# Feature flag: Draft-Pattern (Sprint 1 infra — default off)
+DRAFT_MODE_ENABLED = os.getenv("DRAFT_MODE_ENABLED", "false").lower() == "true"
 
 R1_WELCOME = (
     "Willkommen bei ki-sicherheit.jetzt! Ich bin ein KI-Assistent und "

--- a/routes/chat.py
+++ b/routes/chat.py
@@ -861,6 +861,9 @@ def _build_session_state(
     summary_sent = _has_summary_been_sent(session)
     completable = last_section and all_done and summary_sent
 
+    # Draft-Pattern state (backward-compatible: old sessions without column → {})
+    draft = getattr(session, 'draft_state', None) or {}
+
     return ChatSessionState(
         session_id=session.id,
         report_type=session.report_type,
@@ -876,6 +879,9 @@ def _build_session_state(
         total_fields=total,
         next_fields=next_fields,
         is_completable=completable,
+        pending_field=draft.get("pending_field"),
+        pending_value=draft.get("pending_value"),
+        dialog_mode=draft.get("dialog_mode", False),
     )
 
 

--- a/routes/chat.py
+++ b/routes/chat.py
@@ -33,6 +33,7 @@ from schemas.chat import (
     ChatSessionSummary,
     ChatStartRequest,
     ChatStartResponse,
+    ConfirmFieldRequest,
     QuickReply,
     QuickReplyOption,
 )
@@ -463,6 +464,19 @@ async def chat_message(req: ChatMessageRequest, db: Session = Depends(get_db)):
             "X-Accel-Buffering": "no",
         },
     )
+
+
+# ===========================================================================
+# POST /api/chat/confirm  (Draft-Pattern — Sprint 1 skeleton only)
+# ===========================================================================
+
+@router.post("/confirm")
+async def confirm_field(req: ConfirmFieldRequest, db: Session = Depends(get_db)):
+    """Confirm a draft value and write it to collected_fields (Sprint 2)."""
+    if not DRAFT_MODE_ENABLED:
+        raise HTTPException(status_code=404, detail="Draft mode not enabled")
+    # TODO Sprint 2: Implement confirm/edit logic
+    raise HTTPException(status_code=501, detail="Not yet implemented")
 
 
 # ===========================================================================

--- a/schemas/chat.py
+++ b/schemas/chat.py
@@ -117,6 +117,17 @@ class ChatSessionResponse(BaseModel):
 
 
 # ---------------------------------------------------------------------------
+# POST /api/chat/confirm  (Draft-Pattern — Sprint 2 logic, Sprint 1 skeleton)
+# ---------------------------------------------------------------------------
+
+class ConfirmFieldRequest(BaseModel):
+    session_id: UUID
+    field: str
+    value: Optional[Any] = None  # Optional: user can send corrected value
+    action: str = "confirm"  # "confirm" or "edit"
+
+
+# ---------------------------------------------------------------------------
 # POST /api/chat/complete  (not in PoC)
 # ---------------------------------------------------------------------------
 

--- a/schemas/chat.py
+++ b/schemas/chat.py
@@ -67,6 +67,11 @@ class ChatSessionState(BaseModel):
     next_fields: list[str]
     is_completable: bool
 
+    # Draft-Pattern (Sprint 1: always null/false until Sprint 2 activates writes)
+    pending_field: Optional[str] = None
+    pending_value: Optional[Any] = None
+    dialog_mode: bool = False
+
     # Quick Replies
     quick_replies: Optional[list[QuickReply]] = None
 


### PR DESCRIPTION
## Summary
This PR introduces the foundational infrastructure for the Draft-Pattern feature, enabling a two-step confirmation workflow for chat field collection. The implementation is feature-flagged and backward-compatible, with actual confirmation logic deferred to Sprint 2.

## Key Changes

- **Feature Flag**: Added `DRAFT_MODE_ENABLED` environment variable to control Draft-Pattern activation (defaults to `false`)

- **Database Schema**: 
  - Added `draft_state` JSONB column to `chat_sessions` table with default empty object
  - Migration file ensures backward compatibility with existing sessions

- **Data Model Updates**:
  - Extended `ChatSessionState` schema with three new optional fields: `pending_field`, `pending_value`, and `dialog_mode`
  - Added `ConfirmFieldRequest` schema for the confirmation endpoint

- **API Endpoint**:
  - Implemented skeleton `POST /api/chat/confirm` endpoint that returns 501 (Not Implemented) when draft mode is enabled
  - Endpoint returns 404 when draft mode is disabled

- **State Management**:
  - Modified `_build_session_state()` to extract and include draft state from sessions
  - Conditionally excludes draft fields from SSE state_update events when `DRAFT_MODE_ENABLED` is false

- **SSE Event Helpers**:
  - Added three helper functions for future draft-related events: `_sse_draft_value()`, `_sse_field_confirmed()`, and `_sse_dialog_mode()`
  - These are defined but not yet called (Sprint 2 integration point)

## Implementation Details

- All draft-related fields are optional and default to null/false, ensuring zero impact on existing sessions
- The `draft_state` column uses `getattr()` with fallback to maintain compatibility with sessions created before this migration
- SSE output is dynamically filtered based on feature flag status, maintaining identical pre-draft behavior when disabled
- The confirm endpoint is guarded by the feature flag and returns appropriate HTTP status codes for both disabled and unimplemented states

https://claude.ai/code/session_01KzkRafGMjWUVnVfH1RXraN