### PR TITLE
fix: handle draft state in QR click path (wrong QR buttons bug)

### DIFF
--- a/routes/chat.py
+++ b/routes/chat.py
@@ -232,18 +232,82 @@ async def chat_message(req: ChatMessageRequest, db: Session = Depends(get_db)):
             # This applies to both QR (single-select) and MS (multi-select) fields,
             # regardless of DRAFT_MODE_ENABLED. Only free-text goes through Draft.
             qr_field = req.quick_reply_field
-            qr_result = normalize_field(qr_field, req.quick_reply_value, collected, report_type=rt)
-            if qr_result.confidence != "low":
-                collected[qr_field] = qr_result.value
-                normalized[qr_field] = qr_result.value
-                field_meta[qr_field] = {
-                    "confidence": qr_result.confidence,
-                    "source_turn": turn,
-                    "raw_input": req.quick_reply_value,
-                    "normalized": True,
-                    "confirmed": True,  # User clicked explicitly
-                }
-            log.info("[CHAT] Quick reply: %s=%s → %s", qr_field, req.quick_reply_value, qr_result.value)
+
+            # --- Draft-mode QR handling (confirm/edit buttons + stale draft cleanup) ---
+            if DRAFT_MODE_ENABLED:
+                _qr_draft = dict(getattr(session, 'draft_state', None) or {})
+                _qr_pending = _qr_draft.get("pending_field")
+
+                if qr_field == "_draft_action":
+                    # Handle confirm/edit QR buttons for pending draft value
+                    if _qr_pending and req.quick_reply_value == "confirm":
+                        _cf = _qr_draft["pending_field"]
+                        _cv = _qr_draft["pending_value"]
+                        collected[_cf] = _cv
+                        normalized[_cf] = _cv
+                        field_meta[_cf] = {
+                            "confidence": "high",
+                            "source_turn": turn,
+                            "raw_input": "confirmed_via_qr",
+                            "normalized": True,
+                            "confirmed": True,
+                        }
+                        _draft_confirmed_field = _cf
+                        _draft_confirmed_value = _cv
+                        log.info("[CHAT] Draft QR confirm: %s=%r", _cf, _cv)
+                    else:
+                        log.info("[CHAT] Draft QR edit/discard: clearing pending %s", _qr_pending)
+                    # Always clear draft state after _draft_action
+                    session.draft_state = {"pending_field": None, "pending_value": None, "dialog_mode": False}
+
+                else:
+                    # Regular QR click while draft pending → auto-confirm the pending
+                    # value (user explicitly moved on by clicking a different field).
+                    if _qr_pending:
+                        _cf = _qr_draft["pending_field"]
+                        _cv = _qr_draft["pending_value"]
+                        collected[_cf] = _cv
+                        normalized[_cf] = _cv
+                        field_meta[_cf] = {
+                            "confidence": "high",
+                            "source_turn": turn,
+                            "raw_input": "auto_confirmed_via_qr",
+                            "normalized": True,
+                            "confirmed": True,
+                        }
+                        _draft_confirmed_field = _cf
+                        _draft_confirmed_value = _cv
+                        log.info("[CHAT] Draft auto-confirm (QR click on %s): %s=%r", qr_field, _cf, _cv)
+                    session.draft_state = {"pending_field": None, "pending_value": None, "dialog_mode": False}
+
+                    # Now process the actual QR click (same as non-draft path)
+                    qr_result = normalize_field(qr_field, req.quick_reply_value, collected, report_type=rt)
+                    if qr_result.confidence != "low":
+                        collected[qr_field] = qr_result.value
+                        normalized[qr_field] = qr_result.value
+                        field_meta[qr_field] = {
+                            "confidence": qr_result.confidence,
+                            "source_turn": turn,
+                            "raw_input": req.quick_reply_value,
+                            "normalized": True,
+                            "confirmed": True,  # User clicked explicitly
+                        }
+                    log.info("[CHAT] Quick reply: %s=%s → %s", qr_field, req.quick_reply_value, qr_result.value)
+
+            else:
+                # Non-draft mode: standard QR handling
+                qr_result = normalize_field(qr_field, req.quick_reply_value, collected, report_type=rt)
+                if qr_result.confidence != "low":
+                    collected[qr_field] = qr_result.value
+                    normalized[qr_field] = qr_result.value
+                    field_meta[qr_field] = {
+                        "confidence": qr_result.confidence,
+                        "source_turn": turn,
+                        "raw_input": req.quick_reply_value,
+                        "normalized": True,
+                        "confirmed": True,  # User clicked explicitly
+                    }
+                log.info("[CHAT] Quick reply: %s=%s → %s", qr_field, req.quick_reply_value, qr_result.value)
         else:
             # Free text: call LLM extractor (Claude Haiku)
             # Run in background task so we can yield heartbeats while waiting.


### PR DESCRIPTION
Two bugs in the QR path when DRAFT_MODE_ENABLED=true:

1. _draft_action QR buttons (confirm/edit) were not handled — the QR path tried to normalize_field("_draft_action") which is not a real field, so the pending draft was never confirmed. The confirm button was completely broken.

2. Regular QR clicks did not clear stale pending draft state. If a previous free-text turn set session.draft_state.pending_field, and the user then clicked a QR button, the stale draft persisted. On the QR generation check (line 553), this caused confirm/edit buttons to appear instead of the correct next-field QR options.

Fix:
- Handle _draft_action=confirm: move pending value to collected_fields
- Handle _draft_action=edit: clear pending (re-ask the field)
- Regular QR clicks: auto-confirm any stale pending draft (user explicitly moved on by clicking a different field)
- Always clear session.draft_state after QR processing

Non-draft mode (DRAFT_MODE_ENABLED=false) is completely unchanged.

https://claude.ai/code/session_01XPKyvrM4hxHGByKoD1Rp4b