### PR TITLE
KIS-1124 S3: Phase 2 block-specific prompts and field routing

### DIFF
--- a/routes/chat.py
+++ b/routes/chat.py
@@ -166,6 +166,7 @@ def _init_phase_state() -> dict:
         "selected_blocks": [],
         "completed_blocks": [],
         "current_block": None,
+        "block_stale_turns": 0,
     }
 
 
@@ -178,6 +179,7 @@ def _get_phase_state(session) -> dict:
         "selected_blocks": ps.get("selected_blocks", []),
         "completed_blocks": ps.get("completed_blocks", []),
         "current_block": ps.get("current_block"),
+        "block_stale_turns": ps.get("block_stale_turns", 0),
     }
 
 
@@ -448,6 +450,20 @@ async def chat_message(req: ChatMessageRequest, db: Session = Depends(get_db)):
                     else:
                         log.warning("[CHAT] Checkpoint: invalid selection %r", _cp_value)
                 # Skip normal QR processing for checkpoint
+                _no_extraction = True
+
+            # --- Block transition QR handling (Phase 2 inter-block) ---
+            elif qr_field == "__block_transition__":
+                _bt_value = req.quick_reply_value
+                if _bt_value == "report":
+                    # User wants report now → skip to summary
+                    _phase_state["conversation_phase"] = "summary"
+                    log.info("[CHAT] Block transition: user chose REPORT")
+                elif _bt_value == "continue":
+                    # Continue with next block (current_block already set)
+                    _phase_state["block_stale_turns"] = 0
+                    log.info("[CHAT] Block transition: user chose CONTINUE → block %s",
+                             _phase_state.get("current_block"))
                 _no_extraction = True
 
             # --- Draft housekeeping (pre-step, only when DRAFT_MODE_ENABLED) ---
@@ -1010,6 +1026,7 @@ async def chat_message(req: ChatMessageRequest, db: Session = Depends(get_db)):
 
         # --- Phase 1: Completion check + checkpoint trigger ---
         _checkpoint_triggered = False
+        _block_just_completed = False
         if _cur_conv_phase == "phase_1" and rt == "r1":
             _missing_p1_after = [f for f in PHASE_1_FIELDS if f not in collected
                                  and not _should_skip_qr_field(f, collected)]
@@ -1055,15 +1072,60 @@ async def chat_message(req: ChatMessageRequest, db: Session = Depends(get_db)):
             _cur_block = _phase_state.get("current_block")
             if _cur_block:
                 _block_remaining = _get_block_fields(_cur_block, collected)
-                all_missing = _block_remaining
-                if _no_extraction and _asked_field and _asked_field not in collected:
-                    next_fields = [_asked_field]
-                    log.info("[CHAT] Phase 2 block %s: no extraction, keeping next_fields=[%s]", _cur_block, _asked_field)
+
+                # Stale turn tracking: increment on no extraction, reset on extraction
+                if normalized and not _no_extraction:
+                    _phase_state["block_stale_turns"] = 0
+                elif not _is_qr_click or (req.quick_reply_field == "__block_transition__"):
+                    _phase_state["block_stale_turns"] = _phase_state.get("block_stale_turns", 0) + 1
+
+                _stale = _phase_state.get("block_stale_turns", 0)
+
+                # Block completion: no remaining fields OR stale >= 2
+                if not _block_remaining or _stale >= 2:
+                    if not _block_remaining:
+                        log.info("[CHAT] Phase 2: block %s complete (all fields collected)", _cur_block)
+                    else:
+                        log.info("[CHAT] Phase 2: block %s auto-close (stale_turns=%d)", _cur_block, _stale)
+
+                    # Mark block as completed
+                    completed = _phase_state.get("completed_blocks", [])
+                    if _cur_block not in completed:
+                        completed.append(_cur_block)
+                    _phase_state["completed_blocks"] = completed
+                    _phase_state["block_stale_turns"] = 0
+
+                    # Determine next block
+                    remaining_blocks = [b for b in _phase_state.get("selected_blocks", [])
+                                        if b not in completed]
+                    if remaining_blocks:
+                        _phase_state["current_block"] = remaining_blocks[0]
+                        log.info("[CHAT] Phase 2: next block → %s", remaining_blocks[0])
+                    else:
+                        _phase_state["current_block"] = None
+                        log.info("[CHAT] Phase 2: all blocks done → summary")
+
+                    _block_just_completed = True
+                    all_missing = []
+                    next_fields = []
                 else:
-                    next_fields = _block_remaining[:1]
+                    all_missing = _block_remaining
+                    if _no_extraction and _asked_field and _asked_field not in collected:
+                        next_fields = [_asked_field]
+                        log.info("[CHAT] Phase 2 block %s: no extraction, keeping next_fields=[%s]", _cur_block, _asked_field)
+                    else:
+                        next_fields = _block_remaining[:1]
             else:
                 all_missing = []
                 next_fields = []
