### PR TITLE
KIS-1124 Sprint 4: Conservative defaults & form switch for unsurveyed blocks

### DIFF
--- a/gpt_analyze.py
+++ b/gpt_analyze.py
@@ -1273,6 +1273,25 @@ def build_strategic_context_block(answers: dict, lang: str = "de") -> str:
         high_conf_count = sum(1 for h in hits if h.is_high_confidence)
         log.info("🛡️ Guardrails v5: %d auto-detected (high_conf=%d, no explicit)", len(hits), high_conf_count)
 
+    # KIS-1124 Sprint 4 S4-BE-2: Signal unsurveyed areas to LLM
+    unsurveyed = answers.get("_chat_unsurveyed_blocks", [])
+    if unsurveyed:
+        _block_labels = {
+            "A": "Fördermittel & Budget",
+            "B": "KI-Strategie & Roadmap",
+            "C": "Tools & Automatisierung",
+            "D": "Recht & Datenschutz",
+        }
+        _unsurveyed_names = [_block_labels.get(b, b) for b in unsurveyed]
+        lines.append(
+            "HINWEIS — Nicht vertiefte Bereiche:\n"
+            f"Die folgenden Themenbereiche wurden im Chat nicht vertieft: "
+            f"{', '.join(_unsurveyed_names)}.\n"
+            "Für diese Bereiche: Keine spezifischen Empfehlungen aussprechen. "
+            "Stattdessen allgemeine Best-Practice-Hinweise geben und den "
+            "Bereich kürzer halten. Empfehlung zur Vertiefung aussprechen."
+        )
+
     return "\n\n".join(lines)
 # =========================================================================
 

--- a/routes/chat.py
+++ b/routes/chat.py
@@ -483,6 +483,13 @@ async def chat_message(req: ChatMessageRequest, db: Session = Depends(get_db)):
                         log.info("[CHAT] Checkpoint: user chose blocks %s", _selected)
                     else:
                         log.warning("[CHAT] Checkpoint: invalid selection %r", _cp_value)
+                # KIS-1124 Sprint 4 Fix B: Auto-set interesse_foerderung when
+                # user chose Block A (Fördermittel & Budget) — interest is obvious.
+                _sel = _phase_state.get("selected_blocks", [])
+                if "A" in _sel and "interesse_foerderung" not in collected:
+                    collected["interesse_foerderung"] = "ja"
+                    log.info("[CHAT] Checkpoint: auto-set interesse_foerderung=ja (Block A selected)")
+
                 # Skip normal QR processing for checkpoint
                 _no_extraction = True
 
