### PR TITLE
Strengthen anti-repetition rules and improve field decline handling

### DIFF
--- a/routes/chat.py
+++ b/routes/chat.py
@@ -893,8 +893,18 @@ async def chat_message(req: ChatMessageRequest, db: Session = Depends(get_db)):
 
         # Check if all fields are done → send summary
         # Also regenerate summary after an edit was applied
+        # KIS-1124-S0-BE-1: Check ALL sections, not just current, to prevent
+        # premature summary when earlier-section fields (e.g. ki_hemmnisse) are missing.
         last_section = _current_section >= len(sections) - 1
-        all_fields_done = len(qr_next) == 0 and last_section
+        _globally_complete = False
+        if last_section and len(qr_next) == 0:
+            _globally_complete = True
+            for _si in range(len(sections)):
+                _mr, _mo = get_missing_fields(collected, _si, rt)
+                if _mr or _mo:
+                    _globally_complete = False
+                    break
+        all_fields_done = last_section and _globally_complete
         _should_send_summary = (
             (all_fields_done and not _has_summary_been_sent(session))
             or _edit_applied

--- a/routes/chat.py
+++ b/routes/chat.py
@@ -546,12 +546,28 @@ async def chat_message(req: ChatMessageRequest, db: Session = Depends(get_db)):
                 _pending_after_turn = bool(draft_state.get("pending_field"))
 
         # Handle "weiter" / skip for optional fields
+        # KIS-1124-S0-BE-2: Extended skip detection with decline phrases
         skip_words = {"weiter", "skip", "überspringen", "nächste", "weiter bitte", "nächste frage"}
+        _DECLINE_PATTERNS = [
+            "weiß nicht", "weiss nicht", "keine ahnung", "kann ich nicht",
+            "überspring", "überspringen", "skip", "egal", "später",
+            "das kann ich jetzt nicht", "schwer zu sagen", "müsste ich nachschauen",
+            "ist mir nicht wichtig", "spielt keine rolle", "unwichtig",
+            "nächste frage", "weiter", "kann ich nicht entscheiden",
+            "kann ich nicht sagen", "keine angabe", "k.a.", "kein kommentar",
+            "keine meinung", "weiß ich nicht", "weiss ich nicht",
+            "kann ich nicht beantworten", "keine idee", "noch keine idee",
+        ]
+        _msg_lower = req.message.strip().lower()
+        _is_skip_word = _msg_lower in skip_words
+        _is_decline = (not normalized and not _is_qr_click and not _is_help_request
+                       and any(p in _msg_lower for p in _DECLINE_PATTERNS))
         _skip_confirmed_draft = False
-        if req.message.strip().lower() in skip_words and not normalized:
+
+        if (_is_skip_word or _is_decline) and not normalized:
             # In draft mode with pending: "weiter" confirms the pending value
             # but does NOT also skip the next field (confirm only).
-            if DRAFT_MODE_ENABLED:
+            if DRAFT_MODE_ENABLED and _is_skip_word:
                 draft_state = dict(_draft_state_snapshot)
                 if draft_state.get("pending_field"):
                     _cf = draft_state["pending_field"]
@@ -579,13 +595,34 @@ async def chat_message(req: ChatMessageRequest, db: Session = Depends(get_db)):
                 if asked:
                     skip_field = asked[0]
                     skip_reg = registry.get(skip_field, {})
+                    # Count how many times this field has been declined
+                    _field_meta_entry = field_meta.get(skip_field, {})
+                    _skip_attempts = _field_meta_entry.get("skip_attempts", 0) + 1
                     if not skip_reg.get("required"):
+                        # Optional field → skip immediately
                         collected[skip_field] = "" if skip_reg.get("type") == "text" else None
                         field_meta[skip_field] = {
                             "confidence": "high", "source_turn": turn,
                             "raw_input": "skipped", "normalized": True, "confirmed": True,
                         }
                         log.info("[CHAT] User skipped optional field: %s", skip_field)
+                    elif _skip_attempts >= 2:
+                        # Required field declined 2+ times → force-skip with keine_angabe
+                        collected[skip_field] = "keine_angabe"
+                        field_meta[skip_field] = {
+                            "confidence": "medium", "source_turn": turn,
+                            "raw_input": "declined_twice", "normalized": True, "confirmed": True,
+                        }
+                        log.info("[CHAT] User declined required field %s twice, setting keine_angabe", skip_field)
+                    else:
+                        # Required field, first decline → track attempt, stay on field
+                        # Sonnet will offer QR buttons as fallback
+                        field_meta[skip_field] = {
+                            **_field_meta_entry,
+                            "skip_attempts": _skip_attempts,
+                        }
+                        _no_extraction = True
+                        log.info("[CHAT] User declined required field %s (attempt %d), staying on field", skip_field, _skip_attempts)
 
         # Evaluate conditionals: remove hidden fields BEFORE writing
         for cond_field in ["selbststaendig", "bundesland"]:
@@ -765,6 +802,26 @@ async def chat_message(req: ChatMessageRequest, db: Session = Depends(get_db)):
                 f"Aktuelle Felder:\n{field_list}\n\n"
                 f"Fragen Sie den Nutzer, welches Feld geändert werden soll und auf welchen Wert."
             )
