### PR TITLE
KIS-1136: Handle partially surveyed blocks in chat completion

### DIFF
--- a/gpt_analyze.py
+++ b/gpt_analyze.py
@@ -1298,6 +1298,27 @@ def build_strategic_context_block(answers: dict, lang: str = "de") -> str:
             "Bereich kürzer halten. Empfehlung zur Vertiefung aussprechen."
         )
 
+    # KIS-1136: Signal partially surveyed blocks to LLM
+    partially = answers.get("_chat_partially_surveyed", [])
+    if partially:
+        _block_labels = {
+            "A": "Fördermittel & Budget",
+            "B": "KI-Strategie & Roadmap",
+            "C": "Tools & Automatisierung",
+            "D": "Recht & Datenschutz",
+        }
+        _partial_names = []
+        for ps in partially:
+            label = _block_labels.get(ps["block"], ps["block"])
+            _partial_names.append(f"{label} (fehlend: {', '.join(ps['missing'])})")
+        lines.append(
+            "HINWEIS — Teilweise erfasste Bereiche:\n"
+            f"Die folgenden Bereiche wurden begonnen aber nicht vollständig beantwortet: "
+            f"{'; '.join(_partial_names)}.\n"
+            "Für die fehlenden Felder: Sections kürzer halten, keinen Platzhalter-Content "
+            "generieren. Empfehlung zur Vertiefung aussprechen."
+        )
+
     return "\n\n".join(lines)
 # =========================================================================
 

--- a/routes/chat.py
+++ b/routes/chat.py
@@ -2795,6 +2795,46 @@ def _complete_r1(
         answers["_chat_surveyed_blocks"] = surveyed_blocks
         log.info("[CHAT] Complete R1: unsurveyed blocks %s → defaults applied", unsurveyed)
 
+    # KIS-1136 Fix 3: Blocks selected but never entered → treat as unsurveyed
+    completed_blocks = ps.get("completed_blocks", [])
+    selected_not_entered = [b for b in surveyed_blocks if b not in completed_blocks]
+    if selected_not_entered:
+        for block_id in selected_not_entered:
+            defaults = _REPORT_BLOCK_DEFAULTS.get(block_id, {})
+            for field, default_val in defaults.items():
+                if field not in answers and default_val is not None:
+                    answers[field] = default_val
+        unsurveyed = unsurveyed + selected_not_entered
+        surveyed_blocks = [b for b in surveyed_blocks if b not in selected_not_entered]
+        answers["_chat_unsurveyed_blocks"] = unsurveyed
+        answers["_chat_surveyed_blocks"] = surveyed_blocks
+        log.info("[CHAT] Complete R1: selected but never entered blocks %s → treated as unsurveyed", selected_not_entered)
+
+    # KIS-1136 Fix 1: Surveyed (entered) blocks — check for missing required text fields
+    _partially_surveyed = []
+    for block_id in surveyed_blocks:
+        if block_id == "D":
+            branche = answers.get("branche", "")
+            block_fields = _get_datenschutz_block_fields(branche)
+        else:
+            block_fields = BLOCK_FIELDS.get(block_id, [])
+        _missing_in_block = []
+        for field_name in block_fields:
+            field_def = FIELD_REGISTRY.get(field_name, {})
+            is_required = field_def.get("required", False)
+            is_text = field_def.get("type") == "text"
+            skip = field_def.get("skip_in_chat", False)
+            if is_required and is_text and not skip and field_name not in answers:
+                _missing_in_block.append(field_name)
+        if _missing_in_block:
+            _partially_surveyed.append({
+                "block": block_id,
+                "missing": _missing_in_block,
+            })
+    if _partially_surveyed:
+        answers["_chat_partially_surveyed"] = _partially_surveyed
+        log.warning("[CHAT-COMPLETE] Partially surveyed blocks: %s", _partially_surveyed)
+
     # Extract user from JWT — user_id may already be set from /start
     user_id, user_email = _resolve_user(request, db)
     if not user_id:


### PR DESCRIPTION
## Summary
This PR addresses KIS-1136 by implementing detection and handling of partially surveyed blocks in the chat completion flow. It identifies blocks that were selected but never entered, and blocks that were entered but have missing required text fields, then communicates this information to the LLM for appropriate response generation.

## Key Changes

- **routes/chat.py**
  - Added logic to detect blocks that were selected but never entered (`selected_not_entered`) and treat them as unsurveyed by applying defaults and moving them out of the surveyed blocks list
  - Implemented validation of surveyed blocks to identify missing required text fields, tracking which fields are incomplete per block
  - Store partially surveyed block information in `_chat_partially_surveyed` for downstream processing

- **gpt_analyze.py**
  - Enhanced `build_strategic_context_block()` to signal partially surveyed blocks to the LLM
  - Added a new "HINWEIS" (notice) section that lists incomplete blocks with their missing fields
  - Instructs the LLM to keep sections shorter and avoid placeholder content for incomplete areas, recommending deeper exploration instead

## Implementation Details

- The detection distinguishes between two scenarios:
  1. Blocks selected but never entered (no interaction) → treated as unsurveyed
  2. Blocks entered but incomplete (missing required text fields) → flagged as partially surveyed
- Special handling for block D (Datenschutz) which has dynamic fields based on the `branche` value
- Fields marked with `skip_in_chat` are excluded from the missing field check
- The LLM receives clear guidance on how to handle incomplete information to improve report quality

https://claude.ai/code/session_01X5YFJLD5uhGfYcnBLtkEeb