### PR TITLE
Centralize confirmation rules & fix Phase 1b/2 field coverage tracking

### DIFF
--- a/routes/chat.py
+++ b/routes/chat.py
@@ -167,6 +167,8 @@ def _init_phase_state() -> dict:
         "completed_blocks": [],
         "current_block": None,
         "block_stale_turns": 0,
+        "phase_1b_asked_fields": [],   # KIS-1124 Testrun-Fix Bug 7
+        "block_asked_fields": [],      # KIS-1124 Testrun-Fix Bug 8
     }
 
 
@@ -180,6 +182,8 @@ def _get_phase_state(session) -> dict:
         "completed_blocks": ps.get("completed_blocks", []),
         "current_block": ps.get("current_block"),
         "block_stale_turns": ps.get("block_stale_turns", 0),
+        "phase_1b_asked_fields": ps.get("phase_1b_asked_fields", []),
+        "block_asked_fields": ps.get("block_asked_fields", []),
     }
 
 
@@ -462,6 +466,7 @@ async def chat_message(req: ChatMessageRequest, db: Session = Depends(get_db)):
                 elif _bt_value == "continue":
                     # Continue with next block (current_block already set)
                     _phase_state["block_stale_turns"] = 0
+                    _phase_state["block_asked_fields"] = []  # Reset for new block
                     log.info("[CHAT] Block transition: user chose CONTINUE → block %s",
                              _phase_state.get("current_block"))
                 _no_extraction = True
@@ -915,6 +920,10 @@ async def chat_message(req: ChatMessageRequest, db: Session = Depends(get_db)):
             "kann ich nicht sagen", "keine angabe", "k.a.", "kein kommentar",
             "keine meinung", "weiß ich nicht", "weiss ich nicht",
             "kann ich nicht beantworten", "keine idee", "noch keine idee",
+            # KIS-1124 Testrun-Fix Bug 4: additional skip-signal phrases
+            "weiß nicht genau", "weiss nicht genau", "keine vorstellung",
+            "passe", "überspring das", "kein plan", "wüsste ich nicht",
+            "da bin ich überfragt", "keine präferenz", "mir egal",
         ]
         _msg_lower = req.message.strip().lower()
         _is_skip_word = _msg_lower in skip_words
@@ -1055,19 +1064,48 @@ async def chat_message(req: ChatMessageRequest, db: Session = Depends(get_db)):
                                  and not _should_skip_qr_field(f, collected)]
             all_missing = _missing_p1_after
 
-            if not _missing_p1_after:
-                # All Phase 1 fields collected → trigger checkpoint
-                _phase_state["conversation_phase"] = "checkpoint"
-                _checkpoint_triggered = True
-                next_fields = []
-                log.info("[CHAT] Phase 1 COMPLETE — triggering checkpoint")
+            # KIS-1124 Testrun-Fix Bug 7: Track which Phase 1b fields
+            # Sonnet has asked about. A field extracted via multi-field
+            # extraction is only considered "covered" if Sonnet asked
+            # about it (it appeared in next_fields) at least once.
+            _p1b_asked = _phase_state.get("phase_1b_asked_fields", [])
+            if not _post_phase_1a and _asked_field and _asked_field in PHASE_1B_OPEN_FIELDS:
+                if _asked_field not in _p1b_asked:
+                    _p1b_asked.append(_asked_field)
+                    _phase_state["phase_1b_asked_fields"] = _p1b_asked
 
-                # Persist phase_state change immediately
-                db.execute(
-                    _sa_text("UPDATE chat_sessions SET phase_state = CAST(:ps AS jsonb) WHERE id = :sid"),
-                    {"ps": json.dumps(_phase_state), "sid": str(session.id)},
-                )
-                db.commit()
+            if not _missing_p1_after:
+                # All Phase 1 fields are in collected. But before triggering
+                # checkpoint, verify all Phase 1b fields were actually asked about.
+                _unasked_p1b = [f for f in PHASE_1B_OPEN_FIELDS
+                                if f in collected and f not in _p1b_asked]
+                if _unasked_p1b:
+                    # Some Phase 1b fields were extracted but never asked about.
+                    # Force Sonnet to ask about the first unasked field before checkpoint.
+                    next_fields = [_unasked_p1b[0]]
+                    # Add it to asked list so next turn can proceed
+                    _p1b_asked.append(_unasked_p1b[0])
+                    _phase_state["phase_1b_asked_fields"] = _p1b_asked
+                    log.info("[CHAT] Phase 1b: field %s was extracted but never asked — forcing question before checkpoint", _unasked_p1b[0])
+                    # Persist phase_state
+                    db.execute(
+                        _sa_text("UPDATE chat_sessions SET phase_state = CAST(:ps AS jsonb) WHERE id = :sid"),
+                        {"ps": json.dumps(_phase_state), "sid": str(session.id)},
+                    )
+                    db.commit()
+                else:
+                    # All Phase 1b fields were asked about → trigger checkpoint
+                    _phase_state["conversation_phase"] = "checkpoint"
+                    _checkpoint_triggered = True
+                    next_fields = []
+                    log.info("[CHAT] Phase 1 COMPLETE — triggering checkpoint")
+
+                    # Persist phase_state change immediately
+                    db.execute(
+                        _sa_text("UPDATE chat_sessions SET phase_state = CAST(:ps AS jsonb) WHERE id = :sid"),
+                        {"ps": json.dumps(_phase_state), "sid": str(session.id)},
+                    )
+                    db.commit()
             elif _no_extraction and _asked_field and _asked_field not in collected:
                 next_fields = [_asked_field]
                 log.info("[CHAT] Phase 1 QR-Sync: keeping next_fields=[%s]", _asked_field)