+
+        # KIS-1124-S0-BE-2: When user declines a required field, tell Sonnet
+        # to acknowledge gracefully and point to QR buttons as easy fallback.
+        if _is_decline and not _help_ctx:
+            _decline_field = _asked_field
+            _decline_reg = registry.get(_decline_field, {})
+            if _decline_reg.get("required"):
+                _decline_meta = field_meta.get(_decline_field, {})
+                _decline_attempts = _decline_meta.get("skip_attempts", 0)
+                if _decline_attempts == 1:
+                    _help_ctx = (
+                        f"\n\nAKTUELLER MODUS: NUTZER KANN NICHT ANTWORTEN\n"
+                        f"Der Nutzer hat signalisiert, dass er das Feld \"{_decline_field}\" "
+                        f"gerade nicht beantworten kann.\n"
+                        f"REAGIERE SO:\n"
+                        f"- Verstehe und akzeptiere das (1 kurzer Satz, z.B. 'Verstehe.').\n"
+                        f"- Weise darauf hin, dass es unten Buttons zur Auswahl gibt, "
+                        f"die die Antwort erleichtern.\n"
+                        f"- Maximal 2 Sätze total. NICHT insistieren."
+                    )
 
         async def _token_producer():
             try:

--- a/services/chat_conversation.py
+++ b/services/chat_conversation.py
@@ -97,8 +97,7 @@ KI-Potenzial" oder "von A bis B lassen sich oft X% automatisieren".
 
 SMART GROUPING — BESTÄTIGUNGSREGEL:
 Wenn der Nutzer auf eine Frage mit mehreren Feldern antwortet:
-- Bestätigen Sie die Eingabe KURZ: "Verstanden." oder "Notiert." \
-oder "Erfasst."
+- Bestätigen Sie die Eingabe KURZ.
 - Wiederholen Sie NICHT die einzelnen Werte die der Nutzer gewählt hat.
 - Verwenden Sie NICHT die Wörter "teilweise", "zum Teil" oder \
 "bedingt" in Bestätigungen, es sei denn der Nutzer hat exakt \
@@ -107,6 +106,25 @@ diesen Wert gewählt.
 FALSCH: "Teilweise, verstanden. Bei KI-Governance..."
 RICHTIG: "Verstanden. Weiter zu den Governance-Aspekten:"
 
+BESTÄTIGUNGS-REGELN (STRIKT):
+- Maximal 1 Satz Bestätigung, dann direkt zur nächsten Frage.
+- Verwende JEDE Bestätigung nur EINMAL im gesamten Chat. \
+Nach Gebrauch ist sie verbrannt.
+- Varianten-Pool (verwende jede nur 1×, dann streichen):
+  "Notiert.", "Danke.", "Klar.", "Verstehe.", "Gut.", \
+  "Passt.", "Erfasst.", "Alles klar.", "In Ordnung.", \
+  direkter Einstieg OHNE Bestätigungswort \
+  (z.B. "Bei Ihrem Profil..."), \
+  kurzer Rückbezug \
+  (z.B. "Zusammen mit Ihrer Angabe zu [vorheriges Feld]..."), \
+  Einordnung (z.B. "Das ist typisch für [Branche].")
+- VERBOTEN (zusätzlich zur bestehenden Blacklist):
+  "Verstanden." (zu häufig — max. 1× pro Gespräch), \
+  "Gut erfasst." (zu häufig), \
+  "Perfekt." (zu enthusiastisch für neutrale Angaben), \
+  "Da Sie..." als Satzeinstieg nach Bestätigung \
+  (Pattern zu repetitiv)
+- NIE zweimal denselben Satzanfang in 3 aufeinanderfolgenden Antworten.
 - Variieren Sie Ihre Satzanfänge RADIKAL. Beginnen Sie NIEMALS \
 zwei Antworten im Gespräch mit demselben Wort oder derselben \
 Phrase.
