### PR TITLE
Fix PDF layout and text truncation issues (KIS-1126, KIS-1127)

### DIFF
--- a/gpt_analyze.py
+++ b/gpt_analyze.py
@@ -8817,17 +8817,17 @@ def _build_prompt_vars(briefing: Dict[str, Any], scores: Dict[str, Any]) -> Dict
     # - sections gets deduped by O2 (42 chars) → html.replace misses 194-char GPT text
     # - html.replace fails on UTF-8 encoded HTML (für ≠ fÃ¼r)
     # Solution: Truncate in briefing ONCE → ALL GPT prompts get short version
-    # KIS-1126 / C2 FIX: Increased from 77→150 chars to prevent mid-word cuts
-    # in German compound descriptions (e.g. "Einführung" was cut to "Einfü")
+    # KIS-1126 / C2 FIX: Increased from 77→150→300 chars to prevent mid-word cuts
+    # in German compound descriptions (e.g. "Einführung" was cut to "Einfü"/"Einführun")
     _hl_source = briefing.get("hauptleistung", "")
-    if isinstance(_hl_source, str) and len(_hl_source) > 160:
-        _hl_truncated = _hl_source[:150].rsplit(' ', 1)[0] + '…'
+    if isinstance(_hl_source, str) and len(_hl_source) > 310:
+        _hl_truncated = _hl_source[:300].rsplit(' ', 1)[0] + '…'
         briefing["hauptleistung"] = _hl_truncated
         log.info("[X1] DEFINITIVE: briefing['hauptleistung'] truncated at source: %d→%d chars", len(_hl_source), len(_hl_truncated))
     # X4: Also truncate uppercase variant
     _hl_upper = briefing.get("HAUPTLEISTUNG", "")
-    if isinstance(_hl_upper, str) and len(_hl_upper) > 160:
-        briefing["HAUPTLEISTUNG"] = _hl_upper[:150].rsplit(' ', 1)[0] + '…'
+    if isinstance(_hl_upper, str) and len(_hl_upper) > 310:
+        briefing["HAUPTLEISTUNG"] = _hl_upper[:300].rsplit(' ', 1)[0] + '…'
         log.info("[X4] briefing['HAUPTLEISTUNG'] truncated: %d→%d chars", len(_hl_upper), len(briefing["HAUPTLEISTUNG"]))
     hauptleistung_raw = briefing.get("hauptleistung", "")
 

