### PR TITLE
feat(chat): add display_section_title as single source of truth

### DIFF
--- a/docs/MINI_TICKETS_OPEN.md
+++ b/docs/MINI_TICKETS_OPEN.md
@@ -1,0 +1,32 @@
+# Open Mini-Tickets
+
+Small observations discovered during smoke tests that are not production
+blockers. Each entry should be picked up as its own lightweight commit.
+
+## SSE-STREAM-TRUNCATION — Bot message starts mid-word
+
+**Observed:** 2026-04-19, KIS-1162 smoke test session.
+**Symptom:** A Sonnet response began with `"e Vision!"` — most likely a
+truncation of `"Tolle Vision!"` where the stream dropped the first tokens
+before rendering.
+**Bug severity:** cosmetic; message content downstream is intact.
+**Reporter:** smoke-test run after KIS-1161 hotfix v2 merge.
+
+**Suspected area:**
+- `services/chat_conversation.py::generate_response` — streams via
+  `client.messages.stream(...)` and yields each `text_stream` chunk.
+- `routes/chat.py::_token_producer` → SSE `event: token` frames.
+- Frontend (`make-ki-frontend`) may drop early tokens if a connection
+  races with the `event: typing` indicator.
+
+**Diagnosis starting points:**
+1. Add a debug log at the first `yield text` in `generate_response` to
+   confirm whether the backend emits the full prefix.
+2. Check the `_post_process_response` pass (`routes/chat.py`, called right
+   before `text_replace`) — whether any sanitiser eats leading characters
+   when the response starts with a confirmation word already in a
+   forbidden-patterns regex.
+3. Inspect the `text_replace` event payload vs. the accumulated tokens
+   in the frontend — mismatches point to a client-side drop.
+
+**Not a blocker.** Park until after KIS-1163 (Bug 6) ships.

