### PR TITLE
KIS-1128A: Enforce Phase 2 brevity and add typing indicator

### DIFF
--- a/routes/chat.py
+++ b/routes/chat.py
@@ -1123,6 +1123,7 @@ async def chat_message(req: ChatMessageRequest, db: Session = Depends(get_db)):
         # desired state (previous fields + this turn's additions/deletions).
         # draft_state MUST be included here — ORM assignments to
         # session.draft_state are not reliably flushed after raw SQL commits.
+        now = datetime.now(timezone.utc)
         _draft_for_sql = None
         if DRAFT_MODE_ENABLED or _is_edit_request or _is_in_edit_mode:
             _draft_for_sql = json.dumps(

--- a/routes/chat.py
+++ b/routes/chat.py
@@ -1621,6 +1621,7 @@ async def chat_message(req: ChatMessageRequest, db: Session = Depends(get_db)):
             _checkpoint_text = (
                 "Ich habe jetzt ein gutes Bild von Ihrem Unternehmen. "
                 "Damit kann ich bereits einen soliden KI-Report erstellen.\n\n"
+                "Am Ende können Sie alle Angaben nochmal prüfen und bei Bedarf korrigieren.\n\n"
                 "Sie können die Analyse aber gezielt vertiefen — "
                 "welche Bereiche interessieren Sie besonders?"
             )

--- a/routes/chat.py
+++ b/routes/chat.py
@@ -2266,6 +2266,45 @@ _CONTEXT_REF_PATTERNS = [
     r'Mit Ihren? (?:umfangreichen|hohen|breiten|starken|bisherigen)\b',
 ]
 
+# KIS-1128A V2-BE: Preamble patterns to strip (Danke/Lob/Rückbezug)
+_PREAMBLE_PATTERNS = [
+    re.compile(r'^Danke\b', re.IGNORECASE),
+    re.compile(r'^Vielen Dank\b', re.IGNORECASE),
+    re.compile(r'^Da Sie\b', re.IGNORECASE),
+    re.compile(r'^Mit Ihrer\b', re.IGNORECASE),
+    re.compile(r'^Bei Ihrer\b', re.IGNORECASE),
+    re.compile(r'^Bei Ihrem\b', re.IGNORECASE),
+    re.compile(r'^Ihre\b.*zeig', re.IGNORECASE),
+    re.compile(r'^Spannend\b', re.IGNORECASE),
+    re.compile(r'^Interessant\b', re.IGNORECASE),
+    re.compile(r'^Sehr gut\b', re.IGNORECASE),
+    re.compile(r'^Perfekt\b', re.IGNORECASE),
+    re.compile(r'^Verstanden\b.*,\s', re.IGNORECASE),
+    re.compile(r'^Notiert\b.*,\s', re.IGNORECASE),
+]
+
+
+def _strip_context_preamble(text: str) -> str:
+    """Strip Danke/context preamble sentences, keep only the question.
+
+    KIS-1128A V2-BE: Phase 2 answers should be ≤15 words. This safety net
+    strips known preamble patterns (Danke, Rückbezug, Lob) when the last
+    sentence is a question.
+    """
+    sentences = re.split(r'(?<=[.!?])\s+', text.strip())
+    if len(sentences) <= 1:
+        return text
+
+    # Only strip if last sentence is a question
+    if not sentences[-1].strip().endswith('?'):
+        return text
+
+    cleaned = [s for s in sentences
+               if not any(p.search(s) for p in _PREAMBLE_PATTERNS)]
+    if cleaned:
+        return ' '.join(cleaned)
+    return text
+
 
 def _post_process_response(
     text: str,
@@ -2374,6 +2413,9 @@ def _post_process_response(
             rf'(?:^|\.\s+){pattern}[^.!?]*[.!?]',
             '.', text, flags=re.IGNORECASE,
         )
+
+    # 6b. KIS-1128A V2-BE: Strip Danke/context preambles, keep only the question.
+    text = _strip_context_preamble(text)
 
     # 7. Double-question guard: when QR buttons are present and text contains
     # 2+ questions, truncate after the first question mark to prevent

--- a/routes/chat.py
+++ b/routes/chat.py
@@ -1697,6 +1697,12 @@ async def chat_message(req: ChatMessageRequest, db: Session = Depends(get_db)):
             finally:
                 await queue.put(_SENTINEL)
 
+        # KIS-1128A V4-BE: Send typing event before Sonnet call.
+        # Skip for template turns (checkpoint, block transition, report start)
+        # which are fast enough (<200ms) that a typing indicator would flicker.
+        if not (_checkpoint_text or _block_transition_text or _report_start_requested):
+            yield f'event: typing\ndata: {json.dumps({"status": "thinking"})}\n\n'
+
         producer = asyncio.create_task(_token_producer())
         full_response = ""
         try:

--- a/services/chat_conversation.py
+++ b/services/chat_conversation.py
@@ -1563,6 +1563,28 @@ _BLOCK_PROMPTS: dict[str, str] = {
     "D": BLOCK_D_PROMPT,
 }
 
+# ---------------------------------------------------------------------------
+# KIS-1128A V2-BE: Phase 2 brevity enforcement
+# ---------------------------------------------------------------------------
+PHASE2_BREVITY_RULES = """
+ANTWORT-LÄNGE — ABSOLUT VERBINDLICH (Phase 2):
+- Deine Antwort hat MAXIMAL 15 Wörter.
+- KEIN Dank ("Danke", "Vielen Dank", "Danke für die Einschätzung")
+- KEIN Rückbezug ("Da Sie bereits...", "Mit Ihrer...", "Bei Ihrem...")
+- KEIN Lob ("Spannend!", "Interessant!", "Sehr gut!", "Perfekt!")
+- NUR die nächste Frage, direkt und klar.
+
+BEISPIELE:
+FALSCH: "Danke für die Einschätzung! Da Sie bereits einen hohen \
+Automatisierungsgrad haben, interessiert mich besonders, in welchen \
+Bereichen Sie KI einsetzen möchten."
+RICHTIG: "In welchen Bereichen setzen Sie KI ein?"
+
+FALSCH: "Vielen Dank für die detaillierten Informationen! Jetzt \
+schauen wir uns Ihre Marktposition an."
+RICHTIG: "Wie schätzen Sie Ihre Marktposition ein?"
+"""
+
 
 def _build_phase_2_prompt(
     block_id: str,
@@ -1608,6 +1630,8 @@ def _build_phase_2_prompt(
     # Inject shared prompt rules (blacklist, confirmation pool, neutrality)
     shared_rules = _build_shared_prompt_rules(used_confirmations)
     prompt = prompt.replace("{{shared_prompt_rules}}", shared_rules)
+    # KIS-1128A V2-BE: append Phase 2 brevity enforcement
+    prompt += PHASE2_BREVITY_RULES
     return prompt
 
 

--- a/services/chat_conversation.py
+++ b/services/chat_conversation.py
@@ -215,6 +215,10 @@ Sie den VOLLEN Wortlaut oder erwähnen Sie sie gar nicht.
 Beschreibung" oder ähnlichen Bewertungen.
 
 ABSOLUTE VERBOTE:
+- Weisen Sie den Nutzer NICHT darauf hin, dass er Antworten ändern \
+kann. Bieten Sie KEINE Korrekturmöglichkeit pro Frage an. \
+Am Ende gibt es eine Zusammenfassung, wo alle Angaben geprüft \
+werden können — das reicht.
 - Fragen Sie NIEMALS nach dem Namen des Unternehmens, der Firma \
 oder des Geschäfts. Der Firmenname wird aus Datenschutzgründen \
 nicht erhoben. Sie kennen: Branche, Größe, Standort und \
@@ -1134,6 +1138,8 @@ Unternehmensgröße, Land und Budget werden als Buttons angezeigt.
 6. Wenn der Nutzer "weiß nicht" sagt: Feld überspringen, nicht insistieren.
 7. Tonfall: Professionell, aber nicht steif. Wie ein Berater-Erstgespräch.
 8. Fragen Sie NIEMALS nach dem Namen des Unternehmens oder der Firma.
+9. Weisen Sie den Nutzer NICHT darauf hin, dass er Antworten ändern \
+kann. Bieten Sie KEINE Korrekturmöglichkeit pro Frage an.
 
 QR-FELDER (werden als Buttons angezeigt, NICHT im Text fragen):
 branche, unternehmensgroesse, selbststaendig, country, bundesland, \


### PR DESCRIPTION
## Summary
Implements brevity enforcement for Phase 2 responses and adds a typing indicator before AI calls. This improves UX by showing thinking status and ensures Phase 2 answers remain concise (≤15 words) by stripping preambles and enforcing strict word limits.

## Key Changes

- **Phase 2 Brevity Enforcement**: Added `PHASE2_BREVITY_RULES` prompt injection that limits responses to 15 words maximum, explicitly forbidding thank-yous, context references, and praise. Appended to all Phase 2 prompts.

- **Preamble Stripping**: Implemented `_strip_context_preamble()` function that removes common German preambles (Danke, Vielen Dank, Da Sie, Mit Ihrer, etc.) when the last sentence is a question, keeping only the actual question.

- **Typing Indicator**: Added server-sent event (`event: typing`) before Sonnet API calls to indicate thinking status. Skipped for fast template turns (checkpoints, block transitions, report start) to avoid UI flicker.

- **Checkpoint Message Update**: Enhanced German checkpoint message to clarify that all entries can be reviewed and corrected at the end, reducing user confusion about correction timing.

- **Prompt Guidelines**: Updated system prompts to explicitly forbid offering per-question correction options, directing users to the final summary review instead.

- **UTC Timestamp**: Added explicit UTC timezone handling for draft state timestamps.

## Implementation Details

- Preamble patterns use case-insensitive regex matching to catch variations
- Typing event only sent when response will take time (not for template text)
- Post-processing applies preamble stripping as step 6b, before double-question guard
- Phase 2 brevity rules injected into all phase 2 prompts via template replacement

https://claude.ai/code/session_01NhdjMAditUeAcT7PkrrKkd