--- a/services/content_quality_enforcer.py
+++ b/services/content_quality_enforcer.py
@@ -617,6 +617,8 @@ TEXT_GLITCH_REPLACEMENTS = [
     # Word corruption glitches
     (r'\bresourceselung\b', 'Ressourcenstaffelung', 'corrupted word'),
     (r'\bRessourceselung\b', 'Ressourcenstaffelung', 'corrupted word capitalized'),
+    # KIS-1127/C9: "Bausteinering" = corrupted "Engineering" (Engine→Baustein leaking into compound)
+    (r'\bBausteinering\b', 'Engineering', 'corrupted Engineering'),
     # Zero resource display suppression
     (r'Ressourcen:\s*0\b', '', 'zero resources'),
     (r'Ressourcen\s*:\s*0\b', '', 'zero resources with space'),

--- a/services/report_healer.py
+++ b/services/report_healer.py
@@ -1025,8 +1025,8 @@ SOLO_TERM_REPLACEMENTS_EXTENDED: Dict[str, str] = {
     "modular": "flexibel",
     "Modul": "Baustein",
     "modul": "baustein",
-    "Engine": "Baustein",
-    "engine": "baustein",
+    # "Engine" removed: str.replace("Engine", "Baustein") corrupts "Engineering"
+    # → "Bausteinering". Handled by content_quality_enforcer with regex word boundaries.
     "Baukasten": "Werkzeugkasten",
     "baukasten": "werkzeugkasten",
     # Additional enterprise terms

--- a/services/report_renderer.py
+++ b/services/report_renderer.py
@@ -1305,9 +1305,9 @@ def render(briefing_obj: Any,
     log.info("[Z+1c-POST] Total post-render: %d", _z1c_post)
 
     # U1b (V1): Global hauptleistung replace using ORIGINAL saved before U2
-    # KIS-1126 / C2 FIX: Increased from 77→150 to prevent mid-word cuts
-    if _hl_original and len(_hl_original) > 160:
-        _hl_trunc = _hl_original[:150].rsplit(' ', 1)[0] + '…'
+    # KIS-1126 / C2 FIX: Increased from 77→150→300 to prevent mid-word cuts
+    if _hl_original and len(_hl_original) > 310:
+        _hl_trunc = _hl_original[:300].rsplit(' ', 1)[0] + '…'
         _before = len(re.findall(re.escape(_hl_original), html, re.IGNORECASE))
         # W2: Case-insensitive replace to catch GPT casing variants
         html = re.sub(re.escape(_hl_original), _hl_trunc, html, flags=re.IGNORECASE)

--- a/templates/pdf_template_v7.html
+++ b/templates/pdf_template_v7.html
@@ -861,6 +861,46 @@ h1, h2, h3, h4 {
     break-inside: avoid;
 }
 
+/* KIS-1127 / C3 FIX: Allow page breaks INSIDE large containers
+   to prevent near-empty pages (Puppeteer pushes oversized blocks
+   to the next page as a whole, leaving >40% whitespace). */
+
+/* 90-Tage-Roadmap: Phase cards may break internally */
+.roadmap-phase-card {
+    break-inside: auto;
+    page-break-inside: auto;
+}
+
+/* Starter-Kit: Container and tool grid may break across pages */
+.starter-kit {
+    break-inside: auto;
+    page-break-inside: auto;
+}
+.starter-kit__tools {
+    break-inside: auto;
+    page-break-inside: auto;
+}
+/* Individual tool cards are small — keep together */
+.tool-card {
+    break-inside: avoid;
+    page-break-inside: avoid;
+}
+
+/* Vendor-Audit: Allow break between summary and details */
+.vendor-audit-engine {
+    break-inside: auto;
+    page-break-inside: auto;
+}
+.vendor-details-section {
+    break-inside: auto;
+    page-break-inside: auto;
+}
+/* Individual vendor cards are compact — keep together */
+.vendor-card {
+    break-inside: avoid;
+    page-break-inside: avoid;
+}
+
 /* ══════════════════════════════════════════════════════
    v7.1 NEUE ELEMENTE — Clean Corporate Plus
    ══════════════════════════════════════════════════════ */
@@ -1003,6 +1043,11 @@ h1, h2, h3, h4 {
     .section { break-inside: auto; }
     .mgmt-card, .decision-card, .funding-card, .kpi-card,
     .glance-box, .contact-box, .card-nobreak { break-inside: avoid; }
+    /* KIS-1127/C3: Large containers flow across pages */
+    .roadmap-phase-card, .starter-kit, .starter-kit__tools,
+    .vendor-audit-engine, .vendor-details-section { break-inside: auto; }
+    /* Small cards stay together */
+    .tool-card, .vendor-card { break-inside: avoid; }
 }
     </style>
 </head>


### PR DESCRIPTION
## Summary
This PR addresses three related issues affecting PDF rendering quality and text handling:
1. **PDF page break optimization** – Allow large container sections to break across pages, preventing excessive whitespace
2. **Text truncation refinement** – Increase hauptleistung truncation threshold to prevent mid-word cuts in German compound words
3. **Word corruption prevention** – Fix regex-based text replacement to avoid corrupting compound words like "Engineering"

## Key Changes

### PDF Template (templates/pdf_template_v7.html)
- **KIS-1127/C3 FIX**: Added CSS rules to allow page breaks inside large containers (roadmap phase cards, starter kit, vendor audit sections) while keeping small individual cards together
- Updated print media query to apply the same break-inside rules consistently across responsive layouts
- Prevents Puppeteer from pushing oversized blocks to the next page as a whole, which was leaving >40% whitespace on previous pages

### Text Truncation (gpt_analyze.py, services/report_renderer.py)
- **KIS-1126/C2 FIX**: Increased hauptleistung truncation threshold from 150 → 300 characters
- Updated threshold check from 160 → 310 characters to match new truncation point
- Prevents mid-word cuts in German compound descriptions (e.g., "Einführung" was being cut to "Einfü" or "Einführun")
- Applied consistently across both `_build_prompt_vars()` and `_y6_disambiguate()` functions

### Word Corruption Prevention (services/report_healer.py, services/content_quality_enforcer.py)
- **Removed problematic string replacement**: Disabled simple `str.replace("Engine", "Baustein")` in sanitize_template_phrases
- **Root cause**: The replacement was corrupting compound words like "Engineering" → "Bausteinering"
- **Solution**: Delegated to content_quality_enforcer with regex word boundaries (`\b`) for precise matching
- Added regex pattern to detect and fix "Bausteinering" corruption back to "Engineering"

## Implementation Details
- All changes maintain backward compatibility with existing PDF templates
- Text truncation uses `rsplit(' ', 1)[0]` to break at word boundaries, preserving readability
- CSS break-inside rules use both modern (`break-inside`) and legacy (`page-break-inside`) properties for broader browser/renderer support
- Regex-based fixes use word boundary anchors to avoid unintended substring matches

https://claude.ai/code/session_01SW5FsdekA9mrE45b5gz8Jo