### PR TITLE
fix(KIS-1130): R1 cover — remove kundencode leak + fix logo rendering

### DIFF
--- a/services/gamechanger_deep_dive.py
+++ b/services/gamechanger_deep_dive.py
@@ -874,9 +874,10 @@ def render_deep_dive_html(sections: Dict[str, str],
         # Set report_date for "Generiert am" display (same pattern as Report 1)
         from datetime import datetime
         template_vars['report_date'] = datetime.now().strftime("%d.%m.%Y")
-        # Use kundencode (company identifier) as company_name, NOT hauptleistung
+        # KIS-1130: Use BRANCHE_LABEL for company_name — kundencode is internal
+        # and must not appear as customer-facing company name
         template_vars['company_name'] = (
-            context.get('kundencode')
+            context.get('BRANCHE_LABEL')
             or context.get('HAUPTLEISTUNG')
             or 'Ihr Unternehmen'
         )

--- a/templates/pdf_template_v7.html
+++ b/templates/pdf_template_v7.html
@@ -6,7 +6,7 @@
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>KI-Status-Report {{ report_id }} – {{ company_name or kundencode or ('Your Company' if ((lang or briefing_lang or report_lang or 'de')|lower)[:2] == 'en' else 'Ihr Unternehmen') }}</title>
+    <title>KI-Status-Report {{ report_id }} – {{ BRANCHE_LABEL|default('KI-Readiness Assessment') }}</title>
     <style>
 /* ═══════════════════════════════════════════════════════
    v7.1 CLEAN CORPORATE PLUS — Design System
@@ -1149,9 +1149,10 @@ h1, h2, h3, h4 {
         <p class="cover-subtitle">{{ REPORT_SUBTITLE }}</p>
         {% endif %}
         <p class="cover-meta">
-            {{ ui("company_label_colon") }}
-            <strong>{{ company_name or kundencode or ui("your_company") }}</strong>
-            <span class="muted"> · </span>{{ BRANCHE_LABEL }}
+            {# KIS-1130/Bug2: Removed company_name/kundencode display — we don't collect
+               company names for privacy reasons, so the internal kundencode (e.g. "KND")
+               was leaking to the cover, damaging customer trust. #}
+            <strong>{{ BRANCHE_LABEL }}</strong>
             <span class="muted"> · </span>{{ UNTERNEHMENSGROESSE_LABEL }}
         </p>
     </div>
@@ -1367,7 +1368,7 @@ h1, h2, h3, h4 {
         {% if CORE_MESSAGE_HTML %}
         {{ CORE_MESSAGE_HTML }}
         {% else %}
-        Score {{ score_int }}/100 ({{ score_rating }}). {{ REPORT_SUBTITLE|default('KI-Readiness Assessment für ' ~ (company_name or kundencode or 'Ihr Unternehmen')) }}.
+        Score {{ score_int }}/100 ({{ score_rating }}). {{ REPORT_SUBTITLE|default('KI-Readiness Assessment') }}.
         {% endif %}
     </div>
 

--- a/utils/logo_embedder.py
+++ b/utils/logo_embedder.py
@@ -86,86 +86,46 @@ def optimize_base64_image(
             log.warning("[LOGO-OPTIMIZE] SVG minification failed: %s", e)
             return data, mime_type
 
-    # --- PNG/JPEG → Lossless WebP with 8-bit color depth ---
+    # --- PNG/JPEG/WebP → Optimized PNG for data URI embedding ---
+    # KIS-1130/Bug1: ALWAYS output PNG format for data URIs.
+    # B42-FIX established that WebP data URIs can fail in Puppeteer PDF rendering
+    # (badges/logos show alt-text instead of image). The original B42-FIX only
+    # converted WebP inputs to PNG but still converted PNG inputs TO WebP —
+    # which caused the same rendering failure. Now ALL raster images are
+    # output as optimized PNG, which is universally supported.
     if PILLOW_AVAILABLE and mime_type in ("image/png", "image/jpeg", "image/jpg", "image/webp"):
         try:
-            # B42-FIX: Convert WebP → PNG for data URI embedding.
-            # WebP data URIs render correctly when loaded as files in Chromium,
-            # but can fail as inline data URIs in Puppeteer PDF rendering
-            # (badges show alt-text instead of image). PNG data URIs are
-            # universally supported. R2 template works because its rendering
-            # pipeline differs from R1's.
-            if mime_type == "image/webp":
-                img: Image.Image = Image.open(io.BytesIO(data))
-                # Resize if too large
-                if max_dimension and (img.width > max_dimension or img.height > max_dimension):
-                    img.thumbnail((max_dimension, max_dimension), Image.Resampling.LANCZOS)
-                output = io.BytesIO()
-                img.save(output, format="PNG", optimize=True)
-                png_data = output.getvalue()
-                log.info("[LOGO-OPTIMIZE] WebP→PNG for data URI: %d → %d bytes", original_size, len(png_data))
-                return png_data, "image/png"
-
-            img = Image.open(io.BytesIO(data))
+            img: Image.Image = Image.open(io.BytesIO(data))
 
             # Resize if too large
             if max_dimension and (img.width > max_dimension or img.height > max_dimension):
                 img.thumbnail((max_dimension, max_dimension), Image.Resampling.LANCZOS)
                 log.debug("[LOGO-OPTIMIZE] Resized to %dx%d", img.width, img.height)
 
+            # Ensure compatible mode for PNG output
+            if img.mode not in ("RGB", "RGBA", "L", "P"):
+                img = img.convert("RGBA")
+
             # Reduce color depth to 8-bit (palette mode) for smaller files
-            # Only for images without critical transparency
-            original_mode = img.mode
-            if img.mode == "RGBA":
-                # FIX-L1: RGBA images — skip quantization entirely.
-                # MEDIANCUT/FASTOCTREE don't support RGBA, and WebP handles
-                # RGBA natively. Save directly without color reduction.
-                pass
-            elif img.mode in ("RGB", "L"):
-                # Convert to palette mode (8-bit)
+            # Only for images without transparency
+            if img.mode in ("RGB", "L"):
                 img = img.quantize(colors=256, method=Image.Quantize.MEDIANCUT)
                 img = img.convert("RGB")
+            # RGBA images keep full color depth (transparency needs it)
 
-            # Try lossless WebP first
             output = io.BytesIO()
-            if lossless:
-                img.save(output, format="WEBP", lossless=True, quality=100)
-            else:
-                img.save(output, format="WEBP", quality=webp_quality, lossless=False)
-
+            img.save(output, format="PNG", optimize=True)
             optimized_bytes = output.getvalue()
             new_size = len(optimized_bytes)
 
-            # If lossless is too large, fall back to lossy with quality reduction
-            if new_size > MAX_LOGO_SIZE_BYTES and lossless:
-                log.debug("[LOGO-OPTIMIZE] Lossless too large (%d bytes), trying lossy", new_size)
-                output = io.BytesIO()
-                img.save(output, format="WEBP", quality=webp_quality, lossless=False)
-                optimized_bytes = output.getvalue()
-                new_size = len(optimized_bytes)
-
-                # If still too large, reduce quality further
-                if new_size > MAX_LOGO_SIZE_BYTES:
-                    for quality in [60, 50, 40]:
-                        output = io.BytesIO()
-                        img.save(output, format="WEBP", quality=quality, lossless=False)
-                        optimized_bytes = output.getvalue()
-                        new_size = len(optimized_bytes)
-                        if new_size <= MAX_LOGO_SIZE_BYTES:
-                            log.debug("[LOGO-OPTIMIZE] Reduced quality to %d to meet size limit", quality)
-                            break
-
-            # Only use WebP if actually smaller
-            if new_size < original_size:
-                log.debug("[LOGO-OPTIMIZE] %s → WebP: %d → %d bytes (%.0f%% saved)",
-                         mime_type, original_size, new_size, (1 - new_size/original_size) * 100)
-                return optimized_bytes, "image/webp"
-            else:
-                log.debug("[LOGO-OPTIMIZE] WebP not smaller, keeping original")
-                return data, mime_type
+            log.info("[LOGO-OPTIMIZE] %s → PNG: %d → %d bytes (%.0f%% %s)",
+                     mime_type, original_size, new_size,
+                     abs(1 - new_size / original_size) * 100,
+                     "saved" if new_size < original_size else "larger but PNG-safe")
+            return optimized_bytes, "image/png"
 
         except Exception as e:
-            log.warning("[LOGO-OPTIMIZE] PNG/JPEG→WebP failed: %s", e)
+            log.warning("[LOGO-OPTIMIZE] Image optimization failed: %s", e)
             return data, mime_type
 
     # No optimization possible


### PR DESCRIPTION
Bug 2 (CRITICAL): "Unternehmen: KND" on cover page exposed internal kundencode to customers. We don't collect company names for privacy, so the fallback chain `company_name or kundencode` leaked internal IDs.

Fix: Removed company_name/kundencode display from R1 cover, <title>, and mgmt-summary fallback. Cover now shows BRANCHE_LABEL + size only. Also fixed KPA's company_name to use BRANCHE_LABEL instead of kundencode. Strategy was already safe (defaults to "Ihr Unternehmen").

Bug 1: Logo in header shows alt-text instead of image. Root cause: logo_embedder.py converts PNG→WebP for data URIs, but B42-FIX already documented that "WebP data URIs can fail in Puppeteer PDF rendering". The B42-FIX only handled WebP→PNG input conversion but still converted PNG inputs TO WebP — causing the same rendering failure.

Fix: optimize_base64_image() now ALWAYS outputs PNG format for data URIs. WebP conversion removed entirely. PNG is universally supported in Puppeteer/Chromium PDF rendering.

https://claude.ai/code/session_01LyiZfC4Et9zBoKAnTs9iTS