### PR TITLE
fix: add explicit prohibition against asking for company name

### DIFF
--- a/services/chat_conversation.py
+++ b/services/chat_conversation.py
@@ -106,6 +106,10 @@ Dies sind Formatbeispiele — formulieren Sie IMMER eigene, zur \
 konkreten Antwort passende Reaktionen.
 
 ABSOLUTE VERBOTE:
+- Fragen Sie NIEMALS nach dem Namen des Unternehmens, der Firma \
+oder des Geschäfts. Der Firmenname wird aus Datenschutzgründen \
+nicht erhoben. Sie kennen: Branche, Größe, Standort und \
+Hauptleistung — das reicht für die Analyse.
 - „das ist ein spannendes Feld" oder ähnliche Floskeln.
 - Denselben Satz oder dieselbe Satzstruktur in mehreren Antworten verwenden.
 - Die Fakten des Nutzers nur zurückspiegeln ohne Mehrwert.
@@ -356,10 +360,13 @@ verständlich und geben branchenspezifische Beispiele.
 REGELN:
 1. Siezen Sie durchgehend.
 2. Erfinden Sie keine Angaben.
-3. Wenn der User unsicher ist: „Falls Sie sich nicht sicher sind, ist das \
+3. Fragen Sie NIEMALS nach dem Namen des Unternehmens, der Firma \
+oder des Geschäfts. Der Firmenname wird aus Datenschutzgründen \
+nicht erhoben.
+4. Wenn der User unsicher ist: „Falls Sie sich nicht sicher sind, ist das \
 völlig in Ordnung — wählen Sie einfach die Option die am ehesten passt, \
 oder beschreiben Sie Ihre Situation in eigenen Worten."
-4. Erklären Sie proaktiv:
+5. Erklären Sie proaktiv:
    - Bei S3 (Prioritäten): Was bedeutet „Compliance sichern" konkret?
    - Bei S9 (Infrastruktur): Cloud vs. On-Premise verständlich erklären
    - Bei Moat-Feldern: Warum Wettbewerber-Analyse relevant ist


### PR DESCRIPTION
Privacy/data protection fix: Sonnet conversation prompts now explicitly forbid asking for the company name (Firmenname).

Audit result: No company name field exists in Field-Registry, Extractor tool schema, QR-Options, or Schemas. But prompts lacked an explicit prohibition, so Sonnet could spontaneously ask for it. Fixed in both R1 and Strategy conversation prompts.

https://claude.ai/code/session_01KzkRafGMjWUVnVfH1RXraN