### PR TITLE
Add help requests, edit mode, and smart grouping confirmations

### DIFF
--- a/routes/chat.py
+++ b/routes/chat.py
@@ -209,7 +209,10 @@ async def chat_message(req: ChatMessageRequest, db: Session = Depends(get_db)):
     # inside event_stream() so the SSE connection starts immediately and
     # heartbeats keep the connection alive during the Haiku call.
     rt = session.report_type
-    from services.chat_conversation import generate_response, FIELD_DESCRIPTIONS, build_help_context
+    from services.chat_conversation import (
+        generate_response, FIELD_DESCRIPTIONS, build_help_context,
+        EDIT_MODE_SONNET_PROMPT, build_edit_extraction_context,
+    )
 
     _HB_INTERVAL = 12  # seconds between keepalive heartbeats
 
@@ -248,6 +251,17 @@ async def chat_message(req: ChatMessageRequest, db: Session = Depends(get_db)):
 
         _is_qr_click = bool(req.quick_reply_field and req.quick_reply_value)
         _is_help_request = "__HELP_REQUEST__" in req.message
+
+        # Edit-mode detection: check if user wants to change a field after summary
+        _is_in_edit_mode = bool(_draft_state_snapshot.get("edit_mode"))
+        _edit_words = {"ändern", "etwas ändern", "korrigieren", "anpassen", "nein, etwas ändern", "nein ändern"}
+        _is_edit_request = (
+            not _is_qr_click
+            and not _is_help_request
+            and _has_summary_been_sent(session)
+            and req.message.strip().lower() in _edit_words
+        )
+        _edit_applied = False  # True when an edit was successfully applied this turn
 
         if _is_qr_click:
             # Quick reply: direct write, no Draft — user click is explicit confirmation.
@@ -330,8 +344,47 @@ async def chat_message(req: ChatMessageRequest, db: Session = Depends(get_db)):
             if _is_help_request:
                 _no_extraction = True
                 log.info("[CHAT] Help request detected for field %s, skipping extraction", cur_field)
-                # Clean the marker from the message for Sonnet context
-                # (the marker is a frontend signal, not user-visible text)
+
+            # Edit-request: user wants to change a field after summary
+            if _is_edit_request:
+                _no_extraction = True
+                # Activate edit_mode in draft_state
+                session.draft_state = {
+                    **(session.draft_state or {}),
+                    "edit_mode": True,
+                }
+                log.info("[CHAT] Edit request detected, activating edit_mode")
+
+            # Edit-mode: try to parse field change from user message
+            if _is_in_edit_mode and not _is_edit_request:
+                _no_extraction = True  # Skip normal extraction
+                _edit_field, _edit_value = _parse_edit_from_message(
+                    req.message, collected, registry, rt,
+                )
+                if _edit_field and _edit_value is not None:
+                    # Apply the edit
+                    result = normalize_field(_edit_field, _edit_value, collected, report_type=rt)
+                    if result.confidence != "low":
+                        collected[_edit_field] = result.value
+                        normalized[_edit_field] = result.value
+                        field_meta[_edit_field] = {
+                            "confidence": result.confidence,
+                            "source_turn": turn,
+                            "raw_input": str(_edit_value),
+                            "normalized": True,
+                            "confirmed": True,
+                        }
+                        _edit_applied = True
+                        # Deactivate edit_mode
+                        session.draft_state = {
+                            **(session.draft_state or {}),
+                            "edit_mode": False,
+                        }
+                        log.info("[CHAT] Edit applied: %s=%r", _edit_field, result.value)
+                    else:
+                        log.info("[CHAT] Edit: low confidence for %s=%r, asking again", _edit_field, _edit_value)
+                else:
+                    log.info("[CHAT] Edit: could not parse field change from message")
 
             # Draft-mode: read pending state for extractor context
             _draft = dict(_draft_state_snapshot)
@@ -547,7 +600,7 @@ async def chat_message(req: ChatMessageRequest, db: Session = Depends(get_db)):
         # draft_state MUST be included here — ORM assignments to
         # session.draft_state are not reliably flushed after raw SQL commits.
         _draft_for_sql = None
