### PR TITLE
fix(chat): pre-Haiku pointer guard so "siehe oben" actually re-asks

### DIFF
--- a/routes/chat.py
+++ b/routes/chat.py
@@ -57,6 +57,7 @@ from services.chat_normalizer import (
     get_registry_for_report,
     get_sections_for_report,
     is_field_visible,
+    is_pointer_phrase,
     is_section_complete,
     normalize_field,
 )
@@ -791,6 +792,25 @@ async def chat_message(req: ChatMessageRequest, db: Session = Depends(get_db)):
                 _no_extraction = True
                 log.info("[CHAT] Help request detected for field %s, skipping extraction", cur_field)
 
+            # KIS-1161 Hotfix: Pre-Haiku pointer guard. Catch "siehe oben" /
+            # "s.o." / "wie oben" / "dito" / "idem" / "ebenso" at the raw
+            # message layer. Without this, Haiku resolves the pointer against
+            # the conversation context and returns substantive content from an
+            # earlier turn — bypassing the normalizer-level validator.
+            _is_low_quality_input = (
+                not _is_qr_click
+                and not _is_help_request
+                and not _is_edit_request
+                and not _is_in_edit_mode
+                and is_pointer_phrase(req.message)
+            )
+            if _is_low_quality_input:
+                _no_extraction = True
+                log.info(
+                    "[CHAT] Pre-Haiku reject: pointer phrase %r for field %s — re-ask",
+                    req.message, cur_field,
+                )
+
             # Edit-request: user wants to change a field after summary
             if _is_edit_request:
                 _no_extraction = True
@@ -837,8 +857,8 @@ async def chat_message(req: ChatMessageRequest, db: Session = Depends(get_db)):
             _pf = _draft.get("pending_field") if DRAFT_MODE_ENABLED else None
             _pv = _draft.get("pending_value") if DRAFT_MODE_ENABLED else None
 
-            if _is_help_request:
-                # Help request: skip extraction entirely
+            if _is_help_request or _is_low_quality_input:
+                # Skip extraction entirely (pointer phrase or help request).
                 raw_extracted = {"signal": "question", "fields": {}} if DRAFT_MODE_ENABLED else {}
             elif _in_phase_1b and not _is_in_edit_mode and not _is_edit_request:
                 # --- Phase 1: Multi-field extraction ---
@@ -1663,6 +1683,29 @@ async def chat_message(req: ChatMessageRequest, db: Session = Depends(get_db)):
                 f"Der Nutzer möchte eine Angabe ändern, aber die Angabe war nicht eindeutig.\n"
                 f"Aktuelle Felder:\n{field_list}\n\n"
                 f"Fragen Sie den Nutzer, welches Feld geändert werden soll und auf welchen Wert."
+            )
+
+        # KIS-1161 Hotfix: Pointer phrase ("siehe oben", "dito", …) — ask
+        # Sonnet to re-pose the question with a constructive nudge so the
+        # user gives a substantive answer for THIS field. Constructive, not
+        # accusatory; keep the original question intact.
+        if _is_low_quality_input and not _help_ctx and _asked_field:
+            _lq_label = (
+                FIELD_DESCRIPTIONS.get(_asked_field, _asked_field)
+                .split("(")[0].strip()
+            )
+            _help_ctx = (
+                f"\n\nAKTUELLER MODUS: KONKRETISIERUNG GEWÜNSCHT\n"
+                f"Der Nutzer hat mit einem Verweis (z.B. 'siehe oben', 's.o.', "
+                f"'dito') auf eine frühere Antwort verwiesen, statt eine eigene "
+                f"Antwort für \"{_lq_label}\" zu geben. Jede Frage erfasst einen "
+                f"anderen Aspekt, daher brauchen wir hier eine spezifische Angabe.\n"
+                f"REAGIERE SO:\n"
+                f"- Stelle die ursprüngliche Frage erneut, klar und konkret.\n"
+                f"- Ergänze einen kurzen Hinweis, dass eine eigene Formulierung "
+                f"hier hilft (z.B. 'Können Sie das in einem Satz konkretisieren?').\n"
+                f"- Konstruktiv und einladend, NICHT vorwurfsvoll.\n"
+                f"- Maximal 2 Sätze total."
             )
 
         # KIS-1124-S0-BE-2: When user declines a field, tell Sonnet

