### PR TITLE
Skip datenschutz field in chat mode

### DIFF
--- a/services/chat_normalizer.py
+++ b/services/chat_normalizer.py
@@ -74,7 +74,7 @@ FIELD_REGISTRY: dict[str, dict] = {
     "vision_prioritaet":    {"type": "enum",  "required": False, "section": 5, "chat_mode": "QR"},
     "innovationsprozess":   {"type": "enum",  "required": False, "section": 5, "chat_mode": "QR"},
     # --- Section 6: Recht & Datenschutz ---
-    "datenschutz":          {"type": "bool",  "required": True,  "section": 6, "chat_mode": "QR"},
+    "datenschutz":          {"type": "bool",  "required": True,  "section": 6, "chat_mode": "QR", "skip_in_chat": True},
     "datenschutzbeauftragter": {"type": "enum", "required": False, "section": 6, "chat_mode": "QR"},
     "technische_massnahmen": {"type": "enum", "required": False, "section": 6, "chat_mode": "QR"},
     "folgenabschaetzung":   {"type": "enum",  "required": False, "section": 6, "chat_mode": "QR"},


### PR DESCRIPTION
## Summary
Updated the datenschutz (data protection) field configuration to skip it during chat interactions while maintaining its required status for form validation.

## Changes
- Added `"skip_in_chat": True` flag to the datenschutz field definition in the NormResult schema
- This allows the field to remain required for data integrity purposes but prevents it from being presented to users during chat-based interactions

## Implementation Details
The datenschutz field in Section 6 (Recht & Datenschutz) is a boolean field used in QR chat mode. By adding the `skip_in_chat` flag, the normalizer will now bypass this field during chat workflows while still enforcing its presence in complete form submissions.

https://claude.ai/code/session_01UFBeF796QrPKtr4pKBki8u