### PR TITLE
Smart field grouping and regulated industry compliance filtering

### DIFF
--- a/routes/chat.py
+++ b/routes/chat.py
@@ -545,7 +545,12 @@ async def chat_message(req: ChatMessageRequest, db: Session = Depends(get_db)):
         sections = get_sections_for_report(rt)
         missing_req, missing_opt = get_missing_fields(collected, _current_section, rt)
         all_missing = missing_req + missing_opt
-        next_fields = get_next_fields(collected, _current_section, report_type=rt)
+        # Smart Grouping: ask up to 3 optional fields at once
+        # (required fields still come one at a time)
+        if missing_req:
+            next_fields = get_next_fields(collected, _current_section, max_fields=1, report_type=rt)
+        else:
+            next_fields = get_next_fields(collected, _current_section, max_fields=3, report_type=rt)
         current_section = sections[_current_section]
 
         log.info("[CHAT] Turn %d: normalized=%s, next=%s", turn, list(normalized.keys()), next_fields)
@@ -629,7 +634,12 @@ async def chat_message(req: ChatMessageRequest, db: Session = Depends(get_db)):
 
         # QR generation — QR clicks always get normal next-field buttons.
         # Draft suppression only applies to free-text turns.
-        qr_next = get_next_fields(collected, _current_section, report_type=rt)
+        # Smart Grouping: group up to 3 optional fields for QR
+        _qr_miss_req, _qr_miss_opt = get_missing_fields(collected, _current_section, rt)
+        if _qr_miss_req:
+            qr_next = get_next_fields(collected, _current_section, max_fields=1, report_type=rt)
+        else:
+            qr_next = get_next_fields(collected, _current_section, max_fields=3, report_type=rt)
 
         # Fix 4: For strategy sessions, load R1 profile for context-aware QR
         _profile_ctx = None