--- a/services/chat_normalizer.py
+++ b/services/chat_normalizer.py
@@ -38,9 +38,10 @@ class NormResult:
 # for those types.
 # ===========================================================================
 
-# Case-insensitive substrings that mark a freetext answer as a pointer to an
-# earlier answer rather than substance. Matched after lower-case + stripping
-# trailing punctuation.
+# Pointer markers — canonical user-typed spellings. Compared after both
+# sides are normalised by ``_normalise_for_marker`` (lower-case, strip
+# whitespace + trailing ASCII punctuation). The pre-computed
+# ``_MARKERS_NORMALISED`` set is what membership checks actually use.
 _LOW_QUALITY_TEXT_MARKERS: frozenset[str] = frozenset({
     "siehe oben",
     "s.o.",
@@ -52,13 +53,50 @@ _LOW_QUALITY_TEXT_MARKERS: frozenset[str] = frozenset({
 })
 
 
+def _normalise_for_marker(text: str) -> str:
+    """Lower-case, strip whitespace, then strip trailing ASCII punctuation.
+
+    Used on both marker definitions and incoming messages so dot-bearing
+    abbreviations like "s.o." compare equal to "S.O." or "s.o" after a
+    user's stray comma.
+    """
+    return text.strip().lower().rstrip(" .!?,;:")
+
+
+_MARKERS_NORMALISED: frozenset[str] = frozenset(
+    _normalise_for_marker(m) for m in _LOW_QUALITY_TEXT_MARKERS
+)
+
+
+def is_pointer_phrase(message: str) -> bool:
+    """True when *message* (lower + trailing punctuation stripped) exactly
+    matches a pointer marker like "siehe oben" / "s.o." / "dito".
+
+    Used as a pre-Haiku guard in routes/chat.py so the extractor never gets a
+    chance to silently resolve the pointer against the conversation context
+    and substitute substantive content from an earlier turn. The normalizer
+    sees the raw value too, so this acts as defense-in-depth — but the
+    normalizer alone cannot stop Haiku from resolving the pointer first.
+    """
+    if not message:
+        return False
+    normalised = _normalise_for_marker(str(message))
+    if not normalised:
+        return False
+    return normalised in _MARKERS_NORMALISED
+
+
 def is_low_quality_text(raw: str, min_words: int = 3) -> bool:
     """Return True if *raw* should be rejected as a substantive freetext answer.
 
     A value is "low quality" when it either
-      1. matches one of ``_LOW_QUALITY_TEXT_MARKERS`` (case-insensitive,
-         ignoring trailing punctuation), or
+      1. exactly matches one of ``_LOW_QUALITY_TEXT_MARKERS`` (case-insensitive,
+         after stripping trailing punctuation/whitespace), or
       2. has fewer than ``min_words`` whitespace-separated tokens.
+
+    Exact-match (no prefix-match) on purpose — sentences that *start* with a
+    pointer phrase but continue substantively (e.g. "Dito wie bei X, plus …")
+    must pass through. The word-count rule still catches stubby variants.
     """
     if raw is None:
         return True
@@ -66,15 +104,9 @@ def is_low_quality_text(raw: str, min_words: int = 3) -> bool:
     if not cleaned:
         return True
 
-    # Normalise for marker match: lower + trim trailing punctuation / whitespace.
-    normalised = cleaned.lower().rstrip(" .!?,;:")
-    if normalised in _LOW_QUALITY_TEXT_MARKERS:
+    normalised = _normalise_for_marker(cleaned)
+    if normalised in _MARKERS_NORMALISED:
         return True
-    # Some markers also appear as prefixes ("s.o." followed by explanation is
-    # rare, but "siehe oben, Punkt 2" should still be flagged).
-    for marker in _LOW_QUALITY_TEXT_MARKERS:
-        if normalised.startswith(marker):
-            return True
 
     if len(cleaned.split()) < min_words:
         return True

--- a/tests/test_kis_1161_quality_validator.py
+++ b/tests/test_kis_1161_quality_validator.py
@@ -1,20 +1,26 @@
 # -*- coding: utf-8 -*-
 """
-KIS-1161: Freitext-Quality-Validator.
+KIS-1161 + KIS-1161-Hotfix: Freitext-Quality-Validator.
 
-Rejects low-quality freetext answers ("siehe oben", <3 word stubs) so the
-chat re-asks instead of silently marking the field as answered.
+Two-layer defense against low-quality freetext answers:
+  1. ``is_pointer_phrase`` — exact-match guard, called pre-Haiku in
+     routes/chat.py so the extractor never gets to silently resolve
+     "siehe oben" against the conversation context.
+  2. ``is_low_quality_text`` (+ in-tree call from ``normalize_field``) —
+     defense-in-depth at the normalizer layer for the case where Haiku
+     does forward the literal pointer string.
 
 Must NOT interfere with:
   - enum / bool / multi answers (ja / nein / nö / multi-select values)
   - slider / numeric values ("5", 7)
   - QR clicks (already normalised to canonical enum values upstream)
-  - The existing "keine_angabe" skip path (required for Bug 3 fix).
+  - The existing "keine_angabe" skip path (required for KIS-1160 fix).
 """
 
 import pytest
 
 from services.chat_normalizer import (
+    is_pointer_phrase,
     is_low_quality_text,
     normalize_field,
     _LOW_QUALITY_TEXT_MARKERS,
@@ -22,11 +28,11 @@ from services.chat_normalizer import (
 
 
 # ---------------------------------------------------------------------------
-# is_low_quality_text — unit level
+# is_pointer_phrase — pre-Haiku gate, exact-match only
 # ---------------------------------------------------------------------------
 
-class TestLowQualityMarkers:
-    """Bug reproducer inputs must be classified low-quality."""
+class TestIsPointerPhrase:
+    """Exact-match (after lower + trailing punctuation strip)."""
 
     @pytest.mark.parametrize("raw", [
         "siehe oben",
@@ -34,7 +40,55 @@ class TestLowQualityMarkers:
         "SIEHE OBEN",
         "siehe oben.",
         "siehe oben!",
-        "Siehe oben, Punkt 2",
+        "siehe oben,",
+        "  siehe oben  ",
+        "s.o.",
+        "S.O.",
+        "s. o.",
+        "wie oben",
+        "Wie oben.",
+        "dito",
+        "Dito!",
+        "idem",
+        "ebenso",
+    ])
+    def test_pointer_detected(self, raw):
+        assert is_pointer_phrase(raw), f"should be pointer: {raw!r}"
+
+    @pytest.mark.parametrize("raw", [
+        # Substantive sentences that *start* with a pointer phrase but
+        # continue with content — must pass through (the user explicitly
+        # asked for this in the KIS-1161 hotfix spec).
+        "Dito wie bei den Zielen, plus Marktreichweite ausbauen",
+        "Siehe oben, Punkt 2 ist mein Hauptfokus für 2026",
+        "Wie oben beschrieben, aber zusätzlich Compliance-Themen",
+        # Common short answers that must not be misread as pointers.
+        "ja",
+        "nein",
+        "nö",
+        "5",
+        "Beratung",
+        "API-Entwicklung für KMU",
+        "",
+        " ",
+    ])
+    def test_not_pointer(self, raw):
+        assert not is_pointer_phrase(raw), f"false pointer: {raw!r}"
+
+
+# ---------------------------------------------------------------------------
+# is_low_quality_text — exact-match + min-words rule (no prefix-match)
+# ---------------------------------------------------------------------------
+
+class TestLowQualityMarkers:
+    """Pointer markers (exact match) classified as low quality."""
+
+    @pytest.mark.parametrize("raw", [
+        "siehe oben",
+        "Siehe oben",
+        "SIEHE OBEN",
+        "siehe oben.",
+        "siehe oben!",
         "s.o.",
         "S.O.",
         "s. o.",
@@ -47,6 +101,18 @@ class TestLowQualityMarkers:
     ])
     def test_marker_variants_rejected(self, raw):
         assert is_low_quality_text(raw), f"should reject: {raw!r}"
+
+    @pytest.mark.parametrize("raw", [
+        # Sentences that *start* with a marker but have substance afterwards
+        # MUST pass — exact-match only (KIS-1161 hotfix).
+        "Dito wie bei den Zielen, plus Marktreichweite",
+        "Siehe oben, Punkt 2 ist mein Fokus für 2026",
+        "Wie oben beschrieben plus Compliance",
+    ])
+    def test_marker_with_continuation_accepted(self, raw):
+        # is_low_quality_text uses both the marker check AND the word-count
+        # rule. These have ≥3 words and don't exactly match a marker.
+        assert not is_low_quality_text(raw), f"false reject: {raw!r}"
 
 
 class TestWordCountThreshold:
@@ -68,7 +134,7 @@ class TestWordCountThreshold:
     @pytest.mark.parametrize("raw", [
         "Beratung im Mittelstand",                     # 3 words
         "Wir bieten KI-Beratung für Solo-Selbstständige",
-        "Content-Generierung, Datenanalyse, Proposal-Automation",  # comma-sep
+        "Content-Generierung, Datenanalyse, Proposal-Automation",
         "White-Label-Tool, Branchen-Reports und Proposal-Generator",
     ])
     def test_substantive_accepted(self, raw):
@@ -102,17 +168,25 @@ class TestNormalizeFieldTextFT:
         assert r.confidence == "low"
 
     def test_keine_angabe_still_passes(self):
-        # Bug-3 skip path must stay intact.
+        # KIS-1160 skip path must stay intact.
         r = normalize_field("strategische_ziele", "keine_angabe", {}, "r1")
         assert r.confidence == "high"
         assert r.value == ""
+
+    def test_marker_with_continuation_accepted(self):
+        # KIS-1161 hotfix: pointer phrase as prefix + substance must pass.
+        r = normalize_field(
+            "strategische_ziele",
+            "Dito wie bei den Zielen, plus Marktreichweite ausbauen",
+            {}, "r1",
+        )
+        assert r.confidence == "high"
 
 
 class TestNormalizeFieldNonText:
     """Enum / bool / slider / multi must be unaffected by KIS-1161."""
 
     def test_enum_ja_passes(self):
-        # roadmap_vorhanden is enum("ja","teilweise","nein","unklar").
         r = normalize_field("roadmap_vorhanden", "ja", {}, "r1")
         assert r.confidence == "high"
         assert r.value == "ja"
@@ -123,19 +197,16 @@ class TestNormalizeFieldNonText:
         assert r.value == "nein"
 
     def test_slider_single_digit_passes(self):
-        # digitalisierungsgrad is slider 1–10.
         r = normalize_field("digitalisierungsgrad", "5", {}, "r1")
         assert r.confidence == "high"
         assert r.value == 5
 
     def test_risikofreude_single_digit_passes(self):
-        # risikofreude is slider 1–5.
         r = normalize_field("risikofreude", "3", {}, "r1")
         assert r.confidence == "high"
         assert r.value == 3
 
     def test_bool_short_value_passes(self):
-        # datenschutzbeauftragter is enum but answered with short tokens.
         r = normalize_field("datenschutzbeauftragter", "nein", {}, "r1")
         assert r.confidence == "high"
 
@@ -147,3 +218,56 @@ class TestMarkersSet:
         expected = {"siehe oben", "s.o.", "wie oben", "dito", "idem", "ebenso"}
         missing = expected - _LOW_QUALITY_TEXT_MARKERS
         assert not missing, f"missing markers: {missing}"
+
+
+# ---------------------------------------------------------------------------
+# Live-path regression: the normalizer-only fix (KIS-1161 v1) was bypassed
+# in production because Haiku resolved the pointer to substantive content
+# *before* normalize_field saw it. The pre-Haiku gate at routes/chat.py
+# is the actual fix; this section guards against regressions where someone
+# accidentally removes the routes-level guard or routes around it.
+# ---------------------------------------------------------------------------
+
+class TestLivePathRegressionGuard:
+    """Verify the routes-level helper is in place and reachable.
+
+    A truly faithful integration test would spin up the FastAPI app + DB +
+    mock the Anthropic client. That's heavy; the practical guard is to
+    assert (a) the helper exists, (b) the routes module imports it, and
+    (c) the flag the guard sets is referenced where it must be.
+    """
+
+    def test_routes_imports_pre_haiku_guard(self):
+        # Importing the helper from routes.chat catches any accidental
+        # removal of the import at the top of the file.
+        from routes.chat import is_pointer_phrase as routes_helper
+        assert routes_helper is is_pointer_phrase
+
+    def test_routes_chat_references_low_quality_input_flag(self):
+        # The flag _is_low_quality_input must be both *set* (pre-extraction)
+        # and *consulted* (extraction-skip + help_ctx). Catches reverts that
+        # only remove one usage.
+        import inspect
+        import routes.chat as chat_module
+        src = inspect.getsource(chat_module)
+        # Set: assignment expression appears.
+        assert "_is_low_quality_input = (" in src, (
+            "Pre-Haiku guard assignment missing — KIS-1161 hotfix regression."
+        )
+        # Consult: extraction-skip branch and help_ctx branch.
+        assert "_is_help_request or _is_low_quality_input" in src, (
+            "Extraction-skip does not honour _is_low_quality_input."
+        )
+        assert "if _is_low_quality_input and not _help_ctx" in src, (
+            "Sonnet help_ctx for low-quality input is missing."
+        )
+
+    def test_pointer_phrase_independent_of_haiku(self):
+        # Whatever Haiku might *resolve* the pointer to, the pre-Haiku
+        # gate fires on the raw user message — Haiku is bypassed entirely.
+        # This test documents the contract by checking the helper directly
+        # on the exact bug-report inputs.
+        for raw in ("siehe oben", "s.o.", "wie oben", "dito"):
+            assert is_pointer_phrase(raw), (
+                f"pointer guard would not catch live input {raw!r}"
+            )


### PR DESCRIPTION
The KIS-1161 v1 fix put the validator at the normalizer layer only. In production Haiku silently resolves pointer phrases against the conversation context and forwards the substantive earlier-turn content, so normalize_field never sees the pointer string and the chat happily moves on. Live smoke test confirmed the bypass.

This hotfix:
- Adds is_pointer_phrase() — exact-match guard (lower + trailing-punct strip) for "siehe oben" / "s.o." / "wie oben" / "dito" / "idem" / "ebenso", computed via _normalise_for_marker on both sides so dot- bearing abbreviations compare correctly.
- Calls the guard in routes/chat.py *before* the extract_fields call, same gate as _is_help_request: sets _no_extraction=True, skips Haiku entirely, no DB write.
- Injects a constructive Sonnet help_ctx ("Können Sie das in einem Satz konkretisieren?") so the re-ask is inviting, not accusatory, and re-poses the original question.
- Removes the prefix-match in is_low_quality_text so longer sentences that *start* with a pointer phrase ("Dito wie bei X, plus …") pass through. Word-count rule still catches stubs.
- Live-path regression guard tests assert the routes module imports the helper, sets _is_low_quality_input, and consults it both at the extraction-skip site and the help_ctx site. A revert that drops any one of these turns the test red.

Bug 3 (KIS-1160) regressions: ja/nein/nö/numeric/QR-click paths all remain green (74 + 33 = 107 tests pass).

KIS-1161 hotfix.

https://claude.ai/code/session_01VfiRYYLYWWdTKptF1eLV8g