### PR TITLE
Refine conversation guidelines and reduce field grouping

### DIFF
--- a/routes/chat.py
+++ b/routes/chat.py
@@ -562,12 +562,12 @@ async def chat_message(req: ChatMessageRequest, db: Session = Depends(get_db)):
         sections = get_sections_for_report(rt)
         missing_req, missing_opt = get_missing_fields(collected, _current_section, rt)
         all_missing = missing_req + missing_opt
-        # Smart Grouping: ask up to 3 optional fields at once
+        # Smart Grouping: ask up to 2 optional fields at once
         # (required fields still come one at a time)
         if missing_req:
             next_fields = get_next_fields(collected, _current_section, max_fields=1, report_type=rt)
         else:
-            next_fields = get_next_fields(collected, _current_section, max_fields=3, report_type=rt)
+            next_fields = get_next_fields(collected, _current_section, max_fields=2, report_type=rt)
         current_section = sections[_current_section]
 
         log.info("[CHAT] Turn %d: normalized=%s, next=%s", turn, list(normalized.keys()), next_fields)
@@ -673,12 +673,12 @@ async def chat_message(req: ChatMessageRequest, db: Session = Depends(get_db)):
 
         # QR generation — QR clicks always get normal next-field buttons.
         # Draft suppression only applies to free-text turns.
-        # Smart Grouping: group up to 3 optional fields for QR
+        # Smart Grouping: group up to 2 optional fields for QR
         _qr_miss_req, _qr_miss_opt = get_missing_fields(collected, _current_section, rt)
         if _qr_miss_req:
             qr_next = get_next_fields(collected, _current_section, max_fields=1, report_type=rt)
         else:
-            qr_next = get_next_fields(collected, _current_section, max_fields=3, report_type=rt)
+            qr_next = get_next_fields(collected, _current_section, max_fields=2, report_type=rt)
 
         # Fix 4: For strategy sessions, load R1 profile for context-aware QR
         _profile_ctx = None