+
+            # Persist stale_turns update
+            if _cur_conv_phase == "phase_2":
+                db.execute(
+                    _sa_text("UPDATE chat_sessions SET phase_state = CAST(:ps AS jsonb) WHERE id = :sid"),
+                    {"ps": json.dumps(_phase_state), "sid": str(session.id)},
+                )
+                db.commit()
 
         else:
             # Legacy / Strategy: section-based next fields
@@ -1246,11 +1308,43 @@ async def chat_message(req: ChatMessageRequest, db: Session = Depends(get_db)):
                 "welche Bereiche interessieren Sie besonders?"
             )
 
+        # Block completion: inject inter-block transition text
+        _block_transition_text = None
+        if _cur_conv_phase == "phase_2" and rt == "r1" and _block_just_completed:
+            _completed_label = BLOCK_LABELS.get(_cur_block, _cur_block)
+            _remaining_blocks_after = [b for b in _phase_state.get("selected_blocks", [])
+                                       if b not in _phase_state.get("completed_blocks", [])]
+            if _remaining_blocks_after:
+                _next_label = BLOCK_LABELS.get(_remaining_blocks_after[0], "")
+                _block_transition_text = (
+                    f"Bereich „{_completed_label}" abgeschlossen. "
+                    f"Sollen wir mit „{_next_label}" weitermachen, "
+                    f"oder reicht das für den Report?"
+                )
+            else:
+                # All blocks done → transition to summary
+                _phase_state["conversation_phase"] = "summary"
+                db.execute(
+                    _sa_text("UPDATE chat_sessions SET phase_state = CAST(:ps AS jsonb) WHERE id = :sid"),
+                    {"ps": json.dumps(_phase_state), "sid": str(session.id)},
+                )
+                db.commit()
+                _block_transition_text = (
+                    f"Bereich „{_completed_label}" abgeschlossen — "
+                    f"damit haben wir alle gewählten Bereiche behandelt. "
+                    f"Ich erstelle jetzt Ihre Zusammenfassung."
+                )
+
         async def _token_producer():
             try:
                 if _checkpoint_text:
                     # Checkpoint: send static text, no Sonnet call
                     await queue.put(_checkpoint_text)