@@ -1079,6 +1117,12 @@ async def chat_message(req: ChatMessageRequest, db: Session = Depends(get_db)):
                 # Phase 1b: next open-conversation field (no QR)
                 _p1b_missing = [f for f in PHASE_1B_OPEN_FIELDS if f not in collected]
                 next_fields = _p1b_missing[:1]
+                # Persist phase_1b_asked_fields
+                db.execute(
+                    _sa_text("UPDATE chat_sessions SET phase_state = CAST(:ps AS jsonb) WHERE id = :sid"),
+                    {"ps": json.dumps(_phase_state), "sid": str(session.id)},
+                )
+                db.commit()
 
         elif _cur_conv_phase == "checkpoint" and rt == "r1":
             # Checkpoint phase — next_fields is empty, QR handles navigation
@@ -1096,6 +1140,13 @@ async def chat_message(req: ChatMessageRequest, db: Session = Depends(get_db)):
             if _cur_block:
                 _block_remaining = _get_block_fields(_cur_block, collected)
 
+                # KIS-1124 Testrun-Fix Bug 8: Track which fields in the
+                # current block Sonnet has asked about.
+                _block_asked = _phase_state.get("block_asked_fields", [])
+                if _asked_field and _asked_field not in _block_asked:
+                    _block_asked.append(_asked_field)
+                    _phase_state["block_asked_fields"] = _block_asked
+
                 # Stale turn tracking: increment on no extraction, reset on extraction
                 if normalized and not _no_extraction:
                     _phase_state["block_stale_turns"] = 0
@@ -1104,12 +1155,24 @@ async def chat_message(req: ChatMessageRequest, db: Session = Depends(get_db)):
 
                 _stale = _phase_state.get("block_stale_turns", 0)
 
+                # KIS-1124 Testrun-Fix Bug 8: Check if there are remaining
+                # fields that Sonnet has never asked about. If so, the block
+                # should NOT auto-close — instead redirect Sonnet to ask about
+                # those unasked fields first.
+                _unasked_remaining = [f for f in _block_remaining if f not in _block_asked]
+
                 # Block completion: no remaining fields OR stale >= 2
-                if not _block_remaining or _stale >= 2:
+                # BUT: don't auto-close if there are unasked remaining fields
+                _should_close = (
+                    not _block_remaining
+                    or (_stale >= 2 and not _unasked_remaining)
+                    or _stale >= 4  # Hard limit: force-close after 4 stale turns
+                )
+                if _should_close:
                     if not _block_remaining:
                         log.info("[CHAT] Phase 2: block %s complete (all fields collected)", _cur_block)
                     else:
-                        log.info("[CHAT] Phase 2: block %s auto-close (stale_turns=%d)", _cur_block, _stale)
+                        log.info("[CHAT] Phase 2: block %s auto-close (stale_turns=%d, unasked=%d)", _cur_block, _stale, len(_unasked_remaining))
 
                     # Mark block as completed
                     completed = _phase_state.get("completed_blocks", [])
@@ -1117,6 +1180,7 @@ async def chat_message(req: ChatMessageRequest, db: Session = Depends(get_db)):
                         completed.append(_cur_block)
                     _phase_state["completed_blocks"] = completed
                     _phase_state["block_stale_turns"] = 0
+                    _phase_state["block_asked_fields"] = []  # Reset for next block
 
                     # Determine next block
                     remaining_blocks = [b for b in _phase_state.get("selected_blocks", [])
@@ -1131,6 +1195,14 @@ async def chat_message(req: ChatMessageRequest, db: Session = Depends(get_db)):
                     _block_just_completed = True
                     all_missing = []
                     next_fields = []
+                elif _stale >= 2 and _unasked_remaining:
+                    # Stale threshold hit but there are unasked fields — redirect
+                    # Sonnet to ask about the first unasked field instead of closing.
+                    all_missing = _block_remaining
+                    next_fields = [_unasked_remaining[0]]
+                    _phase_state["block_stale_turns"] = 0  # Reset to give the field a chance
+                    log.info("[CHAT] Phase 2 block %s: stale but %d unasked fields remain — redirecting to %s",
+                             _cur_block, len(_unasked_remaining), _unasked_remaining[0])
                 else:
                     all_missing = _block_remaining
                     if _no_extraction and _asked_field and _asked_field not in collected:
@@ -1214,6 +1286,25 @@ async def chat_message(req: ChatMessageRequest, db: Session = Depends(get_db)):
             if m.get("role") == "assistant" and m.get("content")
         ][-3:]
 