@@ -1262,11 +1262,11 @@ def _build_session_state(
     section = sections[section_idx]
 
     missing_req, missing_opt = get_missing_fields(collected, section_idx, rt)
-    # Smart Grouping: group up to 3 optional fields
+    # Smart Grouping: group up to 2 optional fields
     if missing_req:
         next_fields = get_next_fields(collected, section_idx, max_fields=1, report_type=rt)
     else:
-        next_fields = get_next_fields(collected, section_idx, max_fields=3, report_type=rt)
+        next_fields = get_next_fields(collected, section_idx, max_fields=2, report_type=rt)
 
     total = len(registry)
     collected_count = len(collected)

--- a/routes/chat.py
+++ b/routes/chat.py
@@ -852,9 +852,10 @@ async def chat_session_get(session_id: UUID, db: Session = Depends(get_db)):
 
     rt = session.report_type
     state = _build_session_state(session)
-    next_fields = get_next_fields(session.collected_fields, session.current_section, report_type=rt)
+    # Use state.next_fields (already computed with correct max_fields logic)
+    # instead of calling get_next_fields again with default max_fields=1
     _profile_ctx = _load_r1_profile_for_strategy(session, db) if rt == "strategy" else None
-    state.quick_replies = _build_quick_replies(next_fields, rt, session.collected_fields, _profile_ctx)
+    state.quick_replies = _build_quick_replies(state.next_fields, rt, session.collected_fields, _profile_ctx)
 
     # Last 10 messages
     all_msgs = session.messages or []

--- a/services/chat_conversation.py
+++ b/services/chat_conversation.py
@@ -94,8 +94,13 @@ Oft reicht auch GAR KEINE Bestätigung — einfach die nächste Frage stellen.
 die konkrete Antwort verstanden haben, dann die nächste Frage.
 - KEINE generischen Einordnungen wie "X ist ein Bereich mit enormem \
 KI-Potenzial" oder "von A bis B lassen sich oft X% automatisieren".
-- Variieren Sie Ihre Satzanfänge — beginnen Sie NIEMALS zwei \
-aufeinanderfolgende Antworten gleich.
+- Variieren Sie Ihre Satzanfänge RADIKAL. Beginnen Sie NIEMALS \
+zwei Antworten im Gespräch mit demselben Wort oder derselben \
+Phrase. VERBOTENE Anfänge (über das gesamte Gespräch): \
+"Als KI-Berater...", "Als Solo-Berater...", "Als [Branche]...", \
+"Mit Ihrer...", "Mit KI...", "Ihre [Noun]...". \
+STATTDESSEN direkt inhaltlich einsteigen: Fakt, Zahl, Frage, \
+oder kurze Bestätigung ("Gut.", "Verstanden.", "Weiter.").
 - Ihre Reaktion muss sich IMMER auf die LETZTE Antwort des Nutzers \
 beziehen, nicht auf eine frühere Frage oder ein früheres Feld.
 
@@ -151,6 +156,11 @@ ABSOLUTE VERBOTE:
 oder des Geschäfts. Der Firmenname wird aus Datenschutzgründen \
 nicht erhoben. Sie kennen: Branche, Größe, Standort und \
 Hauptleistung — das reicht für die Analyse.
+- Erwähnen Sie NIEMALS einen konkreten Standort (Stadt, Bundesland, \
+Region) bevor der Nutzer ihn selbst angegeben hat. Prüfen Sie in \
+"AKTUELLER STAND" ob ein Bundesland erfasst ist. Wenn nicht: \
+KEIN Standort nennen. Auch KEINE Vermutungen wie "Sie sind \
+vermutlich in..." oder "In Ihrer Region...".
 - „das ist ein spannendes Feld" oder ähnliche Floskeln.
 - Denselben Satz oder dieselbe Satzstruktur in mehreren Antworten verwenden. \
 Insbesondere NICHT: "[Branche] [verb] [etwas] — von X bis Y." \
@@ -220,6 +230,9 @@ Fragestil an:
     "Welche KI-Projekte laufen aktuell bei Ihnen?"
 - Wenn der Nutzer offensichtlich KEIN KI-Experte ist, erklären \
 Sie Begriffe kurz und geben Sie praxisnahe Beispiele.
+  → Erwähnen Sie die Branche oder Rolle des Nutzers NICHT in \
+jeder Antwort. Der Nutzer weiß wer er ist. Einmal im Gespräch \
+reicht. Danach: direkt zur Sache.
 
 FOKUS-REGEL:
 - Reagieren Sie NUR auf die letzte Antwort des Nutzers.
@@ -574,6 +587,13 @@ als Bestätigung, dann SOFORT die nächste Frage.
 die konkrete Antwort verstanden haben, dann die nächste Frage.
 - KEINE generischen Einordnungen wie "X ist ein Bereich mit enormem \
 KI-Potenzial" oder "von A bis B lassen sich oft X% automatisieren".
+- Variieren Sie Ihre Satzanfänge RADIKAL. Beginnen Sie NIEMALS \
+zwei Antworten im Gespräch mit demselben Wort oder derselben \
+Phrase. VERBOTENE Anfänge (über das gesamte Gespräch): \
+"Als KI-Berater...", "Als Solo-Berater...", "Als [Branche]...", \
+"Mit Ihrer...", "Mit KI...", "Ihre [Noun]...". \
+STATTDESSEN direkt inhaltlich einsteigen: Fakt, Zahl, Frage, \
+oder kurze Bestätigung ("Gut.", "Verstanden.", "Weiter.").
 - Ihre Reaktion muss sich IMMER auf die LETZTE Antwort des Nutzers \
 beziehen, nicht auf eine frühere Frage oder ein früheres Feld.
 
@@ -594,6 +614,11 @@ UMGANG MIT FREITEXT-ANTWORTEN:
 Sie den VOLLEN Wortlaut oder erwähnen Sie sie gar nicht.
 
 VERBOTE:
+- Erwähnen Sie NIEMALS einen konkreten Standort (Stadt, Bundesland, \
+Region) bevor der Nutzer ihn selbst angegeben hat. Prüfen Sie in \
+"AKTUELLER STAND" ob ein Bundesland erfasst ist. Wenn nicht: \
+KEIN Standort nennen. Auch KEINE Vermutungen wie "Sie sind \
+vermutlich in..." oder "In Ihrer Region...".
 - Kommentieren Sie NIEMALS einen bereits bestätigten Wert erneut. \
 Bestätigte Felder sind abgeschlossen.
 - Wenn ein Entwurf offen ist (MODUS: BESTÄTIGUNG), stellen Sie \
@@ -638,6 +663,9 @@ Fragestil an:
     "Welche KI-Projekte laufen aktuell bei Ihnen?"
 - Wenn der Nutzer offensichtlich KEIN KI-Experte ist, erklären \
 Sie Begriffe kurz und geben Sie praxisnahe Beispiele.
+  → Erwähnen Sie die Branche oder Rolle des Nutzers NICHT in \
+jeder Antwort. Der Nutzer weiß wer er ist. Einmal im Gespräch \
+reicht. Danach: direkt zur Sache.
 
 KONTEXTUELLE ANPASSUNG:
 Sie MÜSSEN jede Frage VOR dem Stellen auf Passung prüfen. \


### PR DESCRIPTION
## Summary
This PR refines the AI conversation guidelines to improve response quality and adjusts the field grouping strategy to reduce cognitive load on users.

## Key Changes

### Conversation Guidelines (services/chat_conversation.py)
- **Enhanced sentence variation rules**: Expanded guidance on varying sentence openings with explicit forbidden patterns ("Als KI-Berater...", "Mit Ihrer...", etc.) and recommended direct content-first approaches (facts, numbers, questions, brief confirmations)
- **Location mention restrictions**: Added explicit prohibition against mentioning specific locations (cities, states, regions) before the user provides them, preventing speculative statements like "You're probably in..."
- **Reduced brand/role repetition**: Clarified that user's industry/role should be mentioned only once in conversation, then move directly to substantive content without constant reminders

### Field Grouping Strategy (routes/chat.py)
- **Reduced optional field grouping**: Changed maximum optional fields per question from 3 to 2
  - Affects `_run_extraction()` function
  - Affects `_token_producer()` function for QR generation
  - Affects `_build_session_state()` function
- **Fixed state consistency**: Updated `chat_session_get()` to use pre-computed `state.next_fields` instead of recalculating with default parameters, ensuring consistent field grouping logic across the application

## Implementation Details
- The field grouping changes maintain the distinction between required fields (always 1 at a time) and optional fields (now max 2 instead of 3)
- All three locations where field grouping occurs now use consistent logic
- The conversation guidelines changes are duplicated in both the initial system prompt and the `build_conversation_messages()` function to ensure consistency across different code paths

https://claude.ai/code/session_01V2ca7DKkRP2kg43TyCoLh8