### PR TITLE
hotfix(chat): default-init _is_low_quality_input to fix QR-click crash

### DIFF
--- a/routes/chat.py
+++ b/routes/chat.py
@@ -593,6 +593,11 @@ async def chat_message(req: ChatMessageRequest, db: Session = Depends(get_db)):
         _no_extraction = False  # True when free-text yielded no field extraction (user asked a question)
         _asked_field = ""  # The field that was being asked when the user sent this message
         _report_start_requested = False  # True when user clicked "Auswertung starten"
+        # KIS-1161 hotfix v2: must be defined for ALL turn paths (QR click, edit
+        # mode, …), not only the free-text branch where the pre-Haiku gate
+        # lives. Reading this flag before the free-text branch runs would
+        # otherwise raise UnboundLocalError on every QR-click turn.
+        _is_low_quality_input = False
 
         _is_qr_click = bool(req.quick_reply_field and req.quick_reply_value)
         _is_help_request = "__HELP_REQUEST__" in req.message

--- a/tests/test_kis_1161_quality_validator.py
+++ b/tests/test_kis_1161_quality_validator.py
@@ -262,6 +262,36 @@ class TestLivePathRegressionGuard:
             "Sonnet help_ctx for low-quality input is missing."
         )
 
+    def test_low_quality_input_initialised_before_qr_branch(self):
+        """KIS-1161 hotfix v2: variable must default to False *before* the
+        ``if _is_qr_click`` branch — otherwise a QR-click turn reaches the
+        downstream ``if _is_low_quality_input ...`` read with the name
+        unbound and crashes with UnboundLocalError. Production blocker."""
+        import inspect
+        import routes.chat as chat_module
+        src = inspect.getsource(chat_module)
+
+        init_idx = src.find("_is_low_quality_input = False")
+        qr_branch_idx = src.find("if _is_qr_click:")
+        guard_assign_idx = src.find("_is_low_quality_input = (")
+        helpctx_read_idx = src.find("if _is_low_quality_input and not _help_ctx")
+
+        assert init_idx != -1, (
+            "Default initialisation '_is_low_quality_input = False' missing."
+        )
+        assert qr_branch_idx != -1, "QR-click branch went missing."
+        assert guard_assign_idx != -1, "Pre-Haiku guard assignment went missing."
+        assert helpctx_read_idx != -1, "help_ctx read of the flag went missing."
+
+        assert init_idx < qr_branch_idx, (
+            "Default init must come BEFORE the QR-click branch — without "
+            "it, a QR turn never enters the free-text branch where the "
+            "flag is otherwise assigned, then crashes at the help_ctx read."
+        )
+        assert init_idx < helpctx_read_idx, (
+            "Default init must come BEFORE the help_ctx read."
+        )
+
     def test_pointer_phrase_independent_of_haiku(self):
         # Whatever Haiku might *resolve* the pointer to, the pre-Haiku
         # gate fires on the raw user message — Haiku is bypassed entirely.


### PR DESCRIPTION
KIS-1161 v2 (e731a5c) only assigned _is_low_quality_input inside the free-text branch of /api/chat/message. Every QR-button turn skipped that branch, then hit the downstream "if _is_low_quality_input and not _help_ctx and _asked_field" read with the name unbound, raising UnboundLocalError and crashing the entire SSE stream.

Production blocker — every chat turn was failing.

Minimal hotfix: declare _is_low_quality_input = False alongside the other turn-state defaults (right after _report_start_requested), so all paths see a sane value. The free-text branch still overrides it when the pointer guard fires.

Regression test asserts that the default initialisation appears *before* the QR-click branch in the source. A revert that moves the init below the branch (or removes it entirely) turns the test red.

KIS-1161 hotfix v2.

https://claude.ai/code/session_01VfiRYYLYWWdTKptF1eLV8g