### PR TITLE
KIS-1124-S2-HOTFIX: Split Phase 1 into QR-first (1a) and open convers…

### DIFF
--- a/routes/chat.py
+++ b/routes/chat.py
@@ -77,11 +77,19 @@ PHASE_1_FIELDS: list[str] = [
     "ki_ziele", "investitionsbudget",
 ]
 
-# Fields that need QR buttons in Phase 1 (not extractable from free text)
-PHASE_1_QR_FIELDS: set[str] = {
+# Phase 1a: QR fields collected sequentially (ordered)
+PHASE_1A_QR_FIELDS: list[str] = [
     "branche", "unternehmensgroesse", "country", "bundesland",
     "investitionsbudget",
-}
+]
+
+# Phase 1b: Open conversation fields (extracted via multi-field Haiku)
+PHASE_1B_OPEN_FIELDS: list[str] = [
+    "hauptleistung", "ki_kompetenz", "digitalisierungsgrad", "ki_ziele",
+]
+
+# Fields that need QR buttons in Phase 1 (not extractable from free text)
+PHASE_1_QR_FIELDS: set[str] = set(PHASE_1A_QR_FIELDS)
 
 # Fields that Haiku can extract from free conversation in Phase 1
 PHASE_1_EXTRACTABLE_FIELDS: set[str] = {
@@ -145,6 +153,7 @@ def _init_phase_state() -> dict:
     """Create initial phase_state for a new R1 session."""
     return {
         "conversation_phase": "phase_1",
+        "phase_1_qr_complete": False,
         "selected_blocks": [],
         "completed_blocks": [],
         "current_block": None,
@@ -156,10 +165,40 @@ def _get_phase_state(session) -> dict:
     ps = getattr(session, "phase_state", None) or {}
     return {
         "conversation_phase": ps.get("conversation_phase", "phase_1"),
+        "phase_1_qr_complete": ps.get("phase_1_qr_complete", False),
         "selected_blocks": ps.get("selected_blocks", []),
         "completed_blocks": ps.get("completed_blocks", []),
         "current_block": ps.get("current_block"),
     }
+
+
+def _is_phase_1a(phase_state: dict, collected: dict) -> bool:
+    """Check if we're in Phase 1a (QR fields still missing)."""
+    if phase_state.get("conversation_phase") != "phase_1":
+        return False
+    if phase_state.get("phase_1_qr_complete"):
+        return False
+    # Check if any QR fields are still missing
+    return any(f not in collected for f in PHASE_1A_QR_FIELDS
+               if f != "bundesland" or collected.get("country") in ("DE", "AT"))
+
+
+def _is_phase_1b(phase_state: dict, collected: dict) -> bool:
+    """Check if we're in Phase 1b (open conversation, QR done)."""
+    if phase_state.get("conversation_phase") != "phase_1":
+        return False
+    return not _is_phase_1a(phase_state, collected)
+
+
+def _get_next_phase_1a_field(collected: dict) -> str | None:
+    """Get the next QR field in Phase 1a sequence."""
+    for f in PHASE_1A_QR_FIELDS:
+        # Skip bundesland if country is not DE or AT
+        if f == "bundesland" and collected.get("country") not in ("DE", "AT"):
+            continue
+        if f not in collected:
+            return f
+    return None
 
 R1_WELCOME = (
     "Willkommen bei ki-sicherheit.jetzt! Ich führe Sie durch eine "
@@ -460,16 +499,22 @@ async def chat_message(req: ChatMessageRequest, db: Session = Depends(get_db)):
 
             # Phase 1 mode: determine fields differently
             _conv_phase = _phase_state.get("conversation_phase", "phase_1") if rt == "r1" else None
-            _is_phase_1 = (_conv_phase == "phase_1" and rt == "r1")
+            _in_phase_1a = (rt == "r1" and _is_phase_1a(_phase_state, collected))
+            _in_phase_1b = (rt == "r1" and _is_phase_1b(_phase_state, collected))
 
-            if _is_phase_1:
-                # Phase 1: next fields come from PHASE_1_FIELDS, not sections
-                _missing_p1 = [f for f in PHASE_1_FIELDS if f not in collected]
+            if _in_phase_1a:
+                # Phase 1a: QR sequential — single-field extraction like legacy
+                _next_qr = _get_next_phase_1a_field(collected)
+                _all_missing = [f for f in PHASE_1_FIELDS if f not in collected]
+                asked_fields = [_next_qr] if _next_qr else []
+                cur_field = _next_qr or ""
+                cur_desc = FIELD_DESCRIPTIONS.get(cur_field, "")
+                _asked_field = cur_field
+            elif _in_phase_1b:
+                # Phase 1b: open conversation — multi-field extraction
+                _missing_p1 = [f for f in PHASE_1B_OPEN_FIELDS if f not in collected]
                 _all_missing = _missing_p1
-                # Determine which Phase 1 field to ask next (QR fields first if missing)
-                _missing_qr = [f for f in _missing_p1 if f in PHASE_1_QR_FIELDS]
-                _missing_free = [f for f in _missing_p1 if f not in PHASE_1_QR_FIELDS]
-                asked_fields = (_missing_qr[:1] if _missing_qr else _missing_free[:1])
+                asked_fields = _missing_p1[:1]
                 cur_field = asked_fields[0] if asked_fields else ""
                 cur_desc = FIELD_DESCRIPTIONS.get(cur_field, "")
                 _asked_field = cur_field
@@ -535,7 +580,7 @@ async def chat_message(req: ChatMessageRequest, db: Session = Depends(get_db)):
             if _is_help_request:
                 # Help request: skip extraction entirely
                 raw_extracted = {"signal": "question", "fields": {}} if DRAFT_MODE_ENABLED else {}
-            elif _is_phase_1 and not _is_in_edit_mode and not _is_edit_request:
+            elif _in_phase_1b and not _is_in_edit_mode and not _is_edit_request:
                 # --- Phase 1: Multi-field extraction ---
                 from services.chat_extractor import extract_fields_multi
                 from services.chat_normalizer import ENUM_VALUES
@@ -919,6 +964,20 @@ async def chat_message(req: ChatMessageRequest, db: Session = Depends(get_db)):
         # Determine next fields
         sections = get_sections_for_report(rt)
 
+        # Re-evaluate sub-phase after extraction (collected may have changed)
+        _post_phase_1a = (rt == "r1" and _is_phase_1a(_phase_state, collected))
+        _post_phase_1b = (rt == "r1" and _is_phase_1b(_phase_state, collected))
+
+        # Auto-transition Phase 1a → 1b when all QR fields are collected
+        if _cur_conv_phase == "phase_1" and rt == "r1" and not _post_phase_1a and not _phase_state.get("phase_1_qr_complete"):
+            _phase_state["phase_1_qr_complete"] = True
+            db.execute(
+                _sa_text("UPDATE chat_sessions SET phase_state = CAST(:ps AS jsonb) WHERE id = :sid"),
+                {"ps": json.dumps(_phase_state), "sid": str(session.id)},
+            )
+            db.commit()
+            log.info("[CHAT] Phase 1a → 1b transition: all QR fields collected")
+
         # --- Phase 1: Completion check + checkpoint trigger ---
         _checkpoint_triggered = False
         if _cur_conv_phase == "phase_1" and rt == "r1":
@@ -941,11 +1000,14 @@ async def chat_message(req: ChatMessageRequest, db: Session = Depends(get_db)):
             elif _no_extraction and _asked_field and _asked_field not in collected:
                 next_fields = [_asked_field]
                 log.info("[CHAT] Phase 1 QR-Sync: keeping next_fields=[%s]", _asked_field)
+            elif _post_phase_1a:
+                # Phase 1a: next QR field in sequence
+                _next_qr = _get_next_phase_1a_field(collected)
+                next_fields = [_next_qr] if _next_qr else []
             else:
-                # Phase 1: next QR field first, then free-text fields
-                _p1_qr_missing = [f for f in _missing_p1_after if f in PHASE_1_QR_FIELDS]
-                _p1_free_missing = [f for f in _missing_p1_after if f not in PHASE_1_QR_FIELDS]
-                next_fields = (_p1_qr_missing[:1] if _p1_qr_missing else _p1_free_missing[:1])
+                # Phase 1b: next open-conversation field (no QR)
+                _p1b_missing = [f for f in PHASE_1B_OPEN_FIELDS if f not in collected]
+                next_fields = _p1b_missing[:1]
 
         elif _cur_conv_phase == "checkpoint" and rt == "r1":
             # Checkpoint phase — next_fields is empty, QR handles navigation
@@ -1111,8 +1173,14 @@ async def chat_message(req: ChatMessageRequest, db: Session = Depends(get_db)):
 
         # Compute Phase 1 missing fields for Sonnet prompt
         _missing_p1_for_sonnet = None
-        if _cur_conv_phase == "phase_1":
-            _missing_p1_for_sonnet = [f for f in PHASE_1_FIELDS if f not in collected]
+        # Determine effective sub-phase for Sonnet prompt routing
+        _sonnet_conv_phase = _cur_conv_phase
+        if _cur_conv_phase == "phase_1" and rt == "r1":
+            if _post_phase_1a:
+                _sonnet_conv_phase = "phase_1a"
+            else:
+                _sonnet_conv_phase = "phase_1b"
+                _missing_p1_for_sonnet = [f for f in PHASE_1B_OPEN_FIELDS if f not in collected]
 
         # Checkpoint: inject checkpoint text instead of streaming Sonnet
         _checkpoint_text = None
@@ -1146,7 +1214,7 @@ async def chat_message(req: ChatMessageRequest, db: Session = Depends(get_db)):
                     next_field_qr_context=_next_field_qr_context,
                     user_profile_summary=_user_profile_summary,
                     recent_bot_messages=_recent_bot_msgs,
-                    conversation_phase=_cur_conv_phase,
+                    conversation_phase=_sonnet_conv_phase,
                     missing_phase_1_fields=_missing_p1_for_sonnet,
                 ):
                     await queue.put(token)
@@ -1231,16 +1299,17 @@ async def chat_message(req: ChatMessageRequest, db: Session = Depends(get_db)):
         elif _final_phase == "summary":
             # Summary phase: no QR, will generate summary below
             quick_replies = []
-        elif _final_phase == "phase_1":
-            # Phase 1: show QR for next Phase 1 field
+        elif _final_phase == "phase_1" and _post_phase_1a:
+            # Phase 1a: show QR for next sequential QR field
             if _no_extraction and _asked_field and _asked_field not in collected:
                 qr_next = [_asked_field]
             else:
-                _p1_missing = [f for f in PHASE_1_FIELDS if f not in collected]
-                _p1_qr = [f for f in _p1_missing if f in PHASE_1_QR_FIELDS]
-                _p1_free = [f for f in _p1_missing if f not in PHASE_1_QR_FIELDS]
-                qr_next = _p1_qr[:1] if _p1_qr else _p1_free[:1]
+                _next_qr = _get_next_phase_1a_field(collected)
+                qr_next = [_next_qr] if _next_qr else []
             quick_replies = _build_quick_replies(qr_next, rt, collected, _profile_ctx)
+        elif _final_phase == "phase_1":
+            # Phase 1b: open conversation — NO QR buttons
+            quick_replies = []
         else:
             # Legacy / Phase 2: section-based QR
             if _no_extraction and _asked_field and _asked_field not in collected:

--- a/services/chat_conversation.py
+++ b/services/chat_conversation.py
@@ -1029,7 +1029,65 @@ def build_help_context(
 
 
 # ---------------------------------------------------------------------------
-# KIS-1124 Sprint 2: Phase 1 Prompt — Open Conversation Mode
+# KIS-1124 S2-HOTFIX: Phase 1a Prompt — QR Sequential Mode
+# ---------------------------------------------------------------------------
+
+PHASE_1A_SYSTEM_PROMPT = """\
+Sie sind ein KI-Assistent von ki-sicherheit.jetzt und führen den \
+Einstieg in eine professionelle Bestandsaufnahme zur KI-Readiness.
+
+IHRE ROLLE:
+Kompetenter, freundlicher Berater. Sie siezen durchgehend.
+In dieser Phase klären wir einige Basisdaten per Auswahl-Buttons.
+
+BEREITS ERFASST:
+{collected_fields_summary}
+
+NÄCHSTES FELD:
+{next_field_info}
+
+REGELN:
+1. Bestätigen Sie die letzte Angabe des Nutzers kurz (max 1 Satz).
+2. Leiten Sie zum nächsten Feld über — die Auswahl-Buttons sprechen \
+für sich, Sie müssen die Optionen NICHT aufzählen.
+3. Maximal 2 Sätze gesamt.
+4. Stellen Sie KEINE offene Freitext-Frage in dieser Phase.
+5. Fragen Sie NIEMALS nach dem Firmennamen.
+6. Erwähnen Sie KEINEN konkreten Standort, bevor der Nutzer \
+ihn angegeben hat.
+
+BESTÄTIGUNGS-REGELN (STRIKT):
+- Varianten-Pool (jede nur 1× verwenden):
+  "Notiert.", "Danke.", "Klar.", "Verstehe.", "Gut.", \
+  "Passt.", "Erfasst.", "Alles klar.", "In Ordnung.", \
+  oder GAR KEINE Bestätigung — direkt die Überleitung.
+- VERBOTEN: "Verstanden." (max 1× pro Gespräch), "Gut erfasst.", \
+  "Perfekt.", "Da Sie..." als Satzeinstieg.
+- NIE zweimal denselben Satzanfang hintereinander.
+
+VERBOTENE FORMULIERUNGEN:
+- "als KI-Berater" in jeder Variante
+- "Als [Branche]-Experte", "Als Solo-Berater..."
+- "Das ist eine gute/wichtige/interessante Frage"
+- "die ideale Basis", "Alles klar zu..."
+- "Bei Ihrer Expertise", "eine starke/solide/gute Basis"
+"""
+
+
+def _build_phase_1a_prompt(
+    collected_fields: dict,
+    next_field_qr_context: str | None = None,
+) -> str:
+    """Build the Phase 1a system prompt for QR sequential mode."""
+    nf_info = next_field_qr_context or "Kein spezifisches nächstes Feld."
+    return PHASE_1A_SYSTEM_PROMPT.format(
+        collected_fields_summary=_format_collected_summary(collected_fields),
+        next_field_info=nf_info,
+    )
+
+
+# ---------------------------------------------------------------------------
+# KIS-1124 Sprint 2: Phase 1b Prompt — Open Conversation Mode
 # ---------------------------------------------------------------------------
 
 PHASE_1_SYSTEM_PROMPT = """\
@@ -1178,12 +1236,18 @@ async def generate_response(
         yield "Entschuldigung, ich bin gerade nicht erreichbar. Bitte versuchen Sie es gleich nochmal."
         return
 
-    # Phase 1: Use dedicated open conversation prompt
-    if conversation_phase == "phase_1":
+    # Phase 1b: open conversation prompt
+    if conversation_phase == "phase_1b":
         system_prompt = _build_phase_1_prompt(
             collected_fields=collected_fields,
             missing_phase_1=missing_phase_1_fields or [],
             next_fields=next_fields,
+            next_field_qr_context=next_field_qr_context,
+        )
+    elif conversation_phase == "phase_1a":
+        # Phase 1a: QR-focused — use legacy prompt with Phase 1 context
+        system_prompt = _build_phase_1a_prompt(
+            collected_fields=collected_fields,
             next_field_qr_context=next_field_qr_context,
         )
     else:
@@ -1239,8 +1303,8 @@ async def generate_response(
     # Next-field QR context for coherent transitions (KIS-1123 Fix 1).
     # Skip in dialog/help mode — Sonnet should answer the user's question,
     # not transition to the next field.
-    # Skip in Phase 1 — already embedded in the Phase 1 prompt template.
-    if next_field_qr_context and not dialog_mode and not help_context and conversation_phase != "phase_1":
+    # Skip in Phase 1a/1b — already embedded in their prompt templates.
+    if next_field_qr_context and not dialog_mode and not help_context and conversation_phase not in ("phase_1a", "phase_1b"):
         system_prompt += (
             f"\n\nNÄCHSTES FELD (für deine Überleitung):\n"
             f"{next_field_qr_context}\n\n"


### PR DESCRIPTION
…ation (1b) sub-phases

Bug: Phase 1 showed QR buttons for one topic (e.g. "Land") while Sonnet asked an open question about a different topic (e.g. "Was ist Ihre Hauptdienstleistung?"). This created a confusing desync where the user didn't know whether to answer the text question or click the buttons.

Root cause: Phase 1 treated QR fields and open-conversation fields as one mixed pool, letting Sonnet generate open questions while QR buttons independently showed the next enum field.

Fix: Split Phase 1 into two sequential sub-phases:

Phase 1a (QR sequential):
- Collects branche → unternehmensgroesse → country → bundesland → investitionsbudget in order via QR buttons
- Uses legacy-style single-field extraction
- New PHASE_1A_SYSTEM_PROMPT: short confirmations + QR transitions
- Sonnet receives phase_1a tag, never asks open questions
- QR buttons always match Sonnet's topic

Phase 1b (open conversation):
- Activates automatically when all QR fields are collected
- Collects hauptleistung, ki_kompetenz, digitalisierungsgrad, ki_ziele via multi-field Haiku extraction
- NO QR buttons shown — pure free-text conversation
- Uses existing PHASE_1_SYSTEM_PROMPT (now phase_1b)

Implementation:
- PHASE_1A_QR_FIELDS ordered list + PHASE_1B_OPEN_FIELDS list
- _is_phase_1a()/_is_phase_1b() helpers check sub-phase state
- _get_next_phase_1a_field() returns next QR field in sequence
- phase_state tracks phase_1_qr_complete boolean for transition
- Auto-transition 1a→1b when all QR fields collected
- Sonnet prompt routing: phase_1a → short QR prompt, phase_1b → open conversation prompt
- QR generation: phase_1a → next QR field, phase_1b → no buttons

https://claude.ai/code/session_01RM5fc84FQA4uuUS6opUYH1