### PR TITLE
KIS-1124-FIX: Move datenschutz from Phase 1a to Block D

### DIFF
--- a/routes/chat.py
+++ b/routes/chat.py
@@ -74,14 +74,14 @@ DRAFT_MODE_ENABLED = os.getenv("DRAFT_MODE_ENABLED", "false").lower() == "true"
 PHASE_1_FIELDS: list[str] = [
     "branche", "unternehmensgroesse", "country", "bundesland",
     "hauptleistung", "ki_kompetenz", "digitalisierungsgrad",
-    "ki_ziele", "investitionsbudget", "datenschutz",
+    "ki_ziele", "investitionsbudget",
 ]
 
 # Phase 1a: QR fields collected sequentially (ordered)
 PHASE_1A_QR_FIELDS: list[str] = [
     "branche", "unternehmensgroesse", "selbststaendig",
     "country", "bundesland",
-    "investitionsbudget", "datenschutz",
+    "investitionsbudget",
 ]
 
 # Phase 1b: Open conversation fields (extracted via multi-field Haiku)
@@ -102,10 +102,10 @@ PHASE_1_EXTRACTABLE_FIELDS: set[str] = {
 def _get_datenschutz_block_fields(branche: str) -> list[str]:
     """Return Block D fields based on branche (Beratung → reduced set)."""
     if branche == "beratung":
-        return ["datenschutzbeauftragter", "ai_act_kenntnis", "ki_hemmnisse",
-                "governance_richtlinien"]
+        return ["datenschutz", "datenschutzbeauftragter", "ai_act_kenntnis",
+                "ki_hemmnisse", "governance_richtlinien"]
     return [
-        "datenschutzbeauftragter", "technische_massnahmen",
+        "datenschutz", "datenschutzbeauftragter", "technische_massnahmen",
         "folgenabschaetzung", "meldewege", "loeschregeln",
         "ai_act_kenntnis", "regulierte_branche", "ki_hemmnisse",
         "governance_richtlinien",

--- a/services/chat_conversation.py
+++ b/services/chat_conversation.py
@@ -1137,7 +1137,7 @@ Unternehmensgröße, Land und Budget werden als Buttons angezeigt.
 
 QR-FELDER (werden als Buttons angezeigt, NICHT im Text fragen):
 branche, unternehmensgroesse, selbststaendig, country, bundesland, \
-investitionsbudget, datenschutz
+investitionsbudget
 
 FREI EXTRAHIERBARE FELDER (aus dem Gespräch ableitbar):
 hauptleistung, ki_kompetenz, digitalisierungsgrad, ki_ziele, \
@@ -1413,9 +1413,9 @@ def _build_phase_2_prompt(
         branche = collected_fields.get("branche", "")
         if branche == "beratung":
             beratung_hint = (
-                "CONDITIONAL: Branche ist Beratung → nur 4 Felder abfragen: "
-                "datenschutzbeauftragter, ai_act_kenntnis, ki_hemmnisse, "
-                "governance_richtlinien. Restliche Felder überspringen."
+                "CONDITIONAL: Branche ist Beratung → nur 5 Felder abfragen: "
+                "datenschutz, datenschutzbeauftragter, ai_act_kenntnis, "
+                "ki_hemmnisse, governance_richtlinien. Restliche Felder überspringen."
             )
         else:
             beratung_hint = "CONDITIONAL: Vollständige Datenschutz-Prüfung (alle Felder)."


### PR DESCRIPTION
datenschutz as a QR in Phase 1a broke the quick-entry rhythm and belongs thematically with Recht & Datenschutz (Block D).

Changes:
- Remove datenschutz from PHASE_1A_QR_FIELDS and PHASE_1_FIELDS
- Add datenschutz as first field in _get_datenschutz_block_fields() for both beratung (5 fields) and full (10 fields) variants
- Update beratung_hint in Block D prompt to list datenschutz
- Remove datenschutz from Phase 1b prompt QR field list

Phase 1a sequence is now: branche -> groesse -> [selbststaendig] ->
land -> [bundesland] -> budget -> Phase 1b.

https://claude.ai/code/session_01GckaevdHRBFzt9L9PL9yXz