### PR TITLE
KIS-1124: Implement hybrid conversation model with Phase 1 & checkpoint

### DIFF
--- a/core/migrate.py
+++ b/core/migrate.py
@@ -158,6 +158,8 @@ DDL = [
     )"""),
     # FIX: draft_state column was missing — existing tables need ALTER TABLE
     text("ALTER TABLE chat_sessions ADD COLUMN IF NOT EXISTS draft_state JSONB DEFAULT '{}'::jsonb"),
+    # KIS-1124 Sprint 2: phase tracking for hybrid conversation model
+    text("ALTER TABLE chat_sessions ADD COLUMN IF NOT EXISTS phase_state JSONB DEFAULT '{}'::jsonb"),
     text("CREATE INDEX IF NOT EXISTS idx_chat_sessions_status ON chat_sessions(status)"),
     text("CREATE INDEX IF NOT EXISTS idx_chat_sessions_user ON chat_sessions(user_id)"),
     text("CREATE INDEX IF NOT EXISTS idx_chat_sessions_activity ON chat_sessions(last_activity_at)"),

--- a/models.py
+++ b/models.py
@@ -499,6 +499,9 @@ class ChatSession(Base):
     # Draft-Pattern State (Sprint 1: infra only, never written yet)
     draft_state: Mapped[dict] = mapped_column(JSONType, default=dict, nullable=False)
 
+    # Phase tracking (hybrid conversation model, KIS-1124 Sprint 2)
+    phase_state: Mapped[dict] = mapped_column(JSONType, default=dict, nullable=False)
+
     # Conversation
     messages: Mapped[list] = mapped_column(JSONType, default=list, nullable=False)
     turn_count: Mapped[int] = mapped_column(Integer, default=0, nullable=False)

--- a/routes/chat.py
+++ b/routes/chat.py
@@ -369,6 +369,31 @@ async def chat_message(req: ChatMessageRequest, db: Session = Depends(get_db)):
             # regardless of DRAFT_MODE_ENABLED. Only free-text goes through Draft.
             qr_field = req.quick_reply_field
 
+            # --- Checkpoint QR handling (Phase 1 → Phase 2 transition) ---
+            if qr_field == "__checkpoint__":
+                _cp_value = req.quick_reply_value
+                if _cp_value == "REPORT":
+                    # User wants report now → skip to summary
+                    _phase_state["conversation_phase"] = "summary"
+                    log.info("[CHAT] Checkpoint: user chose REPORT NOW")
+                elif _cp_value == "ALL":
+                    _phase_state["conversation_phase"] = "phase_2"
+                    _phase_state["selected_blocks"] = ["A", "B", "C", "D"]
+                    _phase_state["current_block"] = "A"
+                    log.info("[CHAT] Checkpoint: user chose ALL blocks")
+                else:
+                    # Individual block(s) selected — may be comma-separated
+                    _selected = [b.strip() for b in _cp_value.split(",") if b.strip() in BLOCK_LABELS]
+                    if _selected:
+                        _phase_state["conversation_phase"] = "phase_2"
+                        _phase_state["selected_blocks"] = _selected
+                        _phase_state["current_block"] = _selected[0]
+                        log.info("[CHAT] Checkpoint: user chose blocks %s", _selected)
+                    else:
+                        log.warning("[CHAT] Checkpoint: invalid selection %r", _cp_value)
+                # Skip normal QR processing for checkpoint
+                _no_extraction = True
+
             # --- Draft housekeeping (pre-step, only when DRAFT_MODE_ENABLED) ---
             # Clears any pending draft. Does NOT affect the QR value write below.
             if DRAFT_MODE_ENABLED:
@@ -433,12 +458,28 @@ async def chat_message(req: ChatMessageRequest, db: Session = Depends(get_db)):
             # Run in background task so we can yield heartbeats while waiting.
             from services.chat_extractor import extract_fields
 
-            missing_req, missing_opt = get_missing_fields(collected, _current_section, rt)
-            _all_missing = missing_req + missing_opt
-            asked_fields = get_next_fields(collected, _current_section, report_type=rt)
-            cur_field = asked_fields[0] if asked_fields else ""
-            cur_desc = FIELD_DESCRIPTIONS.get(cur_field, "")
-            _asked_field = cur_field
+            # Phase 1 mode: determine fields differently
+            _conv_phase = _phase_state.get("conversation_phase", "phase_1") if rt == "r1" else None
+            _is_phase_1 = (_conv_phase == "phase_1" and rt == "r1")
+
+            if _is_phase_1:
+                # Phase 1: next fields come from PHASE_1_FIELDS, not sections
+                _missing_p1 = [f for f in PHASE_1_FIELDS if f not in collected]
+                _all_missing = _missing_p1
+                # Determine which Phase 1 field to ask next (QR fields first if missing)
+                _missing_qr = [f for f in _missing_p1 if f in PHASE_1_QR_FIELDS]
+                _missing_free = [f for f in _missing_p1 if f not in PHASE_1_QR_FIELDS]
+                asked_fields = (_missing_qr[:1] if _missing_qr else _missing_free[:1])
+                cur_field = asked_fields[0] if asked_fields else ""
+                cur_desc = FIELD_DESCRIPTIONS.get(cur_field, "")
+                _asked_field = cur_field
+            else:
+                missing_req, missing_opt = get_missing_fields(collected, _current_section, rt)
+                _all_missing = missing_req + missing_opt
+                asked_fields = get_next_fields(collected, _current_section, report_type=rt)
+                cur_field = asked_fields[0] if asked_fields else ""
+                cur_desc = FIELD_DESCRIPTIONS.get(cur_field, "")
+                _asked_field = cur_field
 
             # Help-request: skip extraction entirely, stay on current field
             if _is_help_request:
@@ -494,6 +535,109 @@ async def chat_message(req: ChatMessageRequest, db: Session = Depends(get_db)):
             if _is_help_request:
                 # Help request: skip extraction entirely
                 raw_extracted = {"signal": "question", "fields": {}} if DRAFT_MODE_ENABLED else {}
+            elif _is_phase_1 and not _is_in_edit_mode and not _is_edit_request:
+                # --- Phase 1: Multi-field extraction ---
+                from services.chat_extractor import extract_fields_multi
+                from services.chat_normalizer import ENUM_VALUES
+
+                # Build target fields for multi-field extractor
+                _target_fields = []
+                for _fname in PHASE_1_FIELDS:
+                    if _fname in collected:
+                        continue
+                    _freg = registry.get(_fname, {})
+                    _fdesc = FIELD_DESCRIPTIONS.get(_fname, _fname)
+                    _ftype = _freg.get("type", "text")
+                    _field_def: dict = {"name": _fname, "type": _ftype, "description": _fdesc}
+                    # Add enum options
+                    if _ftype in ("enum", "multi"):
+                        _opts = ENUM_VALUES.get(_fname)
+                        if _opts:
+                            _field_def["options"] = _opts
+                    _target_fields.append(_field_def)
+
+                # Also try to extract bonus fields (zielgruppen, jahresumsatz, etc.)
+                for _bname in PHASE_1_EXTRACTABLE_FIELDS:
+                    if _bname in collected or _bname in [f["name"] for f in _target_fields]:
+                        continue
+                    _breg = registry.get(_bname, {})
+                    _bdesc = FIELD_DESCRIPTIONS.get(_bname, _bname)
+                    _btype = _breg.get("type", "text")
+                    _bfield_def: dict = {"name": _bname, "type": _btype, "description": _bdesc}
+                    if _btype in ("enum", "multi"):
+                        _bopts = ENUM_VALUES.get(_bname)
+                        if _bopts:
+                            _bfield_def["options"] = _bopts
+                    _target_fields.append(_bfield_def)
+
+                async def _run_multi_extraction() -> dict:
+                    try:
+                        return await asyncio.wait_for(
+                            extract_fields_multi(
+                                req.message,
+                                messages[-6:],
+                                _target_fields,
+                                collected,
+                            ),
+                            timeout=30,
+                        )
+                    except asyncio.TimeoutError:
+                        log.warning("[CHAT] Phase 1 multi-extraction timeout, retrying...")
+                        try:
+                            return await asyncio.wait_for(
+                                extract_fields_multi(
+                                    req.message,
+                                    messages[-6:],
+                                    _target_fields,
+                                    collected,
+                                ),
+                                timeout=30,
+                            )
+                        except asyncio.TimeoutError:
+                            log.error("[CHAT] Phase 1 multi-extraction timeout on retry")
+                            return {}
+
+                extract_task = asyncio.create_task(_run_multi_extraction())
+                while not extract_task.done():
+                    try:
+                        await asyncio.wait_for(asyncio.shield(extract_task), timeout=_HB_INTERVAL)
+                    except asyncio.TimeoutError:
+                        yield f"event: heartbeat\ndata: {{}}\n\n"
+                    except Exception:
+                        break
+
+                _multi_raw = extract_task.result() if not extract_task.cancelled() else {}
+                _skip = _multi_raw.pop("__skip_signal", False)
+
+                # Normalize and write all extracted fields
+                for _mf_name, _mf_val in _multi_raw.items():
+                    if _mf_name not in registry:
+                        continue
+                    if not is_field_visible(_mf_name, collected):
+                        continue
+                    if _mf_name in collected:
+                        continue
+                    result = normalize_field(_mf_name, _mf_val, collected, report_type=rt)
+                    if result.confidence == "low":
+                        log.info("[CHAT] Phase 1: field %s low confidence, skipping", _mf_name)
+                        continue
+                    collected[_mf_name] = result.value
+                    normalized[_mf_name] = result.value
+                    field_meta[_mf_name] = {
+                        "confidence": result.confidence,
+                        "source_turn": turn,
+                        "raw_input": str(_mf_val),
+                        "normalized": True,
+                        "confirmed": True,
+                    }
+                    log.info("[CHAT] Phase 1: extracted %s=%r", _mf_name, result.value)
+
+                if not normalized and not _skip:
+                    _no_extraction = True
+                    log.info("[CHAT] Phase 1: no extraction from free text")
+
+                # Wrap as raw_extracted for compatibility with downstream code
+                raw_extracted = {}
             else:
                 async def _run_extraction() -> dict:
                     try:
@@ -765,26 +909,66 @@ async def chat_message(req: ChatMessageRequest, db: Session = Depends(get_db)):
         db.commit()
 
         # Check section transition (raw SQL inside, commits internally)
-        section_advanced = _check_section_transition(session, collected, db, rt)
-        if section_advanced:
-            _current_section = session.current_section
+        # Skip for Phase 1 — sections aren't used until Phase 2/legacy
+        _cur_conv_phase = _phase_state.get("conversation_phase", "phase_1") if rt == "r1" else None
+        if _cur_conv_phase not in ("phase_1", "checkpoint"):
+            section_advanced = _check_section_transition(session, collected, db, rt)
+            if section_advanced:
+                _current_section = session.current_section
 
         # Determine next fields
         sections = get_sections_for_report(rt)
-        missing_req, missing_opt = get_missing_fields(collected, _current_section, rt)
-        all_missing = missing_req + missing_opt
 
-        if _no_extraction and _asked_field and _asked_field not in collected:
-            # No extraction: user asked a question or gave unclear answer.
-            # Stay on current field — do NOT advance to next field.
-            next_fields = [_asked_field]
-            log.info("[CHAT] QR-Sync: no extraction, keeping next_fields=[%s]", _asked_field)
+        # --- Phase 1: Completion check + checkpoint trigger ---
+        _checkpoint_triggered = False
+        if _cur_conv_phase == "phase_1" and rt == "r1":
+            _missing_p1_after = [f for f in PHASE_1_FIELDS if f not in collected]
+            all_missing = _missing_p1_after
+
+            if not _missing_p1_after:
+                # All Phase 1 fields collected → trigger checkpoint
+                _phase_state["conversation_phase"] = "checkpoint"
+                _checkpoint_triggered = True
+                next_fields = []
+                log.info("[CHAT] Phase 1 COMPLETE — triggering checkpoint")
+
+                # Persist phase_state change immediately
+                db.execute(
+                    _sa_text("UPDATE chat_sessions SET phase_state = CAST(:ps AS jsonb) WHERE id = :sid"),
+                    {"ps": json.dumps(_phase_state), "sid": str(session.id)},
+                )
+                db.commit()
+            elif _no_extraction and _asked_field and _asked_field not in collected:
+                next_fields = [_asked_field]
+                log.info("[CHAT] Phase 1 QR-Sync: keeping next_fields=[%s]", _asked_field)
+            else:
+                # Phase 1: next QR field first, then free-text fields
+                _p1_qr_missing = [f for f in _missing_p1_after if f in PHASE_1_QR_FIELDS]
+                _p1_free_missing = [f for f in _missing_p1_after if f not in PHASE_1_QR_FIELDS]
+                next_fields = (_p1_qr_missing[:1] if _p1_qr_missing else _p1_free_missing[:1])
+
+        elif _cur_conv_phase == "checkpoint" and rt == "r1":
+            # Checkpoint phase — next_fields is empty, QR handles navigation
+            all_missing = []
+            next_fields = []
+
+        elif _cur_conv_phase == "summary" and rt == "r1":
+            # Summary phase — triggered by checkpoint "Report jetzt erstellen"
+            all_missing = []
+            next_fields = []
+
         else:
-            # Smart Grouping disabled: always ask 1 field at a time.
-            # With max_fields=2 Sonnet didn't reliably address both fields
-            # in its question, leaving QR buttons without context (KIS-1122).
-            next_fields = get_next_fields(collected, _current_section, max_fields=1, report_type=rt)
-        current_section = sections[_current_section]
+            # Legacy / Phase 2 / Strategy: section-based next fields
+            missing_req, missing_opt = get_missing_fields(collected, _current_section, rt)
+            all_missing = missing_req + missing_opt
+
+            if _no_extraction and _asked_field and _asked_field not in collected:
+                next_fields = [_asked_field]
+                log.info("[CHAT] QR-Sync: no extraction, keeping next_fields=[%s]", _asked_field)
+            else:
+                next_fields = get_next_fields(collected, _current_section, max_fields=1, report_type=rt)
+
+        current_section = sections[min(_current_section, len(sections) - 1)]
 
         log.info("[CHAT] Turn %d: normalized=%s, next=%s, no_extraction=%s", turn, list(normalized.keys()), next_fields, _no_extraction)
 
@@ -925,8 +1109,28 @@ async def chat_message(req: ChatMessageRequest, db: Session = Depends(get_db)):
                         f"- Maximal 2 Sätze total. NICHT insistieren."
                     )
 
+        # Compute Phase 1 missing fields for Sonnet prompt
+        _missing_p1_for_sonnet = None
+        if _cur_conv_phase == "phase_1":
+            _missing_p1_for_sonnet = [f for f in PHASE_1_FIELDS if f not in collected]
+
+        # Checkpoint: inject checkpoint text instead of streaming Sonnet
+        _checkpoint_text = None
+        if _checkpoint_triggered:
+            _checkpoint_text = (
+                "Ich habe jetzt ein gutes Bild von Ihrem Unternehmen. "
+                "Damit kann ich bereits einen soliden KI-Report erstellen.\n\n"
+                "Sie können die Analyse aber gezielt vertiefen — "
+                "welche Bereiche interessieren Sie besonders?"
+            )
+
         async def _token_producer():
             try:
+                if _checkpoint_text:
+                    # Checkpoint: send static text, no Sonnet call
+                    await queue.put(_checkpoint_text)
+                    return
+
                 async for token in generate_response(
                     session_messages=list(session.messages),
                     collected_fields=collected,
@@ -942,6 +1146,8 @@ async def chat_message(req: ChatMessageRequest, db: Session = Depends(get_db)):
                     next_field_qr_context=_next_field_qr_context,
                     user_profile_summary=_user_profile_summary,
                     recent_bot_messages=_recent_bot_msgs,
+                    conversation_phase=_cur_conv_phase,
+                    missing_phase_1_fields=_missing_p1_for_sonnet,
                 ):
                     await queue.put(token)
             except Exception as exc:
@@ -997,43 +1203,69 @@ async def chat_message(req: ChatMessageRequest, db: Session = Depends(get_db)):
             if _signal == "question":
                 yield _sse_dialog_mode(active=True)
 
-        # QR generation — QR clicks always get normal next-field buttons.
-        # Draft suppression only applies to free-text turns.
-        # QR always shows 1 field at a time (Smart Grouping disabled, KIS-1122)
-        if _no_extraction and _asked_field and _asked_field not in collected:
-            # No extraction: keep QR on the current field
-            qr_next = [_asked_field]
-        else:
-            qr_next = get_next_fields(collected, _current_section, max_fields=1, report_type=rt)
-
+        # QR generation — phase-aware
         # Fix 4: For strategy sessions, load R1 profile for context-aware QR
         _profile_ctx = None
         if rt == "strategy":
             _profile_ctx = _load_r1_profile_for_strategy(session, db)
 
-        if _is_qr_click:
-            # QR clicks are explicit user actions — never show confirm/edit
-            # buttons. Draft was already handled in the QR housekeeping step.
-            quick_replies = _build_quick_replies(qr_next, rt, collected, _profile_ctx)
-        elif DRAFT_MODE_ENABLED and _pending_after_turn:
-            # Free-text turn with pending draft value → show confirm/edit
+        # Determine qr_next based on conversation phase
+        _final_phase = _phase_state.get("conversation_phase") if rt == "r1" else None
+
+        if _checkpoint_triggered or _final_phase == "checkpoint":
+            # Checkpoint: show topic selection buttons
             quick_replies = [QuickReply(
-                field="_draft_action",
-                label="Angabe bestätigen",
+                field="__checkpoint__",
+                label="Bereiche vertiefen",
                 options=[
-                    QuickReplyOption(value="confirm", label="✓ Übernehmen"),
-                    QuickReplyOption(value="edit", label="✏️ Ändern"),
+                    QuickReplyOption(value="A", label="Fördermittel & Budget"),
+                    QuickReplyOption(value="B", label="KI-Strategie & Roadmap"),
+                    QuickReplyOption(value="C", label="Tools & Automatisierung"),
+                    QuickReplyOption(value="D", label="Recht & Datenschutz"),
+                    QuickReplyOption(value="ALL", label="Alle Bereiche vertiefen"),
+                    QuickReplyOption(value="REPORT", label="Report jetzt erstellen"),
                 ],
-                multi_select=False,
+                multi_select=True,
+                max_select=4,
             )]
-        elif DRAFT_MODE_ENABLED and _signal == "question":
-            # Dialog mode → no QR buttons
+        elif _final_phase == "summary":
+            # Summary phase: no QR, will generate summary below
             quick_replies = []
-        elif _is_edit_request or (_is_in_edit_mode and not _edit_applied):
-            # Edit mode: no QR buttons, user types what to change
-            quick_replies = []
-        else:
+        elif _final_phase == "phase_1":
+            # Phase 1: show QR for next Phase 1 field
+            if _no_extraction and _asked_field and _asked_field not in collected:
+                qr_next = [_asked_field]
+            else:
+                _p1_missing = [f for f in PHASE_1_FIELDS if f not in collected]
+                _p1_qr = [f for f in _p1_missing if f in PHASE_1_QR_FIELDS]
+                _p1_free = [f for f in _p1_missing if f not in PHASE_1_QR_FIELDS]
+                qr_next = _p1_qr[:1] if _p1_qr else _p1_free[:1]
             quick_replies = _build_quick_replies(qr_next, rt, collected, _profile_ctx)
+        else:
+            # Legacy / Phase 2: section-based QR
+            if _no_extraction and _asked_field and _asked_field not in collected:
+                qr_next = [_asked_field]
+            else:
+                qr_next = get_next_fields(collected, _current_section, max_fields=1, report_type=rt)
+
+            if _is_qr_click and not (req.quick_reply_field == "__checkpoint__"):
+                quick_replies = _build_quick_replies(qr_next, rt, collected, _profile_ctx)
+            elif DRAFT_MODE_ENABLED and _pending_after_turn:
+                quick_replies = [QuickReply(
+                    field="_draft_action",
+                    label="Angabe bestätigen",
+                    options=[
+                        QuickReplyOption(value="confirm", label="✓ Übernehmen"),
+                        QuickReplyOption(value="edit", label="✏️ Ändern"),
+                    ],
+                    multi_select=False,
+                )]
+            elif DRAFT_MODE_ENABLED and _signal == "question":
+                quick_replies = []
+            elif _is_edit_request or (_is_in_edit_mode and not _edit_applied):
+                quick_replies = []
+            else:
+                quick_replies = _build_quick_replies(qr_next, rt, collected, _profile_ctx)
 
         assistant_msg = {
             "role": "assistant",
@@ -1052,11 +1284,15 @@ async def chat_message(req: ChatMessageRequest, db: Session = Depends(get_db)):
 
         # Check if all fields are done → send summary
         # Also regenerate summary after an edit was applied
+        # KIS-1124: Also trigger summary when user selects "Report jetzt erstellen"
+        # from the checkpoint (conversation_phase == "summary").
+        _phase_summary_requested = (_final_phase == "summary" and not _has_summary_been_sent(session))
+
         # KIS-1124-S0-BE-1: Check ALL sections, not just current, to prevent
         # premature summary when earlier-section fields (e.g. ki_hemmnisse) are missing.
         last_section = _current_section >= len(sections) - 1
         _globally_complete = False
-        if last_section and len(qr_next) == 0:
+        if last_section and not next_fields:
             _globally_complete = True
             for _si in range(len(sections)):
                 _mr, _mo = get_missing_fields(collected, _si, rt)
@@ -1067,6 +1303,7 @@ async def chat_message(req: ChatMessageRequest, db: Session = Depends(get_db)):
         _should_send_summary = (
             (all_fields_done and not _has_summary_been_sent(session))
             or _edit_applied
+            or _phase_summary_requested
         )
         if _should_send_summary:
             from services.chat_conversation import build_summary

--- a/routes/chat.py
+++ b/routes/chat.py
@@ -66,6 +66,101 @@ log = logging.getLogger(__name__)
 # Feature flag: Draft-Pattern (Sprint 1 infra — default off)
 DRAFT_MODE_ENABLED = os.getenv("DRAFT_MODE_ENABLED", "false").lower() == "true"
 
+# ---------------------------------------------------------------------------
+# KIS-1124 Sprint 2: Hybrid Conversation Model — Phase & Block Definitions
+# ---------------------------------------------------------------------------
+
+# Phase 1 required fields — must be collected before checkpoint
+PHASE_1_FIELDS: list[str] = [
+    "branche", "unternehmensgroesse", "country", "bundesland",
+    "hauptleistung", "ki_kompetenz", "digitalisierungsgrad",
+    "ki_ziele", "investitionsbudget",
+]
+
+# Fields that need QR buttons in Phase 1 (not extractable from free text)
+PHASE_1_QR_FIELDS: set[str] = {
+    "branche", "unternehmensgroesse", "country", "bundesland",
+    "investitionsbudget",
+}
+
+# Fields that Haiku can extract from free conversation in Phase 1
+PHASE_1_EXTRACTABLE_FIELDS: set[str] = {
+    "hauptleistung", "ki_kompetenz", "digitalisierungsgrad",
+    "ki_ziele", "zielgruppen", "jahresumsatz", "ki_einsatz",
+}
+
+
+def _get_datenschutz_block_fields(branche: str) -> list[str]:
+    """Return Block D fields based on branche (Beratung → reduced set)."""
+    if branche == "beratung":
+        return ["datenschutzbeauftragter", "ai_act_kenntnis", "ki_hemmnisse"]
+    return [
+        "datenschutzbeauftragter", "technische_massnahmen",
+        "folgenabschaetzung", "meldewege", "loeschregeln",
+        "ai_act_kenntnis", "regulierte_branche", "ki_hemmnisse",
+    ]
+
+
+# Phase 2 thematic blocks
+BLOCK_FIELDS: dict[str, list[str]] = {
+    "A": [
+        "bisherige_foerdermittel", "interesse_foerderung",
+        "erfahrung_beratung", "marktposition",
+        "benchmark_wettbewerb", "risikofreude", "jahresumsatz",
+    ],
+    "B": [
+        "vision_3_jahre", "strategische_ziele", "ki_guardrails",
+        "geschaeftsmodell_evolution", "roadmap_vorhanden",
+        "change_management", "massnahmen_komplexitaet",
+        "vision_prioritaet", "innovationsprozess",
+    ],
+    "C": [
+        "automatisierungsgrad", "ki_einsatz", "anwendungsfaelle",
+        "ki_projekte", "pilot_bereich", "zeitersparnis_prioritaet",
+        "vorhandene_tools", "trainings_interessen", "zeitbudget",
+        "prozesse_papierlos",
+    ],
+    # Block D is dynamic — see _get_datenschutz_block_fields()
+}
+
+BLOCK_LABELS: dict[str, str] = {
+    "A": "Fördermittel & Budget",
+    "B": "KI-Strategie & Roadmap",
+    "C": "Tools & Automatisierung",
+    "D": "Recht & Datenschutz",
+}
+
+
+def _get_block_fields(block_id: str, collected_fields: dict) -> list[str]:
+    """Get remaining (uncollected) fields for a block."""
+    if block_id == "D":
+        branche = collected_fields.get("branche", "")
+        all_fields = _get_datenschutz_block_fields(branche)
+    else:
+        all_fields = BLOCK_FIELDS.get(block_id, [])
+    return [f for f in all_fields if f not in collected_fields]
+
+
+def _init_phase_state() -> dict:
+    """Create initial phase_state for a new R1 session."""
+    return {
+        "conversation_phase": "phase_1",
+        "selected_blocks": [],
+        "completed_blocks": [],
+        "current_block": None,
+    }
+
+
+def _get_phase_state(session) -> dict:
+    """Read phase_state from session, with safe defaults."""
+    ps = getattr(session, "phase_state", None) or {}
+    return {
+        "conversation_phase": ps.get("conversation_phase", "phase_1"),
+        "selected_blocks": ps.get("selected_blocks", []),
+        "completed_blocks": ps.get("completed_blocks", []),
+        "current_block": ps.get("current_block"),
+    }
+
 R1_WELCOME = (
     "Willkommen bei ki-sicherheit.jetzt! Ich führe Sie durch eine "
     "kurze Bestandsaufnahme — in ca. 10–15 Minuten. Am Ende erhalten "
@@ -125,6 +220,9 @@ async def chat_start(
 
     now = datetime.now(timezone.utc)
 
+    # Initialize phase_state for R1 sessions (hybrid conversation model)
+    phase_state = _init_phase_state() if req.report_type == "r1" else {}
+
     session = ChatSession(
         report_type=req.report_type,
         lang=req.lang,
@@ -138,6 +236,7 @@ async def chat_start(
         turn_count=0,
         briefing_id=req.briefing_id,
         user_id=user_id,
+        phase_state=phase_state,
     )
     db.add(session)
     db.commit()
@@ -229,7 +328,7 @@ async def chat_message(req: ChatMessageRequest, db: Session = Depends(get_db)):
         # After db.commit() at l.202 the closure `session` object is
         # unreliable inside this async generator.
         _row = db.execute(
-            _sa_text("SELECT collected_fields, field_meta, current_section, draft_state "
+            _sa_text("SELECT collected_fields, field_meta, current_section, draft_state, phase_state "
                      "FROM chat_sessions WHERE id = :sid"),
             {"sid": str(session.id)}
         ).fetchone()
@@ -237,6 +336,7 @@ async def chat_message(req: ChatMessageRequest, db: Session = Depends(get_db)):
         field_meta = dict(_row[1] or {})
         _current_section = _row[2]
         _draft_state_snapshot = dict(_row[3] or {})
+        _phase_state = dict(_row[4] or {})
         log.info("[CHAT] Turn %d init: collected_keys=%s", turn, list(collected.keys()))
 
         # Draft-mode tracking variables (only meaningful when DRAFT_MODE_ENABLED)
@@ -649,6 +749,7 @@ async def chat_message(req: ChatMessageRequest, db: Session = Depends(get_db)):
                 SET collected_fields = CAST(:cf AS jsonb),
                     field_meta = CAST(:fm AS jsonb),
                     draft_state = CAST(:ds AS jsonb),
+                    phase_state = CAST(:ps AS jsonb),
                     updated_at = :ts
                 WHERE id = :sid
             """),