-        if DRAFT_MODE_ENABLED:
+        if DRAFT_MODE_ENABLED or _is_edit_request or _is_in_edit_mode:
             _draft_for_sql = json.dumps(
                 getattr(session, 'draft_state', None)
                 or {"pending_field": None, "pending_value": None, "dialog_mode": False}
@@ -621,6 +674,11 @@ async def chat_message(req: ChatMessageRequest, db: Session = Depends(get_db)):
             _sonnet_pending_field = None
             _sonnet_pending_value = None
             _sonnet_dialog_mode = False
+        elif _is_edit_request or (_is_in_edit_mode and not _edit_applied):
+            # Edit mode: Sonnet asks what to change or clarifies
+            _sonnet_pending_field = None
+            _sonnet_pending_value = None
+            _sonnet_dialog_mode = True
         elif _no_extraction and not DRAFT_MODE_ENABLED:
             # Legacy mode: no extraction → dialog mode so Sonnet answers
             # the user's question instead of advancing to next field
@@ -639,6 +697,27 @@ async def chat_message(req: ChatMessageRequest, db: Session = Depends(get_db)):
         _help_ctx = None
         if _is_help_request and _asked_field:
             _help_ctx = build_help_context(_asked_field, collected, rt)
+        elif _is_edit_request:
+            _help_ctx = EDIT_MODE_SONNET_PROMPT
+        elif _edit_applied:
+            # Edit was applied — Sonnet confirms the change
+            edit_field_label = FIELD_DESCRIPTIONS.get(list(normalized.keys())[0], "").split("(")[0].strip() if normalized else "Feld"
+            edit_new_val = list(normalized.values())[0] if normalized else ""
+            _help_ctx = (
+                f"\n\nAKTUELLER MODUS: ÄNDERUNG BESTÄTIGT\n"
+                f"Die Angabe wurde geändert: {edit_field_label} = \"{edit_new_val}\".\n"
+                f"Bestätigen Sie die Änderung in EINEM kurzen Satz.\n"
+                f"Danach folgt automatisch die aktualisierte Zusammenfassung."
+            )
+        elif _is_in_edit_mode and not _edit_applied:
+            # Still in edit mode but couldn't parse the change — ask for clarification
+            field_list = build_edit_extraction_context(collected, rt)
+            _help_ctx = (
+                f"\n\nAKTUELLER MODUS: ÄNDERUNG\n"
+                f"Der Nutzer möchte eine Angabe ändern, aber die Angabe war nicht eindeutig.\n"
+                f"Aktuelle Felder:\n{field_list}\n\n"
+                f"Fragen Sie den Nutzer, welches Feld geändert werden soll und auf welchen Wert."
+            )
 
         async def _token_producer():
             try:
@@ -745,6 +824,9 @@ async def chat_message(req: ChatMessageRequest, db: Session = Depends(get_db)):
         elif DRAFT_MODE_ENABLED and _signal == "question":
             # Dialog mode → no QR buttons
             quick_replies = []
+        elif _is_edit_request or (_is_in_edit_mode and not _edit_applied):
+            # Edit mode: no QR buttons, user types what to change
+            quick_replies = []
         else:
             quick_replies = _build_quick_replies(qr_next, rt, collected, _profile_ctx)
 
@@ -764,9 +846,14 @@ async def chat_message(req: ChatMessageRequest, db: Session = Depends(get_db)):
         db.commit()
 
         # Check if all fields are done → send summary
+        # Also regenerate summary after an edit was applied
         last_section = _current_section >= len(sections) - 1
         all_fields_done = len(qr_next) == 0 and last_section
-        if all_fields_done and not _has_summary_been_sent(session):
+        _should_send_summary = (
+            (all_fields_done and not _has_summary_been_sent(session))
+            or _edit_applied
+        )
+        if _should_send_summary:
             from services.chat_conversation import build_summary
             summary_text = build_summary(collected, rt)
             yield f"event: token\ndata: {json.dumps({'text': summary_text})}\n\n"
@@ -1367,6 +1454,74 @@ def _has_summary_been_sent(session: ChatSession) -> bool:
                 return True
             break  # Only check the last assistant message
     return False
+
+
+def _parse_edit_from_message(
+    message: str,
+    collected: dict,
+    registry: dict,
+    report_type: str = "r1",
+) -> tuple[str | None, object]:
+    """Parse a field edit from a user message. Returns (field_name, new_value) or (None, None).
+
+    Tries deterministic matching first:
+    - Match field labels or technical names in the message
+    - Extract the value from common patterns like "X soll Y sein" or "X auf Y"
+    """
+    from services.chat_conversation import FIELD_DESCRIPTIONS
+    msg_lower = message.strip().lower()
+
+    # Build lookup: label fragments → field_name
+    label_map: dict[str, str] = {}
+    for field_name in collected:
+        if field_name not in registry:
+            continue
+        desc = FIELD_DESCRIPTIONS.get(field_name, "")
+        label = desc.split("(")[0].strip().lower() if desc else ""
+        if label:
+            label_map[label] = field_name
+        # Also map the technical name
+        label_map[field_name.lower()] = field_name
+
+    # Try to find which field the user is referring to
+    matched_field = None
+    for label, field_name in sorted(label_map.items(), key=lambda x: -len(x[0])):
+        if label in msg_lower:
+            matched_field = field_name
+            break
+
+    if not matched_field:
+        return None, None
+
+    # Try to extract the new value from common patterns
+    # Patterns: "X soll Y sein", "X auf Y", "X: Y", "X = Y", "X ändern auf Y"
+    import re
+    patterns = [
+        rf"(?:soll|auf|=|:|ändern auf|ändern zu|wird|wäre)\s+(.+)",
+        rf"{re.escape(matched_field)}\s+(.+)",
+    ]
+    new_value = None
+    for pattern in patterns:
+        m = re.search(pattern, message, re.IGNORECASE)
+        if m:
+            new_value = m.group(1).strip().rstrip(".")
+            break
+
+    # If no pattern matched but field was found, the message might just be the value
+    # e.g., user says "Bayern" after being asked what to change
+    if not new_value and matched_field:
+        # Check if the whole message (minus the field reference) could be a value
+        remainder = msg_lower
+        for label, fn in label_map.items():
+            if fn == matched_field:
+                remainder = remainder.replace(label, "").strip()
+        if remainder and remainder != msg_lower:
+            new_value = remainder.strip().rstrip(".")
+
+    if not new_value:
+        return matched_field, None
+
+    return matched_field, new_value
 
 
 # ---------------------------------------------------------------------------

--- a/routes/chat.py
+++ b/routes/chat.py
@@ -209,7 +209,7 @@ async def chat_message(req: ChatMessageRequest, db: Session = Depends(get_db)):
     # inside event_stream() so the SSE connection starts immediately and
     # heartbeats keep the connection alive during the Haiku call.
     rt = session.report_type
-    from services.chat_conversation import generate_response, FIELD_DESCRIPTIONS
+    from services.chat_conversation import generate_response, FIELD_DESCRIPTIONS, build_help_context
 
     _HB_INTERVAL = 12  # seconds between keepalive heartbeats
 
@@ -247,6 +247,7 @@ async def chat_message(req: ChatMessageRequest, db: Session = Depends(get_db)):
         _asked_field = ""  # The field that was being asked when the user sent this message
 
         _is_qr_click = bool(req.quick_reply_field and req.quick_reply_value)
+        _is_help_request = "__HELP_REQUEST__" in req.message
 
         if _is_qr_click:
             # Quick reply: direct write, no Draft — user click is explicit confirmation.
@@ -325,30 +326,23 @@ async def chat_message(req: ChatMessageRequest, db: Session = Depends(get_db)):
             cur_desc = FIELD_DESCRIPTIONS.get(cur_field, "")
             _asked_field = cur_field
 
+            # Help-request: skip extraction entirely, stay on current field
+            if _is_help_request:
+                _no_extraction = True
+                log.info("[CHAT] Help request detected for field %s, skipping extraction", cur_field)
+                # Clean the marker from the message for Sonnet context
+                # (the marker is a frontend signal, not user-visible text)
+
             # Draft-mode: read pending state for extractor context
             _draft = dict(_draft_state_snapshot)
             _pf = _draft.get("pending_field") if DRAFT_MODE_ENABLED else None
             _pv = _draft.get("pending_value") if DRAFT_MODE_ENABLED else None
 
-            async def _run_extraction() -> dict:
-                try:
-                    return await asyncio.wait_for(
-                        extract_fields(
-                            req.message,
-                            messages[-6:],
-                            _all_missing,
-                            collected,
-                            report_type=rt,
-                            current_field=cur_field,
-                            current_field_description=cur_desc,
-                            draft_mode=DRAFT_MODE_ENABLED,
-                            pending_field=_pf,
-                            pending_value=_pv,
-                        ),
-                        timeout=30,
-                    )
-                except asyncio.TimeoutError:
-                    log.warning("[CHAT] Extraction timeout, retrying once...")
+            if _is_help_request:
+                # Help request: skip extraction entirely
+                raw_extracted = {"signal": "question", "fields": {}} if DRAFT_MODE_ENABLED else {}
+            else:
+                async def _run_extraction() -> dict:
                     try:
                         return await asyncio.wait_for(
                             extract_fields(
@@ -366,21 +360,39 @@ async def chat_message(req: ChatMessageRequest, db: Session = Depends(get_db)):
                             timeout=30,
                         )
                     except asyncio.TimeoutError:
-                        log.error("[CHAT] Extraction timeout on retry")
-                        return {"signal": None, "fields": {}} if DRAFT_MODE_ENABLED else {}
+                        log.warning("[CHAT] Extraction timeout, retrying once...")
+                        try:
+                            return await asyncio.wait_for(
+                                extract_fields(
+                                    req.message,
+                                    messages[-6:],
+                                    _all_missing,
+                                    collected,
+                                    report_type=rt,
+                                    current_field=cur_field,
+                                    current_field_description=cur_desc,
+                                    draft_mode=DRAFT_MODE_ENABLED,
+                                    pending_field=_pf,
+                                    pending_value=_pv,
+                                ),
+                                timeout=30,
+                            )
+                        except asyncio.TimeoutError:
+                            log.error("[CHAT] Extraction timeout on retry")
+                            return {"signal": None, "fields": {}} if DRAFT_MODE_ENABLED else {}
 
-            extract_task = asyncio.create_task(_run_extraction())
-            while not extract_task.done():
-                try:
-                    await asyncio.wait_for(asyncio.shield(extract_task), timeout=_HB_INTERVAL)
-                except asyncio.TimeoutError:
-                    yield f"event: heartbeat\ndata: {{}}\n\n"
-                except Exception:
-                    break  # task raised — handled below
+                extract_task = asyncio.create_task(_run_extraction())
+                while not extract_task.done():
+                    try:
+                        await asyncio.wait_for(asyncio.shield(extract_task), timeout=_HB_INTERVAL)
+                    except asyncio.TimeoutError:
+                        yield f"event: heartbeat\ndata: {{}}\n\n"
+                    except Exception:
+                        break  # task raised — handled below
 
-            raw_extracted = extract_task.result() if not extract_task.cancelled() else (
-                {"signal": None, "fields": {}} if DRAFT_MODE_ENABLED else {}
-            )
+                raw_extracted = extract_task.result() if not extract_task.cancelled() else (
+                    {"signal": None, "fields": {}} if DRAFT_MODE_ENABLED else {}
+                )
 
             if not DRAFT_MODE_ENABLED:
                 # ----- Legacy flow: normalize + direct write to collected_fields -----
@@ -623,6 +635,11 @@ async def chat_message(req: ChatMessageRequest, db: Session = Depends(get_db)):
             _sonnet_pending_value = _ds.get("pending_value")
             _sonnet_dialog_mode = _ds.get("dialog_mode", False)
 
+        # Build help context if this is a help request
+        _help_ctx = None
+        if _is_help_request and _asked_field:
+            _help_ctx = build_help_context(_asked_field, collected, rt)
+
         async def _token_producer():
             try:
                 async for token in generate_response(
@@ -636,6 +653,7 @@ async def chat_message(req: ChatMessageRequest, db: Session = Depends(get_db)):
                     pending_field=_sonnet_pending_field,
                     pending_value=_sonnet_pending_value,
                     dialog_mode=_sonnet_dialog_mode,
+                    help_context=_help_ctx,
                 ):
                     await queue.put(token)
             except Exception as exc:

--- a/routes/chat.py
+++ b/routes/chat.py
@@ -243,6 +243,8 @@ async def chat_message(req: ChatMessageRequest, db: Session = Depends(get_db)):
         _draft_confirmed_field = None
         _draft_confirmed_value = None
         _pending_after_turn = False  # True when a pending draft exists AFTER this turn's processing
+        _no_extraction = False  # True when free-text yielded no field extraction (user asked a question)
+        _asked_field = ""  # The field that was being asked when the user sent this message
 
         _is_qr_click = bool(req.quick_reply_field and req.quick_reply_value)
 
@@ -321,6 +323,7 @@ async def chat_message(req: ChatMessageRequest, db: Session = Depends(get_db)):
             asked_fields = get_next_fields(collected, _current_section, report_type=rt)
             cur_field = asked_fields[0] if asked_fields else ""
             cur_desc = FIELD_DESCRIPTIONS.get(cur_field, "")
+            _asked_field = cur_field
 
             # Draft-mode: read pending state for extractor context
             _draft = dict(_draft_state_snapshot)
@@ -406,6 +409,10 @@ async def chat_message(req: ChatMessageRequest, db: Session = Depends(get_db)):
                         "normalized": True,
                         "confirmed": False,
                     }
+                # No fields extracted from free text → user likely asked a question
+                if not normalized:
+                    _no_extraction = True
+                    log.info("[CHAT] Legacy: no extraction from free text, staying on field %s", _asked_field)
             else:
                 # ----- Draft flow: extract → pending, not collected -----
                 _signal = raw_extracted.get("signal")
@@ -562,15 +569,22 @@ async def chat_message(req: ChatMessageRequest, db: Session = Depends(get_db)):
         sections = get_sections_for_report(rt)
         missing_req, missing_opt = get_missing_fields(collected, _current_section, rt)
         all_missing = missing_req + missing_opt
-        # Smart Grouping: ask up to 2 optional fields at once
-        # (required fields still come one at a time)
-        if missing_req:
-            next_fields = get_next_fields(collected, _current_section, max_fields=1, report_type=rt)
+
+        if _no_extraction and _asked_field and _asked_field not in collected:
+            # No extraction: user asked a question or gave unclear answer.
+            # Stay on current field — do NOT advance to next field.
+            next_fields = [_asked_field]
+            log.info("[CHAT] QR-Sync: no extraction, keeping next_fields=[%s]", _asked_field)
         else:
-            next_fields = get_next_fields(collected, _current_section, max_fields=2, report_type=rt)
+            # Smart Grouping: ask up to 2 optional fields at once
+            # (required fields still come one at a time)
+            if missing_req:
+                next_fields = get_next_fields(collected, _current_section, max_fields=1, report_type=rt)
+            else:
+                next_fields = get_next_fields(collected, _current_section, max_fields=2, report_type=rt)
         current_section = sections[_current_section]
 
-        log.info("[CHAT] Turn %d: normalized=%s, next=%s", turn, list(normalized.keys()), next_fields)
+        log.info("[CHAT] Turn %d: normalized=%s, next=%s, no_extraction=%s", turn, list(normalized.keys()), next_fields, _no_extraction)
 
         # ------------------------------------------------------------------
         # Phase 2: Stream Sonnet response with heartbeat keepalive
@@ -595,6 +609,12 @@ async def chat_message(req: ChatMessageRequest, db: Session = Depends(get_db)):
             _sonnet_pending_field = None
             _sonnet_pending_value = None
             _sonnet_dialog_mode = False
+        elif _no_extraction and not DRAFT_MODE_ENABLED:
+            # Legacy mode: no extraction → dialog mode so Sonnet answers
+            # the user's question instead of advancing to next field
+            _sonnet_pending_field = None
+            _sonnet_pending_value = None
+            _sonnet_dialog_mode = True
         else:
             # No change → use snapshot (covers: no draft mode, or
             # existing pending draft carried over from previous turn)
@@ -674,11 +694,15 @@ async def chat_message(req: ChatMessageRequest, db: Session = Depends(get_db)):
         # QR generation — QR clicks always get normal next-field buttons.
         # Draft suppression only applies to free-text turns.
         # Smart Grouping: group up to 2 optional fields for QR
-        _qr_miss_req, _qr_miss_opt = get_missing_fields(collected, _current_section, rt)
-        if _qr_miss_req:
-            qr_next = get_next_fields(collected, _current_section, max_fields=1, report_type=rt)
+        if _no_extraction and _asked_field and _asked_field not in collected:
+            # No extraction: keep QR on the current field
+            qr_next = [_asked_field]
         else:
-            qr_next = get_next_fields(collected, _current_section, max_fields=2, report_type=rt)
+            _qr_miss_req, _qr_miss_opt = get_missing_fields(collected, _current_section, rt)
+            if _qr_miss_req:
+                qr_next = get_next_fields(collected, _current_section, max_fields=1, report_type=rt)
+            else:
+                qr_next = get_next_fields(collected, _current_section, max_fields=2, report_type=rt)
 
         # Fix 4: For strategy sessions, load R1 profile for context-aware QR
         _profile_ctx = None

--- a/routes/chat.py
+++ b/routes/chat.py
@@ -1272,6 +1272,16 @@ def _build_session_state(
     total = len(registry)
     collected_count = len(collected)
 
+    # Build per-field metadata for next_fields (optional flag, type)
+    nf_meta = {}
+    for nf in next_fields:
+        nf_reg = registry.get(nf, {})
+        nf_meta[nf] = {
+            "optional": not nf_reg.get("required", False),
+            "type": nf_reg.get("type", "text"),
+            "chat_mode": nf_reg.get("chat_mode", "FT"),
+        }
+
     section_name: str = section["name"]
 
     # is_completable: only after last section and summary has been sent
@@ -1297,6 +1307,7 @@ def _build_session_state(
         missing_optional=missing_opt,
         total_fields=total,
         next_fields=next_fields,
+        next_fields_meta=nf_meta,
         is_completable=completable,
         pending_field=draft.get("pending_field"),
         pending_value=draft.get("pending_value"),
@@ -1897,8 +1908,10 @@ def _build_quick_replies(
             if suggestions:
                 options = [QuickReplyOption(value=s, label=s) for s in suggestions]
                 label = _get_context_label(field_name, profile)
+                is_optional = not reg.get("required", False)
                 replies.append(QuickReply(
                     field=field_name, label=f"{label} (Vorschläge)", options=options,
+                    optional=is_optional,
                 ))
             continue
 
@@ -1925,9 +1938,11 @@ def _build_quick_replies(
         label = _get_context_label(field_name, profile)
         is_multi = reg.get("type") == "multi"
         max_sel = reg.get("max_select") if is_multi else None
+        is_optional = not reg.get("required", False)
         replies.append(QuickReply(
             field=field_name, label=label, options=options,
             multi_select=is_multi, max_select=max_sel,
+            optional=is_optional,
         ))
 
     return replies

--- a/schemas/chat.py
+++ b/schemas/chat.py
@@ -39,6 +39,7 @@ class QuickReply(BaseModel):
     options: list[QuickReplyOption]
     multi_select: bool = False
     max_select: Optional[int] = None
+    optional: bool = False
 
 
 # ---------------------------------------------------------------------------
@@ -65,6 +66,7 @@ class ChatSessionState(BaseModel):
 
     # Next steps
     next_fields: list[str]
+    next_fields_meta: Optional[dict[str, dict]] = None
     is_completable: bool
 
     # Draft-Pattern (Sprint 1: always null/false until Sprint 2 activates writes)

--- a/services/chat_conversation.py
+++ b/services/chat_conversation.py
@@ -865,6 +865,75 @@ def _format_collected_summary(collected: dict) -> str:
 
 
 # ---------------------------------------------------------------------------
+# Help-Request Prompt
+# ---------------------------------------------------------------------------
+
+HELP_REQUEST_PROMPT = """\
+Der Nutzer hat um eine Erklärung zum Feld "{field_label}" gebeten.
+
+Kontext des Nutzers:
+- Branche: {branche}
+- Unternehmensgröße: {segment_label}
+- Hauptleistung: {hauptleistung}
+- KI-Erfahrungslevel: {experience_level}
+
+Deine Aufgabe:
+1. Erkläre in 2–3 Sätzen, was mit diesem Feld gemeint ist — \
+branchenspezifisch für {branche}.
+2. Erkläre kurz, warum diese Angabe für den KI-Status-Report relevant ist.
+3. Gib 2–3 KURZE Stichworte als Denkanstoß.
+
+WICHTIGE REGELN:
+- Gib KEINE fertigen Antworten vor, die der Nutzer kopieren könnte.
+- Gib KEINE Listen mit konkreten Beispielen ("Typische No-Gos sind: ...").
+- Stattdessen: Stelle Reflexionsfragen ("Wo wären für Sie rote Linien?", \
+"In welchem Bereich sehen Sie den größten Hebel?").
+- Halte dich kurz: maximal 4 Sätze.
+- Schließe mit der ursprünglichen Frage ab (reformuliert, nicht \
+wortwörtlich wiederholt).
+"""
+
+
+def build_help_context(
+    field_name: str,
+    collected_fields: dict,
+    report_type: str = "r1",
+) -> str:
+    """Build the help-request context block for the system prompt."""
+    desc = FIELD_DESCRIPTIONS.get(field_name, field_name)
+    label = desc.split("(")[0].strip() if desc else field_name
+
+    branche = collected_fields.get("branche", "unbekannt")
+    groesse = collected_fields.get("unternehmensgroesse", "unbekannt")
+    hauptleistung = collected_fields.get("hauptleistung", "")
+    ki_kompetenz = collected_fields.get("ki_kompetenz", "")
+
+    segment_labels = {
+        "1": "Solo/Freiberuflich",
+        "2–10": "Kleines Team (2–10)",
+        "11–100": "KMU (11–100)",
+    }
+    segment_label = segment_labels.get(groesse, groesse)
+
+    experience_map = {
+        "hoch": "Fortgeschritten",
+        "sehr_hoch": "Experte",
+        "mittel": "Mittel",
+        "niedrig": "Einsteiger",
+        "keine": "Keine KI-Erfahrung",
+    }
+    experience_level = experience_map.get(ki_kompetenz, "Nicht erfasst")
+
+    return HELP_REQUEST_PROMPT.format(
+        field_label=label,
+        branche=branche,
+        segment_label=segment_label,
+        hauptleistung=hauptleistung or "Nicht erfasst",
+        experience_level=experience_level,
+    )
+
+
+# ---------------------------------------------------------------------------
 # Streaming Response Generator
 # ---------------------------------------------------------------------------
 
@@ -879,6 +948,7 @@ async def generate_response(
     pending_field: str | None = None,
     pending_value: object = None,
     dialog_mode: bool = False,
+    help_context: str | None = None,
 ) -> AsyncGenerator[str, None]:
     """
     Generate streaming AI response.
@@ -887,6 +957,7 @@ async def generate_response(
 
     When draft_mode=True, injects a context block describing the current
     draft state (dialog / pending confirmation / normal question).
+    When help_context is provided, appends field-specific help instructions.
     """
     client = _get_async_client()
     if client is None:
@@ -914,6 +985,10 @@ async def generate_response(
     # Draft-mode context injection (also used in legacy mode for dialog_mode)
     if draft_mode or dialog_mode:
         system_prompt += _build_draft_context(pending_field, pending_value, dialog_mode)
+
+    # Help-request context injection (field-specific explanation prompt)
+    if help_context:
+        system_prompt += f"\n\nHILFE-ANFRAGE:\n{help_context}"
 
     messages = build_conversation_messages(session_messages)
 

--- a/services/chat_conversation.py
+++ b/services/chat_conversation.py
@@ -911,8 +911,8 @@ async def generate_response(
     if hint:
         system_prompt += f"\n\nHINWEIS FÜR DIESEN ABSCHNITT:\n{hint}"
 
-    # Draft-mode context injection
-    if draft_mode:
+    # Draft-mode context injection (also used in legacy mode for dialog_mode)
+    if draft_mode or dialog_mode:
         system_prompt += _build_draft_context(pending_field, pending_value, dialog_mode)
 
     messages = build_conversation_messages(session_messages)

--- a/services/chat_conversation.py
+++ b/services/chat_conversation.py
@@ -1061,6 +1061,55 @@ REGELN FÜR DIESEN MODUS:
 wenn diese Wörter in den letzten 3 Antworten bereits vorkamen."""
 
 
+# ---------------------------------------------------------------------------
+# Edit-Mode Prompts (Summary-Edit-Flow)
+# ---------------------------------------------------------------------------
+
+EDIT_MODE_SONNET_PROMPT = """\
+
+AKTUELLER MODUS: ÄNDERUNG
+Der Nutzer möchte eine Angabe ändern.
+
+REGELN FÜR DIESEN MODUS:
+- Fragen Sie den Nutzer, was genau geändert werden soll.
+- Akzeptieren Sie Freitext wie "Bundesland soll Bayern sein" oder \
+"KI-Kompetenz auf Mittel ändern".
+- Akzeptieren Sie auch kurze Angaben wie "Branche" oder "Budget".
+- Wenn der Nutzer ein Feld nennt ohne neuen Wert: Fragen Sie nach \
+dem gewünschten neuen Wert.
+- Maximal 2 Sätze.
+"""
+
+
+EDIT_EXTRACTION_PROMPT = """\
+Der Nutzer möchte eine Angabe im Fragebogen ändern.
+Aktuelle Felder und Werte:
+{field_list_with_values}
+
+Extrahiere aus der Nutzer-Nachricht:
+- field_name: Der technische Feldname (aus der Liste oben)
+- new_value: Der neue Wert
+
+Falls der Nutzer nicht klar genug ist, gib zurück:
+- field_name: null
+- new_value: null
+"""
+
+
+def build_edit_extraction_context(collected_fields: dict, report_type: str = "r1") -> str:
+    """Build the field list for edit extraction."""
+    registry = get_registry_for_report(report_type)
+    lines = []
+    for field_name, value in collected_fields.items():
+        if field_name not in registry:
+            continue
+        desc = FIELD_DESCRIPTIONS.get(field_name, field_name)
+        label = desc.split("(")[0].strip() if desc else field_name
+        display = _format_value_for_display(field_name, value)
+        lines.append(f"- {field_name} ({label}): {display}")
+    return "\n".join(lines) if lines else "Keine Felder erfasst."
+
+
 # ===========================================================================
 # Template-based summary (no LLM — deterministic)
 # ===========================================================================

--- a/services/chat_conversation.py
+++ b/services/chat_conversation.py
@@ -94,6 +94,19 @@ Oft reicht auch GAR KEINE Bestätigung — einfach die nächste Frage stellen.
 die konkrete Antwort verstanden haben, dann die nächste Frage.
 - KEINE generischen Einordnungen wie "X ist ein Bereich mit enormem \
 KI-Potenzial" oder "von A bis B lassen sich oft X% automatisieren".
+
+SMART GROUPING — BESTÄTIGUNGSREGEL:
+Wenn der Nutzer auf eine Frage mit mehreren Feldern antwortet:
+- Bestätigen Sie die Eingabe KURZ: "Verstanden." oder "Notiert." \
+oder "Erfasst."
+- Wiederholen Sie NICHT die einzelnen Werte die der Nutzer gewählt hat.
+- Verwenden Sie NICHT die Wörter "teilweise", "zum Teil" oder \
+"bedingt" in Bestätigungen, es sei denn der Nutzer hat exakt \
+diesen Wert gewählt.
+- Gehen Sie direkt zur nächsten Frage über.
+FALSCH: "Teilweise, verstanden. Bei KI-Governance..."
+RICHTIG: "Verstanden. Weiter zu den Governance-Aspekten:"
+
 - Variieren Sie Ihre Satzanfänge RADIKAL. Beginnen Sie NIEMALS \
 zwei Antworten im Gespräch mit demselben Wort oder derselben \
 Phrase.
@@ -599,6 +612,19 @@ als Bestätigung, dann SOFORT die nächste Frage.
 die konkrete Antwort verstanden haben, dann die nächste Frage.
 - KEINE generischen Einordnungen wie "X ist ein Bereich mit enormem \
 KI-Potenzial" oder "von A bis B lassen sich oft X% automatisieren".
+
+SMART GROUPING — BESTÄTIGUNGSREGEL:
+Wenn der Nutzer auf eine Frage mit mehreren Feldern antwortet:
+- Bestätigen Sie die Eingabe KURZ: "Verstanden." oder "Notiert." \
+oder "Erfasst."
+- Wiederholen Sie NICHT die einzelnen Werte die der Nutzer gewählt hat.
+- Verwenden Sie NICHT die Wörter "teilweise", "zum Teil" oder \
+"bedingt" in Bestätigungen, es sei denn der Nutzer hat exakt \
+diesen Wert gewählt.
+- Gehen Sie direkt zur nächsten Frage über.
+FALSCH: "Teilweise, verstanden. Bei KI-Governance..."
+RICHTIG: "Verstanden. Weiter zu den Governance-Aspekten:"
+
 - Variieren Sie Ihre Satzanfänge RADIKAL. Beginnen Sie NIEMALS \
 zwei Antworten im Gespräch mit demselben Wort oder derselben \
 Phrase.

--- a/services/chat_conversation.py
+++ b/services/chat_conversation.py
@@ -96,11 +96,21 @@ die konkrete Antwort verstanden haben, dann die nächste Frage.
 KI-Potenzial" oder "von A bis B lassen sich oft X% automatisieren".
 - Variieren Sie Ihre Satzanfänge RADIKAL. Beginnen Sie NIEMALS \
 zwei Antworten im Gespräch mit demselben Wort oder derselben \
-Phrase. VERBOTENE Anfänge (über das gesamte Gespräch): \
-"Als KI-Berater...", "Als Solo-Berater...", "Als [Branche]...", \
-"Mit Ihrer...", "Mit KI...", "Ihre [Noun]...". \
+Phrase.
+
+VERBOTENE FORMULIERUNGEN (NIEMALS verwenden, auch nicht in Variationen):
+- Jede Formulierung die mit "Als KI-Berater" beginnt — egal was danach \
+kommt ("Als KI-Berater...", "Als erfahrener KI-Berater...", \
+"Als KI-Berater mit...", "Als Ihr KI-Berater..." — ALLES verboten)
+- Jede Formulierung die mit "Als [Branche]-Experte" oder \
+"Als [Branche]-Berater" beginnt
+- "Als Solo-Berater...", "Als [Branche]...", \
+"Mit Ihrer...", "Mit KI...", "Ihre [Noun]..."
+- "Das ist eine gute/wichtige/interessante Frage"
+- "Gute Frage"
 STATTDESSEN direkt inhaltlich einsteigen: Fakt, Zahl, Frage, \
 oder kurze Bestätigung ("Gut.", "Verstanden.", "Weiter.").
+
 - Ihre Reaktion muss sich IMMER auf die LETZTE Antwort des Nutzers \
 beziehen, nicht auf eine frühere Frage oder ein früheres Feld.
 
@@ -169,9 +179,11 @@ nächsten Mal eine völlig andere Formulierung. Variieren Sie: \
 Fragesätze, kurze Fakten, direkte Ansprache, Vergleiche.
 - Die Fakten des Nutzers nur zurückspiegeln ohne Mehrwert.
 - Den bisherigen Gesprächsverlauf zusammenfassen.
-- Beginnen Sie NIEMALS eine Antwort mit „Als [Branche]...", \
-„Als KI-Berater...", „Als Solo-Berater..." oder ähnlichen \
-Rollenwiederholungen. Der Nutzer WEISS wer er ist.
+- Beginnen Sie NIEMALS eine Antwort mit „Als KI-Berater" — in keiner \
+Variante (auch nicht „Als erfahrener KI-Berater", „Als Ihr KI-Berater", \
+„Als KI-Berater mit…"). Gleiches gilt für „Als [Branche]...", \
+„Als Solo-Berater..." oder ähnliche Rollenwiederholungen. \
+Der Nutzer WEISS wer er ist.
 - Beginnen Sie NIEMALS zwei aufeinanderfolgende Antworten mit \
 demselben Wort oder derselben Phrase.
 - Starten Sie direkt mit dem inhaltlichen Impuls zur Antwort.
@@ -589,11 +601,21 @@ die konkrete Antwort verstanden haben, dann die nächste Frage.
 KI-Potenzial" oder "von A bis B lassen sich oft X% automatisieren".
 - Variieren Sie Ihre Satzanfänge RADIKAL. Beginnen Sie NIEMALS \
 zwei Antworten im Gespräch mit demselben Wort oder derselben \
-Phrase. VERBOTENE Anfänge (über das gesamte Gespräch): \
-"Als KI-Berater...", "Als Solo-Berater...", "Als [Branche]...", \
-"Mit Ihrer...", "Mit KI...", "Ihre [Noun]...". \
+Phrase.
+
+VERBOTENE FORMULIERUNGEN (NIEMALS verwenden, auch nicht in Variationen):
+- Jede Formulierung die mit "Als KI-Berater" beginnt — egal was danach \
+kommt ("Als KI-Berater...", "Als erfahrener KI-Berater...", \
+"Als KI-Berater mit...", "Als Ihr KI-Berater..." — ALLES verboten)
+- Jede Formulierung die mit "Als [Branche]-Experte" oder \
+"Als [Branche]-Berater" beginnt
+- "Als Solo-Berater...", "Als [Branche]...", \
+"Mit Ihrer...", "Mit KI...", "Ihre [Noun]..."
+- "Das ist eine gute/wichtige/interessante Frage"
+- "Gute Frage"
 STATTDESSEN direkt inhaltlich einsteigen: Fakt, Zahl, Frage, \
 oder kurze Bestätigung ("Gut.", "Verstanden.", "Weiter.").
+
 - Ihre Reaktion muss sich IMMER auf die LETZTE Antwort des Nutzers \
 beziehen, nicht auf eine frühere Frage oder ein früheres Feld.
 


### PR DESCRIPTION
## Summary
This PR adds three major features to the chat conversation flow: help request handling, edit mode for changing previously entered fields, and improved confirmation messages for smart grouping. It also includes enhanced prompt engineering to prevent forbidden phrasings and improve response quality.

## Key Changes

### Help Request Handling
- Detect help requests via `__HELP_REQUEST__` marker in user messages
- Skip field extraction when help is requested and stay on current field
- Build field-specific help context using `build_help_context()` that provides branche-specific explanations without giving away answers
- Inject help context into system prompt to guide Sonnet's response

### Edit Mode (Post-Summary Field Changes)
- Detect edit requests after summary is sent using German keywords ("ändern", "korrigieren", "anpassen", etc.)
- Implement `_parse_edit_from_message()` to extract field name and new value from user input
- Normalize and apply edits directly to collected fields with confidence checking
- Regenerate summary after successful edit application
- Provide clarification prompts when edit parsing is ambiguous
- Add `EDIT_MODE_SONNET_PROMPT` and `build_edit_extraction_context()` for edit mode guidance

### Smart Grouping Improvements
- Add confirmation rule to system prompt: brief acknowledgments ("Verstanden.", "Notiert.") without repeating values
- Prevent forbidden phrasings like "Das ist eine gute Frage" and all "Als KI-Berater" variants
- Improve sentence variation rules in prompt

### Session State & QR Enhancements
- Add `next_fields_meta` to session state with per-field metadata (optional flag, type, chat_mode)
- Add `optional` flag to `QuickReply` model
- Suppress QR buttons in edit mode and help request mode
- Keep QR on current field when no extraction occurs (user asked question)

### Dialog Mode Handling
- Activate dialog mode when no extraction occurs in legacy mode (user asked question)
- Activate dialog mode in edit mode to allow clarification
- Pass `help_context` parameter through `generate_response()` function

### Logging & Debugging
- Add detailed logging for help requests, edit detection, edit application, and no-extraction scenarios
- Include `no_extraction` flag in turn logging

## Implementation Details

- Help requests and edit mode both set `_no_extraction = True` to prevent normal field extraction
- Edit mode persists in `session.draft_state["edit_mode"]` across turns
- Field matching in edit parsing uses longest-match-first strategy on field labels
- Edit value extraction tries multiple regex patterns (soll/auf/=/: operators)
- Summary regeneration is triggered when `_edit_applied = True`
- Draft state is always persisted to SQL when edit mode is active, even outside DRAFT_MODE_ENABLED

https://claude.ai/code/session_01FqshMoXG4dQko7EqVafza8