### PR TITLE
Fix draft state handling in Sonnet context for current turn

### DIFF
--- a/routes/chat.py
+++ b/routes/chat.py
@@ -561,8 +561,30 @@ async def chat_message(req: ChatMessageRequest, db: Session = Depends(get_db)):
         _SENTINEL = object()
         queue: asyncio.Queue = asyncio.Queue()
 
-        # Draft context for Sonnet
-        _ds = dict(_draft_state_snapshot)
+        # Draft context for Sonnet — must reflect THIS turn's state,
+        # not the snapshot from turn start.
+        if DRAFT_MODE_ENABLED and _draft_new_field:
+            # New draft created this turn → tell Sonnet to confirm
+            _sonnet_pending_field = _draft_new_field
+            _sonnet_pending_value = _draft_new_value
+            _sonnet_dialog_mode = False
+        elif DRAFT_MODE_ENABLED and _signal == "question":
+            # User asked a question → dialog mode, keep existing draft
+            _sonnet_pending_field = _draft_state_snapshot.get("pending_field")
+            _sonnet_pending_value = _draft_state_snapshot.get("pending_value")
+            _sonnet_dialog_mode = True
+        elif DRAFT_MODE_ENABLED and _draft_confirmed_field:
+            # Draft was just confirmed → no pending, ask next question
+            _sonnet_pending_field = None
+            _sonnet_pending_value = None
+            _sonnet_dialog_mode = False
+        else:
+            # No change → use snapshot (covers: no draft mode, or
+            # existing pending draft carried over from previous turn)
+            _ds = dict(_draft_state_snapshot)
+            _sonnet_pending_field = _ds.get("pending_field")
+            _sonnet_pending_value = _ds.get("pending_value")
+            _sonnet_dialog_mode = _ds.get("dialog_mode", False)
 
         async def _token_producer():
             try:
@@ -574,9 +596,9 @@ async def chat_message(req: ChatMessageRequest, db: Session = Depends(get_db)):
                     section=current_section,
                     report_type=rt,
                     draft_mode=DRAFT_MODE_ENABLED,
-                    pending_field=_ds.get("pending_field"),
-                    pending_value=_ds.get("pending_value"),
-                    dialog_mode=_ds.get("dialog_mode", False),
+                    pending_field=_sonnet_pending_field,
+                    pending_value=_sonnet_pending_value,
+                    dialog_mode=_sonnet_dialog_mode,
                 ):
                     await queue.put(token)
             except Exception as exc:

--- a/services/chat_conversation.py
+++ b/services/chat_conversation.py
@@ -152,7 +152,11 @@ oder des Geschäfts. Der Firmenname wird aus Datenschutzgründen \
 nicht erhoben. Sie kennen: Branche, Größe, Standort und \
 Hauptleistung — das reicht für die Analyse.
 - „das ist ein spannendes Feld" oder ähnliche Floskeln.
-- Denselben Satz oder dieselbe Satzstruktur in mehreren Antworten verwenden.
+- Denselben Satz oder dieselbe Satzstruktur in mehreren Antworten verwenden. \
+Insbesondere NICHT: "[Branche] [verb] [etwas] — von X bis Y." \
+Wenn Sie eine Struktur einmal verwendet haben, wählen Sie beim \
+nächsten Mal eine völlig andere Formulierung. Variieren Sie: \
+Fragesätze, kurze Fakten, direkte Ansprache, Vergleiche.
 - Die Fakten des Nutzers nur zurückspiegeln ohne Mehrwert.
 - Den bisherigen Gesprächsverlauf zusammenfassen.
 - Beginnen Sie NIEMALS eine Antwort mit „Als [Branche]...", \


### PR DESCRIPTION
## Summary
This PR fixes the draft state context passed to Sonnet by ensuring it reflects the current turn's state rather than always using the snapshot from turn start. It also enhances prompt instructions to prevent repetitive sentence structures.

## Key Changes

### Draft State Context (routes/chat.py)
- **Replaced** simple snapshot usage with conditional logic that handles three distinct draft scenarios:
  - **New draft created this turn**: Sets pending field/value and disables dialog mode to request confirmation
  - **User asked a question**: Enables dialog mode while preserving existing draft from snapshot
  - **Draft just confirmed**: Clears pending field/value and disables dialog mode to proceed to next question
  - **No change**: Falls back to snapshot (handles cases where draft mode is disabled or existing pending draft carries over)

- **Updated** Sonnet prompt parameters to use the newly computed `_sonnet_pending_field`, `_sonnet_pending_value`, and `_sonnet_dialog_mode` variables instead of directly accessing the snapshot dictionary

### Prompt Enhancement (services/chat_conversation.py)
- **Extended** the instruction against repetitive sentence structures with specific examples and guidance:
  - Explicitly warns against the "[Industry] [verb] [something] — from X to Y" pattern
  - Provides concrete alternatives: questions, short facts, direct address, comparisons
  - Emphasizes varying formulation on subsequent uses

## Implementation Details
The draft state logic now properly distinguishes between:
- State changes that occurred during the current turn (new draft, confirmation, question response)
- Persistent state from previous turns (snapshot fallback)

This ensures Sonnet receives accurate context about what draft-related action should be taken in the current response.

https://claude.ai/code/session_017Cu1kWeGe9Yf7WYJkHchA4