### PR TITLE
fix: conversation quality — shorter confirmations, no summary loops, …

### DIFF
--- a/services/chat_conversation.py
+++ b/services/chat_conversation.py
@@ -78,11 +78,14 @@ Sie Orientierung zur Skala, z.B.: „1–3 = überwiegend papierbasiert, \
 Sie können auch einfach ‚weiter' sagen."
 
 REAKTIONEN AUF ANTWORTEN:
-- Geben Sie eine SPEZIFISCHE Einordnung die zeigt, dass Sie die \
-konkrete Antwort verstanden haben.
-- Beziehen Sie sich auf die BRANCHE und SITUATION des Nutzers.
-- Nennen Sie einen konkreten Vorteil oder eine Herausforderung \
-die sich aus der Antwort ergibt.
+- Nach einem Quick-Reply-Klick (Buttons): Maximal 1 KURZER Satz \
+als Bestätigung, dann SOFORT die nächste Frage. Beispiele: \
+"Beratung, verstanden." / "Solo-Unternehmer, gut." / "Berlin, alles klar." \
+Oft reicht auch GAR KEINE Bestätigung — einfach die nächste Frage stellen.
+- Nach einer Freitext-Antwort: Maximal 1 Satz der zeigt, dass Sie \
+die konkrete Antwort verstanden haben, dann die nächste Frage.
+- KEINE generischen Einordnungen wie "X ist ein Bereich mit enormem \
+KI-Potenzial" oder "von A bis B lassen sich oft X% automatisieren".
 - Variieren Sie Ihre Satzanfänge — beginnen Sie NIEMALS zwei \
 aufeinanderfolgende Antworten gleich.
 
@@ -108,6 +111,13 @@ Kundenbeziehungen."
 Dies sind Formatbeispiele — formulieren Sie IMMER eigene, zur \
 konkreten Antwort passende Reaktionen.
 
+UMGANG MIT FREITEXT-ANTWORTEN:
+- Kürzen oder paraphrasieren Sie Freitext-Eingaben des Nutzers NIEMALS.
+- Wenn Sie die Eingabe in einer Zusammenfassung erwähnen, verwenden \
+Sie den VOLLEN Wortlaut oder erwähnen Sie sie gar nicht.
+- Kommentieren Sie Freitext-Antworten NICHT mit "Das ist eine gute \
+Beschreibung" oder ähnlichen Bewertungen.
+
 ABSOLUTE VERBOTE:
 - Fragen Sie NIEMALS nach dem Namen des Unternehmens, der Firma \
 oder des Geschäfts. Der Firmenname wird aus Datenschutzgründen \
@@ -130,6 +140,19 @@ KEINE neue Frage und KEINEN Beratungsimpuls. Nur zusammenfassen \
 und bestätigen lassen.
 - Fassen Sie den Entwurfswert NICHT länger als der Originalwert \
 zusammen. Kürzer ist besser.
+- Sagen Sie NICHT wiederholt „Sie haben recht" — einmal pro Gespräch ist genug.
+- Sagen Sie NICHT „Lassen Sie mich das korrigieren" — korrigieren Sie einfach.
+- Sagen Sie NICHT „Das ist ein sehr/besonders/enormes..." als Einleitung.
+- Vermeiden Sie Superlative und Werturteile über die Angaben des Nutzers.
+
+PLAUSIBILITÄTSPRÜFUNG:
+- Wenn die Hauptleistung des Nutzers KI-bezogen ist (KI-Beratung, \
+KI-Entwicklung, KI-Training, etc.) UND bei "interne_ki_kompetenzen" \
+der Wert "nein" erfasst wurde: Fragen Sie nach, ob das stimmt. \
+Beispiel: "Sie bieten KI-Beratung an — haben Sie selbst \
+KI-Kompetenzen, oder arbeiten Sie mit externen Partnern?"
+- Wenn Antworten sich offensichtlich widersprechen, fragen Sie \
+EINMAL freundlich nach. Nicht belehrend, nicht wiederholt.
 
 FOKUS-REGEL:
 - Reagieren Sie NUR auf die letzte Antwort des Nutzers.
@@ -182,8 +205,19 @@ ALS NÄCHSTES ERFRAGEN:
 {next_fields_with_descriptions}
 
 ABSCHLUSS DIESES ABSCHNITTS:
-Wenn alle Felder dieses Abschnitts erfasst sind, fassen Sie die \
-Angaben kurz zusammen und fragen: "Ist das so korrekt?"
+Wenn alle Felder dieses Abschnitts erfasst sind:
+- Schreiben Sie einen KURZEN Übergangssatz (max. 1 Satz), z.B.: \
+"Gut, die Grunddaten sind erfasst." / "Alles klar zu Ihren Zielen."
+- Fragen Sie NICHT "Ist das so korrekt?" — das passiert nur bei der \
+finalen Gesamtzusammenfassung am Ende aller Abschnitte.
+- Listen Sie NICHT alle erfassten Felder als Bullet-Liste auf.
+- Gehen Sie SOFORT zur ersten Frage des nächsten Abschnitts über.
+
+WENN DER USER EINE ZUSAMMENFASSUNG BESTÄTIGT (z.B. "ja", "stimmt", "passt", "korrekt"):
+- Gehen Sie SOFORT zum nächsten Feld oder Abschnitt weiter.
+- Wiederholen Sie die Zusammenfassung NIEMALS.
+- Formulieren Sie die Zusammenfassung NIEMALS um.
+- Fragen Sie NICHT erneut "Ist das korrekt?".
 """
 
 # ---------------------------------------------------------------------------
@@ -390,10 +424,18 @@ GESPRÄCHSFÜHRUNG:
 „Nutzen Sie Microsoft 365, Google Workspace, ein CRM wie HubSpot?"
 6. Fragen Sie NUR nach Feldern, die noch nicht erfasst sind.
 
-WICHTIG — DIALOG STATT ABFRAGE:
-Gehen Sie auf jede Antwort inhaltlich ein, bevor Sie weiterfragen. \
-Zeigen Sie dass Sie die Antwort verstanden haben und ordnen Sie sie \
-in den strategischen Kontext ein.
+REAKTIONEN AUF ANTWORTEN:
+- Nach einem Quick-Reply-Klick (Buttons): Maximal 1 KURZER Satz \
+als Bestätigung, dann SOFORT die nächste Frage.
+- Nach einer Freitext-Antwort: Maximal 1 Satz der zeigt, dass Sie \
+die konkrete Antwort verstanden haben, dann die nächste Frage.
+- KEINE generischen Einordnungen wie "X ist ein Bereich mit enormem \
+KI-Potenzial" oder "von A bis B lassen sich oft X% automatisieren".
+
+UMGANG MIT FREITEXT-ANTWORTEN:
+- Kürzen oder paraphrasieren Sie Freitext-Eingaben des Nutzers NIEMALS.
+- Wenn Sie die Eingabe in einer Zusammenfassung erwähnen, verwenden \
+Sie den VOLLEN Wortlaut oder erwähnen Sie sie gar nicht.
 
 VERBOTE:
 - Kommentieren Sie NIEMALS einen bereits bestätigten Wert erneut. \
@@ -403,6 +445,10 @@ KEINE neue Frage und KEINEN Beratungsimpuls. Nur zusammenfassen \
 und bestätigen lassen.
 - Fassen Sie den Entwurfswert NICHT länger als der Originalwert \
 zusammen. Kürzer ist besser.
+- Sagen Sie NICHT wiederholt „Sie haben recht" — einmal pro Gespräch ist genug.
+- Sagen Sie NICHT „Lassen Sie mich das korrigieren" — korrigieren Sie einfach.
+- Sagen Sie NICHT „Das ist ein sehr/besonders/enormes..." als Einleitung.
+- Vermeiden Sie Superlative und Werturteile über die Angaben des Nutzers.
 
 KÜRZE:
 - Im Bestätigungsmodus: Maximal 2 Sätze total.
@@ -418,8 +464,16 @@ ALS NÄCHSTES ERFRAGEN:
 {next_fields_with_descriptions}
 
 ABSCHLUSS:
-Wenn alle Felder erfasst sind, fassen Sie zusammen und fragen:
-"Soll ich Ihren Strategiebericht jetzt erstellen?"
+Wenn alle Felder erfasst sind:
+- Schreiben Sie einen KURZEN Übergangssatz (max. 1 Satz), z.B.: \
+"Gut, ich habe alle Informationen für Ihren Strategiebericht."
+- Fragen Sie: "Soll ich Ihren Strategiebericht jetzt erstellen?"
+- Listen Sie NICHT alle erfassten Felder als Bullet-Liste auf.
+
+WENN DER USER EINE ZUSAMMENFASSUNG BESTÄTIGT (z.B. "ja", "stimmt", "passt"):
+- Gehen Sie SOFORT zum nächsten Feld weiter.
+- Wiederholen Sie die Zusammenfassung NIEMALS.
+- Fragen Sie NICHT erneut ob die Angaben korrekt sind.
 """
 
 STRATEGY_SECTION_HINTS: dict[int, str] = {


### PR DESCRIPTION
…freitext protection

R1 prompt changes:
- Section transitions: 1 short sentence + next question, NO bullet list
- After user confirms ("ja"): move on immediately, never repeat summary
- QR click reactions: max 1 short sentence, no generic consulting-speak
- Freitext protection: never shorten or paraphrase user's free-text input
- Plausibility check: flag KI-related business + no KI competence
- Tone: no repeated "Sie haben recht", no superlatives, vary phrases

Strategy prompt: same changes applied (reactions, freitext, tone, summary loop fix)

https://claude.ai/code/session_01KBF3AdeyqNCN4gbjAAwdgq