+        # KIS-1124 Testrun-Fix Bug 2: Track used confirmation phrases
+        # across the entire conversation so Sonnet can avoid repeating them.
+        _CONFIRMATION_WORDS = {
+            "notiert.", "danke.", "klar.", "verstehe.", "gut.",
+            "passt.", "erfasst.", "alles klar.", "in ordnung.",
+            "verstanden.", "weiter.", "okay.", "gut erfasst.",
+        }
+        _used_confirmations: list[str] = []
+        for _bot_msg in (m["content"] for m in session.messages
+                         if m.get("role") == "assistant" and m.get("content")):
+            _first_sentence = _bot_msg.strip().split("\n")[0].split(".")[0] + "." if _bot_msg.strip() else ""
+            _first_word_lower = _first_sentence.strip().lower()
+            for _cw in _CONFIRMATION_WORDS:
+                if _first_word_lower.startswith(_cw):
+                    _canon = _cw.capitalize()
+                    if _canon not in _used_confirmations:
+                        _used_confirmations.append(_canon)
+                    break
+
         # ------------------------------------------------------------------
         # Phase 2: Stream Sonnet response with heartbeat keepalive
         # ------------------------------------------------------------------
@@ -1282,8 +1373,8 @@ async def chat_message(req: ChatMessageRequest, db: Session = Depends(get_db)):
                 f"Fragen Sie den Nutzer, welches Feld geändert werden soll und auf welchen Wert."
             )
 
-        # KIS-1124-S0-BE-2: When user declines a required field, tell Sonnet
-        # to acknowledge gracefully and point to QR buttons as easy fallback.
+        # KIS-1124-S0-BE-2: When user declines a field, tell Sonnet
+        # to acknowledge gracefully.
         if _is_decline and not _help_ctx:
             _decline_field = _asked_field
             _decline_reg = registry.get(_decline_field, {})
@@ -1301,6 +1392,17 @@ async def chat_message(req: ChatMessageRequest, db: Session = Depends(get_db)):
                         f"die die Antwort erleichtern.\n"
                         f"- Maximal 2 Sätze total. NICHT insistieren."
                     )
+            else:
+                # KIS-1124 Testrun-Fix Bug 4: Skip-friendly message for optional fields
+                _help_ctx = (
+                    f"\n\nAKTUELLER MODUS: FELD ÜBERSPRUNGEN\n"
+                    f"Der Nutzer hat das optionale Feld \"{_decline_field}\" übersprungen.\n"
+                    f"REAGIERE SO:\n"
+                    f"- Kurze freundliche Bestätigung (z.B. 'Kein Problem, das lassen wir offen.').\n"
+                    f"- Dann SOFORT zur nächsten Frage weiter.\n"
+                    f"- NICHT 'Notiert.' sagen — das klingt so, als wäre die Ablehnung ein Wert.\n"
+                    f"- Maximal 1 Satz, dann die nächste Frage."
+                )
 
         # Compute Phase 1 missing fields for Sonnet prompt
         _missing_p1_for_sonnet = None
@@ -1389,6 +1491,7 @@ async def chat_message(req: ChatMessageRequest, db: Session = Depends(get_db)):
                     missing_phase_1_fields=_missing_p1_for_sonnet,
                     current_block=_sonnet_block_id,
                     remaining_block_fields=_sonnet_block_remaining,
+                    used_confirmations=_used_confirmations,
                 ):
                     await queue.put(token)
             except Exception as exc:

--- a/services/chat_conversation.py
+++ b/services/chat_conversation.py
@@ -1156,25 +1156,7 @@ verändern?"
 Dies sind Beispiele — passen Sie die Fragen an den bisherigen \
 Gesprächsverlauf an.
 
-BESTÄTIGUNGS-REGELN (STRIKT):
-- Maximal 1 Satz Bestätigung, dann direkt zur nächsten Frage.
-- Verwende JEDE Bestätigung nur EINMAL im gesamten Chat.
-- Varianten-Pool (verwende jede nur 1×, dann streichen):
-  "Notiert.", "Danke.", "Klar.", "Verstehe.", "Gut.", \
-  "Passt.", "Erfasst.", "Alles klar.", "In Ordnung.", \
-  direkter Einstieg OHNE Bestätigungswort, \
-  kurzer Rückbezug, Einordnung.
-- VERBOTEN: "Verstanden." (max. 1×), "Gut erfasst.", "Perfekt.", \
-  "Da Sie..." als Satzeinstieg nach Bestätigung.
-- NIE zweimal denselben Satzanfang in 3 aufeinanderfolgenden Antworten.
-
-VERBOTENE FORMULIERUNGEN:
-- "als KI-Berater" in jeder Schreibweise
-- "Als [Branche]-Experte", "Als Solo-Berater..."
-- "Das ist eine gute/wichtige/interessante Frage"
-- "die ideale Basis", "ohne große Vorarbeit"
-- "Alles klar zu..." (zu generisch)
-- "Bei Ihrer Expertise", "eine starke/solide/gute Basis"
+{{shared_prompt_rules}}
 
 KÜRZE-REGEL (STRIKT):
 - Bei QR-Feldern: Maximal 2 Sätze.
