### PR TITLE
KIS-1124: Improve QR button handling and multi-question prevention

### DIFF
--- a/routes/chat.py
+++ b/routes/chat.py
@@ -2600,6 +2600,24 @@ def _build_session_state(
     # Phase tracking (hybrid conversation model, KIS-1124)
     ps = _get_phase_state(session)
 
+    # KIS-1124: Unsurveyed note — only in summary phase when blocks were skipped
+    unsurveyed_note: str | None = None
+    if ps["conversation_phase"] == "summary":
+        _all_blocks = ["A", "B", "C", "D"]
+        _unsurveyed = [b for b in _all_blocks if b not in ps["selected_blocks"]]
+        if _unsurveyed:
+            _block_labels = {
+                "A": "Fördermittel & Budget",
+                "B": "KI-Strategie & Roadmap",
+                "C": "Tools & Automatisierung",
+                "D": "Recht & Datenschutz",
+            }
+            _names = [_block_labels.get(b, b) for b in _unsurveyed]
+            unsurveyed_note = (
+                f"Nicht vertiefte Bereiche: {', '.join(_names)}. "
+                "Diese werden im Report mit branchenüblichen Standardwerten ergänzt."
+            )
+
     return ChatSessionState(
         session_id=session.id,
         report_type=session.report_type,
@@ -2623,6 +2641,7 @@ def _build_session_state(
         selected_blocks=ps["selected_blocks"],
         completed_blocks=ps["completed_blocks"],
         current_block=ps["current_block"],
+        unsurveyed_note=unsurveyed_note,
     )
 
 

--- a/routes/chat.py
+++ b/routes/chat.py
@@ -2253,6 +2253,25 @@ def _post_process_response(
                 '', text, flags=re.IGNORECASE,
             )
 
+        # KIS-1124: Catch-all — remove any line whose content (after stripping
+        # list markers "- ", "* ", "🔘 ", digits) exactly matches a QR label.
+        label_set = {lbl.lower().strip() for lbl in qr_labels}
+        cleaned_lines = []
+        for line in text.split('\n'):
+            stripped = line.strip().lstrip('-*🔘 ').strip()
+            # Also strip leading digits + optional parenthesized text
+            stripped_no_num = re.sub(r'^\d+\s*(?:\([^)]*\))?\s*', '', stripped).strip()
+            if stripped.lower() in label_set or stripped_no_num.lower() in label_set:
+                continue  # drop this line — it's a bare QR label
+            cleaned_lines.append(line)
+        text = '\n'.join(cleaned_lines)
+
+        # KIS-1124: Numbered scale labels like "1 (sehr vorsichtig)", "2", "3 (ausgewogen)"
+        text = re.sub(
+            r'(?:^|\n)\s*[-*]?\s*\d+\s*(?:\([^)]*\))?\s*$',
+            '', text, flags=re.MULTILINE,
+        )
+
     # 4. English exclamations (Bug 9 reopen)
     for word in _ENGLISH_EXCLAMATIONS:
         text = re.sub(
@@ -2274,6 +2293,16 @@ def _post_process_response(
             rf'(?:^|\.\s+){pattern}[^.!?]*[.!?]',
             '.', text, flags=re.IGNORECASE,
         )
+
+    # 7. Double-question guard: when QR buttons are present and text contains
+    # 2+ questions, truncate after the first question mark to prevent
+    # Sonnet from asking about two fields in one turn.
+    if qr_labels and text.count('?') >= 2:
+        first_q = text.index('?')
+        rest = text[first_q + 1:].strip()
+        # Only truncate if the second question starts a new sentence
+        if rest and rest[0].isupper():
+            text = text[:first_q + 1].strip()
 
     # Clean up artifacts
     text = re.sub(r'^[\s.]+', '', text)  # Leading dots/spaces

--- a/schemas/chat.py
+++ b/schemas/chat.py
@@ -79,6 +79,7 @@ class ChatSessionState(BaseModel):
     selected_blocks: list[str] = []
     completed_blocks: list[str] = []
     current_block: Optional[str] = None
+    unsurveyed_note: Optional[str] = None
 
     # Quick Replies
     quick_replies: Optional[list[QuickReply]] = None

--- a/services/chat_conversation.py
+++ b/services/chat_conversation.py
@@ -1374,6 +1374,14 @@ WIEDERHOLUNG (STRIKT):
 - SCHLECHT: "Da Sie bereits API-Integrationen nutzen, interessiert mich..."
 - GUT: "Welche Datentypen nutzen Sie für Ihre Analysen?"
 
+EINE FRAGE PRO TURN (STRIKT):
+- Stelle pro Antwort MAXIMAL EINE Frage zu EINEM Thema.
+- Kombiniere NIEMALS zwei verschiedene Felder in einer Frage.
+- SCHLECHT: "Wie risikobereit sind Sie? Und vergleichen Sie sich mit Wettbewerbern?"
+- GUT: "Wie risikobereit sind Sie bei neuen Technologien?"
+- Wenn Quick-Reply-Buttons angeboten werden, muss die Frage exakt zu den \
+Button-Optionen passen.
+
 QR-BUTTONS (STRIKT):
 - Wenn Quick-Reply-Buttons angeboten werden, liste die Optionen \
 NICHT zusätzlich im Antworttext auf.

--- a/services/chat_normalizer.py
+++ b/services/chat_normalizer.py
@@ -466,9 +466,12 @@ ENUM_VALUES: dict[str, list[str]] = {
 _ENUM_SYNONYMS: dict[str, dict[str, str]] = {
     "marktposition": {
         "im aufbau": "nachzuegler",
+        "noch im aufbau": "nachzuegler",
         "aufbau": "nachzuegler",
         "testphase": "nachzuegler",
         "gerade erst gestartet": "nachzuegler",
+        "gerade erst angefangen": "nachzuegler",
+        "ganz am anfang": "nachzuegler",
         "neu am markt": "nachzuegler",
         "start": "nachzuegler",
         "startup": "nachzuegler",


### PR DESCRIPTION
## Summary
This PR implements improvements to chat response post-processing and conversation flow to better handle Quick Reply (QR) buttons and prevent multiple questions in a single turn. It also adds tracking for unsurveyed survey blocks and enhances enum synonym matching.

## Key Changes

- **QR Label Cleanup**: Added logic to remove lines from responses that exactly match QR button labels (after stripping list markers and numbering), preventing duplicate content between buttons and text.

- **Numbered Scale Removal**: Implemented regex-based removal of standalone numbered scale labels (e.g., "1 (sehr vorsichtig)", "2", "3 (ausgewogen)") that appear on their own lines.

- **Double-Question Guard**: Added a catch-all mechanism that truncates responses after the first question mark when QR buttons are present and the text contains 2+ questions. This prevents Claude from asking about multiple fields in one turn, which conflicts with the single-question-per-turn design.

- **Conversation Rules Enhancement**: Updated prompt rules to explicitly enforce "one question per turn" constraint, with clear examples of good vs. bad question phrasing when QR buttons are used.

- **Unsurveyed Blocks Tracking**: Added `unsurveyed_note` field to `ChatSessionState` that generates a German-language note listing survey blocks that were skipped, informing users that these will be filled with industry-standard defaults in the final report.

- **Enum Synonym Expansion**: Extended `marktposition` (market position) synonyms to catch more variations of "early stage" entries:
  - "noch im aufbau" → "nachzuegler"
  - "gerade erst angefangen" → "nachzuegler"
  - "ganz am anfang" → "nachzuegler"

## Implementation Details

- The QR label cleanup uses case-insensitive matching and handles various list markers (`-`, `*`, `🔘`) and leading digits with optional parenthesized text.
- The double-question guard only truncates if a second question starts a new sentence (uppercase first letter), avoiding false positives.
- Unsurveyed note generation maps block codes (A, B, C, D) to their German labels and only appears in the summary phase when blocks were actually skipped.

https://claude.ai/code/session_01EcLYhC2GN2EY13h6h3SLXk