### PR TITLE
fix: force fresh DB read for collected_fields in SSE stream (root cause)

### DIFF
--- a/routes/chat.py
+++ b/routes/chat.py
@@ -217,8 +217,17 @@ async def chat_message(req: ChatMessageRequest, db: Session = Depends(get_db)):
         # ------------------------------------------------------------------
         registry = get_registry_for_report(rt)
         normalized = {}
+
+        # Force fresh DB read — after db.commit() at l.202 all ORM
+        # attributes are expired.  The lazy-load that SQLAlchemy would do
+        # on first access can return stale/empty collected_fields, causing
+        # every QR turn to overwrite previous fields.  db.refresh()
+        # guarantees a SELECT with the latest committed state.
+        db.refresh(session, attribute_names=["collected_fields", "field_meta", "current_section", "draft_state"])
+
         field_meta = dict(session.field_meta or {})
         collected = dict(session.collected_fields or {})
+        log.info("[CHAT] Turn %d init: collected_keys=%s", turn, list(collected.keys()))
 
         # Draft-mode tracking variables (only meaningful when DRAFT_MODE_ENABLED)
         _signal = None


### PR DESCRIPTION
The actual root cause of the wrong-QR-field bug: inside event_stream() (an async generator), collected_fields was initialized via ORM lazy-load after db.commit() expired all attributes. The lazy-load returned an empty dict instead of the accumulated fields from previous turns.

Result: each turn started with collected={}, added only the current turn's field, then OVERWROTE session.collected_fields — erasing all prior fields. get_next_fields() then returned already-collected fields because they were missing from the overwritten dict.

Proof from Railway logs (every session, 100% reproducible):
  Turn 1: normalized=['branche'], next=['unternehmensgroesse']  ← OK
  Turn 2: normalized=['unternehmensgroesse'], next=['branche']  ← BUG

Fix: db.refresh(session, attribute_names=[...]) before reading collected_fields. This forces a SELECT with the latest committed state, guaranteeing the full accumulated dict.

Also adds diagnostic log line for verification in Railway.

https://claude.ai/code/session_01KBF3AdeyqNCN4gbjAAwdgq