### PR TITLE
Add draft_state column to chat_sessions table

### DIFF
--- a/core/migrate.py
+++ b/core/migrate.py
@@ -153,8 +153,11 @@ DDL = [
         completed_at TIMESTAMPTZ,
         messages JSONB DEFAULT '[]'::jsonb,
         turn_count INTEGER DEFAULT 0,
-        conversation_summary TEXT
+        conversation_summary TEXT,
+        draft_state JSONB DEFAULT '{}'::jsonb
     )"""),
+    # FIX: draft_state column was missing — existing tables need ALTER TABLE
+    text("ALTER TABLE chat_sessions ADD COLUMN IF NOT EXISTS draft_state JSONB DEFAULT '{}'::jsonb"),
     text("CREATE INDEX IF NOT EXISTS idx_chat_sessions_status ON chat_sessions(status)"),
     text("CREATE INDEX IF NOT EXISTS idx_chat_sessions_user ON chat_sessions(user_id)"),
     text("CREATE INDEX IF NOT EXISTS idx_chat_sessions_activity ON chat_sessions(last_activity_at)"),


### PR DESCRIPTION
## Summary
Added a `draft_state` JSONB column to the `chat_sessions` table to support storing draft message state for chat sessions.

## Changes
- Added `draft_state JSONB DEFAULT '{}'::jsonb` column to the `chat_sessions` table schema definition
- Added an `ALTER TABLE` migration statement to ensure existing tables are updated with the new column using `IF NOT EXISTS` to prevent errors on re-runs

## Implementation Details
The `draft_state` column defaults to an empty JSON object (`'{}'::jsonb`) and is designed to store draft message information as JSONB data. The migration includes both the schema definition update and a separate ALTER TABLE statement to handle existing database instances, ensuring idempotent migrations that won't fail if the column already exists.

https://claude.ai/code/session_01XPKyvrM4hxHGByKoD1Rp4b