### PR TITLE
fix: use populate_existing() to refresh session via identity map

### DIFF
--- a/routes/chat.py
+++ b/routes/chat.py
@@ -218,18 +218,15 @@ async def chat_message(req: ChatMessageRequest, db: Session = Depends(get_db)):
         registry = get_registry_for_report(rt)
         normalized = {}
 
-        # Force fresh DB read — after db.commit() at l.202 all ORM
-        # attributes are expired.  The lazy-load that SQLAlchemy would do
-        # on first access can return stale/empty collected_fields, causing
-        # every QR turn to overwrite previous fields.  Fresh query
-        # guarantees a SELECT with the latest committed state.
-        # NOTE: must NOT reassign `session` — it's a closure variable from
-        # the outer scope; any `session = ...` would make it local to the
-        # entire generator and break all prior references.
-        _fresh = db.query(ChatSession).filter(ChatSession.id == session.id).one()
-
-        field_meta = dict(_fresh.field_meta or {})
-        collected = dict(_fresh.collected_fields or {})
+        # Force-refresh the expired session object via identity map.
+        # populate_existing() guarantees the already-tracked `session`
+        # object gets its attributes overwritten with fresh DB data.
+        db.query(ChatSession).populate_existing().filter(
+            ChatSession.id == session.id
+        ).one()
+        # `session` is now refreshed — safe to read.
+        field_meta = dict(session.field_meta or {})
+        collected = dict(session.collected_fields or {})
         log.info("[CHAT] Turn %d init: collected_keys=%s", turn, list(collected.keys()))
 
         # Draft-mode tracking variables (only meaningful when DRAFT_MODE_ENABLED)


### PR DESCRIPTION
Replace _fresh variable approach with a query that refreshes the existing `session` closure variable in-place via SQLAlchemy's identity map.  populate_existing() forces attribute overwrite on the already-tracked object — no reassignment, no new variable.

https://claude.ai/code/session_01KBF3AdeyqNCN4gbjAAwdgq