### PR TITLE
KIS-1160: Recognize plain "nein"/"nö" as decline and block "Vielversprechend"

### DIFF
--- a/routes/chat.py
+++ b/routes/chat.py
@@ -72,6 +72,46 @@ DRAFT_MODE_ENABLED = os.getenv("DRAFT_MODE_ENABLED", "false").lower() == "true"
 SUMMARY_MARKER = "**Zusammenfassung Ihrer Angaben:**"
 
 # ---------------------------------------------------------------------------
+# Skip / Decline detection (module scope so tests can import)
+# ---------------------------------------------------------------------------
+# Exact-match skip words: whole-message equality check after strip+lower.
+SKIP_WORDS: frozenset[str] = frozenset({
+    "weiter", "skip", "überspringen", "nächste", "weiter bitte", "nächste frage",
+})
+
+# Substring patterns that mark a message as a decline. Checked via
+# `any(p in msg_lower for p in _DECLINE_PATTERNS)`; only effective when
+# Haiku produced no extraction this turn.
+_DECLINE_PATTERNS: list[str] = [
+    "weiß nicht", "weiss nicht", "keine ahnung", "kann ich nicht",
+    "überspring", "überspringen", "skip", "egal", "später",
+    "das kann ich jetzt nicht", "schwer zu sagen", "müsste ich nachschauen",
+    "ist mir nicht wichtig", "spielt keine rolle", "unwichtig",
+    "nächste frage", "weiter", "kann ich nicht entscheiden",
+    "kann ich nicht sagen", "keine angabe", "k.a.", "kein kommentar",
+    "keine meinung", "weiß ich nicht", "weiss ich nicht",
+    "kann ich nicht beantworten", "keine idee", "noch keine idee",
+    # KIS-1124 Testrun-Fix Bug 4: additional skip-signal phrases
+    "weiß nicht genau", "weiss nicht genau", "keine vorstellung",
+    "passe", "überspring das", "kein plan", "wüsste ich nicht",
+    "da bin ich überfragt", "keine präferenz", "mir egal",
+    # KIS-1160: plain "nein" / "nö" must register as decline so Sonnet
+    # receives the decline help-context instead of praising earlier answers.
+    "nein", "nö", "nein danke",
+]
+
+
+def is_decline_message(message: str) -> bool:
+    """True when the stripped, lowered *message* contains any decline marker."""
+    msg_lower = message.strip().lower()
+    return any(p in msg_lower for p in _DECLINE_PATTERNS)
+
+
+def is_skip_word(message: str) -> bool:
+    """True when *message* (after strip+lower) is an exact skip word."""
+    return message.strip().lower() in SKIP_WORDS
+
+# ---------------------------------------------------------------------------
 # KIS-1124 Sprint 2: Hybrid Conversation Model — Phase & Block Definitions
 # ---------------------------------------------------------------------------
 
@@ -1087,21 +1127,9 @@ async def chat_message(req: ChatMessageRequest, db: Session = Depends(get_db)):
 
         # Handle "weiter" / skip for optional fields
         # KIS-1124-S0-BE-2: Extended skip detection with decline phrases