@@ -1213,7 +1223,11 @@ def _build_session_state(
     section = sections[section_idx]
 
     missing_req, missing_opt = get_missing_fields(collected, section_idx, rt)
-    next_fields = get_next_fields(collected, section_idx, report_type=rt)
+    # Smart Grouping: group up to 3 optional fields
+    if missing_req:
+        next_fields = get_next_fields(collected, section_idx, max_fields=1, report_type=rt)
+    else:
+        next_fields = get_next_fields(collected, section_idx, max_fields=3, report_type=rt)
 
     total = len(registry)
     collected_count = len(collected)

--- a/services/chat_conversation.py
+++ b/services/chat_conversation.py
@@ -61,7 +61,15 @@ passt, beschreiben Sie einfach, was Sie tun — ich ordne das \
 dann zu."
 
 GESPRÄCHSFÜHRUNG:
-1. Stellen Sie pro Antwort GENAU EINE Frage — niemals zwei oder drei gleichzeitig.
+1. Stellen Sie pro Antwort normalerweise EINE Frage. \
+AUSNAHME: Wenn unter "ALS NÄCHSTES ERFRAGEN" mehrere \
+optionale Felder aufgelistet sind, fassen Sie diese in \
+EINER natürlichen Frage zusammen. Beispiel bei 3 offenen \
+Feldern (prozesse_papierlos, automatisierungsgrad, ki_kompetenz): \
+"Wie papierlos arbeiten Sie, wie hoch ist der Automatisierungsgrad, \
+und wie schätzen Sie Ihre KI-Kompetenz ein?" Der Nutzer sieht \
+für jedes Feld eigene Buttons. Stellen Sie die Felder NICHT \
+als nummerierte Liste dar — formulieren Sie einen fließenden Satz.
 2. Bestätigen Sie zuerst kurz, was Sie verstanden haben.
 3. Geben Sie bei der nächsten Frage 1–2 Sätze Kontext oder ein Beispiel, \
 das zur Branche/Situation des Nutzers passt.
@@ -501,7 +509,7 @@ SECTION_HINTS: dict[int, str] = {
     2: "PATHOS-SCHWERPUNKT: Wichtigster Abschnitt für Report-Qualität. Helfen Sie dem Nutzer, sich Möglichkeiten VORZUSTELLEN: 'Was wäre, wenn Sie die Hälfte der Zeit für X einsparen könnten?' Bei Freitextfeldern: 'Stichworte reichen völlig.'",
     3: "ETHOS-SCHWERPUNKT: Keine KI-Strategie zu haben ist normal — normalisieren. 'Nein' bei Roadmap oder Governance ist völlig valide. Vermitteln: der Report liefert genau dafür die Grundlage.",
     4: "LOGOS-SCHWERPUNKT: Kurz halten. Bei Tools konkreter Praxisbezug: 'Viele nutzen bereits KI-Funktionen in bestehenden Tools, ohne es zu wissen.'",
-    5: "ETHOS-SCHWERPUNKT: Datenschutz-Fragen verunsichern KMU. Konsequent normalisieren: 'Nein' oder 'noch nicht' ist kein Problem — der Report zeigt dann konkrete nächste Schritte.",
+    5: "ETHOS-SCHWERPUNKT: Datenschutz-Fragen verunsichern KMU. Konsequent normalisieren: 'Nein' oder 'noch nicht' ist kein Problem — der Report zeigt dann konkrete nächste Schritte. HINWEIS: Bei nicht-regulierten Branchen werden nur 2–3 Kernfragen gestellt. Weisen Sie NICHT darauf hin dass Fragen übersprungen wurden.",
     6: "LOGOS+PATHOS: Bei Förderung konkreten Logos-Impuls ('BAFA fördert KI-Beratung je nach Bundesland mit bis zu 80%'). Bei Budget Pathos-Impuls ('Selbst mit kleinem Budget sind spürbare erste Schritte möglich.'). Zügig abfragen.",
     7: "PATHOS-SCHWERPUNKT: Fast geschafft — kurzer motivierender Impuls: 'Ihre Angaben ergeben ein klares Bild — daraus entsteht jetzt Ihr individueller Report.'",
 }
@@ -539,7 +547,15 @@ oder beschreiben Sie Ihre Situation in eigenen Worten."
    - Bei Moat-Feldern: Warum Wettbewerber-Analyse relevant ist
 
 GESPRÄCHSFÜHRUNG:
-1. Stellen Sie pro Antwort GENAU EINE Frage — niemals zwei oder drei gleichzeitig.
+1. Stellen Sie pro Antwort normalerweise EINE Frage. \
+AUSNAHME: Wenn unter "ALS NÄCHSTES ERFRAGEN" mehrere \
+optionale Felder aufgelistet sind, fassen Sie diese in \
+EINER natürlichen Frage zusammen. Beispiel bei 3 offenen \
+Feldern (prozesse_papierlos, automatisierungsgrad, ki_kompetenz): \
+"Wie papierlos arbeiten Sie, wie hoch ist der Automatisierungsgrad, \
+und wie schätzen Sie Ihre KI-Kompetenz ein?" Der Nutzer sieht \
+für jedes Feld eigene Buttons. Stellen Sie die Felder NICHT \
+als nummerierte Liste dar — formulieren Sie einen fließenden Satz.
 2. Bestätigen Sie kurz, was Sie verstanden haben, dann die nächste Frage.
 3. Listen Sie NIEMALS Optionen auf — der Nutzer sieht klickbare Buttons.
 4. Bei S3 (Prioritäten): Weisen Sie darauf hin dass max. 3 gewählt werden sollen.

--- a/services/chat_normalizer.py
+++ b/services/chat_normalizer.py
@@ -322,6 +322,27 @@ CONDITIONALS: dict[str, dict] = {
         "show_if": {"country": ["DE", "AT", "CH", "GB"]},
         "hide_action": "delete",
     },
+    # Section 6: Extended compliance fields only for regulated industries
+    "technische_massnahmen": {
+        "show_if": {"branche": ["gesundheit", "finanzen", "verwaltung"]},
+        "hide_action": "skip",
+    },
+    "folgenabschaetzung": {
+        "show_if": {"branche": ["gesundheit", "finanzen", "verwaltung"]},
+        "hide_action": "skip",
+    },
+    "meldewege": {
+        "show_if": {"branche": ["gesundheit", "finanzen", "verwaltung"]},
+        "hide_action": "skip",
+    },
+    "loeschregeln": {
+        "show_if": {"branche": ["gesundheit", "finanzen", "verwaltung"]},
+        "hide_action": "skip",
+    },
+    "regulierte_branche": {
+        "show_if": {"branche": ["gesundheit", "finanzen", "verwaltung"]},
+        "hide_action": "skip",
+    },
 }
 
 


### PR DESCRIPTION
## Summary
This PR implements two major improvements to the chat conversation flow:

1. **Smart Field Grouping**: Allow up to 3 optional fields to be asked together in a single natural question, while keeping required fields one-at-a-time. This reduces conversation length while maintaining clarity.

2. **Regulated Industry Compliance**: Add conditional visibility for extended compliance fields (technische_massnahmen, folgenabschaetzung, meldewege, loeschregeln) that only appear for regulated industries (healthcare, finance, government).

## Key Changes

- **chat_conversation.py**: Updated conversation guidelines to explain the new exception for grouping multiple optional fields into one natural question, with concrete examples. Added guidance for handling skipped questions in non-regulated industries.

- **chat_normalizer.py**: Added 5 new conditional field definitions that only show for regulated industries (branche in ["gesundheit", "finanzen", "verwaltung"]), with "skip" hide_action to gracefully omit them from other industries.

- **routes/chat.py**: 
  - Modified `_run_extraction()` to use smart grouping: pass `max_fields=1` when required fields exist, `max_fields=3` for optional-only scenarios
  - Updated QR generation logic to apply the same smart grouping strategy
  - Updated `_build_session_state()` to apply smart grouping when calculating next fields

## Implementation Details

- The grouping logic is applied consistently across three key points: main extraction flow, QR generation, and session state building
- Required fields always come one at a time to maintain clarity on mandatory information
- Optional fields are grouped only when no required fields remain, reducing unnecessary turns
- Regulated industry fields are silently skipped (not shown as "skipped") for non-regulated industries, per the updated conversation guidelines

https://claude.ai/code/session_0199kcEUQ2ECezrsVF2i3ACg