@@ -633,8 +651,7 @@ KI-Potenzial" oder "von A bis B lassen sich oft X% automatisieren".
 
 SMART GROUPING — BESTÄTIGUNGSREGEL:
 Wenn der Nutzer auf eine Frage mit mehreren Feldern antwortet:
-- Bestätigen Sie die Eingabe KURZ: "Verstanden." oder "Notiert." \
-oder "Erfasst."
+- Bestätigen Sie die Eingabe KURZ.
 - Wiederholen Sie NICHT die einzelnen Werte die der Nutzer gewählt hat.
 - Verwenden Sie NICHT die Wörter "teilweise", "zum Teil" oder \
 "bedingt" in Bestätigungen, es sei denn der Nutzer hat exakt \
@@ -643,6 +660,25 @@ diesen Wert gewählt.
 FALSCH: "Teilweise, verstanden. Bei KI-Governance..."
 RICHTIG: "Verstanden. Weiter zu den Governance-Aspekten:"
 
+BESTÄTIGUNGS-REGELN (STRIKT):
+- Maximal 1 Satz Bestätigung, dann direkt zur nächsten Frage.
+- Verwende JEDE Bestätigung nur EINMAL im gesamten Chat. \
+Nach Gebrauch ist sie verbrannt.
+- Varianten-Pool (verwende jede nur 1×, dann streichen):
+  "Notiert.", "Danke.", "Klar.", "Verstehe.", "Gut.", \
+  "Passt.", "Erfasst.", "Alles klar.", "In Ordnung.", \
+  direkter Einstieg OHNE Bestätigungswort \
+  (z.B. "Bei Ihrem Profil..."), \
+  kurzer Rückbezug \
+  (z.B. "Zusammen mit Ihrer Angabe zu [vorheriges Feld]..."), \
+  Einordnung (z.B. "Das ist typisch für [Branche].")
+- VERBOTEN (zusätzlich zur bestehenden Blacklist):
+  "Verstanden." (zu häufig — max. 1× pro Gespräch), \
+  "Gut erfasst." (zu häufig), \
+  "Perfekt." (zu enthusiastisch für neutrale Angaben), \
+  "Da Sie..." als Satzeinstieg nach Bestätigung \
+  (Pattern zu repetitiv)
+- NIE zweimal denselben Satzanfang in 3 aufeinanderfolgenden Antworten.
 - Variieren Sie Ihre Satzanfänge RADIKAL. Beginnen Sie NIEMALS \
 zwei Antworten im Gespräch mit demselben Wort oder derselben \
 Phrase.

--- a/services/chat_conversation.py
+++ b/services/chat_conversation.py
@@ -272,6 +272,12 @@ VERBOTEN: "Das ist eine solide Basis", "Gute Wahl", \
 ERLAUBT (selten): "Mit Digitalisierungsgrad 9 können Sie \
 KI-Automatisierung ohne große Vorarbeit einsetzen." \
 Im Zweifel: NICHT loben, sondern einen nützlichen Fakt liefern.