@@ -657,6 +758,7 @@ async def chat_message(req: ChatMessageRequest, db: Session = Depends(get_db)):
                 "cf": json.dumps(collected),
                 "fm": json.dumps(field_meta),
                 "ds": _draft_for_sql or json.dumps({}),
+                "ps": json.dumps(_phase_state),
                 "ts": now,
             }
         )
@@ -1532,6 +1634,9 @@ def _build_session_state(
     # Draft-Pattern state (backward-compatible: old sessions without column → {})
     draft = getattr(session, 'draft_state', None) or {}
 
+    # Phase tracking (hybrid conversation model, KIS-1124)
+    ps = _get_phase_state(session)
+
     return ChatSessionState(
         session_id=session.id,
         report_type=session.report_type,
@@ -1551,6 +1656,10 @@ def _build_session_state(
         pending_field=draft.get("pending_field"),
         pending_value=draft.get("pending_value"),
         dialog_mode=draft.get("dialog_mode", False),
+        conversation_phase=ps["conversation_phase"],
+        selected_blocks=ps["selected_blocks"],
+        completed_blocks=ps["completed_blocks"],
+        current_block=ps["current_block"],
     )
 
 

--- a/schemas/chat.py
+++ b/schemas/chat.py
@@ -74,6 +74,12 @@ class ChatSessionState(BaseModel):
     pending_value: Optional[Any] = None
     dialog_mode: bool = False
 
+    # Phase tracking (hybrid conversation model, KIS-1124 Sprint 2)
+    conversation_phase: str = "phase_1"
+    selected_blocks: list[str] = []
+    completed_blocks: list[str] = []
+    current_block: Optional[str] = None
+
     # Quick Replies
     quick_replies: Optional[list[QuickReply]] = None
 

--- a/services/chat_conversation.py
+++ b/services/chat_conversation.py
@@ -1029,6 +1029,119 @@ def build_help_context(
 
 
 # ---------------------------------------------------------------------------
+# KIS-1124 Sprint 2: Phase 1 Prompt — Open Conversation Mode
+# ---------------------------------------------------------------------------
+
+PHASE_1_SYSTEM_PROMPT = """\
+Sie sind ein KI-Assistent von ki-sicherheit.jetzt und führen ein kurzes \
+Kennenlerngespräch mit dem Nutzer, um sein Unternehmen zu verstehen.
+
+IHRE ROLLE:
+Sie sind ein kompetenter, freundlicher Berater — kein Chatbot und kein \
+Formular. Sie führen ein natürliches Gespräch, das sich wie ein \
+professionelles Erstgespräch anfühlt. Sie siezen durchgehend.
+
+ZIEL:
+Lernen Sie das Unternehmen des Nutzers kennen. Stellen Sie offene \
+Fragen, die zum Erzählen einladen. Im Hintergrund werden die \
+Antworten automatisch zu strukturierten Daten extrahiert.
+
+TRANSPARENZ:
+Sie sind ein KI-Assistent. Machen Sie das nur zu Gesprächsbeginn \
+transparent (falls noch nicht geschehen).
+
+BEREITS ERFASST:
+{collected_fields_summary}
+
+NOCH FEHLENDE KERNFELDER:
+{missing_phase_1_fields}
+
+GESPRÄCHS-REGELN:
+1. Stelle 1 Frage pro Nachricht, die idealerweise 2–3 Felder abdeckt.
+2. Maximal 2 Sätze pro Antwort.
+3. Keine QR-Button-Themen im Text vorwegnehmen — Felder wie Branche, \
+Unternehmensgröße, Land und Budget werden als Buttons angezeigt.
+4. Kein Bestätigungs-Overkill — kurze Reaktion, dann nächste Frage.
+5. Wenn der Nutzer viel erzählt: Zusammenfassen und weiterfragen.
+6. Wenn der Nutzer "weiß nicht" sagt: Feld überspringen, nicht insistieren.
+7. Tonfall: Professionell, aber nicht steif. Wie ein Berater-Erstgespräch.
+8. Fragen Sie NIEMALS nach dem Namen des Unternehmens oder der Firma.
+
+QR-FELDER (werden als Buttons angezeigt, NICHT im Text fragen):
+branche, unternehmensgroesse, country, bundesland, investitionsbudget
+
+FREI EXTRAHIERBARE FELDER (aus dem Gespräch ableitbar):
+hauptleistung, ki_kompetenz, digitalisierungsgrad, ki_ziele, \
+zielgruppen, jahresumsatz, ki_einsatz
+
+GESPRÄCHS-STRATEGIE:
+- Frage 1 (deckt: hauptleistung, ggf. zielgruppen, ki_kompetenz): \
+"Erzählen Sie mir von Ihrem Unternehmen — was machen Sie, und wie \
+ist Ihr Team aufgestellt?"
+- Frage 2 (deckt: ki_kompetenz, digitalisierungsgrad, ki_einsatz): \
+"Wie digital arbeiten Sie heute — von der Tool-Landschaft bis zum \
+KI-Einsatz?"
+- Frage 3 (deckt: ki_ziele, zeitersparnis_prioritaet): \
+"Was erhoffen Sie sich vom KI-Einsatz — wo soll sich am meisten \
+verändern?"
+Dies sind Beispiele — passen Sie die Fragen an den bisherigen \
+Gesprächsverlauf an.
+
+BESTÄTIGUNGS-REGELN (STRIKT):
+- Maximal 1 Satz Bestätigung, dann direkt zur nächsten Frage.
+- Verwende JEDE Bestätigung nur EINMAL im gesamten Chat.
+- Varianten-Pool (verwende jede nur 1×, dann streichen):
+  "Notiert.", "Danke.", "Klar.", "Verstehe.", "Gut.", \
+  "Passt.", "Erfasst.", "Alles klar.", "In Ordnung.", \
+  direkter Einstieg OHNE Bestätigungswort, \
+  kurzer Rückbezug, Einordnung.
+- VERBOTEN: "Verstanden." (max. 1×), "Gut erfasst.", "Perfekt.", \
+  "Da Sie..." als Satzeinstieg nach Bestätigung.
+- NIE zweimal denselben Satzanfang in 3 aufeinanderfolgenden Antworten.
+
+VERBOTENE FORMULIERUNGEN:
+- "als KI-Berater" in jeder Schreibweise
+- "Als [Branche]-Experte", "Als Solo-Berater..."
+- "Das ist eine gute/wichtige/interessante Frage"
+- "die ideale Basis", "ohne große Vorarbeit"
+- "Alles klar zu..." (zu generisch)
+- "Bei Ihrer Expertise", "eine starke/solide/gute Basis"
+
+KÜRZE-REGEL (STRIKT):
+- Bei QR-Feldern: Maximal 2 Sätze.
+- Bei Freitext-Feldern: Maximal 3 Sätze.
+- NIEMALS Aufzählungen von Optionen im Bot-Text.
+
+NÄCHSTES FELD:
+{next_field_info}
+"""
+
+
+def _build_phase_1_prompt(
+    collected_fields: dict,
+    missing_phase_1: list[str],
+    next_fields: list[str],
+    next_field_qr_context: str | None = None,
+) -> str:
+    """Build the Phase 1 system prompt for open conversation mode."""
+    # Format missing fields
+    missing_lines = []
+    for fname in missing_phase_1:
+        desc = FIELD_DESCRIPTIONS.get(fname, fname)
+        missing_lines.append(f"- {fname}: {desc}")
+    missing_str = "\n".join(missing_lines) if missing_lines else "Alle Kernfelder erfasst."
+
+    # Next field info
+    nf_info = next_field_qr_context or "Kein spezifisches nächstes Feld."
+
+    return PHASE_1_SYSTEM_PROMPT.format(
+        collected_fields_summary=_format_collected_summary(collected_fields),
+        missing_phase_1_fields=missing_str,
+        next_field_info=nf_info,
+    )
+
+
+# ---------------------------------------------------------------------------
 # Streaming Response Generator
 # ---------------------------------------------------------------------------
 
@@ -1047,6 +1160,8 @@ async def generate_response(
     next_field_qr_context: str | None = None,
     user_profile_summary: str | None = None,
     recent_bot_messages: list[str] | None = None,
+    conversation_phase: str | None = None,
+    missing_phase_1_fields: list[str] | None = None,
 ) -> AsyncGenerator[str, None]:
     """
     Generate streaming AI response.
@@ -1056,29 +1171,40 @@ async def generate_response(
     When draft_mode=True, injects a context block describing the current
     draft state (dialog / pending confirmation / normal question).
     When help_context is provided, appends field-specific help instructions.
+    When conversation_phase="phase_1", uses the Phase 1 open conversation prompt.
     """
     client = _get_async_client()
     if client is None:
         yield "Entschuldigung, ich bin gerade nicht erreichbar. Bitte versuchen Sie es gleich nochmal."
         return
 
-    sections = get_sections_for_report(report_type)
-    section_index: int = section["index"]
-    prompt_template = _get_system_prompt(report_type)
-    system_prompt = prompt_template.format(
-        section_name=section["name"],
-        section_number=section_index + 1,
-        total_sections=len(sections),
-        collected_fields_summary=_format_collected_summary(collected_fields),
-        missing_in_section=", ".join(missing_fields) if missing_fields else "alle erfasst",
-        next_fields_with_descriptions=_format_next_fields(next_fields, report_type),
-    )
+    # Phase 1: Use dedicated open conversation prompt
+    if conversation_phase == "phase_1":
+        system_prompt = _build_phase_1_prompt(
+            collected_fields=collected_fields,
+            missing_phase_1=missing_phase_1_fields or [],
+            next_fields=next_fields,
+            next_field_qr_context=next_field_qr_context,
+        )
+    else:
+        # Legacy / Phase 2 / Strategy: use section-based prompt
+        sections = get_sections_for_report(report_type)
+        section_index: int = section["index"]
+        prompt_template = _get_system_prompt(report_type)
+        system_prompt = prompt_template.format(
+            section_name=section["name"],
+            section_number=section_index + 1,
+            total_sections=len(sections),
+            collected_fields_summary=_format_collected_summary(collected_fields),
+            missing_in_section=", ".join(missing_fields) if missing_fields else "alle erfasst",
+            next_fields_with_descriptions=_format_next_fields(next_fields, report_type),
+        )
 
-    # Inject section-specific hint
-    hints = _get_section_hints(report_type)
-    hint = hints.get(section_index, "")
-    if hint:
-        system_prompt += f"\n\nHINWEIS FÜR DIESEN ABSCHNITT:\n{hint}"
+        # Inject section-specific hint
+        hints = _get_section_hints(report_type)
+        hint = hints.get(section_index, "")
+        if hint:
+            system_prompt += f"\n\nHINWEIS FÜR DIESEN ABSCHNITT:\n{hint}"
 
     # Draft-mode context injection (also used in legacy mode for dialog_mode)
     if draft_mode or dialog_mode:
@@ -1113,7 +1239,8 @@ async def generate_response(
     # Next-field QR context for coherent transitions (KIS-1123 Fix 1).
     # Skip in dialog/help mode — Sonnet should answer the user's question,
     # not transition to the next field.
-    if next_field_qr_context and not dialog_mode and not help_context:
+    # Skip in Phase 1 — already embedded in the Phase 1 prompt template.
+    if next_field_qr_context and not dialog_mode and not help_context and conversation_phase != "phase_1":
         system_prompt += (
             f"\n\nNÄCHSTES FELD (für deine Überleitung):\n"
             f"{next_field_qr_context}\n\n"

--- a/services/chat_extractor.py
+++ b/services/chat_extractor.py
@@ -571,3 +571,196 @@ def _format_collected(collected: dict) -> str:
     for k, v in collected.items():
         parts.append(f"{k}={v!r}")
     return ", ".join(parts)
+
+
+# ---------------------------------------------------------------------------
+# KIS-1124 Sprint 2: Multi-Field Extraction for Phase 1 Free Conversation
+# ---------------------------------------------------------------------------
+
+MULTI_FIELD_SYSTEM_PROMPT = """\
+Du bist ein Daten-Extractor für einen KI-Readiness-Fragebogen.
+Analysiere die Nutzerantwort und extrahiere ALLE erkennbaren Werte
+für die unten aufgelisteten Felder. Antworte NUR mit einem JSON-Objekt
+über das Tool extract_multi_fields.
+
+REGELN:
+1. Setze NUR Felder, die der Nutzer tatsächlich genannt oder klar impliziert hat.
+2. Erfinde NIEMALS Werte.
+3. Bei Unsicherheit: Feld NICHT setzen (weglassen).
+4. Bei enum-Feldern: Exakt einen der vorgegebenen Werte verwenden.
+5. Bei multi-Feldern: Array der erkannten Werte.
+6. Bei text-Feldern: Relevanten Textabschnitt in 1–3 Sätzen zusammenfassen.
+7. Bei slider-Feldern: Numerischen Wert ableiten (1–10).
+8. Extrahiere auch implizite Informationen:
+   - "in München" → bundesland: "by" (Bayern)
+   - "8 Mitarbeiter" → unternehmensgroesse: "team"
+   - "komplett digital" → digitalisierungsgrad: 9 oder 10
+   - "viel Papier" → digitalisierungsgrad: 2 oder 3
+   - "ich arbeite mit LLM-APIs" → ki_kompetenz: "hoch"
+   - "ich will automatisieren" → ki_ziele: ["automatisierung"]
+9. Wenn der Nutzer signalisiert, nicht antworten zu wollen \
+(z.B. "weiß nicht", "keine Ahnung", "überspring", "egal", "später", \
+"kann ich nicht", "schwer zu sagen", "nächste Frage"), setze \
+__skip_signal auf true.
+
+FELDER ZUM EXTRAHIEREN:
+{fields_descriptions}
+
+Bereits erfasst (NICHT nochmal setzen): {collected_fields}"""
+
+
+def _build_multi_field_tool(target_fields: list[dict[str, Any]]) -> dict[str, Any]:
+    """Build a dynamic tool schema for multi-field extraction.
+
+    Args:
+        target_fields: List of dicts with keys: name, type, description,
+                       and optionally options (for enum/multi).
+    """
+    properties: dict[str, Any] = {}
+
+    for field in target_fields:
+        fname = field["name"]
+        ftype = field.get("type", "text")
+        fdesc = field.get("description", fname)
+        foptions = field.get("options")
+
+        if ftype == "enum" and foptions:
+            properties[fname] = {
+                "type": "string",
+                "enum": foptions,
+                "description": fdesc,
+            }
+        elif ftype == "multi" and foptions:
+            properties[fname] = {
+                "type": "array",
+                "items": {"type": "string", "enum": foptions},
+                "description": fdesc,
+            }
+        elif ftype == "slider":
+            properties[fname] = {
+                "type": "integer",
+                "description": fdesc,
+            }
+        else:
+            # text or fallback
+            properties[fname] = {
+                "type": "string",
+                "description": fdesc,
+            }
+
+    # Add skip signal
+    properties["__skip_signal"] = {
+        "type": "boolean",
+        "description": (
+            "true wenn der User signalisiert, nicht antworten zu wollen "
+            "(weiß nicht, überspring, egal, etc.)"
+        ),
+    }
+
+    return {
+        "name": "extract_multi_fields",
+        "description": (
+            "Extrahiert mehrere strukturierte Felder gleichzeitig aus der "
+            "User-Nachricht. Nur Felder setzen, die erkennbar sind."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": properties,
+            "required": [],
+        },
+    }
+
+
+def _format_fields_for_prompt(target_fields: list[dict[str, Any]]) -> str:
+    """Format target fields as a readable list for the system prompt."""
+    lines = []
+    for f in target_fields:
+        fname = f["name"]
+        ftype = f.get("type", "text")
+        fdesc = f.get("description", fname)
+        opts = f.get("options")
+        if opts:
+            opts_str = ", ".join(opts[:15])
+            lines.append(f"- {fname} ({ftype}): {fdesc} | Optionen: [{opts_str}]")
+        else:
+            lines.append(f"- {fname} ({ftype}): {fdesc}")
+    return "\n".join(lines)
+
+
+async def extract_fields_multi(
+    user_message: str,
+    conversation_context: list[dict],
+    target_fields: list[dict[str, Any]],
+    collected_fields: dict,
+) -> dict:
+    """
+    Multi-field extraction for Phase 1 free conversation mode.
+
+    Instead of extracting one field at a time, this extracts ALL recognizable
+    values from a single user message across multiple target fields.
+
+    Args:
+        user_message: The current user message
+        conversation_context: Last 6 messages for context
+        target_fields: List of field descriptors, each with:
+            name, type, description, and optionally options
+        collected_fields: Already collected field values
+
+    Returns:
+        Dict with extracted fields. Keys are field names, values are
+        extracted values. Special key "__skip_signal" is True if the
+        user signaled unwillingness to answer.
+    """
+    client = _get_async_client()
+    if client is None:
+        log.error("[CHAT-EXTRACT-MULTI] No async client available")
+        return {}
+
+    # Build messages
+    messages: list[dict] = []
+    for turn in conversation_context[-6:]:
+        messages.append({"role": turn["role"], "content": turn["content"]})
+    messages.append({"role": "user", "content": user_message})
+
+    # Build system prompt
+    fields_desc = _format_fields_for_prompt(target_fields)
+    system = MULTI_FIELD_SYSTEM_PROMPT.format(
+        fields_descriptions=fields_desc,
+        collected_fields=_format_collected(collected_fields),
+    )
+
+    # Build dynamic tool
+    tool = _build_multi_field_tool(target_fields)
+
+    try:
+        response = await client.messages.create(
+            model=EXTRACTOR_MODEL,
+            max_tokens=800,
+            system=system,
+            messages=messages,
+            tools=[tool],
+            tool_choice={"type": "auto"},
+        )
+
+        for block in response.content:
+            if block.type == "tool_use" and block.name == "extract_multi_fields":
+                extracted: dict = dict(block.input)
+                skip = extracted.pop("__skip_signal", False)
+                # Remove None values
+                extracted = {k: v for k, v in extracted.items() if v is not None}
+                log.info(
+                    "[CHAT-EXTRACT-MULTI] Extracted %d fields: %s (skip=%s)",
+                    len(extracted),
+                    list(extracted.keys()),
+                    skip,
+                )
+                if skip:
+                    extracted["__skip_signal"] = True
+                return extracted
+
+        log.info("[CHAT-EXTRACT-MULTI] No fields extracted (question or off-topic)")
+        return {}
+
+    except Exception as exc:
+        log.error("[CHAT-EXTRACT-MULTI] Multi-extraction failed: %s", exc, exc_info=True)
+        return {}


### PR DESCRIPTION
## Summary
Implements the hybrid conversation model for R1 report type, introducing Phase 1 (open conversation with multi-field extraction) and a checkpoint mechanism that transitions to Phase 2 (thematic blocks A–D). This enables a more natural, conversational data collection experience before structured block-based questioning.

## Key Changes

### Phase 1 Infrastructure
- Added `PHASE_1_FIELDS` (9 required fields) and field categorization:
  - `PHASE_1_QR_FIELDS`: Fields shown as quick-reply buttons (branche, unternehmensgroesse, country, bundesland, investitionsbudget)
  - `PHASE_1_EXTRACTABLE_FIELDS`: Fields extracted from free conversation (hauptleistung, ki_kompetenz, digitalisierungsgrad, ki_ziele, etc.)
- Implemented `_init_phase_state()` and `_get_phase_state()` helpers to manage conversation phase tracking
- Added `phase_state` column to `ChatSession` model with fields: `conversation_phase`, `selected_blocks`, `completed_blocks`, `current_block`

### Phase 2 Block Structure
- Defined `BLOCK_FIELDS` dictionary mapping blocks A–D to their respective field sets
- Block D (Recht & Datenschutz) is dynamic: reduced field set for "beratung" branche via `_get_datenschutz_block_fields()`
- Added `BLOCK_LABELS` for user-facing block names
- Implemented `_get_block_fields()` to retrieve remaining uncollected fields per block

### Multi-Field Extraction (Phase 1)
- New `extract_fields_multi()` function in `chat_extractor.py` for simultaneous extraction of multiple fields from a single user message
- Dynamic tool schema generation via `_build_multi_field_tool()` supporting enum, multi, slider, and text field types
- System prompt `MULTI_FIELD_SYSTEM_PROMPT` with extraction rules and implicit information derivation (e.g., "München" → bundesland: "by")
- Includes `__skip_signal` to detect user unwillingness to answer ("weiß nicht", "überspring", etc.)

### Phase 1 Conversation Prompt
- New `PHASE_1_SYSTEM_PROMPT` in `chat_conversation.py` for open, natural conversation mode
- Prompt emphasizes professional consultant tone, single question per turn, max 2–3 sentences
- Includes strict confirmation rules (max 1 sentence, each variant used only once)
- Forbids certain formulaic phrases and enforces brevity
- Built via `_build_phase_1_prompt()` with context on collected/missing fields

### Checkpoint Mechanism
- When all Phase 1 fields are collected, conversation transitions to "checkpoint" phase
- Checkpoint displays topic selection QR buttons (blocks A, B, C, D, ALL, or "Report jetzt erstellen")
- User selection via `__checkpoint__` quick-reply field updates `selected_blocks` and `current_block`
- "Report jetzt erstellen" triggers "summary" phase for immediate report generation

### Event Stream Logic Updates
- Phase 1 mode uses `PHASE_1_FIELDS` instead of section-based field logic
- QR field prioritization: QR fields first, then free-text fields
- Checkpoint QR handling skips normal extraction (`_no_extraction = True`)
- Phase 1 completion check triggers checkpoint automatically
- Section transitions skipped during Phase 1 and checkpoint phases
- Phase-aware QR generation: Phase 1 shows next Phase 1 field, checkpoint shows block selection, summary shows no QR

### Database & Schema
- Added `phase_state` JSONB column to `chat_sessions` table via migration
- Updated `ChatSessionState` schema with phase tracking fields
- Persists phase state on each turn and after checkpoint transitions

### Response Generation
- `generate_response()` now accepts `conversation_phase` and `missing_phase_1_fields` parameters
- Phase 1 mode uses dedicated prompt template instead of section-based template
- Next-field QR context injection skipped in Phase 1 (already embedded in prompt)

https://claude.ai/code/session_01RM5fc84FQA4uuUS6opUYH1