### PR TITLE
Fix idempotency and progress tracking in chat completion flow

### DIFF
--- a/routes/chat.py
+++ b/routes/chat.py
@@ -2428,15 +2428,12 @@ async def chat_complete(
     session = db.query(ChatSession).filter(ChatSession.id == req.session_id).first()
     if not session:
         raise HTTPException(status_code=404, detail="Session nicht gefunden")
-    if session.status != "active":
-        raise HTTPException(status_code=400, detail="Session ist nicht aktiv")
-    if not req.confirmed:
-        raise HTTPException(status_code=400, detail="Bestätigung erforderlich")
 
+    # KIS-1131 Fix 3: Idempotency check BEFORE status guard — the SSE stream
+    # may have already completed the session via _complete_r1(), so a
+    # subsequent /complete call should return the existing briefing_id
+    # instead of 400.
     rt = session.report_type
-    sections = get_sections_for_report(rt)
-
-    # Idempotency: if already completed, return existing briefing_id
     if session.status == "completed" and session.briefing_id:
         redirect = _complete_redirect(rt, session.briefing_id)
         return ChatCompleteResponse(
@@ -2445,6 +2442,13 @@ async def chat_complete(
             report_type=rt,
             redirect_url=redirect,
         )
+
+    if session.status != "active":
+        raise HTTPException(status_code=400, detail="Session ist nicht aktiv")
+    if not req.confirmed:
+        raise HTTPException(status_code=400, detail="Bestätigung erforderlich")
+
+    sections = get_sections_for_report(rt)
 
     # Check all required fields (across all sections)
     collected = dict(session.collected_fields or {})
@@ -2580,6 +2584,9 @@ def _post_process_response(
 
     # 2. Strip other XML-like tags Sonnet might generate
     text = re.sub(r'</?quick_reply[^>]*>', '', text)
+
+    # 2a-bis. KIS-1131 Fix 1: Strip [Quick-Reply Buttons:] header (new Sonnet format)
+    text = re.sub(r'\[Quick-Reply Buttons?:\]\s*', '', text, flags=re.IGNORECASE)
 
     # 2b. KIS-1128C P1: Strip <button>...</button> tags (Sonnet generates HTML buttons)
     text = re.sub(r'\s*<button>[^<]*</button>\s*', '', text, flags=re.DOTALL)
@@ -3045,8 +3052,11 @@ def _build_session_state(
             _blk_all = _get_datenschutz_block_fields(collected.get("branche", ""))
         else:
             _blk_all = BLOCK_FIELDS.get(_cur_blk, [])
-        _blk_total = len(_blk_all)
-        _blk_progress = len([f for f in _blk_all if f in collected])
+        # KIS-1131 Fix 2: Exclude smart-skipped fields from progress count
+        _skip_count = sum(1 for f in _blk_all
+                         if f in collected and _smart_skip_field(f, collected) is not None)
+        _blk_total = len(_blk_all) - _skip_count
+        _blk_progress = len([f for f in _blk_all if f in collected]) - _skip_count
 
     return ChatSessionState(
         session_id=session.id,


### PR DESCRIPTION
## Summary
This PR addresses three related issues in the chat completion flow (KIS-1131) to improve idempotency handling, response formatting, and progress calculation accuracy.

## Key Changes

- **Idempotency check reordering**: Moved the idempotency check (for already-completed sessions) to execute BEFORE the status and confirmation guards. This prevents returning a 400 error when a session has already been completed by the SSE stream via `_complete_r1()`, allowing subsequent `/complete` calls to properly return the existing `briefing_id`.

- **Response formatting**: Added stripping of the `[Quick-Reply Buttons:]` header that the latest Sonnet model generates, preventing this text from appearing in user-facing responses.

- **Progress calculation fix**: Modified `_build_session_state()` to exclude smart-skipped fields from both total and progress counts. This ensures that fields which are automatically skipped (via `_smart_skip_field()`) don't artificially inflate the progress percentage or total field count.

## Implementation Details

- The idempotency fix ensures the completion flow is truly idempotent: if a session is already completed, the endpoint returns the redirect response instead of an error, matching the expected behavior when concurrent requests occur.
- The regex pattern for stripping quick-reply headers is case-insensitive and handles both singular and plural forms.
- Smart-skip field exclusion is calculated once and applied consistently to both `_blk_total` and `_blk_progress` to maintain accurate progress reporting.

https://claude.ai/code/session_01PBTUT2Xo2qH2xc9sWfq2kE