### PR TITLE
fix: use CAST(:cf AS jsonb) instead of ::jsonb operator

### DIFF
--- a/routes/chat.py
+++ b/routes/chat.py
@@ -519,8 +519,8 @@ async def chat_message(req: ChatMessageRequest, db: Session = Depends(get_db)):
         db.execute(
             _sa_text("""
                 UPDATE chat_sessions
-                SET collected_fields = :cf::jsonb,
-                    field_meta = :fm::jsonb,
+                SET collected_fields = CAST(:cf AS jsonb),
+                    field_meta = CAST(:fm AS jsonb),
                     updated_at = :ts
                 WHERE id = :sid
             """),


### PR DESCRIPTION
SQLAlchemy's text() treats :: as a special token.  Use standard SQL CAST() syntax which passes through unambiguously.

https://claude.ai/code/session_01KBF3AdeyqNCN4gbjAAwdgq