+                    return
+
+                if _block_transition_text:
+                    # Block transition: send static text, no Sonnet call
+                    await queue.put(_block_transition_text)
                     return
 
                 async for token in generate_response(
@@ -1367,14 +1461,34 @@ async def chat_message(req: ChatMessageRequest, db: Session = Depends(get_db)):
             # Phase 1b: open conversation — NO QR buttons
             quick_replies = []
         elif _final_phase == "phase_2" and rt == "r1":
-            # Phase 2: block-scoped QR only
-            _cur_block = _phase_state.get("current_block")
-            _block_remaining = _get_block_fields(_cur_block, collected) if _cur_block else []
-            if _no_extraction and _asked_field and _asked_field not in collected:
-                qr_next = [_asked_field]
+            if _block_just_completed:
+                # Block just completed — show inter-block transition QR
+                _remaining_blocks_qr = [b for b in _phase_state.get("selected_blocks", [])
+                                        if b not in _phase_state.get("completed_blocks", [])]
+                if _remaining_blocks_qr:
+                    _next_b = _remaining_blocks_qr[0]
+                    quick_replies = [QuickReply(
+                        field="__block_transition__",
+                        label="Nächster Schritt",
+                        options=[
+                            QuickReplyOption(value="continue",
+                                             label=f"Weiter: {BLOCK_LABELS.get(_next_b, _next_b)}"),
+                            QuickReplyOption(value="report", label="Report erstellen"),
+                        ],
+                        multi_select=False,
+                    )]
+                else:
+                    # All blocks done → summary, no QR needed
+                    quick_replies = []
             else:
-                qr_next = _block_remaining[:1]
-            quick_replies = _build_quick_replies(qr_next, rt, collected, _profile_ctx)
+                # Phase 2: block-scoped QR only
+                _cur_block = _phase_state.get("current_block")
+                _block_remaining = _get_block_fields(_cur_block, collected) if _cur_block else []
+                if _no_extraction and _asked_field and _asked_field not in collected:
+                    qr_next = [_asked_field]
+                else:
+                    qr_next = _block_remaining[:1]
+                quick_replies = _build_quick_replies(qr_next, rt, collected, _profile_ctx)
         else:
             # Legacy / Strategy: section-based QR
             if _no_extraction and _asked_field and _asked_field not in collected:

--- a/routes/chat.py
+++ b/routes/chat.py
@@ -74,14 +74,14 @@ DRAFT_MODE_ENABLED = os.getenv("DRAFT_MODE_ENABLED", "false").lower() == "true"
 PHASE_1_FIELDS: list[str] = [
     "branche", "unternehmensgroesse", "country", "bundesland",
     "hauptleistung", "ki_kompetenz", "digitalisierungsgrad",
-    "ki_ziele", "investitionsbudget",
+    "ki_ziele", "investitionsbudget", "datenschutz",
 ]
 
 # Phase 1a: QR fields collected sequentially (ordered)
 PHASE_1A_QR_FIELDS: list[str] = [
     "branche", "unternehmensgroesse", "selbststaendig",
     "country", "bundesland",
-    "investitionsbudget",
+    "investitionsbudget", "datenschutz",
 ]
 
 # Phase 1b: Open conversation fields (extracted via multi-field Haiku)
@@ -994,7 +994,8 @@ async def chat_message(req: ChatMessageRequest, db: Session = Depends(get_db)):
         # --- Phase 1: Completion check + checkpoint trigger ---
         _checkpoint_triggered = False
         if _cur_conv_phase == "phase_1" and rt == "r1":
-            _missing_p1_after = [f for f in PHASE_1_FIELDS if f not in collected]
+            _missing_p1_after = [f for f in PHASE_1_FIELDS if f not in collected
+                                 and not _should_skip_qr_field(f, collected)]
             all_missing = _missing_p1_after
 
             if not _missing_p1_after:

--- a/routes/chat.py
+++ b/routes/chat.py
@@ -1219,6 +1219,9 @@ async def chat_message(req: ChatMessageRequest, db: Session = Depends(get_db)):
 
         # Compute Phase 1 missing fields for Sonnet prompt
         _missing_p1_for_sonnet = None
+        # Phase 2 block context for Sonnet
+        _sonnet_block_id = None
+        _sonnet_block_remaining = None
         # Determine effective sub-phase for Sonnet prompt routing
         _sonnet_conv_phase = _cur_conv_phase
         if _cur_conv_phase == "phase_1" and rt == "r1":
@@ -1227,6 +1230,11 @@ async def chat_message(req: ChatMessageRequest, db: Session = Depends(get_db)):
             else:
                 _sonnet_conv_phase = "phase_1b"
                 _missing_p1_for_sonnet = [f for f in PHASE_1B_OPEN_FIELDS if f not in collected]
+        elif _cur_conv_phase == "phase_2" and rt == "r1":
+            _sonnet_conv_phase = "phase_2"
+            _sonnet_block_id = _phase_state.get("current_block")
+            if _sonnet_block_id:
+                _sonnet_block_remaining = _get_block_fields(_sonnet_block_id, collected)
 
         # Checkpoint: inject checkpoint text instead of streaming Sonnet
         _checkpoint_text = None
@@ -1262,6 +1270,8 @@ async def chat_message(req: ChatMessageRequest, db: Session = Depends(get_db)):
                     recent_bot_messages=_recent_bot_msgs,
                     conversation_phase=_sonnet_conv_phase,
                     missing_phase_1_fields=_missing_p1_for_sonnet,
+                    current_block=_sonnet_block_id,
+                    remaining_block_fields=_sonnet_block_remaining,
                 ):
                     await queue.put(token)
             except Exception as exc:

--- a/routes/chat.py
+++ b/routes/chat.py
@@ -880,6 +880,29 @@ async def chat_message(req: ChatMessageRequest, db: Session = Depends(get_db)):
                 session.draft_state = draft_state
                 _pending_after_turn = bool(draft_state.get("pending_field"))
 
+        # KIS-1124-S3-BE-4: Block-level skip detection (Phase 2 only)
+        # These phrases end the ENTIRE block, not just one field.
+        _BLOCK_SKIP_PATTERNS = [
+            "reicht", "genug", "nächster bereich", "nächster block",
+            "weitermachen", "das reicht", "können wir weiter",
+            "nächstes thema", "thema wechseln", "report erstellen",
+            "report reicht", "das genügt", "fertig mit dem bereich",
+            "mir reicht das", "reicht mir",
+        ]
+        _conv_phase_for_skip = _phase_state.get("conversation_phase", "phase_1") if rt == "r1" else None
+        _msg_lower_pre = req.message.strip().lower()
+        _is_block_skip = (
+            _conv_phase_for_skip == "phase_2"
+            and not _is_qr_click
+            and not _is_help_request
+            and any(p in _msg_lower_pre for p in _BLOCK_SKIP_PATTERNS)
+        )
+        if _is_block_skip:
+            # Force block_stale_turns to 2 → triggers block completion in the phase_2 branch
+            _phase_state["block_stale_turns"] = 2
+            _no_extraction = True
+            log.info("[CHAT] Block-level skip detected: '%s' → force-closing current block", _msg_lower_pre)
+
         # Handle "weiter" / skip for optional fields
         # KIS-1124-S0-BE-2: Extended skip detection with decline phrases
         skip_words = {"weiter", "skip", "überspringen", "nächste", "weiter bitte", "nächste frage"}

