### PR TITLE
fix(chat): final polish — QR prose stripping, zielgruppen guard, cont…

### DIFF
--- a/routes/chat.py
+++ b/routes/chat.py
@@ -1994,6 +1994,15 @@ _FORBIDDEN_STARTERS = [
     "Ausgezeichnet", "Exzellent", "Hervorragend", "Wunderbar",
     "Beeindruckend", "Fantastisch", "Großartig", "Spannend",
     "Interessant",
+    # KIS-1124 Testrun 4 R5: eingedeutschte Varianten
+    "Brillant", "Prima", "Klasse", "Super", "Toll",
+]
+
+# KIS-1124 Testrun 4 R3: Context reference patterns that Sonnet over-uses
+_CONTEXT_REF_PATTERNS = [
+    r'Da Sie bereits\b',
+    r'Bei Ihrer (?:hohen|aktuellen|starken|bisherigen|umfangreichen)\b',
+    r'Mit Ihren? (?:umfangreichen|hohen|breiten|starken|bisherigen)\b',
 ]
 
 
@@ -2004,9 +2013,10 @@ def _post_process_response(
     """Clean Sonnet response before sending to frontend.
 
     1. Strip <quick_reply_buttons> XML tags (Bug 13)
-    2. Remove QR-label blocks duplicated in prose (Bug 14)
+    2. Remove QR-label blocks duplicated in prose (Bug 14, R1)
     3. Remove English exclamations (Bug 9 reopen)
-    4. Remove forbidden flattery starters (Schmeichelei)
+    4. Remove forbidden flattery starters (Schmeichelei, R5)
+    5. Remove context repetition patterns (R3)
     """
     if not text:
         return text
@@ -2017,35 +2027,52 @@ def _post_process_response(
     # 2. Strip other XML-like tags Sonnet might generate
     text = re.sub(r'</?quick_reply[^>]*>', '', text)
 
-    # 3. Remove QR-labels duplicated in prose (Bug 14)
-    # If ≥3 QR labels appear as a contiguous block (bold, list, or slash-separated)
-    if qr_labels and len(qr_labels) >= 3:
-        # Pattern: labels joined by " / ", newlines, or as markdown bold block
-        # Build escaped label list for regex
-        escaped = [re.escape(lbl) for lbl in qr_labels]
-        # Match lines that contain ≥3 QR labels (possibly bold, separated by whitespace/slashes)
-        # This catches "**Label1 Label2 Label3 Label4**" or "Label1 / Label2 / Label3"
-        label_pattern = r'[\s/,\|]*'.join(escaped[:6])  # First 6 labels
-        text = re.sub(
-            rf'\*{{0,2}}{label_pattern}\*{{0,2}}',
-            '', text, flags=re.IGNORECASE,
-        )
+    # 3. Remove QR-labels duplicated in prose (Bug 14 + R1)
+    if qr_labels and len(qr_labels) >= 2:
+        # R1 Format A/C: Markdown list items matching QR labels ("- Ja\n- Nein")
+        for label in qr_labels:
+            text = re.sub(
+                rf'(?:^|\n)\s*[-*]\s*{re.escape(label)}\s*(?=\n|$)',
+                '', text, flags=re.IGNORECASE,
+            )
+
+        # R1 Format B: Emoji radio buttons ("🔘 Option")
+        text = re.sub(r'(?:^|\n)\s*🔘\s*.+', '', text)
+
+        # R1 Format C: Bold label headers ("**Bisherige Fördermittel:**")
+        text = re.sub(r'\*\*[^*]{3,40}:\*\*\s*\n?', '', text)
+
+        # Original Bug 14: contiguous block of labels (slash/comma/pipe separated)
+        if len(qr_labels) >= 3:
+            escaped = [re.escape(lbl) for lbl in qr_labels]
+            label_pattern = r'[\s/,\|]+'.join(escaped[:6])
+            text = re.sub(
+                rf'\*{{0,2}}{label_pattern}\*{{0,2}}',
+                '', text, flags=re.IGNORECASE,
+            )
 
     # 4. English exclamations (Bug 9 reopen)
     for word in _ENGLISH_EXCLAMATIONS:
-        # Remove "Excellent!" / "Excellent," / "Excellent." at sentence boundaries
         text = re.sub(
             rf'\b{word}[!.,]?\s*', '', text, flags=re.IGNORECASE,
         )
 
-    # 5. Forbidden flattery at sentence start
+    # 5. Forbidden flattery at sentence start (R5: +Exzellent, Brillant, etc.)
     for word in _FORBIDDEN_STARTERS:
-        # Remove "Ausgezeichnet!" or "Ausgezeichnet," at sentence start
         text = re.sub(
             rf'(?:^|(?<=\. )){word}[!.,]\s*', '', text, flags=re.IGNORECASE,
         )
 
-    # Clean up double spaces and leading/trailing whitespace
+    # 6. Context repetition filter (R3: "Da Sie bereits..." etc.)
+    for pattern in _CONTEXT_REF_PATTERNS:
+        # Remove entire sentence starting with the pattern
+        text = re.sub(
+            rf'(?:^|\.\s+){pattern}[^.!?]*[.!?]',
+            '.', text, flags=re.IGNORECASE,
+        )
+
+    # Clean up artifacts
+    text = re.sub(r'^[\s.]+', '', text)  # Leading dots/spaces
     text = re.sub(r'  +', ' ', text)
     text = re.sub(r'\n{3,}', '\n\n', text)
     return text.strip()

--- a/services/chat_conversation.py
+++ b/services/chat_conversation.py
@@ -1288,6 +1288,20 @@ FORBIDDEN_PATTERNS = [
     "Perfect!",
     "Amazing!",
     "Wonderful!",
+    # KIS-1124 Testrun 4 R3: Kontextreferenz-Wiederholungen
+    "Da Sie bereits",
+    "Da Sie ja bereits",
+    "Bei Ihrer hohen",
+    "Bei Ihrer aktuellen",
+    "Bei Ihrer starken",
+    "Mit Ihren umfangreichen",
+    "Mit Ihrer bisherigen",
+    # KIS-1124 Testrun 4 R5: Eingedeutschte Schmeicheleien
+    "Brillant",
+    "Prima",
+    "Klasse",
+    "Super",
+    "Toll",
 ]
 
 
@@ -2159,6 +2173,18 @@ def _format_value_for_display(field_name: str, value: object) -> str:
     str_check = str(value).strip().lower() if value is not None else ""
     if str_check in ("keine_angabe", "keine angabe"):
         return "Nicht angegeben"
+
+    # KIS-1124 Testrun 4 R4: JSON array strings → Python list
+    # When a list is stored as a JSON string (e.g. '["item1", "item2"]'),
+    # parse it back to a list for proper formatting.
+    if isinstance(value, str) and value.startswith("["):
+        import json as _json
+        try:
+            parsed = _json.loads(value)
+            if isinstance(parsed, list):
+                value = parsed
+        except (ValueError, _json.JSONDecodeError):
+            pass
 
     reg = FIELD_REGISTRY.get(field_name) or STRATEGY_FIELD_REGISTRY.get(field_name, {})
     field_type = reg.get("type", "text")

--- a/services/chat_extractor.py
+++ b/services/chat_extractor.py
@@ -610,6 +610,11 @@ def _format_collected(collected: dict) -> str:
 # Post-Extraction Validation (Hallucination Guard)
 # ---------------------------------------------------------------------------
 
+# KIS-1124 Testrun 4 R2: Fields that must NEVER be auto-extracted.
+# These fields are only set via explicit QR selection or direct question.
+# Prompt rules alone cannot prevent Haiku from inferring these.
+NEVER_AUTO_EXTRACT: set[str] = {"zielgruppen"}
+
 # Array fields where Haiku tends to over-generate via category-mapping
 _ARRAY_FIELDS_MAX = {
     "ki_einsatz": 4,
@@ -627,10 +632,21 @@ _ARRAY_FIELDS_MAX = {
 def _validate_extracted(extracted: dict) -> dict:
     """Post-extraction validation to catch hallucination patterns.
 
+    - Removes NEVER_AUTO_EXTRACT fields (e.g. zielgruppen).
     - Caps array fields at a reasonable max (truncates excess).
     - Clamps digitalisierungsgrad: "komplett digital" → max 9.
     - Logs warnings for suspicious extractions.
     """
+    # Remove fields that must not be auto-extracted
+    for field in NEVER_AUTO_EXTRACT:
+        if field in extracted:
+            log.info(
+                "[CHAT-EXTRACT-VALIDATE] Removing auto-extracted '%s' "
+                "(NEVER_AUTO_EXTRACT): %s",
+                field, extracted[field],
+            )
+            del extracted[field]
+
     for field, max_len in _ARRAY_FIELDS_MAX.items():
         if field in extracted and isinstance(extracted[field], list):
             original_len = len(extracted[field])


### PR DESCRIPTION
…ext dedup, summary format (R1-R5)

R1: Post-processor now strips QR labels in all Sonnet output formats:
- Markdown lists matching QR labels ("- Ja\n- Nein")
- Emoji radio buttons ("🔘 Option")
- Bold label headers ("**Fördermittel:**")
- Contiguous label blocks (slash/comma separated)

R2: zielgruppen added to NEVER_AUTO_EXTRACT set in _validate_extracted(). After 3 failed prompt-based fixes across 4 testruns, this is a hard code guard — zielgruppen is only set via explicit QR selection in Block B, never via automatic extraction. Prevents hallucinated "B2B, KMU" values.

R3: Backend post-processor now strips "Da Sie bereits..." and similar context repetition patterns. Removes entire sentences starting with these patterns. Also added to FORBIDDEN_PATTERNS for prompt enforcement.

R4: _format_value_for_display() now parses JSON array strings back to Python lists before formatting. Fixes ki_ziele showing as raw '["item1", "item2"]' with brackets in the summary.

R5: Extended _FORBIDDEN_STARTERS with "Brillant", "Prima", "Klasse", "Super", "Toll". Added same to FORBIDDEN_PATTERNS for prompt enforcement. "Exzellent" was already covered in both lists.

https://claude.ai/code/session_01XFaW5uYfBXcDnEgdJN8ykk