### PR TITLE
KIS-1161: Add freetext quality validator to reject low-quality answers

### DIFF
--- a/services/chat_normalizer.py
+++ b/services/chat_normalizer.py
@@ -29,6 +29,59 @@ class NormResult:
 
 
 # ===========================================================================
+# KIS-1161: Freitext-Quality-Validator
+#
+# Rejects degenerate answers on freetext ("text" / chat_mode="FT") fields so
+# the chat re-asks instead of silently incrementing progress with placeholder
+# content. Does NOT fire on enum / bool / slider / multi — those handle their
+# own canonicalisation, and short tokens like "ja", "nein" or "5" are valid
+# for those types.
+# ===========================================================================
+
+# Case-insensitive substrings that mark a freetext answer as a pointer to an
+# earlier answer rather than substance. Matched after lower-case + stripping
+# trailing punctuation.
+_LOW_QUALITY_TEXT_MARKERS: frozenset[str] = frozenset({
+    "siehe oben",
+    "s.o.",
+    "s. o.",
+    "wie oben",
+    "dito",
+    "idem",
+    "ebenso",
+})
+
+
+def is_low_quality_text(raw: str, min_words: int = 3) -> bool:
+    """Return True if *raw* should be rejected as a substantive freetext answer.
+
+    A value is "low quality" when it either
+      1. matches one of ``_LOW_QUALITY_TEXT_MARKERS`` (case-insensitive,
+         ignoring trailing punctuation), or
+      2. has fewer than ``min_words`` whitespace-separated tokens.
+    """
+    if raw is None:
+        return True
+    cleaned = str(raw).strip()
+    if not cleaned:
+        return True
+
+    # Normalise for marker match: lower + trim trailing punctuation / whitespace.
+    normalised = cleaned.lower().rstrip(" .!?,;:")
+    if normalised in _LOW_QUALITY_TEXT_MARKERS:
+        return True
+    # Some markers also appear as prefixes ("s.o." followed by explanation is
+    # rare, but "siehe oben, Punkt 2" should still be flagged).
+    for marker in _LOW_QUALITY_TEXT_MARKERS:
+        if normalised.startswith(marker):
+            return True
+
+    if len(cleaned.split()) < min_words:
+        return True
+    return False
+
+
+# ===========================================================================
 # Field Registry — PoC Block 1 (Section 0) + full structure for later
 # ===========================================================================
 
