### PR TITLE
fix: skip re-extraction of already collected fields in draft and lega…

### DIFF
--- a/routes/chat.py
+++ b/routes/chat.py
@@ -386,6 +386,9 @@ async def chat_message(req: ChatMessageRequest, db: Session = Depends(get_db)):
                         continue
                     if not is_field_visible(field_name, collected):
                         continue
+                    if field_name in collected:
+                        log.info("[CHAT] Legacy: field %s already collected, skipping re-extraction", field_name)
+                        continue
 
                     result = normalize_field(field_name, raw_value, collected, report_type=rt)
 
@@ -442,6 +445,9 @@ async def chat_message(req: ChatMessageRequest, db: Session = Depends(get_db)):
                         if field_name not in registry:
                             continue
                         if not is_field_visible(field_name, collected):
+                            continue
+                        if field_name in collected:
+                            log.info("[CHAT] Draft: field %s already collected, skipping re-extraction", field_name)
                             continue
 
                         result = normalize_field(field_name, raw_value, collected, report_type=rt)


### PR DESCRIPTION
…cy flow

When the user types free text for hauptleistung containing a keyword like "Beratung", Haiku would extract branche="beratung" — a field already collected via QR button. The draft chip then showed the wrong field.

Add `field_name in collected` guard in both the draft extraction loop (line ~444) and the legacy flow (line ~384) so already-collected fields are never overwritten or shown as pending drafts.

https://claude.ai/code/session_017Cu1kWeGe9Yf7WYJkHchA4