--- a/routes/chat.py
+++ b/routes/chat.py
@@ -3243,12 +3243,20 @@ def _build_session_state(
         _blk_total = len(_blk_all) - _skip_count
         _blk_progress = len([f for f in _blk_all if f in collected]) - _skip_count
 
+    # KIS-1162: Single source of truth for the UI section header. In Phase 2
+    # the legacy current_section_name lags behind because sections don't align
+    # with the hybrid thematic blocks. block_label, when present, always names
+    # the currently active block; otherwise we fall back to the legacy label,
+    # which is correct for Phase 1 / checkpoint / summary / strategy flows.
+    display_section_title = _blk_label or section_name
+
     return ChatSessionState(
         session_id=session.id,
         report_type=session.report_type,
         status=session.status,
         current_section=section_idx,
         current_section_name=section_name,
+        display_section_title=display_section_title,
         total_sections=len(sections),
         progress_percent=calculate_progress(collected, rt),
         collected_fields=collected,

--- a/schemas/chat.py
+++ b/schemas/chat.py
@@ -55,6 +55,13 @@ class ChatSessionState(BaseModel):
     # Progress
     current_section: int
     current_section_name: str
+    # KIS-1162: Single source of truth for the UI section header. Computed
+    # server-side as ``block_label or current_section_name`` so the header
+    # tracks the active Phase-2 block instead of the legacy 8-section index
+    # (which lags behind in the hybrid conversation model). Always populated;
+    # falls back to current_section_name outside Phase 2. Frontend should
+    # prefer this field over current_section_name for display.
+    display_section_title: str
     total_sections: int = 8
     progress_percent: int
 

--- a/tests/test_kis_1162_display_section_title.py
+++ b/tests/test_kis_1162_display_section_title.py
@@ -1,0 +1,176 @@
+# -*- coding: utf-8 -*-
+"""
+KIS-1162: ``display_section_title`` as single source of truth for the
+section header displayed in the chat UI.
+
+Rule:  display_section_title = block_label or current_section_name.
+
+- Phase 1 / checkpoint / summary / strategy: falls back to
+  ``current_section_name`` (legacy 8-section label).
+- Phase 2 with an active block: ``block_label`` wins — the label tracks
+  the actual block the user is in, not the lag-behind section index.
+
+``current_section_name`` is preserved unchanged for backwards
+compatibility; the frontend can migrate to ``display_section_title``
+in its own time.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+from uuid import UUID, uuid4
+
+from routes.chat import _build_session_state
+
+
+@dataclass
+class _FakeChatSession:
+    """Lightweight stand-in for ``models.ChatSession`` that only exposes the
+    attributes ``_build_session_state`` actually reads. Avoids spinning up a
+    real SQLAlchemy model + DB session for a pure-projection test."""
+
+    report_type: str = "r1"
+    status: str = "active"
+    current_section: int = 0
+    collected_fields: dict = field(default_factory=dict)
+    draft_state: dict = field(default_factory=dict)
+    phase_state: dict = field(default_factory=dict)
+    messages: list = field(default_factory=list)
+    id: UUID = field(default_factory=uuid4)
+
+
+def _make_session(**overrides: Any) -> _FakeChatSession:
+    base = _FakeChatSession()
+    for k, v in overrides.items():
+        setattr(base, k, v)
+    return base
+
+
+# ---------------------------------------------------------------------------
+# Test A — Phase 1: display_section_title falls back to current_section_name
+# ---------------------------------------------------------------------------
+
+class TestDisplayTitlePhase1:
+    """No block active → display_section_title == current_section_name."""
+
+    def test_phase_1_uses_legacy_section_name(self):
+        session = _make_session(
+            current_section=0,
+            phase_state={"conversation_phase": "phase_1"},
+        )
+        state = _build_session_state(session)
+
+        assert state.display_section_title
+        assert state.current_section_name
+        assert state.display_section_title == state.current_section_name, (
+            "Phase 1 must fall back to current_section_name."
+        )
+        # block_label is still None in Phase 1 — core contract.
+        assert state.block_label is None
+
+    def test_phase_1a_uses_legacy_section_name(self):
+        session = _make_session(
+            current_section=0,
+            phase_state={
+                "conversation_phase": "phase_1",
+                "phase_1_qr_complete": False,
+            },
+        )
+        state = _build_session_state(session)
+        assert state.display_section_title == state.current_section_name
+
+    def test_checkpoint_uses_legacy_section_name(self):
+        # Between Phase 1 and Phase 2, no block selected yet → no block_label.
+        session = _make_session(
+            current_section=2,
+            phase_state={"conversation_phase": "checkpoint"},
+        )
+        state = _build_session_state(session)
+        assert state.block_label is None
+        assert state.display_section_title == state.current_section_name
+
+
+# ---------------------------------------------------------------------------
+# Test B — Phase 2 Block B: display_section_title == block_label
+# ---------------------------------------------------------------------------
+
+class TestDisplayTitlePhase2Block:
+    """Active block → display_section_title == block_label, not the lagging
+    current_section_name. This is the exact bug reproducer."""
+
+    def test_phase_2_block_b_overrides_legacy_section(self):
+        session = _make_session(
+            # current_section deliberately lags — e.g. Section 1
+            # "Organisation & Datenlage" — while the user is already in
+            # Block B ("KI-Strategie & Roadmap").
+            current_section=1,
+            phase_state={
+                "conversation_phase": "phase_2",
+                "current_block": "B",
+                "selected_blocks": ["B"],
+            },
+        )
+        state = _build_session_state(session)
+
+        # Legacy label stays where it is (backwards compat).
+        assert state.current_section_name == "Organisation & Datenlage"
+        # block_label is the block we're actually in.
+        assert state.block_label == "KI-Strategie & Roadmap"
+        # display_section_title follows the block, not the stale section.
+        assert state.display_section_title == "KI-Strategie & Roadmap"
+        assert state.display_section_title != state.current_section_name, (
+            "Regression: Bug 5 would re-surface if these became equal "
+            "in a Phase-2-Block-B session."
+        )
+
+    def test_phase_2_each_block_resolves_correctly(self):
+        expected = {
+            "A": "Fördermittel & Budget",
+            "B": "KI-Strategie & Roadmap",
+            "C": "Tools & Automatisierung",
+            "D": "Recht & Datenschutz",
+        }
+        for block_id, label in expected.items():
+            session = _make_session(
+                current_section=3,
+                phase_state={
+                    "conversation_phase": "phase_2",
+                    "current_block": block_id,
+                    "selected_blocks": [block_id],
+                },
+            )
+            state = _build_session_state(session)
+            assert state.display_section_title == label, (
+                f"Block {block_id}: expected {label!r}, got {state.display_section_title!r}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Sanity: existing field shape unchanged, strategy flow unaffected
+# ---------------------------------------------------------------------------
+
+class TestBackwardsCompat:
+    """Legacy callers + strategy flow must stay unaffected."""
+
+    def test_current_section_name_still_populated(self):
+        session = _make_session(
+            current_section=0,
+            phase_state={"conversation_phase": "phase_1"},
+        )
+        state = _build_session_state(session)
+        # Field exists and is non-empty — no regression on the legacy key.
+        assert state.current_section_name
+        assert isinstance(state.current_section_name, str)
+
+    def test_strategy_falls_back_to_legacy(self):
+        # Strategy has no phase_state and no blocks — block_label is always
+        # None, so display_section_title must track current_section_name.
+        session = _make_session(
+            report_type="strategy",
+            current_section=0,
+            phase_state={},
+        )
+        state = _build_session_state(session)
+        assert state.block_label is None
+        assert state.display_section_title == state.current_section_name


### PR DESCRIPTION
Before this commit the chat UI had to pick between two backend fields for its section header — current_section_name (legacy 8-section label) and block_label (Phase-2 block) — and in Phase 2 those often diverge because the legacy section index lags behind the active thematic block. Smoke test 2026-04-19 reproduced the mismatch: header showed "Organisation & Datenlage" while the progress strip already said "KI-Strategie & Roadmap 1/10".

Fix: derive the canonical header server-side and expose it as a new field. Rule is intentionally minimal:

  display_section_title = block_label or current_section_name

which resolves to the active block whenever one is set, and falls back to the legacy label in Phase 1 / checkpoint / summary / strategy flows (where block_label is always None).

- schemas/chat.py: new required string field on ChatSessionState.
- routes/chat.py: computed in _build_session_state and passed through; current_section_name stays unchanged for backwards compatibility so the frontend can migrate at its own pace.
- Two integration-style tests use a lightweight fake session to exercise both branches of the or-rule: Phase 1 falls back to the legacy name, Phase 2 / Block B yields "KI-Strategie & Roadmap" even when current_section_name still lags at "Organisation & Datenlage" — the exact bug-5 reproducer.
- docs/MINI_TICKETS_OPEN.md: parks the "e Vision!" SSE-truncation observation from the same smoke session for a later, separate commit.

No frontend change in this commit.

KIS-1162.

https://claude.ai/code/session_01VfiRYYLYWWdTKptF1eLV8g