--- a/routes/chat.py
+++ b/routes/chat.py
@@ -102,15 +102,19 @@ PHASE_1_EXTRACTABLE_FIELDS: set[str] = {
 def _get_datenschutz_block_fields(branche: str) -> list[str]:
     """Return Block D fields based on branche (Beratung → reduced set)."""
     if branche == "beratung":
-        return ["datenschutzbeauftragter", "ai_act_kenntnis", "ki_hemmnisse"]
+        return ["datenschutzbeauftragter", "ai_act_kenntnis", "ki_hemmnisse",
+                "governance_richtlinien"]
     return [
         "datenschutzbeauftragter", "technische_massnahmen",
         "folgenabschaetzung", "meldewege", "loeschregeln",
         "ai_act_kenntnis", "regulierte_branche", "ki_hemmnisse",
+        "governance_richtlinien",
     ]
 
 
 # Phase 2 thematic blocks
+# Every R1 field must be in exactly ONE location:
+#   Phase 1a (QR), Phase 1b (open), or one Block (A/B/C/D).
 BLOCK_FIELDS: dict[str, list[str]] = {
     "A": [
         "bisherige_foerdermittel", "interesse_foerderung",
@@ -122,12 +126,16 @@ BLOCK_FIELDS: dict[str, list[str]] = {
         "geschaeftsmodell_evolution", "roadmap_vorhanden",
         "change_management", "massnahmen_komplexitaet",
         "vision_prioritaet", "innovationsprozess",
+        "zielgruppen",          # S3-BE-1: was orphan (Section 1)
     ],
     "C": [
         "automatisierungsgrad", "ki_einsatz", "anwendungsfaelle",
         "ki_projekte", "pilot_bereich", "zeitersparnis_prioritaet",
         "vorhandene_tools", "trainings_interessen", "zeitbudget",
         "prozesse_papierlos",
+        "it_infrastruktur",     # S3-BE-1: was orphan (Section 1)
+        "interne_ki_kompetenzen",  # S3-BE-1: was orphan (Section 1)
+        "datenquellen",         # S3-BE-1: was orphan (Section 1)
     ],
     # Block D is dynamic — see _get_datenschutz_block_fields()
 }
@@ -524,6 +532,15 @@ async def chat_message(req: ChatMessageRequest, db: Session = Depends(get_db)):
                 _missing_p1 = [f for f in PHASE_1B_OPEN_FIELDS if f not in collected]
                 _all_missing = _missing_p1
                 asked_fields = _missing_p1[:1]
+                cur_field = asked_fields[0] if asked_fields else ""
+                cur_desc = FIELD_DESCRIPTIONS.get(cur_field, "")
+                _asked_field = cur_field
+            elif _conv_phase == "phase_2" and rt == "r1":
+                # Phase 2: block-scoped extraction — only current block fields
+                _cur_block = _phase_state.get("current_block")
+                _block_remaining = _get_block_fields(_cur_block, collected) if _cur_block else []
+                _all_missing = _block_remaining
+                asked_fields = _block_remaining[:1]
                 cur_field = asked_fields[0] if asked_fields else ""
                 cur_desc = FIELD_DESCRIPTIONS.get(cur_field, "")
                 _asked_field = cur_field
@@ -1033,8 +1050,23 @@ async def chat_message(req: ChatMessageRequest, db: Session = Depends(get_db)):
             all_missing = []
             next_fields = []
 
+        elif _cur_conv_phase == "phase_2" and rt == "r1":
+            # Phase 2: block-scoped fields ONLY — no orphan leakage
+            _cur_block = _phase_state.get("current_block")
+            if _cur_block:
+                _block_remaining = _get_block_fields(_cur_block, collected)
+                all_missing = _block_remaining
+                if _no_extraction and _asked_field and _asked_field not in collected:
+                    next_fields = [_asked_field]
+                    log.info("[CHAT] Phase 2 block %s: no extraction, keeping next_fields=[%s]", _cur_block, _asked_field)
+                else:
+                    next_fields = _block_remaining[:1]
+            else:
+                all_missing = []
+                next_fields = []
+
         else:
-            # Legacy / Phase 2 / Strategy: section-based next fields
+            # Legacy / Strategy: section-based next fields
             missing_req, missing_opt = get_missing_fields(collected, _current_section, rt)
             all_missing = missing_req + missing_opt
 
@@ -1324,8 +1356,17 @@ async def chat_message(req: ChatMessageRequest, db: Session = Depends(get_db)):
         elif _final_phase == "phase_1":
             # Phase 1b: open conversation — NO QR buttons
             quick_replies = []
+        elif _final_phase == "phase_2" and rt == "r1":
+            # Phase 2: block-scoped QR only
+            _cur_block = _phase_state.get("current_block")
+            _block_remaining = _get_block_fields(_cur_block, collected) if _cur_block else []
+            if _no_extraction and _asked_field and _asked_field not in collected:
+                qr_next = [_asked_field]
+            else:
+                qr_next = _block_remaining[:1]
+            quick_replies = _build_quick_replies(qr_next, rt, collected, _profile_ctx)
         else:
-            # Legacy / Phase 2: section-based QR
+            # Legacy / Strategy: section-based QR
             if _no_extraction and _asked_field and _asked_field not in collected:
                 qr_next = [_asked_field]
             else:

--- a/routes/chat.py
+++ b/routes/chat.py
@@ -79,7 +79,8 @@ PHASE_1_FIELDS: list[str] = [
 
 # Phase 1a: QR fields collected sequentially (ordered)
 PHASE_1A_QR_FIELDS: list[str] = [
-    "branche", "unternehmensgroesse", "country", "bundesland",
+    "branche", "unternehmensgroesse", "selbststaendig",
+    "country", "bundesland",
     "investitionsbudget",
 ]
 
@@ -172,15 +173,24 @@ def _get_phase_state(session) -> dict:
     }
 
 
+def _should_skip_qr_field(field: str, collected: dict) -> bool:
+    """Check if a Phase 1a QR field should be skipped due to conditionals."""
+    if field == "bundesland" and collected.get("country") not in ("DE", "AT"):
+        return True
+    if field == "selbststaendig" and collected.get("unternehmensgroesse") != "1":
+        return True
+    return False
+
+
 def _is_phase_1a(phase_state: dict, collected: dict) -> bool:
     """Check if we're in Phase 1a (QR fields still missing)."""
     if phase_state.get("conversation_phase") != "phase_1":
         return False
     if phase_state.get("phase_1_qr_complete"):
         return False
-    # Check if any QR fields are still missing
+    # Check if any QR fields are still missing (skip conditional fields)
     return any(f not in collected for f in PHASE_1A_QR_FIELDS
-               if f != "bundesland" or collected.get("country") in ("DE", "AT"))
+               if not _should_skip_qr_field(f, collected))
 
 
 def _is_phase_1b(phase_state: dict, collected: dict) -> bool:
@@ -193,8 +203,7 @@ def _is_phase_1b(phase_state: dict, collected: dict) -> bool:
 def _get_next_phase_1a_field(collected: dict) -> str | None:
     """Get the next QR field in Phase 1a sequence."""
     for f in PHASE_1A_QR_FIELDS:
-        # Skip bundesland if country is not DE or AT
-        if f == "bundesland" and collected.get("country") not in ("DE", "AT"):
+        if _should_skip_qr_field(f, collected):
             continue
         if f not in collected:
             return f

--- a/routes/chat.py
+++ b/routes/chat.py
@@ -1340,9 +1340,9 @@ async def chat_message(req: ChatMessageRequest, db: Session = Depends(get_db)):
             if _remaining_blocks_after:
                 _next_label = BLOCK_LABELS.get(_remaining_blocks_after[0], "")
                 _block_transition_text = (
-                    f"Bereich „{_completed_label}" abgeschlossen. "
-                    f"Sollen wir mit „{_next_label}" weitermachen, "
-                    f"oder reicht das für den Report?"
+                    f'Bereich \u201e{_completed_label}\u201c abgeschlossen. '
+                    f'Sollen wir mit \u201e{_next_label}\u201c weitermachen, '
+                    f'oder reicht das f\u00fcr den Report?'
                 )
             else:
                 # All blocks done → transition to summary
@@ -1353,9 +1353,9 @@ async def chat_message(req: ChatMessageRequest, db: Session = Depends(get_db)):
                 )
                 db.commit()
                 _block_transition_text = (
-                    f"Bereich „{_completed_label}" abgeschlossen — "
-                    f"damit haben wir alle gewählten Bereiche behandelt. "
-                    f"Ich erstelle jetzt Ihre Zusammenfassung."
+                    f'Bereich \u201e{_completed_label}\u201c abgeschlossen \u2014 '
+                    f'damit haben wir alle gew\u00e4hlten Bereiche behandelt. '
+                    f'Ich erstelle jetzt Ihre Zusammenfassung.'
                 )
 
         async def _token_producer():