@@ -809,6 +862,15 @@ def normalize_field(field_name: str, raw_value: Any, collected: dict, report_typ
         if cleaned.lower() in ("keine_angabe", "keine angabe"):
             return NormResult("", "high", False)
         if len(cleaned) < 3:
+            return NormResult(None, "low", True)
+        # KIS-1161: reject "siehe oben" / "dito" / <3-word stubs so the chat
+        # re-asks instead of silently accepting a non-answer. Only freetext
+        # fields (chat_mode="FT") — enums/bools/sliders are unaffected.
+        if reg.get("chat_mode") == "FT" and is_low_quality_text(cleaned):
+            log.info(
+                "[CHAT-NORM] Low-quality freetext for %s: %r — re-ask",
+                field_name, cleaned,
+            )
             return NormResult(None, "low", True)
         return NormResult(cleaned, "high", False)
 

--- a/tests/test_kis_1161_quality_validator.py
+++ b/tests/test_kis_1161_quality_validator.py
@@ -1,0 +1,149 @@
+# -*- coding: utf-8 -*-
+"""
+KIS-1161: Freitext-Quality-Validator.
+
+Rejects low-quality freetext answers ("siehe oben", <3 word stubs) so the
+chat re-asks instead of silently marking the field as answered.
+
+Must NOT interfere with:
+  - enum / bool / multi answers (ja / nein / nö / multi-select values)
+  - slider / numeric values ("5", 7)
+  - QR clicks (already normalised to canonical enum values upstream)
+  - The existing "keine_angabe" skip path (required for Bug 3 fix).
+"""
+
+import pytest
+
+from services.chat_normalizer import (
+    is_low_quality_text,
+    normalize_field,
+    _LOW_QUALITY_TEXT_MARKERS,
+)
+
+
+# ---------------------------------------------------------------------------
+# is_low_quality_text — unit level
+# ---------------------------------------------------------------------------
+
+class TestLowQualityMarkers:
+    """Bug reproducer inputs must be classified low-quality."""
+
+    @pytest.mark.parametrize("raw", [
+        "siehe oben",
+        "Siehe oben",
+        "SIEHE OBEN",
+        "siehe oben.",
+        "siehe oben!",
+        "Siehe oben, Punkt 2",
+        "s.o.",
+        "S.O.",
+        "s. o.",
+        "wie oben",
+        "Wie oben.",
+        "dito",
+        "Dito!",
+        "idem",
+        "ebenso",
+    ])
+    def test_marker_variants_rejected(self, raw):
+        assert is_low_quality_text(raw), f"should reject: {raw!r}"
+
+
+class TestWordCountThreshold:
+    """Fewer than 3 whitespace-separated tokens → low quality."""
+
+    @pytest.mark.parametrize("raw", [
+        "",
+        " ",
+        "ja",
+        "nein",
+        "5",
+        "Beratung",
+        "API Entwicklung",       # 2 words
+        "sehr gut",              # 2 words
+    ])
+    def test_short_rejected(self, raw):
+        assert is_low_quality_text(raw)
+
+    @pytest.mark.parametrize("raw", [
+        "Beratung im Mittelstand",                     # 3 words
+        "Wir bieten KI-Beratung für Solo-Selbstständige",
+        "Content-Generierung, Datenanalyse, Proposal-Automation",  # comma-sep
+        "White-Label-Tool, Branchen-Reports und Proposal-Generator",
+    ])
+    def test_substantive_accepted(self, raw):
+        assert not is_low_quality_text(raw)
+
+
+# ---------------------------------------------------------------------------
+# normalize_field — integration with text-type fields only
+# ---------------------------------------------------------------------------
+
+class TestNormalizeFieldTextFT:
+    """Validator must only bite on text + chat_mode='FT' fields."""
+
+    def test_siehe_oben_rejected_for_strategische_ziele(self):
+        r = normalize_field("strategische_ziele", "siehe oben", {}, "r1")
+        assert r.confidence == "low"
+        assert r.value is None
+        assert r.needs_confirmation is True
+
+    def test_substantive_accepted_for_strategische_ziele(self):
+        r = normalize_field(
+            "strategische_ziele",
+            "White-Label-Tool, Branchen-Reports, Proposal-Automation",
+            {}, "r1",
+        )
+        assert r.confidence == "high"
+        assert "White-Label" in r.value
+
+    def test_short_single_word_rejected_for_hauptleistung(self):
+        r = normalize_field("hauptleistung", "Beratung", {}, "r1")
+        assert r.confidence == "low"
+
+    def test_keine_angabe_still_passes(self):
+        # Bug-3 skip path must stay intact.
+        r = normalize_field("strategische_ziele", "keine_angabe", {}, "r1")
+        assert r.confidence == "high"
+        assert r.value == ""
+
+
+class TestNormalizeFieldNonText:
+    """Enum / bool / slider / multi must be unaffected by KIS-1161."""
+
+    def test_enum_ja_passes(self):
+        # roadmap_vorhanden is enum("ja","teilweise","nein","unklar").
+        r = normalize_field("roadmap_vorhanden", "ja", {}, "r1")
+        assert r.confidence == "high"
+        assert r.value == "ja"
+
+    def test_enum_nein_passes(self):
+        r = normalize_field("roadmap_vorhanden", "nein", {}, "r1")
+        assert r.confidence == "high"
+        assert r.value == "nein"
+
+    def test_slider_single_digit_passes(self):
+        # digitalisierungsgrad is slider 1–10.
+        r = normalize_field("digitalisierungsgrad", "5", {}, "r1")
+        assert r.confidence == "high"
+        assert r.value == 5
+
+    def test_risikofreude_single_digit_passes(self):
+        # risikofreude is slider 1–5.
+        r = normalize_field("risikofreude", "3", {}, "r1")
+        assert r.confidence == "high"
+        assert r.value == 3
+
+    def test_bool_short_value_passes(self):
+        # datenschutzbeauftragter is enum but answered with short tokens.
+        r = normalize_field("datenschutzbeauftragter", "nein", {}, "r1")
+        assert r.confidence == "high"
+
+
+class TestMarkersSet:
+    """Sanity: marker set contains the canonical phrases from the bug report."""
+
+    def test_expected_markers_present(self):
+        expected = {"siehe oben", "s.o.", "wie oben", "dito", "idem", "ebenso"}
+        missing = expected - _LOW_QUALITY_TEXT_MARKERS
+        assert not missing, f"missing markers: {missing}"


### PR DESCRIPTION
## Summary
Implements a quality validator for freetext chat fields that rejects low-quality answers (e.g., "siehe oben", "dito", or stubs with fewer than 3 words) so the chat re-asks instead of silently accepting placeholder content.

## Key Changes
- **New `is_low_quality_text()` function**: Detects degenerate freetext answers by checking for:
  - Case-insensitive marker phrases ("siehe oben", "s.o.", "wie oben", "dito", "idem", "ebenso")
  - Answers with fewer than 3 whitespace-separated tokens
  - Handles prefix matching (e.g., "siehe oben, Punkt 2" is still flagged)

- **Integration in `normalize_field()`**: Applies the validator only to freetext fields (`chat_mode="FT"`) to avoid interfering with:
  - Enum/bool fields (where short tokens like "ja", "nein" are valid)
  - Slider/numeric fields (where single digits like "5" are valid)
  - The existing "keine_angabe" skip path (required for Bug 3 fix)

- **Comprehensive test suite**: 149 lines of tests covering:
  - Marker variant detection (case variations, punctuation)
  - Word count threshold validation
  - Integration with text vs. non-text field types
  - Preservation of existing "keine_angabe" behavior

## Implementation Details
- Low-quality answers return `NormResult(None, "low", True)` to trigger re-ask
- Marker matching is case-insensitive and strips trailing punctuation
- Validator only fires on fields with `chat_mode="FT"` to maintain backward compatibility
- Includes logging for debugging rejected answers

https://claude.ai/code/session_01VfiRYYLYWWdTKptF1eLV8g