@@ -1191,6 +1173,7 @@ def _build_phase_1_prompt(
     missing_phase_1: list[str],
     next_fields: list[str],
     next_field_qr_context: str | None = None,
+    used_confirmations: list[str] | None = None,
 ) -> str:
     """Build the Phase 1 system prompt for open conversation mode."""
     # Format missing fields
@@ -1203,35 +1186,129 @@ def _build_phase_1_prompt(
     # Next field info
     nf_info = next_field_qr_context or "Kein spezifisches nächstes Feld."
 
-    return PHASE_1_SYSTEM_PROMPT.format(
+    # Inject shared prompt rules (blacklist, confirmation pool, neutrality)
+    shared_rules = _build_shared_prompt_rules(used_confirmations)
+
+    prompt = PHASE_1_SYSTEM_PROMPT.format(
         collected_fields_summary=_format_collected_summary(collected_fields),
         missing_phase_1_fields=missing_str,
         next_field_info=nf_info,
     )
+    # Replace the placeholder with actual shared rules
+    prompt = prompt.replace("{{shared_prompt_rules}}", shared_rules)
+    return prompt
 
 
 # ---------------------------------------------------------------------------
 # KIS-1124 Sprint 3: Phase 2 Block-Specific Prompts
 # ---------------------------------------------------------------------------
 
-_PHASE_2_BASE_RULES = """\
+# ---------------------------------------------------------------------------
+# KIS-1124 Testrun-Fix: Centralized confirmation & blacklist rules
+# Injected into ALL Sonnet prompts (Phase 1b, Blocks A–D) to ensure
+# consistent enforcement across the entire conversation.
+# ---------------------------------------------------------------------------
+
+CONFIRMATION_POOL = [
+    "Notiert.", "Danke.", "Klar.", "Verstehe.", "Gut.",
+    "Passt.", "Erfasst.", "Alles klar.", "In Ordnung.",
+    "Weiter.", "Okay.",
+    # Plus: direkter Einstieg OHNE Bestätigungswort
+    # Plus: kurzer Rückbezug (z.B. "Zusammen mit Ihrer Angabe zu [Feld]...")
+    # Plus: Einordnung (z.B. "Das ist typisch für [Branche].")
+]
+
+CONFIRMATION_BLACKLIST = [
+    "Perfekt",
+    "Verstanden",
+    "Gut erfasst",
+    "Alles klar zu",
+    "Bei Ihrer Expertise",
+    "eine starke Basis",
+    "eine solide Basis",
+    "eine gute Basis",
+    "das macht die Umsetzung",
+    "als KI-Berater",
+    "als Ihr KI-Berater",
+    "als erfahrener KI-Berater",
+    "die ideale Basis",
+    "ohne große Vorarbeit",
+]
+
+FORBIDDEN_PATTERNS = [
+    "als KI-Berater",
+    "Als [Branche]-Experte",
+    "Als [Branche]-Berater",
+    "Als Solo-Berater",
+    "Das ist eine gute Frage",
+    "Das ist eine wichtige Frage",
+    "Das ist eine interessante Frage",
+    "Gute Frage",
+    "die ideale Basis",
+    "ohne große Vorarbeit",
+    "Alles klar zu...",
+    "Bei Ihrer Expertise",
+    "eine starke Basis",
+    "eine solide Basis",
+    "eine gute Basis",
+    "das macht die Umsetzung",
+    "Das ist eine solide Basis",
+    "Das klingt vielversprechend",
+    "Gute Wahl",
+    "Ihre Ziele sind klar definiert",
+]
+
+
+def _build_shared_prompt_rules(used_confirmations: list[str] | None = None) -> str:
+    """Build the shared confirmation/blacklist/neutrality rules block.
+
+    This is injected into EVERY Sonnet prompt (Phase 1b, Blocks A-D)
+    to ensure consistent enforcement.
+
+    Args:
+        used_confirmations: list of confirmation phrases already used
+            in this conversation (from phase_state). Sonnet must avoid these.
+    """
+    blacklist_str = ", ".join(f'"{b}"' for b in CONFIRMATION_BLACKLIST)
+    forbidden_str = "\n".join(f"- {p}" for p in FORBIDDEN_PATTERNS)
+
+    used_str = ""
+    if used_confirmations:
+        used_items = ", ".join(f'"{c}"' for c in used_confirmations)
+        used_str = (
+            f"\n\nBEREITS VERWENDETE BESTÄTIGUNGEN (VERBRANNT — NICHT WIEDERVERWENDEN):\n"
+            f"{used_items}\n"
+            "Wähle eine Bestätigung aus dem Pool, die NICHT in dieser Liste steht. "
+            "Wenn alle verbrannt sind: verwende einen direkten Einstieg OHNE "
+            "Bestätigungswort (z.B. direkt die nächste Frage stellen)."
+        )
+
+    return f"""\
 BESTÄTIGUNGS-REGELN (STRIKT):
 - Maximal 1 Satz Bestätigung, dann direkt zur nächsten Frage.
-- Verwende JEDE Bestätigung nur EINMAL im gesamten Chat.
+- Verwende JEDE Bestätigung nur EINMAL im gesamten Chat. \
+Nach Gebrauch ist sie verbrannt.
 - Varianten-Pool (verwende jede nur 1×, dann streichen):
   "Notiert.", "Danke.", "Klar.", "Verstehe.", "Gut.", \
   "Passt.", "Erfasst.", "Alles klar.", "In Ordnung.", \
-  direkter Einstieg OHNE Bestätigungswort.
-- VERBOTEN: "Verstanden." (max. 1×), "Gut erfasst.", "Perfekt.", \
-  "Da Sie..." als Satzeinstieg.
+  direkter Einstieg OHNE Bestätigungswort, \
+  kurzer Rückbezug, Einordnung.
 - NIE zweimal denselben Satzanfang in 3 aufeinanderfolgenden Antworten.
+- Variiere deine Satzanfänge RADIKAL.{used_str}
 
-VERBOTENE FORMULIERUNGEN:
-- "als KI-Berater" in jeder Schreibweise
-- "Als [Branche]-Experte", "Als Solo-Berater..."
-- "Das ist eine gute/wichtige/interessante Frage"
-- "die ideale Basis", "Alles klar zu..."
-- "Bei Ihrer Expertise", "eine starke/solide/gute Basis"
+BESTÄTIGUNGS-BLACKLIST (NIEMALS verwenden, in KEINER Form):
+{blacklist_str}
+
+VERBOTENE FORMULIERUNGEN (NIEMALS verwenden):
+{forbidden_str}
+
+NEUTRALITÄTS-REGEL (STRIKT):
+- Bewerte NIEMALS eine Antwort, bevor sie gegeben wurde.
+- Formuliere KEINE Einschätzung zu einem Feld, das noch offen ist.
+- Frage NEUTRAL — ohne inhaltliche Einleitung oder Vorwegnahme.
+- FALSCH: "Bei Ihrer hohen Risikobereitschaft..." (Feld noch nicht beantwortet)
+- RICHTIG: "Wie risikofreudig sind Sie bei neuen KI-Technologien?"
+- Bei Quick-Reply-Feldern: Stelle die Frage OHNE den Wert vorwegzunehmen.
 """
 
 
@@ -1259,6 +1336,8 @@ Feld einzeln beantworten.
 - QR-Buttons nur wenn nötig (z.B. Budget-Bänder, Ja/Nein).
 - Max 2 Sätze pro Antwort.
 - Bei "weiß nicht" → Feld überspringen, nicht insistieren.
+- Frage ALLE offenen Felder dieses Blocks ab — insbesondere \
+jahresumsatz NICHT auslassen.
 
 BEISPIEL-FRAGEN:
 - "Haben Sie schon Erfahrung mit Fördermitteln für Digitalisierung?"
@@ -1267,7 +1346,8 @@ BEISPIEL-FRAGEN:
 NÄCHSTES FELD:
 {next_field_info}
 
-""" + _PHASE_2_BASE_RULES
+{{shared_prompt_rules}}
+"""
 
 
 BLOCK_B_PROMPT = """\
@@ -1303,7 +1383,8 @@ BEISPIEL-FRAGEN:
 NÄCHSTES FELD:
 {next_field_info}
 
-""" + _PHASE_2_BASE_RULES
+{{shared_prompt_rules}}
+"""
 
 
 BLOCK_C_PROMPT = """\
@@ -1339,7 +1420,8 @@ BEISPIEL-FRAGEN:
 NÄCHSTES FELD:
 {next_field_info}
 
-""" + _PHASE_2_BASE_RULES
+{{shared_prompt_rules}}
+"""
 
 
 BLOCK_D_PROMPT = """\
@@ -1376,7 +1458,8 @@ zu technischen Maßnahmen?"
 NÄCHSTES FELD:
 {next_field_info}
 
-""" + _PHASE_2_BASE_RULES
+{{shared_prompt_rules}}
+"""
 
 
 _BLOCK_PROMPTS: dict[str, str] = {
@@ -1393,6 +1476,7 @@ def _build_phase_2_prompt(
     remaining_block_fields: list[str],
     next_field_qr_context: str | None = None,
     user_profile_summary: str | None = None,
+    used_confirmations: list[str] | None = None,
 ) -> str:
     """Build the Phase 2 system prompt for a specific thematic block."""
     template = _BLOCK_PROMPTS.get(block_id, BLOCK_A_PROMPT)
@@ -1420,13 +1504,17 @@ def _build_phase_2_prompt(
         else:
             beratung_hint = "CONDITIONAL: Vollständige Datenschutz-Prüfung (alle Felder)."
 
-    return template.format(
+    prompt = template.format(
         user_profile_summary=profile_str,
         collected_fields_summary=_format_collected_summary(collected_fields),
         remaining_fields=remaining_str,
         next_field_info=nf_info,
         beratung_hint=beratung_hint,
     )
+    # Inject shared prompt rules (blacklist, confirmation pool, neutrality)
+    shared_rules = _build_shared_prompt_rules(used_confirmations)
+    prompt = prompt.replace("{{shared_prompt_rules}}", shared_rules)
+    return prompt
 
 
 # ---------------------------------------------------------------------------
@@ -1452,6 +1540,7 @@ async def generate_response(
     missing_phase_1_fields: list[str] | None = None,
     current_block: str | None = None,
     remaining_block_fields: list[str] | None = None,
+    used_confirmations: list[str] | None = None,
 ) -> AsyncGenerator[str, None]:
     """
     Generate streaming AI response.
@@ -1475,6 +1564,7 @@ async def generate_response(
             missing_phase_1=missing_phase_1_fields or [],
             next_fields=next_fields,
             next_field_qr_context=next_field_qr_context,
+            used_confirmations=used_confirmations,
         )
     elif conversation_phase == "phase_1a":
         # Phase 1a: QR-focused — use legacy prompt with Phase 1 context
@@ -1490,6 +1580,7 @@ async def generate_response(
             remaining_block_fields=remaining_block_fields or [],
             next_field_qr_context=next_field_qr_context,
             user_profile_summary=user_profile_summary,
+            used_confirmations=used_confirmations,
         )
     else:
         # Legacy / Strategy: use section-based prompt
@@ -1760,6 +1851,12 @@ _ENUM_DISPLAY: dict[str, dict[str, str]] = {
     "unternehmensgroesse": {
         "1": "1 (Solo)", "2–10": "2–10 (Kleines Team)", "11–100": "11–100 (KMU)",
     },
+    "selbststaendig": {
+        "freiberufler": "Freiberuflich/Selbstständig",
+        "kapitalgesellschaft": "Kapitalgesellschaft",
+        "einzelunternehmer": "Einzelunternehmer",
+        "sonstiges": "Sonstiges",
+    },
     "country": {
         "DE": "Deutschland", "AT": "Österreich", "CH": "Schweiz",
         "FR": "Frankreich", "NL": "Niederlande", "IT": "Italien", "ES": "Spanien",
@@ -1972,8 +2069,15 @@ def build_summary(collected_fields: dict, report_type: str = "r1") -> str:
             if field_name not in collected_fields:
                 continue
             value = collected_fields[field_name]
+            # KIS-1124 Testrun-Fix Bug 6: Skip fields with keine_angabe/empty/None
+            if value is None or value == "" or (isinstance(value, str) and value.strip().lower() in ("keine_angabe", "keine angabe")):
+                continue
+            if isinstance(value, list) and all(str(v).lower() in ("keine_angabe",) for v in value):
+                continue
             label = FIELD_DESCRIPTIONS.get(field_name, field_name).split("(")[0].strip()
             display = _format_value_for_display(field_name, value)
+            if display == "Nicht angegeben":
+                continue  # Don't show "Nicht angegeben" lines in summary
             section_lines.append(f"- {label}: {display}")
 
         if section_lines:
@@ -1986,6 +2090,11 @@ def build_summary(collected_fields: dict, report_type: str = "r1") -> str:
 
 def _format_value_for_display(field_name: str, value: object) -> str:
     """Format a field value for human-readable display."""
+    # KIS-1124 Testrun-Fix Bug 6: Universal catch for raw "keine_angabe" key
+    str_check = str(value).strip().lower() if value is not None else ""
+    if str_check in ("keine_angabe", "keine angabe"):
+        return "Nicht angegeben"
+
     reg = FIELD_REGISTRY.get(field_name) or STRATEGY_FIELD_REGISTRY.get(field_name, {})
     field_type = reg.get("type", "text")
 
@@ -2005,8 +2114,14 @@ def _format_value_for_display(field_name: str, value: object) -> str:
         if not value:
             return "–"
         enum_labels = _ENUM_DISPLAY.get(field_name, {})
-        resolved = [enum_labels.get(str(v), str(v)) for v in value]
-        return ", ".join(resolved)
+        # Filter out "keine_angabe" items from multi-select lists
+        resolved = []
+        for v in value:
+            sv = str(v)
+            if sv.lower() in ("keine_angabe", "keine angabe"):
+                continue
+            resolved.append(enum_labels.get(sv, sv))
+        return ", ".join(resolved) if resolved else "Nicht angegeben"
 
     # Slider: number with context
     if field_type == "slider":

--- a/services/chat_extractor.py
+++ b/services/chat_extractor.py
@@ -30,22 +30,27 @@ Analysiere die Nutzerantwort und extrahiere strukturierte Felder
 mit dem Tool update_intake_fields.
 
 REGELN:
-1. Setze NUR Felder, die der Nutzer tatsächlich genannt hat.
-2. Erfinde NIEMALS Werte.
+1. Setze NUR Felder, die der Nutzer EXPLIZIT genannt hat.
+2. Erfinde NIEMALS Werte. Inferiere KEINE Werte aus dem Kontext.
 3. Wenn unsicher, setze das Feld NICHT.
-4. Extrahiere auch implizite Informationen:
+4. ERLAUBTE Normalisierung (Format-Transformation, KEINE Inhalts-Inferenz):
    - "in München" → bundesland: "München" (wird extern normalisiert)
    - "8 Mitarbeiter" → unternehmensgroesse: "8" (wird extern normalisiert)
    - "Handwerksbetrieb" → branche: "Handwerk" (wird extern normalisiert)
+   VERBOTENE Inferenz: Leite KEINE Feldwerte ab, die der User nicht \
+   direkt genannt hat. Beispiel: Wenn der User "Beratung von Unternehmen" \
+   sagt, extrahiere NICHT daraus zielgruppen — das muss separat gefragt werden.
 5. Bei Freitextfeldern: den Kern der Aussage in 1–3 Sätzen zusammenfassen.
 6. Wenn der Nutzer eine Rückfrage stellt statt zu antworten,
    rufe das Tool NICHT auf.
 7. Wenn der Nutzer auf ein Feld mit einer Ablehnung oder \
 einem Skip-Signal antwortet (z.B. „nein", „keine Ahnung", „noch keine Idee", \
-„weiß nicht", „weiter", „skip", „überspringen", „keine", „k.A.", \
-„noch nicht", „nicht wirklich", „keine Angabe", „das kann ich nicht \
-entscheiden", „schwer zu sagen", „müsste ich nachschauen", „egal", \
-„ist mir nicht wichtig", „spielt keine Rolle"), dann extrahiere \
+„weiß nicht", „weiß nicht genau", „weiter", „skip", „überspringen", \
+„keine", „k.A.", „noch nicht", „nicht wirklich", „keine Angabe", \
+„das kann ich nicht entscheiden", „schwer zu sagen", „müsste ich nachschauen", \
+„egal", „ist mir nicht wichtig", „spielt keine Rolle", \
+„kann ich nicht sagen", „keine Vorstellung", „passe", \
+„überspring das", „kein Plan", „keine Idee"), dann extrahiere \
 das aktuell gefragte Feld mit dem Wert „keine_angabe". \
 Skip-Signale sind GÜLTIGE Antworten, NICHT „off-topic". \
 Auch bei Pflichtfeldern: Wenn der Nutzer klar signalisiert, dass er \
@@ -584,23 +589,29 @@ für die unten aufgelisteten Felder. Antworte NUR mit einem JSON-Objekt
 über das Tool extract_multi_fields.
 
 REGELN:
-1. Setze NUR Felder, die der Nutzer tatsächlich genannt oder klar impliziert hat.
-2. Erfinde NIEMALS Werte.
+1. Setze NUR Felder, die der Nutzer EXPLIZIT genannt hat.
+2. Erfinde NIEMALS Werte. Inferiere KEINE Werte aus dem Kontext.
 3. Bei Unsicherheit: Feld NICHT setzen (weglassen).
 4. Bei enum-Feldern: Exakt einen der vorgegebenen Werte verwenden.
 5. Bei multi-Feldern: Array der erkannten Werte.
 6. Bei text-Feldern: Relevanten Textabschnitt in 1–3 Sätzen zusammenfassen.
 7. Bei slider-Feldern: Numerischen Wert ableiten (1–10).
-8. Extrahiere auch implizite Informationen:
-   - "in München" → bundesland: "by" (Bayern)
-   - "8 Mitarbeiter" → unternehmensgroesse: "team"
-   - "komplett digital" → digitalisierungsgrad: 9 oder 10
-   - "viel Papier" → digitalisierungsgrad: 2 oder 3
-   - "ich arbeite mit LLM-APIs" → ki_kompetenz: "hoch"
-   - "ich will automatisieren" → ki_ziele: ["automatisierung"]
+8. ERLAUBTE Normalisierung (Format-Transformation, KEINE Inhalts-Inferenz):
+   - "in München" → bundesland: "by" (Bayern) — Ort → Region
+   - "8 Mitarbeiter" → unternehmensgroesse: "team" — Zahl → Kategorie
+   - "komplett digital" → digitalisierungsgrad: 9 oder 10 — Beschreibung → Skala
+   - "viel Papier" → digitalisierungsgrad: 2 oder 3 — Beschreibung → Skala
+   - "ich arbeite mit LLM-APIs" → ki_kompetenz: "hoch" — Aussage → Einstufung
+   VERBOTENE Inferenz (Inhalte ableiten, die der User NICHT gesagt hat):
+   - "Beratung von Unternehmen" → NICHT zielgruppen: ["b2b"] ableiten
+   - "KI-Beratung" → NICHT ki_ziele oder ki_einsatz daraus ableiten
+   - "Automatisierung" als Hauptleistung → NICHT ki_ziele: ["automatisierung"] setzen
+   Regel: Wenn der User ein Feld nicht DIREKT anspricht, setze es NICHT.
 9. Wenn der Nutzer signalisiert, nicht antworten zu wollen \
-(z.B. "weiß nicht", "keine Ahnung", "überspring", "egal", "später", \
-"kann ich nicht", "schwer zu sagen", "nächste Frage"), setze \
+(z.B. "weiß nicht", "weiß nicht genau", "keine Ahnung", "überspring", \
+"egal", "später", "kann ich nicht", "kann ich nicht sagen", \
+"schwer zu sagen", "nächste Frage", "keine Vorstellung", "passe", \
+"überspring das", "kein Plan", "keine Idee"), setze \
 __skip_signal auf true.
 
 FELDER ZUM EXTRAHIEREN:


### PR DESCRIPTION
## Summary
This PR refactors prompt engineering to centralize confirmation/blacklist rules across all Sonnet prompts and fixes critical bugs in Phase 1b and Phase 2 field coverage tracking. The changes ensure consistent enforcement of neutrality rules and prevent premature conversation phase transitions when fields are extracted but never explicitly asked about.

## Key Changes

### Prompt Engineering Refactoring
- **Centralized shared rules**: Extracted confirmation pool, blacklist, and neutrality rules into a new `_build_shared_prompt_rules()` function that is injected into all Phase 1b and Phase 2 block prompts via `{{shared_prompt_rules}}` placeholder
- **Dynamic confirmation tracking**: `used_confirmations` parameter now passed through `generate_response()` → `_build_phase_1_prompt()` and `_build_phase_2_prompt()` to prevent Sonnet from reusing confirmation phrases
- **Enhanced neutrality enforcement**: Added explicit rules preventing Sonnet from evaluating answers before fields are answered (e.g., "Bei Ihrer hohen Risikobereitschaft..." when field is still open)
- **Expanded blacklist**: Added 50+ forbidden patterns and confirmation phrases with stricter enforcement

### Phase 1b Field Coverage Tracking (Bug 7)
- Added `phase_1b_asked_fields` to phase state to track which Phase 1b fields Sonnet has explicitly asked about
- Before triggering checkpoint, verify all Phase 1b fields in `collected` were actually asked about by Sonnet
- If fields were extracted via multi-field extraction but never asked, force Sonnet to ask about them before proceeding to checkpoint
- Prevents skipping required fields that happen to be extracted as side effects

### Phase 2 Block Field Coverage Tracking (Bug 8)
- Added `block_asked_fields` to phase state to track which fields in current block Sonnet has asked about
- Modified block completion logic: don't auto-close block if there are remaining fields Sonnet has never asked about
- When stale threshold (≥2) is hit but unasked fields remain, redirect Sonnet to ask about the first unasked field instead of closing
- Hard limit: force-close after 4 stale turns regardless
- Reset `block_asked_fields` when transitioning to new block

### Extraction & Display Improvements
- **Bug 6 - Skip signal handling**: Enhanced skip-word detection with additional phrases ("weiß nicht genau", "keine Vorstellung", "passe", "überspring das", "kein Plan", "keine Idee")
- **Bug 6 - Summary filtering**: Filter out "keine_angabe" values from summaries and multi-select displays to prevent "Nicht angegeben" clutter
- **Extractor rules clarification**: Explicitly distinguish between allowed normalization (format transformation) and forbidden inference (deriving field values user didn't state)
- Added `selbststaendig` enum mapping for self-employment status display

### Session State Management
- Initialize `phase_1b_asked_fields` and `block_asked_fields` in `_init_phase_state()`
- Persist phase state changes immediately when tracking asked fields
- Reset `block_asked_fields` on block transitions and completions

## Implementation Details
- Confirmation tracking extracts first sentence from bot messages and matches against known confirmation words
- Unasked field detection uses set difference: `[f for f in remaining if f not in asked]`
- Stale turn logic now considers unasked fields: only auto-close if no unasked fields remain OR stale ≥ 4
- All Phase 2 block prompts (A, B, C, D) now use shared rules injection instead of hardcoded `_PHASE_2_BASE_RULES`

https://claude.ai/code/session_01FxqbES5heBncaDJLRLHBT3