+- ERWEITERTE MUSTER-BLACKLIST (strukturelle Wiederholungen): \
+"Bei Ihrer Expertise" (zu repetitiv), \
+"eine starke Basis" / "eine solide Basis" / "eine gute Basis" \
+(generisches Lob — nie verwenden), \
+"das macht die Umsetzung" (Floskel). \
+Formulieren Sie stattdessen immer einen NEUEN, konkreten Satz.
 
 PLAUSIBILITÄTSPRÜFUNG:
 - Wenn die Hauptleistung des Nutzers KI-bezogen ist (KI-Beratung, \
@@ -782,6 +788,12 @@ VERBOTEN: "Das ist eine solide Basis", "Gute Wahl", \
 ERLAUBT (selten): "Mit Digitalisierungsgrad 9 können Sie \
 KI-Automatisierung ohne große Vorarbeit einsetzen." \
 Im Zweifel: NICHT loben, sondern einen nützlichen Fakt liefern.
+- ERWEITERTE MUSTER-BLACKLIST (strukturelle Wiederholungen): \
+"Bei Ihrer Expertise" (zu repetitiv), \
+"eine starke Basis" / "eine solide Basis" / "eine gute Basis" \
+(generisches Lob — nie verwenden), \
+"das macht die Umsetzung" (Floskel). \
+Formulieren Sie stattdessen immer einen NEUEN, konkreten Satz.
 
 EXPERTISE-ADAPTION:
 - Wenn die Hauptleistung des Nutzers KI-bezogen ist (KI-Beratung, \

--- a/services/chat_conversation.py
+++ b/services/chat_conversation.py
@@ -163,6 +163,14 @@ Statt "Wo frisst heute am meisten Zeit oder Nerven?" → \
 - Listen Sie NICHT Antwortoptionen im Fließtext auf (z.B. NICHT \
 "Hoch - Mittel - Niedrig"). Die Optionen erscheinen als Buttons.
 
+KÜRZE-REGEL (STRIKT):
+- Wenn das nächste Feld Quick-Reply-Buttons hat: Maximal 2 Sätze. \
+Die Buttons erklären sich selbst — du musst das Thema nicht einleiten. \
+NIEMALS Aufzählungen mit 3+ Optionen im Bot-Text, wenn dieselben \
+Optionen als QR-Buttons erscheinen.
+- Wenn das nächste Feld ein Freitext-Feld ist: Maximal 3 Sätze. \
+Stelle eine offene Frage, die zum Erzählen einlädt.
+
 KÜRZE UND NATÜRLICHKEIT:
 - Reagieren Sie NUR auf die LETZTE Antwort des Nutzers, nicht auf \
 alle bisherigen Antworten zusammen.
@@ -718,6 +726,14 @@ Statt "Wo frisst heute am meisten Zeit oder Nerven?" → \
 NICHT: "Cloud bedeutet... On-Premise bedeutet... Hoch - Mittel - Niedrig" \
 Die Optionen erscheinen automatisch als klickbare Buttons. \
 Ihre Aufgabe ist nur die FRAGE zu stellen, nicht die Optionen zu erklären.
+
+KÜRZE-REGEL (STRIKT):
+- Wenn das nächste Feld Quick-Reply-Buttons hat: Maximal 2 Sätze. \
+Die Buttons erklären sich selbst — du musst das Thema nicht einleiten. \
+NIEMALS Aufzählungen mit 3+ Optionen im Bot-Text, wenn dieselben \
+Optionen als QR-Buttons erscheinen.
+- Wenn das nächste Feld ein Freitext-Feld ist: Maximal 3 Sätze. \
+Stelle eine offene Frage, die zum Erzählen einlädt.
 
 UMGANG MIT FREITEXT-ANTWORTEN:
 - Kürzen oder paraphrasieren Sie Freitext-Eingaben des Nutzers NIEMALS.

--- a/services/chat_conversation.py
+++ b/services/chat_conversation.py
@@ -148,8 +148,10 @@ Frage stellen ohne "letzte/abschließend". \
 Erlaubt: "Diese Angabe ist optional" (ohne "letzte").
 - "die ideale Basis" (zu generisch, wird zu oft wiederverwendet)
 - "ohne große Vorarbeit" (gleicher Grund)
+- "Alles klar zu..." (zu generisch, erzeugt identische Sätze bei \
+verschiedenen Themen — verwende themenspezifische Bestätigungen)
 STATTDESSEN direkt inhaltlich einsteigen: Fakt, Zahl, Frage, \
-oder kurze Bestätigung ("Gut.", "Verstanden.", "Weiter.").
+oder kurze Bestätigung ("Gut.", "Weiter.").
 
 - Ihre Reaktion muss sich IMMER auf die LETZTE Antwort des Nutzers \
 beziehen, nicht auf eine frühere Frage oder ein früheres Feld.
@@ -710,8 +712,10 @@ Frage stellen ohne "letzte/abschließend". \
 Erlaubt: "Diese Angabe ist optional" (ohne "letzte").
 - "die ideale Basis" (zu generisch, wird zu oft wiederverwendet)
 - "ohne große Vorarbeit" (gleicher Grund)
+- "Alles klar zu..." (zu generisch, erzeugt identische Sätze bei \
+verschiedenen Themen — verwende themenspezifische Bestätigungen)
 STATTDESSEN direkt inhaltlich einsteigen: Fakt, Zahl, Frage, \
-oder kurze Bestätigung ("Gut.", "Verstanden.", "Weiter.").
+oder kurze Bestätigung ("Gut.", "Weiter.").
 
 - Ihre Reaktion muss sich IMMER auf die LETZTE Antwort des Nutzers \
 beziehen, nicht auf eine frühere Frage oder ein früheres Feld.
@@ -1116,6 +1120,7 @@ async def generate_response(
         )
 
     # Recent bot messages as anti-repetition context (KIS-1123 Fix 3).
+    # KIS-1124-S0-BE-5: Strengthened anti-repetition rules.
     if recent_bot_messages:
         _msgs_block = "\n".join(
             f'"""\n{msg}\n"""' for msg in recent_bot_messages
@@ -1123,18 +1128,18 @@ async def generate_response(
         system_prompt += (
             f"\n\nDEINE LETZTEN ANTWORTEN (NICHT WIEDERHOLEN):\n"
             f"{_msgs_block}\n\n"
-            "VARIANZ-REGELN:\n"
-            "- Verwende NIE zweimal hintereinander den gleichen "
-            "Satzanfang.\n"
-            "- Variiere deine Bestätigungen: mal Einordnung "
-            '("Das zeigt..."), mal Überleitung ("Dann schauen '
-            'wir..."), mal kurze Bestätigung ("Verstanden."), '
-            'mal Rückbezug ("Zusammen mit Ihrer Erfahrung...").\n'
-            "- Wenn du gerade \"Perfekt\" gesagt hast, sage beim "
-            "nächsten Mal NICHT \"Perfekt\". Alternativen: "
-            '"Gut.", "Verstanden.", "Danke.", oder direkter '
-            "Einstieg ohne Bestätigungswort.\n"
-            "- Maximal 1 Satz Bestätigung, dann Überleitung zur "
+            "ANTI-WIEDERHOLUNGS-REGELN (STRIKT — Verstöße sind VERBOTEN):\n"
+            "1. KEIN Satz aus deinen letzten Antworten darf in deiner "
+            "neuen Antwort wörtlich oder sinngemäß wiederholt werden.\n"
+            "2. KEIN Satzanfang (erstes Wort/Phrase) darf identisch "
+            "sein mit einem Satzanfang aus den letzten 3 Antworten.\n"
+            "3. Wenn du oben 'Alles klar zu...' gesagt hast, verwende "
+            "NICHT nochmal 'Alles klar zu...' — verwende einen "
+            "komplett anderen Satzanfang.\n"
+            "4. Bestätigungswörter: Jedes nur EINMAL im gesamten "
+            "Gespräch. Prüfe VOR dem Schreiben ob du es schon "
+            "oben verwendet hast.\n"
+            "5. Maximal 1 Satz Bestätigung, dann Überleitung zur "
             "nächsten Frage."
         )
 

--- a/services/chat_extractor.py
+++ b/services/chat_extractor.py
@@ -40,12 +40,16 @@ REGELN:
 5. Bei Freitextfeldern: den Kern der Aussage in 1–3 Sätzen zusammenfassen.
 6. Wenn der Nutzer eine Rückfrage stellt statt zu antworten,
    rufe das Tool NICHT auf.
-7. Wenn der Nutzer auf ein optionales Feld mit einer Ablehnung oder \
+7. Wenn der Nutzer auf ein Feld mit einer Ablehnung oder \
 einem Skip-Signal antwortet (z.B. „nein", „keine Ahnung", „noch keine Idee", \
 „weiß nicht", „weiter", „skip", „überspringen", „keine", „k.A.", \
-„noch nicht", „nicht wirklich", „keine Angabe"), dann extrahiere \
+„noch nicht", „nicht wirklich", „keine Angabe", „das kann ich nicht \
+entscheiden", „schwer zu sagen", „müsste ich nachschauen", „egal", \
+„ist mir nicht wichtig", „spielt keine Rolle"), dann extrahiere \
 das aktuell gefragte Feld mit dem Wert „keine_angabe". \
-Skip-Signale sind GÜLTIGE Antworten auf optionale Felder, NICHT „off-topic".
+Skip-Signale sind GÜLTIGE Antworten, NICHT „off-topic". \
+Auch bei Pflichtfeldern: Wenn der Nutzer klar signalisiert, dass er \
+nicht antworten kann oder will, setze „keine_angabe".
 
 AKTUELL GEFRAGTES FELD: {current_field}
 {current_field_hint}


### PR DESCRIPTION
## Summary
This PR significantly strengthens the chat conversation system's anti-repetition mechanisms and improves handling of user field declines, particularly for required fields. The changes enforce stricter confirmation phrase rotation, add comprehensive decline pattern detection, and implement graceful fallback behavior when users cannot answer required fields.

## Key Changes

### Anti-Repetition Rules (KIS-1124-S0-BE-5)
- **Stricter confirmation phrase management**: Each confirmation word (e.g., "Verstanden.", "Notiert.", "Gut.") can now only be used once per entire conversation
- **Enhanced system prompt**: Replaced generic variation rules with explicit anti-repetition constraints that forbid:
  - Identical sentence beginnings within 3 consecutive responses
  - Verbatim or semantic repetition of sentences from recent bot messages
  - Overused phrases like "Alles klar zu...", "eine starke Basis", "Bei Ihrer Expertise"
- **Confirmation variant pool**: Defined explicit one-time-use alternatives including direct topic entry, brief acknowledgments, and contextual framing
- **Blacklist expansion**: Added structural repetition patterns to prevent generic praise and filler phrases

### Field Decline Handling (KIS-1124-S0-BE-2)
- **Extended decline pattern detection**: Added comprehensive list of decline phrases ("weiß nicht", "keine ahnung", "schwer zu sagen", "müsste ich nachschauen", etc.) beyond simple skip words
- **Required field decline tracking**: Implemented `skip_attempts` counter in field metadata to track how many times a user has declined a required field
- **Graceful degradation**:
  - First decline on required field: Stay on field, track attempt, let Sonnet offer QR buttons as fallback
  - Second decline on required field: Auto-fill with "keine_angabe" and move forward
  - Optional fields: Skip immediately on first decline
- **User-friendly messaging**: When user declines a required field, bot acknowledges gracefully and points to QR buttons as easier alternative (max 2 sentences)

### Extraction & Validation Improvements
- **Expanded skip signal handling**: Updated extractor to recognize broader range of decline signals as valid answers (not off-topic)
- **Distinction between skip words and decline patterns**: Separate handling for explicit "weiter"/"skip" vs. implicit "can't answer" signals
- **Summary generation fix (KIS-1124-S0-BE-1)**: Changed premature summary trigger by checking ALL sections for missing fields, not just current section, preventing summary before earlier-section fields (e.g., `ki_hemmnisse`) are completed

### Brevity Rules (KÜRZE-REGEL STRIKT)
- **Quick-reply fields**: Maximum 2 sentences; buttons are self-explanatory
- **Free-text fields**: Maximum 3 sentences with open-ended question to encourage elaboration
- **No redundant option listing**: Removed instruction to repeat button options in bot text

## Implementation Details
- Confirmation phrase management is enforced at prompt generation time by including recent bot messages and explicit rules
- Decline detection uses pattern matching on lowercased, stripped user input
- Field metadata now tracks `skip_attempts` per field to enable progressive fallback behavior
- Summary completion check now iterates through all sections to verify global field coverage

https://claude.ai/code/session_01FzE4t6X1VDM5g7DWHDYjVx