### PR TITLE
Strengthen extraction validation & improve conversation quality

### DIFF
--- a/routes/chat.py
+++ b/routes/chat.py
@@ -1163,10 +1163,12 @@ async def chat_message(req: ChatMessageRequest, db: Session = Depends(get_db)):
 
                 # Block completion: no remaining fields OR stale >= 2
                 # BUT: don't auto-close if there are unasked remaining fields
+                # KIS-1124 Testrun 2 Bug 12: Hard limit raised to 6 to give
+                # unasked fields (like jahresumsatz) a chance to be asked.
                 _should_close = (
                     not _block_remaining
                     or (_stale >= 2 and not _unasked_remaining)
-                    or _stale >= 4  # Hard limit: force-close after 4 stale turns
+                    or _stale >= 6  # Hard limit: force-close after 6 stale turns
                 )
                 if _should_close:
                     if not _block_remaining:

--- a/services/chat_conversation.py
+++ b/services/chat_conversation.py
@@ -540,7 +540,7 @@ FIELD_DESCRIPTIONS: dict[str, str] = {
     "ki_ziele": "Ziele mit KI in den nächsten 3–6 Monaten (Mehrfachauswahl)",
     "ki_projekte": "Bestehende KI-Tests, Tools oder Projekte — auch informell (Freitext)",
     "anwendungsfaelle": "Interessante KI-Anwendungsfälle (Mehrfachauswahl)",
-    "zeitersparnis_prioritaet": "Wo frisst heute am meisten Zeit oder Nerven? (Freitext)",
+    "zeitersparnis_prioritaet": "Welche Aufgabe kostet im Arbeitsalltag am meisten Zeit oder Nerven? (Freitext)",
     "pilot_bereich": "Bester Bereich für ein Pilotprojekt (Kundenservice, Marketing, Vertrieb, etc.)",
     "geschaeftsmodell_evolution": "Ideen, wie KI das Geschäftsmodell verändern könnte (Freitext)",
     "vision_3_jahre": "Wie soll das Unternehmen in 2–3 Jahren mit KI arbeiten? (Freitext)",
@@ -1233,6 +1233,13 @@ CONFIRMATION_BLACKLIST = [
     "als erfahrener KI-Berater",
     "die ideale Basis",
     "ohne große Vorarbeit",
+    # KIS-1124 Testrun 2 Bug 10: Langform-Bestätigungen
+    "Vielen Dank für die",
+    "Vielen Dank für Ihre",
+    "Danke für die ausführlichen",
+    "Danke für die detaillierten",
+    "Danke für die umfangreichen",
+    "Herzlichen Dank",
 ]
 
 FORBIDDEN_PATTERNS = [
@@ -1256,6 +1263,31 @@ FORBIDDEN_PATTERNS = [
     "Das klingt vielversprechend",
     "Gute Wahl",
     "Ihre Ziele sind klar definiert",
+    # KIS-1124 Testrun 2 Bug 10: Langform-Bestätigungen
+    "Vielen Dank für die",
+    "Vielen Dank für Ihre",
+    "Danke für die ausführlichen",
+    "Danke für die detaillierten",
+    # KIS-1124 Testrun 2: Schmeichelei / evaluative Satzanfänge
+    "Spannend",
+    "Interessant",
+    "Exzellent",
+    "Ausgezeichnet",
+    "Beeindruckend",
+    "Sehr gut",
+    "Großartig",
+    "Hervorragend",
+    "Wunderbar",
+    "Excellent",
+    "Amazing",
+    "Great",
+    "Perfect",
+    # KIS-1124 Testrun 2 Bug 9: Englische Ausrufe
+    "Excellent!",
+    "Great!",
+    "Perfect!",
+    "Amazing!",
+    "Wonderful!",
 ]
 
 
@@ -1284,8 +1316,12 @@ def _build_shared_prompt_rules(used_confirmations: list[str] | None = None) -> s
         )
 
     return f"""\
+SPRACHE (STRIKT):
+- Antworte IMMER auf Deutsch. Keine englischen Wörter, Ausrufe oder Phrasen.
+- Auch nicht "Excellent", "Great", "Perfect", "Amazing", "Wonderful".
+
 BESTÄTIGUNGS-REGELN (STRIKT):
-- Maximal 1 Satz Bestätigung, dann direkt zur nächsten Frage.
+- Maximal 3–5 Wörter Bestätigung, dann direkt zur nächsten Frage.
 - Verwende JEDE Bestätigung nur EINMAL im gesamten Chat. \
 Nach Gebrauch ist sie verbrannt.
 - Varianten-Pool (verwende jede nur 1×, dann streichen):
@@ -1294,13 +1330,32 @@ Nach Gebrauch ist sie verbrannt.
   direkter Einstieg OHNE Bestätigungswort, \
   kurzer Rückbezug, Einordnung.
 - NIE zweimal denselben Satzanfang in 3 aufeinanderfolgenden Antworten.
-- Variiere deine Satzanfänge RADIKAL.{used_str}
+- Variiere deine Satzanfänge RADIKAL.
+- KEINE bewertenden Einleitungen. Starte direkt mit der nächsten Frage \
+oder einem kurzen thematischen Übergang.
+- Beginne KEINE Antwort mit "Vielen Dank für die…". \
+Maximal 1× "Vielen Dank" pro gesamtem Gespräch.{used_str}
 
 BESTÄTIGUNGS-BLACKLIST (NIEMALS verwenden, in KEINER Form):
 {blacklist_str}
 
 VERBOTENE FORMULIERUNGEN (NIEMALS verwenden):
 {forbidden_str}
+
+TONALITÄT (STRIKT):
+- Sei sachlich-freundlich, nicht bewertend.
+- VERBOTEN als Satzanfang: "Spannend", "Interessant", "Exzellent", \
+"Ausgezeichnet", "Beeindruckend", "Sehr gut", "Großartig", \
+"Hervorragend", "Wunderbar".
+- Starte mit thematischem Übergang oder direkt mit der Frage.
+- SCHLECHT: "Spannend, dass Sie KI nutzen! Wie digital ist..."
+- GUT: "Wie digital läuft Ihr Geschäft ab — von der Akquise bis zur Lieferung?"
+
+WIEDERHOLUNG (STRIKT):
+- Beziehe dich NICHT wiederholt auf dieselbe Aussage des Users.
+- Wenn du einmal erwähnt hast, dass der User z.B. API-Integrationen nutzt, \
+erwähne es NICHT erneut. Jede Kontextreferenz maximal 1× pro Gespräch.
+- "Da Sie bereits..." — maximal 1× im gesamten Gespräch verwenden.
 
 NEUTRALITÄTS-REGEL (STRIKT):
 - Bewerte NIEMALS eine Antwort, bevor sie gegeben wurde.

--- a/services/chat_extractor.py
+++ b/services/chat_extractor.py
@@ -29,6 +29,12 @@ Du bist ein Daten-Extractor für einen KI-Readiness-Fragebogen.
 Analysiere die Nutzerantwort und extrahiere strukturierte Felder
 mit dem Tool update_intake_fields.
 
+STRIKTE EXTRAKTIONSREGEL:
+Du bist ein EXTRAKTOR, kein ANALYST.
+- Extrahiere NUR Werte, die der User mit eigenen Worten EXPLIZIT gesagt hat.
+- VERBOTEN: Logische Schlussfolgerungen, Kategorie-Mapping, Kontextableitung.
+- Leere Felder sind BESSER als falsche Felder.
+
 REGELN:
 1. Setze NUR Felder, die der Nutzer EXPLIZIT genannt hat.
 2. Erfinde NIEMALS Werte. Inferiere KEINE Werte aus dem Kontext.
@@ -37,13 +43,32 @@ REGELN:
    - "in München" → bundesland: "München" (wird extern normalisiert)
    - "8 Mitarbeiter" → unternehmensgroesse: "8" (wird extern normalisiert)
    - "Handwerksbetrieb" → branche: "Handwerk" (wird extern normalisiert)
-   VERBOTENE Inferenz: Leite KEINE Feldwerte ab, die der User nicht \
-   direkt genannt hat. Beispiel: Wenn der User "Beratung von Unternehmen" \
-   sagt, extrahiere NICHT daraus zielgruppen — das muss separat gefragt werden.
-5. Bei Freitextfeldern: den Kern der Aussage in 1–3 Sätzen zusammenfassen.
-6. Wenn der Nutzer eine Rückfrage stellt statt zu antworten,
+   - "komplett digital" → digitalisierungsgrad: 9 (NICHT 10 — 10 = kein \
+   einziger analoger Prozess denkbar; "komplett/voll digital" → maximal 9)
+   VERBOTENE Inferenz (Inhalte ableiten, die der User NICHT gesagt hat):
+   - "Beratung von Unternehmen" → NICHT zielgruppen: ["b2b"] ableiten. \
+     Das ist NUR relevant für "hauptleistung". Daraus NICHT ableiten: \
+     zielgruppen, ki_einsatz, oder andere Felder.
+   - User nennt "Content-Generierung, Datenanalyse" als Anwendungsfälle → \
+     Trage das NUR bei "anwendungsfaelle" ein — NICHT bei "ki_einsatz".
+   - User sagt "Markteintritt, Kundenakquise" als Ziele → Extrahiere die \
+     WORTE des Users, NICHT Synonyme wie "Wettbewerbsfähigkeit" oder \
+     "Automatisierung".
+   Regel: Wenn der User ein Feld nicht DIREKT anspricht, setze es NICHT.
+5. FELD-ISOLATION (Cross-Contamination verhindern):
+   - ki_einsatz = wo KI HEUTE SCHON produktiv im Einsatz ist. \
+     NUR setzen wenn der User sagt "wir nutzen KI für X" oder "KI läuft bei uns in Y".
+   - anwendungsfaelle = was den User INTERESSIERT oder was er PLANT. \
+     Wenn User Anwendungsfälle als Interesse nennt, NICHT in ki_einsatz kopieren.
+   - ki_ziele = was der User als ZIEL oder WUNSCH formuliert. \
+     NUR die Worte des Users verwenden, KEINE Buzzwords substituieren. \
+     NICHT aus hauptleistung oder anwendungsfaelle ableiten.
+   - zielgruppen = NUR setzen wenn der User explizit "meine Zielgruppe ist X" sagt. \
+     NICHT aus Branche, Hauptleistung oder Kontext ableiten.
+6. Bei Freitextfeldern: den Kern der Aussage in 1–3 Sätzen zusammenfassen.
+7. Wenn der Nutzer eine Rückfrage stellt statt zu antworten,
    rufe das Tool NICHT auf.
-7. Wenn der Nutzer auf ein Feld mit einer Ablehnung oder \
+8. Wenn der Nutzer auf ein Feld mit einer Ablehnung oder \
 einem Skip-Signal antwortet (z.B. „nein", „keine Ahnung", „noch keine Idee", \
 „weiß nicht", „weiß nicht genau", „weiter", „skip", „überspringen", \
 „keine", „k.A.", „noch nicht", „nicht wirklich", „keine Angabe", \
@@ -529,6 +554,7 @@ async def extract_fields(
             if block.type == "tool_use" and block.name == "update_intake_fields":
                 extracted: dict = dict(block.input)
                 signal = extracted.pop("_signal", None)
+                extracted = _validate_extracted(extracted)
                 log.info(
                     "[CHAT-EXTRACT] Extracted %d fields: %s (signal=%s)",
                     len(extracted),
@@ -579,14 +605,71 @@ def _format_collected(collected: dict) -> str:
 
 
 # ---------------------------------------------------------------------------
+# Post-Extraction Validation (Hallucination Guard)
+# ---------------------------------------------------------------------------
+
+# Array fields where Haiku tends to over-generate via category-mapping
+_ARRAY_FIELDS_MAX = {
+    "ki_einsatz": 4,
+    "ki_ziele": 4,
+    "zielgruppen": 4,
+    "anwendungsfaelle": 5,
+    "datenquellen": 5,
+    "ki_hemmnisse": 4,
+    "trainings_interessen": 4,
+    "vorhandene_tools": 6,
+    "regulierte_branche": 3,
+}
+
+
+def _validate_extracted(extracted: dict) -> dict:
+    """Post-extraction validation to catch hallucination patterns.
+
+    - Caps array fields at a reasonable max (truncates excess).
+    - Clamps digitalisierungsgrad: "komplett digital" → max 9.
+    - Logs warnings for suspicious extractions.
+    """
+    for field, max_len in _ARRAY_FIELDS_MAX.items():
+        if field in extracted and isinstance(extracted[field], list):
+            original_len = len(extracted[field])
+            if original_len > max_len:
+                log.warning(
+                    "[CHAT-EXTRACT-VALIDATE] Suspicious: %s has %d values "
+                    "(max %d) — truncating. Values: %s",
+                    field, original_len, max_len, extracted[field],
+                )
+                extracted[field] = extracted[field][:max_len]
+
+    # Digitalisierungsgrad: cap at 9 (10 = no analog process conceivable)
+    if "digitalisierungsgrad" in extracted:
+        val = extracted["digitalisierungsgrad"]
+        if isinstance(val, int) and val >= 10:
+            log.info(
+                "[CHAT-EXTRACT-VALIDATE] digitalisierungsgrad %d → capped to 9",
+                val,
+            )
+            extracted["digitalisierungsgrad"] = 9
+
+    return extracted
+
+
+# ---------------------------------------------------------------------------
 # KIS-1124 Sprint 2: Multi-Field Extraction for Phase 1 Free Conversation
 # ---------------------------------------------------------------------------
 
 MULTI_FIELD_SYSTEM_PROMPT = """\
 Du bist ein Daten-Extractor für einen KI-Readiness-Fragebogen.
-Analysiere die Nutzerantwort und extrahiere ALLE erkennbaren Werte
-für die unten aufgelisteten Felder. Antworte NUR mit einem JSON-Objekt
+Analysiere die Nutzerantwort und extrahiere Werte für die unten
+aufgelisteten Felder. Antworte NUR mit einem JSON-Objekt
 über das Tool extract_multi_fields.
+
+STRIKTE EXTRAKTIONSREGEL:
+Du bist ein EXTRAKTOR, kein ANALYST.
+- Extrahiere NUR Werte, die der User mit eigenen Worten EXPLIZIT gesagt hat.
+- VERBOTEN: Logische Schlussfolgerungen, Kategorie-Mapping, Kontextableitung.
+- Leere Felder sind BESSER als falsche Felder.
+- Wenn ein Feld mehr als 3 Werte hätte: Prüfe kritisch, ob der User wirklich \
+  ALLE diese Werte explizit genannt hat. Im Zweifel weniger extrahieren.
 
 REGELN:
 1. Setze NUR Felder, die der Nutzer EXPLIZIT genannt hat.
@@ -599,15 +682,30 @@ REGELN:
 8. ERLAUBTE Normalisierung (Format-Transformation, KEINE Inhalts-Inferenz):
    - "in München" → bundesland: "by" (Bayern) — Ort → Region
    - "8 Mitarbeiter" → unternehmensgroesse: "team" — Zahl → Kategorie
-   - "komplett digital" → digitalisierungsgrad: 9 oder 10 — Beschreibung → Skala
+   - "komplett digital" → digitalisierungsgrad: 9 (NICHT 10 — 10 = kein \
+   einziger analoger Prozess denkbar; "komplett/voll digital" → maximal 9)
    - "viel Papier" → digitalisierungsgrad: 2 oder 3 — Beschreibung → Skala
    - "ich arbeite mit LLM-APIs" → ki_kompetenz: "hoch" — Aussage → Einstufung
    VERBOTENE Inferenz (Inhalte ableiten, die der User NICHT gesagt hat):
-   - "Beratung von Unternehmen" → NICHT zielgruppen: ["b2b"] ableiten
+   - "Beratung von Unternehmen" → NICHT zielgruppen: ["b2b"] ableiten. \
+     Das ist NUR relevant für "hauptleistung". Daraus NICHT ableiten: \
+     zielgruppen, ki_einsatz, oder andere Felder.
    - "KI-Beratung" → NICHT ki_ziele oder ki_einsatz daraus ableiten
    - "Automatisierung" als Hauptleistung → NICHT ki_ziele: ["automatisierung"] setzen
+   - User nennt Anwendungsfälle → NICHT in ki_einsatz kopieren
+   - User nennt Ziele → NUR seine Worte verwenden, KEINE Buzzword-Synonyme
    Regel: Wenn der User ein Feld nicht DIREKT anspricht, setze es NICHT.
-9. Wenn der Nutzer signalisiert, nicht antworten zu wollen \
+9. FELD-ISOLATION (Cross-Contamination verhindern):
+   - ki_einsatz = wo KI HEUTE SCHON produktiv im Einsatz ist. \
+     NUR setzen wenn der User sagt "wir nutzen KI für X" / "KI läuft bei uns in Y".
+   - anwendungsfaelle = was den User INTERESSIERT oder was er PLANT. \
+     Wenn User Anwendungsfälle als Interesse nennt, NICHT in ki_einsatz kopieren.
+   - ki_ziele = was der User als ZIEL oder WUNSCH formuliert. \
+     NUR die Worte des Users verwenden, KEINE Buzzwords substituieren. \
+     NICHT aus hauptleistung oder anwendungsfaelle ableiten.
+   - zielgruppen = NUR setzen wenn der User explizit "meine Zielgruppe ist X" sagt. \
+     NICHT aus Branche, Hauptleistung oder Kontext ableiten.
+10. Wenn der Nutzer signalisiert, nicht antworten zu wollen \
 (z.B. "weiß nicht", "weiß nicht genau", "keine Ahnung", "überspring", \
 "egal", "später", "kann ich nicht", "kann ich nicht sagen", \
 "schwer zu sagen", "nächste Frage", "keine Vorstellung", "passe", \
@@ -759,6 +857,7 @@ async def extract_fields_multi(
                 skip = extracted.pop("__skip_signal", False)
                 # Remove None values
                 extracted = {k: v for k, v in extracted.items() if v is not None}
+                extracted = _validate_extracted(extracted)
                 log.info(
                     "[CHAT-EXTRACT-MULTI] Extracted %d fields: %s (skip=%s)",
                     len(extracted),


### PR DESCRIPTION
## Summary
This PR hardens the KI-Readiness questionnaire extraction pipeline against hallucination patterns and improves conversation quality by enforcing stricter extraction rules, adding post-extraction validation, and refining conversation tone/repetition guidelines.

## Key Changes

### Extraction Validation & Hallucination Prevention
- **Added `_validate_extracted()` function** to catch and correct suspicious extraction patterns:
  - Caps array fields at reasonable maximums (e.g., `ki_einsatz`: 4, `anwendungsfaelle`: 5) to prevent over-generation
  - Clamps `digitalisierungsgrad` at 9 (not 10, which implies no conceivable analog process)
  - Logs warnings for suspicious extractions
- Applied validation to both single-field (`extract_fields`) and multi-field (`extract_fields_multi`) extraction paths

### Stricter Extraction Rules
- **Enhanced system prompts** with explicit "STRIKTE EXTRAKTIONSREGEL" section emphasizing:
  - Extract ONLY values explicitly stated by user (no logical inference, category-mapping, or context derivation)
  - Empty fields are better than false fields
- **Added FELD-ISOLATION rules** to prevent cross-contamination between related fields:
  - `ki_einsatz` = current productive use only (not planned/interested)
  - `anwendungsfaelle` = interests/plans (not current use)
  - `ki_ziele` = user's own words for goals (no buzzword substitution)
  - `zielgruppen` = explicit statements only (not inferred from industry/service)
- **Clarified forbidden inference patterns** with concrete examples (e.g., "Beratung von Unternehmen" → don't infer B2B target audience)

### Conversation Quality Improvements
- **Language enforcement**: Added strict German-only rule (no English exclamations like "Excellent", "Great", "Perfect")
- **Confirmation brevity**: Reduced from "1 sentence" to "3–5 words" to minimize filler
- **Tone refinement**:
  - Blacklisted evaluative sentence starters ("Spannend", "Interessant", "Exzellent", etc.)
  - Added "Vielen Dank für die…" to forbidden patterns (max 1× per conversation)
  - Enforced sachlich-freundlich (matter-of-fact friendly) tone
- **Repetition prevention**: Added explicit rule against re-referencing same user statements (max 1× per conversation)
- **Updated field label** for `zeitersparnis_prioritaet` to be more specific ("Welche Aufgabe kostet…" instead of "Wo frisst…")

### Extraction Flow Adjustments
- Raised hard stale-turn limit from 4 to 6 to allow unasked fields (e.g., `jahresumsatz`) more opportunity to be asked before auto-closing block

## Implementation Details
- Validation is applied immediately after Claude's tool output, before logging/processing
- Array field truncation is logged with original values for debugging
- All new rules are documented inline with examples of correct vs. incorrect extraction
- Backward compatible: validation only caps/clamps, doesn't reject valid extractions

https://claude.ai/code/session_01XFaW5uYfBXcDnEgdJN8ykk