### PR TITLE
fix(chat): signal strategy questionnaire completion (KIS-1146)

### DIFF
--- a/routes/chat.py
+++ b/routes/chat.py
@@ -1880,6 +1880,20 @@ async def chat_message(req: ChatMessageRequest, db: Session = Depends(get_db)):
         # Determine qr_next based on conversation phase
         _final_phase = _phase_state.get("conversation_phase") if rt == "r1" else None
 
+        # KIS-1146: Strategy has no phase_state, so the r1 "summary" branch
+        # never fires. Precompute whether the strategy questionnaire is
+        # completable (last section + no next field + all required across
+        # all sections filled). Optional fields are opt-out.
+        _strategy_completion_ready = (
+            rt == "strategy"
+            and _current_section >= len(sections) - 1
+            and not next_fields
+            and not any(
+                get_missing_fields(collected, _si, rt)[0]
+                for _si in range(len(sections))
+            )
+        )
+
         if _checkpoint_triggered or _final_phase == "checkpoint":
             # Checkpoint: show topic selection buttons
             _cp_options = [
@@ -1971,6 +1985,20 @@ async def chat_message(req: ChatMessageRequest, db: Session = Depends(get_db)):
                 else:
                     qr_next = _block_remaining[:1]
                 quick_replies = _build_quick_replies(qr_next, rt, collected, _profile_ctx)
+        elif _strategy_completion_ready and not _is_edit_request and (not _is_in_edit_mode or _edit_applied):
+            # KIS-1146: Strategy completion — emit __summary_action__ QR manually.
+            # Mirrors the r1 summary branch above (line ~1913) since strategy
+            # lacks phase_state. Same guard semantics: not an edit request,
+            # and either not in edit mode or an edit was just applied.
+            quick_replies = [QuickReply(
+                field="__summary_action__",
+                label="Nächster Schritt",
+                options=[
+                    QuickReplyOption(value="__start_report__", label="Auswertung starten", style="primary"),
+                    QuickReplyOption(value="__edit_summary__", label="Angaben korrigieren", style="secondary"),
+                ],
+                multi_select=False,
+            )]
         else:
             # Legacy / Strategy: section-based QR
             if _no_extraction and _asked_field and _asked_field not in collected:
@@ -3086,7 +3114,17 @@ def _build_session_state(
     _in_summary_phase = ps["conversation_phase"] == "summary"
     # KIS-1131 FX-4: Not completable while user is editing fields.
     _editing = bool(draft.get("edit_mode"))
-    completable = summary_sent and (all_done or _in_summary_phase) and not _editing
+    if rt == "strategy":
+        # KIS-1146: Strategy has no phase_state and never writes SUMMARY_MARKER
+        # when optional fields are skipped. Signal completable once the user
+        # reaches the last section with all required fields filled.
+        _strategy_all_req_done = not any(
+            get_missing_fields(collected, _si, rt)[0]
+            for _si in range(len(sections))
+        )
+        completable = last_section and _strategy_all_req_done and not _editing
+    else:
+        completable = summary_sent and (all_done or _in_summary_phase) and not _editing
 
     # KIS-1124: Unsurveyed note — only in summary phase when blocks were skipped
     unsurveyed_note: str | None = None

--- a/tests/test_chat_flow.py
+++ b/tests/test_chat_flow.py
@@ -1,0 +1,106 @@
+"""
+KIS-1146 — Strategy questionnaire completion signaling.
+
+Tests that _build_session_state() sets is_completable=True for strategy
+sessions once all REQUIRED fields across all sections are filled, without
+requiring optional fields or a SUMMARY_MARKER.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+from uuid import UUID, uuid4
+
+from routes.chat import _build_session_state
+
+
+@dataclass
+class FakeChatSession:
+    """Minimal stand-in for models.ChatSession — attribute-compatible with
+    what _build_session_state reads. Avoids SQLAlchemy session dependency."""
+    report_type: str = "strategy"
+    status: str = "active"
+    current_section: int = 1
+    collected_fields: dict = field(default_factory=dict)
+    messages: list = field(default_factory=list)
+    draft_state: dict = field(default_factory=dict)
+    phase_state: dict = field(default_factory=dict)
+    id: UUID = field(default_factory=uuid4)
+
+
+# Strategy required fields (per STRATEGY_FIELD_REGISTRY in chat_normalizer.py)
+STRATEGY_REQUIRED = {
+    "s1_budget": "2000_10000",
+    "s2_zeitrahmen": "Sofort (1-3 Monate)",
+    "s3_prioritaeten": ["Kosten senken"],
+    "s4_engpass": "Zu wenig Know-how",
+    "s6_foerderinteresse": "Ja, wenn passend",
+    "s7_entscheidung": "Entscheide allein",
+}
+
+
+def test_strategy_completable_when_all_required_filled():
+    """All required fields filled, on last section → is_completable=True
+    even when optional fields (entire section 1) are skipped."""
+    session = FakeChatSession(
+        current_section=1,  # last strategy section
+        collected_fields=dict(STRATEGY_REQUIRED),
+    )
+    state = _build_session_state(session)
+    assert state.is_completable is True, (
+        f"Expected is_completable=True on last section with all required "
+        f"filled and optionals skipped. Got: {state.is_completable}. "
+        f"missing_required={state.missing_required} "
+        f"missing_optional={state.missing_optional}"
+    )
+
+
+def test_strategy_not_completable_when_required_missing():
+    """Missing one required field (in an earlier section, not the current
+    one) → is_completable=False. The check must scan ALL sections, not
+    just the current one."""
+    partial = dict(STRATEGY_REQUIRED)
+    partial.pop("s7_entscheidung")  # required, in section 0
+    session = FakeChatSession(
+        current_section=1,  # last section — missing field lives in section 0
+        collected_fields=partial,
+    )
+    state = _build_session_state(session)
+    assert state.is_completable is False
+
+
+def test_strategy_not_completable_when_not_on_last_section():
+    """All required in section 0 filled but still on section 0 →
+    is_completable=False. Prevents premature completion signal."""
+    session = FakeChatSession(
+        current_section=0,  # not last section yet
+        collected_fields=dict(STRATEGY_REQUIRED),
+    )
+    state = _build_session_state(session)
+    assert state.is_completable is False
+
+
+def test_strategy_not_completable_in_edit_mode():
+    """User clicked 'Angaben korrigieren' → draft_state.edit_mode=True →
+    is_completable=False until edit is applied. Avoids race where the QR
+    re-appears while the user is mid-edit."""
+    session = FakeChatSession(
+        current_section=1,
+        collected_fields=dict(STRATEGY_REQUIRED),
+        draft_state={"edit_mode": True},
+    )
+    state = _build_session_state(session)
+    assert state.is_completable is False
+
+
+def test_r1_completable_still_requires_summary_marker():
+    """Regression: r1 semantics unchanged. is_completable stays False
+    without SUMMARY_MARKER in assistant messages, even with no missing
+    fields."""
+    session = FakeChatSession(
+        report_type="r1",
+        current_section=0,
+        collected_fields={},  # no fields → missing_req non-empty anyway
+    )
+    state = _build_session_state(session)
+    assert state.is_completable is False


### PR DESCRIPTION
## Summary

- **Root cause:** Strategy has no `phase_state`, so the r1-only `_final_phase == "summary"` branch in `routes/chat.py` never fires. The `__summary_action__` QR was never emitted, and `is_completable` stayed false because `build_summary()` (which writes `SUMMARY_MARKER`) is gated on **all** fields (incl. optional) being filled — strategy users typically skip optional fields.
- **Fix:** Mirror the r1 summary QR branch for strategy when the user reaches the last section with all **required** fields filled. Update `_build_session_state()` so `is_completable` becomes true under the same condition, bypassing the `SUMMARY_MARKER` requirement.
- **Scope:** Backend only. R1 flow is byte-identical — new logic is gated on `rt == "strategy"`.

## Changes

- `routes/chat.py`:
  - New `_strategy_completion_ready` precompute (line ~1883) — derived bool, cheap.
  - New `elif` branch before the legacy/strategy else (line ~1988) — emits `__summary_action__` QR with the same two options as r1 (`__start_report__`, `__edit_summary__`).
  - `_build_session_state()` (line ~3117) — strategy-specific `is_completable` path.
- `tests/test_chat_flow.py` (new):
  - `is_completable=True` when all required filled + last section + optionals skipped.
  - `is_completable=False` when a required field (in any earlier section) is missing.
  - `is_completable=False` on non-last section.
  - `is_completable=False` in edit-mode (mirrors r1 KIS-1131 FX-4 semantic).
  - R1 regression: `is_completable=False` without `SUMMARY_MARKER`.

## Test plan

- [x] Unit tests (5/5 pass locally, `tests/test_chat_flow.py`)
- [x] `tests/test_strategy_sanitizer.py` no regression (all 29 pass)
- [ ] **Browser smoke test — Wolf to run before merge**
  - URL: `https://make.ki-sicherheit.jetzt/strategy.html?briefing_id=<neu>`
  - Expected: two buttons ("Auswertung starten" / "Angaben korrigieren") appear at end, text input hidden or disabled
  - Click "Auswertung starten" → report triggers + redirect
  - Click "Angaben korrigieren" → edit mode opens (required fields only, per KIS-1146 Edit-Scope decision)
  - No further question appears after the Abschluss-Frage
- [ ] **R1 regression smoke — Wolf**
  - Full r1 run → summary flow unchanged, byte-identical output

## Non-code decisions (per KIS-1146 Umsetzungs-Freigabe)

- Edit-mode scope: **required only**. Optional fields are opt-out and stay out of the edit UI.
- Single fix, single commit. No defensive-in-both-directions.
- The log's "user chose START REPORT" after free-text "ja" puzzle remains unresolved but becomes moot: once the completion UI renders reliably, the text input is disabled. If future logs show the same pattern via new code paths, it's a separate tracking case.

## Screenshots

Not attached — browser smoke test is pending on Wolf's side. Expected before/after can be verified against ticket description (leeres Textfeld vs. zwei Buttons im QR-Container).

https://claude.ai/code/session_014vC9gCJYYosx1gbXQ9qPnv