### PR TITLE
Add race condition recovery for field confirmation endpoint

### DIFF
--- a/routes/chat.py
+++ b/routes/chat.py
@@ -2129,15 +2129,32 @@ async def confirm_field(req: ConfirmFieldRequest, db: Session = Depends(get_db))
         raise HTTPException(status_code=400, detail="Session ist nicht aktiv")
 
     pending = dict(getattr(session, 'draft_state', None) or {})
-    if not pending.get("pending_field"):
-        raise HTTPException(status_code=400, detail="Kein offener Entwurf vorhanden")
+    pending_field_db = pending.get("pending_field")
+
+    _recovery = False
+    if not pending_field_db:
+        # Fallback: pending_field wurde zwischen SSE-Emit und Confirm-Click
+        # überschrieben (Race mit weiterem Stream-Turn, der signal="confirm"
+        # setzte). Wenn Client Field+Value mitliefert und Feld noch nicht
+        # in collected_fields ist, akzeptieren wir den Confirm trotzdem.
+        if (req.action == "confirm"
+            and req.field
+            and req.value is not None
+            and req.field not in (session.collected_fields or {})):
+            _recovery = True
+        else:
+            raise HTTPException(status_code=400, detail="Kein offener Entwurf vorhanden")
 
     rt = session.report_type
     now = datetime.now(timezone.utc)
 
     if req.action == "confirm":
-        field = pending["pending_field"]
-        value = req.value if req.value is not None else pending["pending_value"]
+        if _recovery:
+            field = req.field
+            value = req.value
+        else:
+            field = pending["pending_field"]
+            value = req.value if req.value is not None else pending["pending_value"]
 
         collected = dict(session.collected_fields or {})
         collected[field] = value
@@ -2147,7 +2164,7 @@ async def confirm_field(req: ConfirmFieldRequest, db: Session = Depends(get_db))
         field_meta[field] = {
             "confidence": "high",
             "source_turn": session.turn_count,
-            "raw_input": "confirmed_via_endpoint",
+            "raw_input": "confirmed_via_endpoint_recovery" if _recovery else "confirmed_via_endpoint",
             "normalized": True,
             "confirmed": True,
         }
@@ -2163,7 +2180,7 @@ async def confirm_field(req: ConfirmFieldRequest, db: Session = Depends(get_db))
         log.info("[CHAT] Confirm endpoint: %s=%r confirmed", field, value)
 
         return {
-            "status": "confirmed",
+            "status": "confirmed_recovered" if _recovery else "confirmed",
             "field": field,
             "value": value,
             "next_fields": next_fields,


### PR DESCRIPTION
## Summary
This change adds resilience to the field confirmation endpoint by implementing a recovery mechanism for race conditions that can occur between SSE event emission and client confirmation submission.

## Key Changes
- **Race condition detection**: Added fallback logic to handle cases where `pending_field` is cleared between the time a confirmation prompt is sent to the client and when the client submits the confirmation
- **Recovery mode**: When a race condition is detected, the endpoint now accepts field confirmation directly from the client request (if the field hasn't already been collected) instead of rejecting it
- **Metadata tracking**: Added distinction in metadata and response status between normal confirmations and recovered confirmations:
  - `raw_input` field now includes `"confirmed_via_endpoint_recovery"` for recovered confirmations
  - Response status returns `"confirmed_recovered"` instead of `"confirmed"` for recovery cases
- **Validation**: Recovery mode only activates when:
  - Client provides both field name and value
  - The field is not already in `collected_fields`
  - The action is explicitly "confirm"

## Implementation Details
The recovery mechanism gracefully handles a specific race condition where a subsequent stream turn with `signal="confirm"` overwrites the `pending_field` before the user can submit their confirmation. This ensures user confirmations aren't lost due to timing issues while maintaining data integrity by preventing duplicate field collection.

https://claude.ai/code/session_01CufqpjTyZSPY9Wi3zoUZiz