@@ -2138,6 +2145,16 @@ def _post_process_response(
         # Standalone bold headers without list (fallback)
         text = re.sub(r'\*\*[^*]{3,40}:\*\*\s*\n?', '', text)
 
+        # KIS-1124 Sprint 4 Fix C: Non-bold header + markdown list of QR labels
+        # Catches e.g. "Risikofreude (1–5):\n- 1 (sehr vorsichtig)\n- 2\n..."
+        # Header is any line ending with ":" where subsequent list items match QR labels
+        escaped_labels = [re.escape(lbl) for lbl in qr_labels]
+        label_alt = "|".join(escaped_labels)
+        text = re.sub(
+            rf'(?:^|\n)[^\n]{{3,50}}:\s*\n(?:\s*[-*]\s*(?:{label_alt})\s*\n?)+',
+            '', text, flags=re.IGNORECASE,
+        )
+
         # Original Bug 14: contiguous block of labels (slash/comma/pipe separated)
         if len(qr_labels) >= 3:
             escaped = [re.escape(lbl) for lbl in qr_labels]
@@ -2154,9 +2171,11 @@ def _post_process_response(
         )
 
     # 5. Forbidden flattery at sentence start (R5: +Exzellent, Brillant, etc.)
+    # KIS-1124 Sprint 4: also match em dash, colon, semicolon, whitespace after word
     for word in _FORBIDDEN_STARTERS:
         text = re.sub(
-            rf'(?:^|(?<=\. )){word}[!.,]\s*', '', text, flags=re.IGNORECASE,
+            rf'(?:^|(?<=\. )){word}[!.,;:\u2014\u2013]?\s*(?:[\u2014\u2013]\s*)?',
+            '', text, flags=re.IGNORECASE,
         )
 
     # 6. Context repetition filter (R3: "Da Sie bereits..." etc.)

--- a/routes/chat.py
+++ b/routes/chat.py
@@ -2016,6 +2016,39 @@ async def chat_session_get(session_id: UUID, db: Session = Depends(get_db)):
 
 
 # ===========================================================================
+# GET /api/chat/session/{session_id}/fields — export collected fields for form pre-fill
+# KIS-1124 Sprint 4 S4-BE-3: Formular-Wechsel mit Feld-Übernahme
+# ===========================================================================
+
+@router.get("/session/{session_id}/fields")
+async def chat_session_fields(session_id: UUID, db: Session = Depends(get_db)):
+    """Export all collected fields as JSON for form pre-fill.
+
+    Used when the user clicks "Zum Formular wechseln" — the frontend
+    fetches this endpoint and pre-fills the static form with already
+    collected chat values.
+    """
+    from schemas.chat import ChatFieldsExportResponse
+
+    session = db.query(ChatSession).filter(ChatSession.id == session_id).first()
+    if not session:
+        raise HTTPException(status_code=404, detail="Session nicht gefunden")
+
+    collected = dict(session.collected_fields or {})
+    ps = session.phase_state or {}
+
+    return ChatFieldsExportResponse(
+        fields=collected,
+        conversation_phase=ps.get("conversation_phase", "phase_1"),
+        selected_blocks=ps.get("selected_blocks", []),
+        completed_blocks=ps.get("completed_blocks", []),
+        current_block=ps.get("current_block"),
+        collected_count=len(collected),
+        report_type=session.report_type,
+    )
+
+
+# ===========================================================================
 # GET /api/chat/sessions — list open sessions for authenticated user
 # ===========================================================================
 

--- a/routes/chat.py
+++ b/routes/chat.py
@@ -174,6 +174,62 @@ _FIELD_DEFAULTS: dict[str, object] = {
 }
 
 
+# KIS-1124 Sprint 4 S4-BE-2: Conservative defaults for fields in blocks that
+# the user chose NOT to survey.  These are injected at _complete_r1 time so
+# the report pipeline receives plausible, non-hallucinated values.
+# Fields set to None are intentionally omitted → pipeline produces shorter /
+# "recommend deepening" sections.
+_REPORT_BLOCK_DEFAULTS: dict[str, dict[str, object]] = {
+    "A": {
+        "bisherige_foerdermittel": "nein",
+        "interesse_foerderung": "unklar",
+        "erfahrung_beratung": "unklar",
+        "marktposition": "unsicher",
+        "benchmark_wettbewerb": "selten",
+        "risikofreude": 3,
+        "jahresumsatz": None,   # omit — no guessing revenue
+    },
+    "B": {
+        "vision_3_jahre": None,              # omit — pipeline skips section
+        "strategische_ziele": None,          # omit
+        "ki_guardrails": None,               # omit
+        "geschaeftsmodell_evolution": None,   # omit
+        "roadmap_vorhanden": "nein",
+        "change_management": "mittel",
+        "massnahmen_komplexitaet": "unklar",
+        "vision_prioritaet": None,           # omit
+        "innovationsprozess": None,          # omit
+        "zielgruppen": None,                 # omit
+    },
+    "C": {
+        "automatisierungsgrad": "mittel",
+        "ki_einsatz": "nein",
+        "anwendungsfaelle": None,            # omit
+        "ki_projekte": None,                 # omit
+        "pilot_bereich": None,               # omit
+        "zeitersparnis_prioritaet": None,    # omit
+        "vorhandene_tools": None,            # omit
+        "trainings_interessen": None,        # omit
+        "zeitbudget": None,                  # omit
+        "prozesse_papierlos": None,          # omit
+        "it_infrastruktur": "unklar",
+        "interne_ki_kompetenzen": "nein",
+        "datenquellen": None,               # omit
+    },
+    "D": {
+        "datenschutzbeauftragter": None,     # omit
+        "technische_massnahmen": None,       # omit
+        "folgenabschaetzung": None,          # omit
+        "meldewege": None,                   # omit
+        "loeschregeln": None,                # omit
+        "ai_act_kenntnis": "nein",
+        "regulierte_branche": None,          # omit
+        "ki_hemmnisse": None,                # omit
+        "governance_richtlinien": "nein",
+    },
+}
+
+
 def _get_block_fields(block_id: str, collected_fields: dict) -> list[str]:
     """Get remaining (uncollected) fields for a block."""
     if block_id == "D":
@@ -2263,6 +2319,24 @@ def _complete_r1(
     """Complete R1 chat: create a Briefing for the report pipeline."""
     answers = dict(collected)
     answers["datenschutz"] = True  # consent given at chat start
+
+    # KIS-1124 Sprint 4 S4-BE-2: Apply conservative defaults for blocks
+    # that the user chose not to survey.  Only non-None defaults are written;
+    # None means "intentionally omit → pipeline produces shorter section".
+    ps = session.phase_state or {}
+    surveyed_blocks = ps.get("selected_blocks", [])
+    all_blocks = ["A", "B", "C", "D"]
+    unsurveyed = [b for b in all_blocks if b not in surveyed_blocks]
+    for block_id in unsurveyed:
+        defaults = _REPORT_BLOCK_DEFAULTS.get(block_id, {})
+        for field, default_val in defaults.items():
+            if field not in answers and default_val is not None:
+                answers[field] = default_val
+    # Pass metadata so the report pipeline knows which areas were surveyed
+    if unsurveyed:
+        answers["_chat_unsurveyed_blocks"] = unsurveyed
+        answers["_chat_surveyed_blocks"] = surveyed_blocks
+        log.info("[CHAT] Complete R1: unsurveyed blocks %s → defaults applied", unsurveyed)
 
     # Extract user from JWT — user_id may already be set from /start
     user_id, user_email = _resolve_user(request, db)

--- a/schemas/chat.py
+++ b/schemas/chat.py
@@ -167,6 +167,21 @@ class ChatFallbackResponse(BaseModel):
 
 
 # ---------------------------------------------------------------------------
+# GET /api/chat/session/{session_id}/fields  (S4-BE-3: form switch)
+# ---------------------------------------------------------------------------
+
+class ChatFieldsExportResponse(BaseModel):
+    """Export collected fields for form pre-fill on chat→form switch."""
+    fields: dict
+    conversation_phase: str
+    selected_blocks: list[str]
+    completed_blocks: list[str]
+    current_block: Optional[str] = None
+    collected_count: int
+    report_type: str
+
+
+# ---------------------------------------------------------------------------
 # GET /api/chat/sessions
 # ---------------------------------------------------------------------------
 

--- a/services/chat_conversation.py
+++ b/services/chat_conversation.py
@@ -2133,14 +2133,22 @@ _ENUM_DISPLAY: dict[str, dict[str, str]] = {
 }
 
 
+# KIS-1124 Sprint 4 S4-BE-1: Values treated as "empty" in summary display
+_SUMMARY_SKIP_VALUES = {None, "", "keine_angabe", "keine angabe", "nicht_angegeben", "Nicht angegeben"}
+
+
 def build_summary(collected_fields: dict, report_type: str = "r1") -> str:
     """
     Build a structured, template-based summary of all collected fields.
     No LLM involved — purely deterministic from collected data.
+
+    KIS-1124 Sprint 4: Sections with no collected fields are hidden entirely.
+    A "not surveyed" note is appended when sections were skipped.
     """
     sections = get_sections_for_report(report_type)
     registry = get_registry_for_report(report_type)
     lines = ["**Zusammenfassung Ihrer Angaben:**\n"]
+    skipped_sections: list[str] = []
 
     for section in sections:
         section_lines: list[str] = []
@@ -2150,19 +2158,31 @@ def build_summary(collected_fields: dict, report_type: str = "r1") -> str:
                 continue
             value = collected_fields[field_name]
             # KIS-1124 Testrun-Fix Bug 6: Skip fields with keine_angabe/empty/None
-            if value is None or value == "" or (isinstance(value, str) and value.strip().lower() in ("keine_angabe", "keine angabe")):
+            if value is None or value == "" or (isinstance(value, str) and value.strip().lower() in _SUMMARY_SKIP_VALUES):
                 continue
-            if isinstance(value, list) and all(str(v).lower() in ("keine_angabe",) for v in value):
+            if isinstance(value, list) and all(str(v).lower() in ("keine_angabe", "nicht_angegeben") for v in value):
                 continue
             label = FIELD_DESCRIPTIONS.get(field_name, field_name).split("(")[0].strip()
             display = _format_value_for_display(field_name, value)
-            if display == "Nicht angegeben":
-                continue  # Don't show "Nicht angegeben" lines in summary
+            if display in ("Nicht angegeben", "–"):
+                continue  # Don't show empty-ish lines in summary
             section_lines.append(f"- {label}: {display}")
 
         if section_lines:
             lines.append(f"\n**{section['name']}**")
             lines.extend(section_lines)
+        else:
+            # Track sections with zero visible fields (but only real content
+            # sections — skip "Ihr Unternehmen" which is always filled)
+            if section.get("index", 0) >= 1:
+                skipped_sections.append(section["name"])
+
+    # KIS-1124 Sprint 4: Inform user about sections not covered
+    if skipped_sections:
+        lines.append(
+            "\n*Bereiche, die nicht vertieft wurden, werden im Report "
+            "mit branchenüblichen Standardwerten ergänzt.*"
+        )
 
     lines.append("\n\nSind alle Angaben korrekt? Dann starte ich die Auswertung.")
     return "\n".join(lines)

--- a/services/chat_conversation.py
+++ b/services/chat_conversation.py
@@ -1278,6 +1278,7 @@ FORBIDDEN_PATTERNS = [
     "Großartig",
     "Hervorragend",
     "Wunderbar",
+    "Fantastisch",
     "Excellent",
     "Amazing",
     "Great",


### PR DESCRIPTION
## Summary
Implements conservative default values for survey blocks not selected by the user, and adds a new endpoint to export collected fields for form pre-fill when switching from chat to static form. This ensures the report pipeline receives plausible values for unsurveyed areas while allowing the user to transition seamlessly between chat and form interfaces.

## Key Changes

### 1. Conservative Defaults for Unsurveyed Blocks (S4-BE-2)
- Added `_REPORT_BLOCK_DEFAULTS` dictionary mapping each block (A, B, C, D) to sensible default values
- Fields set to `None` are intentionally omitted to allow the pipeline to produce shorter "recommend deepening" sections
- Applied in `_complete_r1()` when generating the R1 report — only blocks not in `selected_blocks` receive defaults
- Metadata fields `_chat_unsurveyed_blocks` and `_chat_surveyed_blocks` are passed to the report pipeline for context

### 2. Form Switch Endpoint (S4-BE-3)
- New `GET /api/chat/session/{session_id}/fields` endpoint exports all collected fields as JSON
- Returns `ChatFieldsExportResponse` with fields, conversation phase, selected/completed blocks, and report type
- Enables frontend to pre-fill static form when user clicks "Zum Formular wechseln"

### 3. Auto-Set Interest When Block A Selected (Fix B)
- When user selects Block A (Fördermittel & Budget), automatically set `interesse_foerderung=ja` if not already collected
- Logged for audit trail

### 4. Enhanced Summary & Post-Processing
- Summary now hides sections with zero visible fields (except "Ihr Unternehmen")
- Appends note about unsurveyed areas receiving standard values
- Improved regex patterns in `_post_process_response()` to handle markdown lists and additional punctuation (em dash, colon, semicolon)
- Added "Fantastisch" to forbidden flattery starters

### 5. LLM Context Enhancement
- `build_strategic_context_block()` now signals unsurveyed areas to the LLM with block labels and instructions to provide general guidance rather than specific recommendations

## Implementation Details
- `_SUMMARY_SKIP_VALUES` constant consolidates empty value detection logic
- Unsurveyed block detection is deterministic: `unsurveyed = [b for b in all_blocks if b not in surveyed_blocks]`
- Default values are only applied if the field is not already in collected answers (user input takes precedence)
- All changes are backward compatible — existing sessions without phase_state metadata continue to work

https://claude.ai/code/session_01E7hsSXEyRs9t8Ny87M5pGU