-        skip_words = {"weiter", "skip", "überspringen", "nächste", "weiter bitte", "nächste frage"}
-        _DECLINE_PATTERNS = [
-            "weiß nicht", "weiss nicht", "keine ahnung", "kann ich nicht",
-            "überspring", "überspringen", "skip", "egal", "später",
-            "das kann ich jetzt nicht", "schwer zu sagen", "müsste ich nachschauen",
-            "ist mir nicht wichtig", "spielt keine rolle", "unwichtig",
-            "nächste frage", "weiter", "kann ich nicht entscheiden",
-            "kann ich nicht sagen", "keine angabe", "k.a.", "kein kommentar",
-            "keine meinung", "weiß ich nicht", "weiss ich nicht",
-            "kann ich nicht beantworten", "keine idee", "noch keine idee",
-            # KIS-1124 Testrun-Fix Bug 4: additional skip-signal phrases
-            "weiß nicht genau", "weiss nicht genau", "keine vorstellung",
-            "passe", "überspring das", "kein plan", "wüsste ich nicht",
-            "da bin ich überfragt", "keine präferenz", "mir egal",
-        ]
+        # KIS-1160: "nein" / "nö" recognized as decline so Sonnet gets the
+        # decline help-context instead of drifting onto unrelated praise.
+        skip_words = SKIP_WORDS
         _msg_lower = req.message.strip().lower()
         _is_skip_word = _msg_lower in skip_words
         _is_decline = (not normalized and not _is_qr_click and not _is_help_request

--- a/services/chat_conversation.py
+++ b/services/chat_conversation.py
@@ -1309,6 +1309,15 @@ FORBIDDEN_PATTERNS = [
     "Klasse",
     "Super",
     "Toll",
+    # KIS-1160: "Vielversprechend" als Substantiv/Adjektiv-Konstrukt.
+    # "Das klingt vielversprechend" steht bereits oben, die Adjektiv-Konstrukte
+    # wie "Vielversprechende Strategie" rutschten bislang durch.
+    "Vielversprechend",
+    "vielversprechend",
+    "Vielversprechende",
+    "vielversprechende",
+    "eine vielversprechende",
+    "Eine vielversprechende",
 ]
 
 

--- a/tests/test_kis_1160_decline_nein.py
+++ b/tests/test_kis_1160_decline_nein.py
@@ -1,0 +1,116 @@
+# -*- coding: utf-8 -*-
+"""
+KIS-1160: Plain "nein" / "nö" registers as decline.
+
+Before the fix, a bare "nein" was not in the decline pattern list — Haiku's
+skip-signal rule stored "keine_angabe" in the field and Sonnet, seeing the
+field "resolved", drifted onto earlier rich answers (e.g. "Vielversprechende
+Strategie..."). This patch adds the missing patterns AND blacklists the
+"Vielversprechend" adjective/noun construction at the prompt level.
+"""
+
+import pytest
+
+from routes.chat import (
+    SKIP_WORDS,
+    _DECLINE_PATTERNS,
+    is_decline_message,
+    is_skip_word,
+)
+from services.chat_conversation import FORBIDDEN_PATTERNS
+
+
+class TestDeclinePatterns:
+    """KIS-1160 patterns must be present in the module-level list."""
+
+    def test_nein_present(self):
+        assert "nein" in _DECLINE_PATTERNS
+
+    def test_noe_present(self):
+        assert "nö" in _DECLINE_PATTERNS
+
+    def test_nein_danke_present(self):
+        assert "nein danke" in _DECLINE_PATTERNS
+
+    def test_prior_patterns_preserved(self):
+        # Sanity: previous decline markers still there.
+        for marker in ("weiß nicht", "keine ahnung", "skip", "egal"):
+            assert marker in _DECLINE_PATTERNS, f"regression: {marker!r} removed"
+
+
+class TestIsDeclineMessage:
+    """is_decline_message correctly classifies common German decline inputs."""
+
+    @pytest.mark.parametrize("msg", [
+        "nein",
+        "Nein",
+        "Nein.",
+        "nein!",
+        "Nein, danke",
+        "nein danke",
+        "nö",
+        "Nö",
+        "Nö!",
+        "weiß nicht",
+        "keine Ahnung",
+        "SKIP",
+    ])
+    def test_declines(self, msg):
+        assert is_decline_message(msg), f"expected decline: {msg!r}"
+
+    @pytest.mark.parametrize("msg", [
+        "",
+        "ja",
+        "Ja, gerne",
+        "ich mache das anders",
+        # "meinen" / "keinen" / "seinen" / "meinem" share letters with "nein"
+        # but do NOT contain the contiguous substring "nein".
+        "was meinen Sie damit?",
+        "ich habe keinen Bedarf",
+        "es sind seinen Kunden wichtig",
+        "das ist meinem Team sehr wichtig",
+        "Berlin hat eine gute Infrastruktur",
+    ])
+    def test_not_declines(self, msg):
+        assert not is_decline_message(msg), f"false positive: {msg!r}"
+
+
+class TestSkipWord:
+    """is_skip_word matches only exact short commands."""
+
+    @pytest.mark.parametrize("msg", [
+        "weiter",
+        "Weiter",
+        " skip ",
+        "nächste frage",
+        "ÜBERSPRINGEN",
+    ])
+    def test_skip(self, msg):
+        assert is_skip_word(msg)
+
+    @pytest.mark.parametrize("msg", [
+        "weiter machen",
+        "bitte weiter zum nächsten",
+        "nein",  # not a skip command — a decline
+        "",
+    ])
+    def test_not_skip(self, msg):
+        assert not is_skip_word(msg)
+
+    def test_skip_words_is_frozenset(self):
+        # Cheap guard against accidental mutation.
+        assert isinstance(SKIP_WORDS, frozenset)
+
+
+class TestForbiddenVielversprechend:
+    """KIS-1160: 'Vielversprechend' blocked in all relevant forms."""
+
+    def test_adjective_forms_present(self):
+        forms = {"Vielversprechend", "vielversprechend",
+                 "Vielversprechende", "vielversprechende"}
+        missing = forms - set(FORBIDDEN_PATTERNS)
+        assert not missing, f"missing forbidden forms: {missing}"
+
+    def test_prior_pattern_preserved(self):
+        # "Das klingt vielversprechend" existed before KIS-1160.
+        assert "Das klingt vielversprechend" in FORBIDDEN_PATTERNS


### PR DESCRIPTION
## Summary
Fix an issue where plain "nein" (no) and "nö" were not recognized as decline responses, causing Sonnet to drift onto unrelated earlier answers instead of providing appropriate decline help-context. Additionally, block the "Vielversprechend" (promising) adjective/noun construction at the prompt level to prevent inappropriate praise.

## Key Changes

- **Refactored skip/decline detection to module scope** (`routes/chat.py`):
  - Moved `SKIP_WORDS` and `_DECLINE_PATTERNS` from function-local to module-level constants for testability
  - Added new helper functions `is_decline_message()` and `is_skip_word()` for cleaner logic
  - Added missing decline patterns: `"nein"`, `"nö"`, and `"nein danke"`

- **Enhanced forbidden patterns** (`services/chat_conversation.py`):
  - Added multiple forms of "Vielversprechend" to `FORBIDDEN_PATTERNS`:
    - Capitalized and lowercase adjective forms
    - Adjective + noun constructions (e.g., "Vielversprechende Strategie")
  - Prevents Sonnet from praising strategies with this term when users decline

- **Added comprehensive test coverage** (`tests/test_kis_1160_decline_nein.py`):
  - Validates all decline patterns are present
  - Tests `is_decline_message()` with various German decline inputs and false positives
  - Tests `is_skip_word()` for exact-match behavior
  - Verifies forbidden "Vielversprechend" forms are blocked

## Implementation Details

The decline detection uses substring matching (`any(p in msg_lower for p in _DECLINE_PATTERNS)`), which correctly handles variations like "Nein!", "nein danke", etc. while avoiding false positives from words containing "nein" as a substring (e.g., "meinen", "keinen").

The refactoring maintains backward compatibility by preserving all existing decline patterns while adding the three new ones needed for KIS-1160.

https://claude.ai/code/session_01VfiRYYLYWWdTKptF1eLV8g