### PR TITLE
Refine conversation guidelines and improve welcome message

### DIFF
--- a/routes/chat.py
+++ b/routes/chat.py
@@ -67,9 +67,11 @@ log = logging.getLogger(__name__)
 DRAFT_MODE_ENABLED = os.getenv("DRAFT_MODE_ENABLED", "false").lower() == "true"
 
 R1_WELCOME = (
-    "Willkommen bei ki-sicherheit.jetzt! Ich bin ein KI-Assistent und "
-    "führe Sie durch eine kurze Bestandsaufnahme Ihres Unternehmens.\n\n"
-    "Lassen Sie uns mit den Grundlagen beginnen: "
+    "Willkommen bei ki-sicherheit.jetzt! Ich führe Sie durch eine "
+    "kurze Bestandsaufnahme — in ca. 10–15 Minuten. Am Ende erhalten "
+    "Sie einen individuellen KI-Report mit konkreten Empfehlungen "
+    "für Ihr Unternehmen. Ihre Angaben werden ausschließlich für "
+    "die Analyse verwendet.\n\n"
     "In welcher Branche ist Ihr Unternehmen tätig? "
     "Falls Sie unsicher sind, beschreiben Sie einfach, was Sie tun "
     "— ich helfe bei der Zuordnung."

--- a/services/chat_conversation.py
+++ b/services/chat_conversation.py
@@ -112,8 +112,12 @@ dann SOFORT die nächste Frage. Beispiele guter Reaktionen: \
 NICHT: "Verstanden, mit 2.000-10.000€ Budget und 1-3 Monaten..." \
 SONDERN: "Gut. Welche Prioritäten haben Sie beim KI-Einsatz?"
 - Nach Freitext-Antworten: MAXIMAL 1 Satz Reaktion, dann nächste Frage.
-- "Diese Angabe ist optional, hilft aber die Empfehlungen zu \
-verbessern" — verwenden Sie diesen Satz MAXIMAL 2x pro Gespräch.
+- Den Satz "Diese Angabe ist optional, hilft aber die Empfehlungen \
+zu verbessern" oder jede sinngleiche Formulierung dürfen Sie \
+EXAKT 1× im gesamten Gespräch verwenden — beim ERSTEN optionalen \
+Feld. Danach NIE WIEDER. Bei allen weiteren optionalen Feldern: \
+Stellen Sie die Frage OHNE Hinweis auf Optionalität. Der Nutzer \
+kann jederzeit "weiter" sagen — das muss nicht wiederholt werden.
 - Im Bestätigungsmodus: Maximal 2 Sätze total.
 - Im Dialogmodus: Maximal 4 Sätze total.
 - Im Fragemodus: Maximal 1 Satz Reaktion + 1 Frage mit kurzem Kontext.
@@ -175,6 +179,14 @@ demselben Wort (auch nicht "Verstanden" zweimal hintereinander).
 - Verwechseln Sie NIEMALS Felder. Wenn der Nutzer gerade \
 "change_management" beantwortet hat, kommentieren Sie NICHT \
 "massnahmen_komplexitaet" oder umgekehrt.
+- Loben Sie den Nutzer MAXIMAL 3× im gesamten Gespräch. \
+Jedes Lob MUSS einen konkreten, spezifischen Grund nennen, \
+der über die Antwort hinausgeht. \
+VERBOTEN: "Das ist eine solide Basis", "Gute Wahl", \
+"Das klingt vielversprechend", "Ihre Ziele sind klar definiert". \
+ERLAUBT (selten): "Mit Digitalisierungsgrad 9 können Sie \
+KI-Automatisierung ohne große Vorarbeit einsetzen." \
+Im Zweifel: NICHT loben, sondern einen nützlichen Fakt liefern.
 
 PLAUSIBILITÄTSPRÜFUNG:
 - Wenn die Hauptleistung des Nutzers KI-bezogen ist (KI-Beratung, \
@@ -586,6 +598,14 @@ mit "Perfekt". Variieren Sie: "Gut.", "Alles klar.", \
 demselben Wort (auch nicht "Verstanden" zweimal hintereinander).
 - Verwechseln Sie NIEMALS Felder. Wenn der Nutzer gerade ein \
 Feld beantwortet hat, kommentieren Sie NICHT ein anderes Feld.
+- Loben Sie den Nutzer MAXIMAL 3× im gesamten Gespräch. \
+Jedes Lob MUSS einen konkreten, spezifischen Grund nennen, \
+der über die Antwort hinausgeht. \
+VERBOTEN: "Das ist eine solide Basis", "Gute Wahl", \
+"Das klingt vielversprechend", "Ihre Ziele sind klar definiert". \
+ERLAUBT (selten): "Mit Digitalisierungsgrad 9 können Sie \
+KI-Automatisierung ohne große Vorarbeit einsetzen." \
+Im Zweifel: NICHT loben, sondern einen nützlichen Fakt liefern.
 
 EXPERTISE-ADAPTION:
 - Wenn die Hauptleistung des Nutzers KI-bezogen ist (KI-Beratung, \
@@ -646,8 +666,12 @@ dann SOFORT die nächste Frage. Beispiele guter Reaktionen: \
 NICHT: "Verstanden, mit 2.000-10.000€ Budget und 1-3 Monaten..." \
 SONDERN: "Gut. Welche Prioritäten haben Sie beim KI-Einsatz?"
 - Nach Freitext-Antworten: MAXIMAL 1 Satz Reaktion, dann nächste Frage.
-- "Diese Angabe ist optional, hilft aber die Empfehlungen zu \
-verbessern" — verwenden Sie diesen Satz MAXIMAL 2x pro Gespräch.
+- Den Satz "Diese Angabe ist optional, hilft aber die Empfehlungen \
+zu verbessern" oder jede sinngleiche Formulierung dürfen Sie \
+EXAKT 1× im gesamten Gespräch verwenden — beim ERSTEN optionalen \
+Feld. Danach NIE WIEDER. Bei allen weiteren optionalen Feldern: \
+Stellen Sie die Frage OHNE Hinweis auf Optionalität. Der Nutzer \
+kann jederzeit "weiter" sagen — das muss nicht wiederholt werden.
 - Im Bestätigungsmodus: Maximal 2 Sätze total.
 - Im Dialogmodus: Maximal 4 Sätze total.
 - Im Fragemodus: Maximal 1 Satz Reaktion + 1 Frage mit kurzem Kontext.


### PR DESCRIPTION
## Summary
This PR updates the AI conversation guidelines in the chat service to enforce stricter constraints on user praise and optional field messaging, while also improving the initial welcome message to set clearer expectations about the assessment duration and data usage.

## Key Changes

### Conversation Guidelines (`services/chat_conversation.py`)
- **Optional field messaging**: Changed from "MAXIMAL 2x per conversation" to "EXAKT 1× im gesamten Gespräch" (exactly once at the first optional field only). Subsequent optional fields should ask without mentioning optionality, and the "weiter" (skip) option no longer needs to be repeated.
- **User praise constraints**: Added new rule limiting praise to a maximum of 3 times per conversation, with strict requirements that each compliment must provide a concrete, specific reason beyond the answer itself. Includes a list of forbidden generic phrases ("Das ist eine solide Basis", "Gute Wahl", etc.) and guidance to provide useful facts instead when in doubt.

### Welcome Message (`routes/chat.py`)
- Removed redundant "Ich bin ein KI-Assistent und" phrasing
- Added explicit duration expectation: "in ca. 10–15 Minuten"
- Added value proposition: "Am Ende erhalten Sie einen individuellen KI-Report mit konkreten Empfehlungen"
- Added data privacy assurance: "Ihre Angaben werden ausschließlich für die Analyse verwendet"
- Improved clarity and user confidence in the assessment process

## Implementation Details
- Guidelines are duplicated in two locations within the file (around lines 112 and 666), both updated consistently
- Changes enforce more disciplined conversation patterns to prevent over-praising and repetitive messaging
- Welcome message now sets proper expectations upfront, improving user experience and trust

https://claude.ai/code/session_01AySgggHcb3tg7RytHUZKtK