### PR TITLE
Fix UnboundLocalError in QR preview generation for strategy mode

### DIFF
--- a/routes/chat.py
+++ b/routes/chat.py
@@ -1808,6 +1808,10 @@ async def chat_message(req: ChatMessageRequest, db: Session = Depends(get_db)):
             # KIS-1128C V5-BE: Optimistic QR preview — send preview of QR buttons
             # before Sonnet responds, so the frontend can render them early.
             # Only for freetext→QR transitions (template mode already bypasses Sonnet).
+            # Hotfix: initialise _profile_ctx early to avoid UnboundLocalError
+            _profile_ctx = None
+            if rt == "strategy":
+                _profile_ctx = _load_r1_profile_for_strategy(session, db)
             if next_fields and is_template_field(next_fields[0]):
                 _pqr = _build_quick_replies(next_fields[:1], rt, collected, _profile_ctx)
                 if _pqr:


### PR DESCRIPTION
## Summary
Fixed an `UnboundLocalError` that occurred when generating optimistic QR previews in strategy mode by ensuring `_profile_ctx` is initialized before use.

## Key Changes
- Initialize `_profile_ctx` to `None` at the start of the QR preview generation logic
- Load the R1 profile context when in strategy mode (`rt == "strategy"`) before attempting to build quick replies
- Prevents undefined variable errors when `_build_quick_replies()` is called with `_profile_ctx`

## Implementation Details
The issue occurred in the optimistic QR preview feature (KIS-1128C V5-BE) which sends QR button previews to the frontend before Sonnet responds. In strategy mode, the code was attempting to use `_profile_ctx` without ensuring it was defined first. This hotfix ensures the variable is always initialized and properly loaded when needed for strategy-mode transitions.

https://claude.ai/code/session_018ZNobXzFK8ohw4PRXiTQoE