### PR TITLE
Fix R1 profile field name: briefing.questionnaire → briefing.answers

### DIFF
--- a/routes/chat.py
+++ b/routes/chat.py
@@ -1961,8 +1961,8 @@ def _load_r1_profile_for_strategy(session, db) -> dict | None:
         briefing = db.query(Briefing).filter(Briefing.id == session.briefing_id).first()
         if not briefing:
             return None
-        # Briefing.questionnaire contains the R1 form data
-        r1_data = getattr(briefing, "questionnaire", None) or {}
+        # Briefing.answers contains the R1 form data
+        r1_data = getattr(briefing, "answers", None) or {}
         if not r1_data or not isinstance(r1_data, dict):
             return None
         return compute_user_profile(r1_data)


### PR DESCRIPTION
The Briefing model uses `answers` (not `questionnaire`) to store R1 form data. The incorrect field name caused `getattr` to always return None, silently disabling profile-aware QR filtering in Strategy chats.

https://claude.ai/code/session_01BTPBthqch3MrP73DD5Gn8M