### PR TITLE
fix: persist draft_state via raw SQL so /confirm endpoint can read it

### DIFF
--- a/routes/chat.py
+++ b/routes/chat.py
@@ -525,11 +525,21 @@ async def chat_message(req: ChatMessageRequest, db: Session = Depends(get_db)):
         # Raw SQL write — direct SET, no ORM involvement.
         # `collected` was read fresh at turn start and contains the full
         # desired state (previous fields + this turn's additions/deletions).
+        # draft_state MUST be included here — ORM assignments to
+        # session.draft_state are not reliably flushed after raw SQL commits.
+        _draft_for_sql = None
+        if DRAFT_MODE_ENABLED:
+            _draft_for_sql = json.dumps(
+                getattr(session, 'draft_state', None)
+                or {"pending_field": None, "pending_value": None, "dialog_mode": False}
+            )
+
         db.execute(
             _sa_text("""
                 UPDATE chat_sessions
                 SET collected_fields = CAST(:cf AS jsonb),
                     field_meta = CAST(:fm AS jsonb),
+                    draft_state = CAST(:ds AS jsonb),
                     updated_at = :ts
                 WHERE id = :sid
             """),
@@ -537,6 +547,7 @@ async def chat_message(req: ChatMessageRequest, db: Session = Depends(get_db)):
                 "sid": str(session.id),
                 "cf": json.dumps(collected),
                 "fm": json.dumps(field_meta),
+                "ds": _draft_for_sql or json.dumps({}),
                 "ts": now,
             }
         )


### PR DESCRIPTION
The raw SQL UPDATE that persists turn state (collected_fields, field_meta) did not include draft_state. ORM assignments to session.draft_state were not reliably flushed after the raw SQL commit, so the /confirm endpoint always found an empty draft_state and returned 400.

Now draft_state is included in the same raw SQL UPDATE, matching the hybrid architecture used for all other per-turn state fields.

https://claude.ai/code/session_017Cu1kWeGe9Yf7WYJkHchA4