### PR TITLE
fix: capture session.id before reassignment (UnboundLocalError)

### DIFF
--- a/routes/chat.py
+++ b/routes/chat.py
@@ -223,7 +223,8 @@ async def chat_message(req: ChatMessageRequest, db: Session = Depends(get_db)):
         # on first access can return stale/empty collected_fields, causing
         # every QR turn to overwrite previous fields.  db.refresh()
         # guarantees a SELECT with the latest committed state.
-        session = db.query(ChatSession).filter(ChatSession.id == session.id).one()
+        session_id = session.id  # capture before reassignment
+        session = db.query(ChatSession).filter(ChatSession.id == session_id).one()
 
         field_meta = dict(session.field_meta or {})
         collected = dict(session.collected_fields or {})


### PR DESCRIPTION
Python marks `session` as local for the entire scope when it sees the assignment on the left side, so `session.id` on the right side of the same line tries to read an unbound local.  Capture the ID first.

https://claude.ai/code/session_01KBF3AdeyqNCN4gbjAAwdgq