--- a/services/chat_conversation.py
+++ b/services/chat_conversation.py
@@ -1211,6 +1211,225 @@ def _build_phase_1_prompt(
 
 
 # ---------------------------------------------------------------------------
+# KIS-1124 Sprint 3: Phase 2 Block-Specific Prompts
+# ---------------------------------------------------------------------------
+
+_PHASE_2_BASE_RULES = """\
+BESTÄTIGUNGS-REGELN (STRIKT):
+- Maximal 1 Satz Bestätigung, dann direkt zur nächsten Frage.
+- Verwende JEDE Bestätigung nur EINMAL im gesamten Chat.
+- Varianten-Pool (verwende jede nur 1×, dann streichen):
+  "Notiert.", "Danke.", "Klar.", "Verstehe.", "Gut.", \
+  "Passt.", "Erfasst.", "Alles klar.", "In Ordnung.", \
+  direkter Einstieg OHNE Bestätigungswort.
+- VERBOTEN: "Verstanden." (max. 1×), "Gut erfasst.", "Perfekt.", \
+  "Da Sie..." als Satzeinstieg.
+- NIE zweimal denselben Satzanfang in 3 aufeinanderfolgenden Antworten.
+
+VERBOTENE FORMULIERUNGEN:
+- "als KI-Berater" in jeder Schreibweise
+- "Als [Branche]-Experte", "Als Solo-Berater..."
+- "Das ist eine gute/wichtige/interessante Frage"
+- "die ideale Basis", "Alles klar zu..."
+- "Bei Ihrer Expertise", "eine starke/solide/gute Basis"
+"""
+
+
+BLOCK_A_PROMPT = """\
+Sie sind ein KI-Assistent von ki-sicherheit.jetzt. \
+Sie führen ein kurzes Fachgespräch zum Thema Fördermittel, \
+Budget und Marktpositionierung. Sie siezen durchgehend.
+
+PHASE 2 — THEMENBLOCK: Fördermittel & Budget
+
+BISHERIGES PROFIL:
+{user_profile_summary}
+
+BEREITS ERFASST:
+{collected_fields_summary}
+
+NOCH OFFENE FELDER IN DIESEM BLOCK:
+{remaining_fields}
+
+REGELN:
+- Stelle 1–2 offene Fragen zum Thema Fördermittel, Budget \
+und Marktposition.
+- Nutze Multi-Feld-Extraktion — der User muss nicht jedes \
+Feld einzeln beantworten.
+- QR-Buttons nur wenn nötig (z.B. Budget-Bänder, Ja/Nein).
+- Max 2 Sätze pro Antwort.
+- Bei "weiß nicht" → Feld überspringen, nicht insistieren.
+
+BEISPIEL-FRAGEN:
+- "Haben Sie schon Erfahrung mit Fördermitteln für Digitalisierung?"
+- "Wie schätzen Sie Ihre Position im Markt ein?"
+
+NÄCHSTES FELD:
+{next_field_info}
+
+""" + _PHASE_2_BASE_RULES
+
+
+BLOCK_B_PROMPT = """\
+Sie sind ein KI-Assistent von ki-sicherheit.jetzt. \
+Sie führen ein kurzes Fachgespräch zum Thema KI-Strategie, \
+Vision und Governance. Sie siezen durchgehend.
+
+PHASE 2 — THEMENBLOCK: KI-Strategie & Roadmap
+
+BISHERIGES PROFIL:
+{user_profile_summary}
+
+BEREITS ERFASST:
+{collected_fields_summary}
+
+NOCH OFFENE FELDER IN DIESEM BLOCK:
+{remaining_fields}
+
+REGELN:
+- Stelle 1–2 offene Fragen zu Vision, Strategie und Governance.
+- Bei "weiß nicht" / "kann ich nicht sagen" → Feld SOFORT \
+überspringen. NICHT insistieren, NICHT alternative \
+Formulierung versuchen.
+- Max 3 Sätze pro Antwort (Strategie-Fragen brauchen etwas \
+mehr Kontext).
+- Keine Aufzählungen von Optionen — der User soll frei erzählen.
+
+BEISPIEL-FRAGEN:
+- "Wo sehen Sie Ihr Unternehmen in 2–3 Jahren mit KI?"
+- "Gibt es No-Gos oder sensible Bereiche beim KI-Einsatz?"
+- "Haben Sie bereits eine KI-Roadmap oder Strategie entwickelt?"
+
+NÄCHSTES FELD:
+{next_field_info}
+
+""" + _PHASE_2_BASE_RULES
+
+
+BLOCK_C_PROMPT = """\
+Sie sind ein KI-Assistent von ki-sicherheit.jetzt. \
+Sie führen ein kurzes Fachgespräch zum Thema Tools, \
+Automatisierung und konkrete KI-Anwendungsfälle. \
+Sie siezen durchgehend.
+
+PHASE 2 — THEMENBLOCK: Tools & Automatisierung
+
+BISHERIGES PROFIL:
+{user_profile_summary}
+
+BEREITS ERFASST:
+{collected_fields_summary}
+
+NOCH OFFENE FELDER IN DIESEM BLOCK:
+{remaining_fields}
+
+REGELN:
+- Stelle 1–2 Fragen zu Tools, Automatisierung und konkreten \
+Use Cases.
+- QR-Buttons bei Feldern mit vordefinierten Listen \
+(ki_einsatz, anwendungsfaelle, vorhandene_tools).
+- Freitext bei offenen Feldern (ki_projekte, pilot_bereich, \
+zeitersparnis_prioritaet).
+- Max 2 Sätze pro Antwort.
+
+BEISPIEL-FRAGEN:
+- "Welche Tools nutzen Sie aktuell und wo liegt der größte Zeitfresser?"
+- "Welche KI-Anwendungen interessieren Sie am meisten?"
+
+NÄCHSTES FELD:
+{next_field_info}
+
+""" + _PHASE_2_BASE_RULES
+
+
+BLOCK_D_PROMPT = """\
+Sie sind ein KI-Assistent von ki-sicherheit.jetzt. \
+Sie führen ein kurzes Fachgespräch zum Thema Recht, \
+Datenschutz und Compliance. Sie siezen durchgehend.
+
+PHASE 2 — THEMENBLOCK: Recht & Datenschutz
+
+{beratung_hint}
+
+BISHERIGES PROFIL:
+{user_profile_summary}
+
+BEREITS ERFASST:
+{collected_fields_summary}
+
+NOCH OFFENE FELDER IN DIESEM BLOCK:
+{remaining_fields}
+
+REGELN:
+- Kurz und sachlich — Datenschutz-Fragen brauchen keine \
+lange Einleitung.
+- QR-Buttons bei Ja/Nein-Feldern und Auswahl-Feldern.
+- Max 2 Sätze pro Antwort.
+- Bei Beratungsbranche: Nur 1–2 Fragen, dann Block abschließen.
+
+BEISPIEL-FRAGEN:
+- Beratung: "Haben Sie einen DSB, und wie gut kennen Sie den \
+EU AI Act?"
+- Andere: "Wie ist Ihr Datenschutz aufgestellt — vom DSB bis \
+zu technischen Maßnahmen?"
+
+NÄCHSTES FELD:
+{next_field_info}
+
+""" + _PHASE_2_BASE_RULES
+
+
+_BLOCK_PROMPTS: dict[str, str] = {
+    "A": BLOCK_A_PROMPT,
+    "B": BLOCK_B_PROMPT,
+    "C": BLOCK_C_PROMPT,
+    "D": BLOCK_D_PROMPT,
+}
+
+
+def _build_phase_2_prompt(
+    block_id: str,
+    collected_fields: dict,
+    remaining_block_fields: list[str],
+    next_field_qr_context: str | None = None,
+    user_profile_summary: str | None = None,
+) -> str:
+    """Build the Phase 2 system prompt for a specific thematic block."""
+    template = _BLOCK_PROMPTS.get(block_id, BLOCK_A_PROMPT)
+
+    # Format remaining fields with descriptions
+    remaining_lines = []
+    for fname in remaining_block_fields:
+        desc = FIELD_DESCRIPTIONS.get(fname, fname)
+        remaining_lines.append(f"- {fname}: {desc}")
+    remaining_str = "\n".join(remaining_lines) if remaining_lines else "Alle Felder dieses Blocks erfasst."
+
+    profile_str = user_profile_summary or "Noch nicht genügend Daten für ein Profil."
+    nf_info = next_field_qr_context or "Kein spezifisches nächstes Feld."
+
+    # Block D special: beratung hint
+    beratung_hint = ""
+    if block_id == "D":
+        branche = collected_fields.get("branche", "")
+        if branche == "beratung":
+            beratung_hint = (
+                "CONDITIONAL: Branche ist Beratung → nur 4 Felder abfragen: "
+                "datenschutzbeauftragter, ai_act_kenntnis, ki_hemmnisse, "
+                "governance_richtlinien. Restliche Felder überspringen."
+            )
+        else:
+            beratung_hint = "CONDITIONAL: Vollständige Datenschutz-Prüfung (alle Felder)."
+
+    return template.format(
+        user_profile_summary=profile_str,
+        collected_fields_summary=_format_collected_summary(collected_fields),
+        remaining_fields=remaining_str,
+        next_field_info=nf_info,
+        beratung_hint=beratung_hint,
+    )
+
+
+# ---------------------------------------------------------------------------
 # Streaming Response Generator
 # ---------------------------------------------------------------------------
 
@@ -1231,6 +1450,8 @@ async def generate_response(
     recent_bot_messages: list[str] | None = None,
     conversation_phase: str | None = None,
     missing_phase_1_fields: list[str] | None = None,
+    current_block: str | None = None,
+    remaining_block_fields: list[str] | None = None,
 ) -> AsyncGenerator[str, None]:
     """
     Generate streaming AI response.
@@ -1261,8 +1482,17 @@ async def generate_response(
             collected_fields=collected_fields,
             next_field_qr_context=next_field_qr_context,
         )
+    elif conversation_phase == "phase_2" and current_block:
+        # Phase 2: block-specific thematic prompt
+        system_prompt = _build_phase_2_prompt(
+            block_id=current_block,
+            collected_fields=collected_fields,
+            remaining_block_fields=remaining_block_fields or [],
+            next_field_qr_context=next_field_qr_context,
+            user_profile_summary=user_profile_summary,
+        )
     else:
-        # Legacy / Phase 2 / Strategy: use section-based prompt
+        # Legacy / Strategy: use section-based prompt
         sections = get_sections_for_report(report_type)
         section_index: int = section["index"]
         prompt_template = _get_system_prompt(report_type)

--- a/services/chat_conversation.py
+++ b/services/chat_conversation.py
@@ -1136,7 +1136,8 @@ Unternehmensgröße, Land und Budget werden als Buttons angezeigt.
 8. Fragen Sie NIEMALS nach dem Namen des Unternehmens oder der Firma.
 
 QR-FELDER (werden als Buttons angezeigt, NICHT im Text fragen):
-branche, unternehmensgroesse, country, bundesland, investitionsbudget
+branche, unternehmensgroesse, selbststaendig, country, bundesland, \
+investitionsbudget, datenschutz
 
 FREI EXTRAHIERBARE FELDER (aus dem Gespräch ableitbar):
 hauptleistung, ki_kompetenz, digitalisierungsgrad, ki_ziele, \

--- a/services/chat_normalizer.py
+++ b/services/chat_normalizer.py
@@ -74,7 +74,7 @@ FIELD_REGISTRY: dict[str, dict] = {
     "vision_prioritaet":    {"type": "enum",  "required": False, "section": 5, "chat_mode": "QR"},
     "innovationsprozess":   {"type": "enum",  "required": False, "section": 5, "chat_mode": "QR"},
     # --- Section 6: Recht & Datenschutz ---
-    "datenschutz":          {"type": "bool",  "required": True,  "section": 6, "chat_mode": "QR", "skip_in_chat": True},
+    "datenschutz":          {"type": "bool",  "required": True,  "section": 6, "chat_mode": "QR"},
     "datenschutzbeauftragter": {"type": "enum", "required": False, "section": 6, "chat_mode": "QR"},
     "technische_massnahmen": {"type": "enum", "required": False, "section": 6, "chat_mode": "QR"},
     "folgenabschaetzung":   {"type": "enum",  "required": False, "section": 6, "chat_mode": "QR"},


### PR DESCRIPTION
## Summary
Implements Phase 2 conversation flow with thematic block-specific prompts (A: Funding/Budget, B: KI Strategy, C: Tools/Automation, D: Legal/Data Protection) and block-scoped field extraction. Adds conditional field skipping, block completion detection, and inter-block transitions.

## Key Changes

### Phase 2 Block Architecture
- Added four block-specific system prompts (`BLOCK_A_PROMPT`, `BLOCK_B_PROMPT`, `BLOCK_C_PROMPT`, `BLOCK_D_PROMPT`) with tailored rules and example questions
- Implemented `_build_phase_2_prompt()` to dynamically construct prompts with user profile, collected fields, and remaining block fields
- Added `_PHASE_2_BASE_RULES` with strict confirmation rules and forbidden formulations to prevent repetitive/robotic responses

### Field Organization & Routing
- Moved `datenschutz` from Phase 1b to Phase 1a QR fields
- Added `selbststaendig` as conditional Phase 1a QR field (only for company size "1")
- Reorganized orphan fields into blocks: `zielgruppen` → Block B, `it_infrastruktur`, `interne_ki_kompetenzen`, `datenquellen` → Block C
- Block D now includes `governance_richtlinien` for all branches (Beratung gets reduced 4-field set)
- Implemented `_should_skip_qr_field()` to conditionally skip `bundesland` (non-DE/AT) and `selbststaendig` (non-solo)

### Block State Management
- Added `current_block` and `block_stale_turns` to phase state tracking
- Implemented stale turn detection: increments on non-extraction turns, resets on field extraction
- Block auto-completes when all fields collected OR stale_turns ≥ 2
- Automatic progression to next selected block or summary phase

### Block Completion & Transitions
- Added block-level skip pattern detection (`"reicht"`, `"nächster block"`, etc.) that force-closes current block
- Implemented inter-block transition QR buttons (`__block_transition__`) with "Continue to next block" or "Generate report" options
- Injected static transition text between blocks to confirm completion and offer next steps

### Phase 2 Extraction & Prompting
- Phase 2 extraction now scoped to current block fields only (prevents orphan field leakage)
- Updated `generate_response()` to accept `current_block` and `remaining_block_fields` parameters
- Conditional beratung hint in Block D prompt (reduced field set for consulting firms)
- Phase 2 quick replies now block-scoped instead of section-based

### Database & Session Persistence
- Phase state updates (stale_turns, block transitions) persisted to `chat_sessions.phase_state` JSONB column
- Checkpoint and block transition logic integrated into token producer flow

## Implementation Details
- Block fields defined in `BLOCK_FIELDS` dict with explicit comment: "Every R1 field must be in exactly ONE location"
- Stale turn tracking prevents infinite loops on unproductive exchanges
- Block transition QR uses special field `__block_transition__` to distinguish from normal field extraction
- Phase 2 prompts include user profile summary and field descriptions for context

https://claude.ai/code/session_01GckaevdHRBFzt9L9PL9yXz