### PR TITLE
fix(chat): pin Block D to DSGVO + detect natural help-requests

### DIFF
--- a/docs/MINI_TICKETS_OPEN.md
+++ b/docs/MINI_TICKETS_OPEN.md
@@ -30,3 +30,30 @@ before rendering.
    in the frontend — mismatches point to a client-side drop.
 
 **Not a blocker.** Park until after KIS-1163 (Bug 6) ships.
+
+
+## CHAT-EVENT-STREAM-INTEGRATION-TEST — Tier 4 coverage
+
+**Context:** KIS-1161 / KIS-1162 / KIS-1163 regressions were caught by
+unit tests plus ``inspect.getsource`` wire-up checks. That is pragmatic
+but incomplete — Tier 4 would mean an end-to-end test that actually
+drives ``POST /api/chat/message`` through FastAPI ``TestClient`` with a
+mocked ``anthropic.AsyncAnthropic`` client, reads the SSE stream, and
+asserts observable behaviour (state_update, help_ctx inclusion, field
+progression).
+
+**Estimated effort:** ~200 LOC + fixtures. Likely reusable for:
+- KIS-1161 (pointer guard end-to-end)
+- KIS-1162 (display_section_title in a live Phase-2-Block-B session)
+- KIS-1163 (natural help_request → build_help_context wiring)
+- Future chat-flow changes.
+
+**Starting points:**
+- ``tests/test_g17_7_prompt_stability.py`` + ``tests/test_report_workflow.py``
+  already use ``TestClient`` elsewhere in the codebase.
+- SQLite in-memory DB is wired in ``tests/conftest.py``.
+- Mock target: ``services.chat_extractor._get_async_client`` and
+  ``services.chat_conversation._get_async_client`` — swap with stubs
+  that yield deterministic tool-use / text-stream responses.
+
+**Priority:** medium. Non-blocking for shipping. Schedule for KW 17/18.

--- a/routes/chat.py
+++ b/routes/chat.py
@@ -112,6 +112,45 @@ def is_skip_word(message: str) -> bool:
     """True when *message* (after strip+lower) is an exact skip word."""
     return message.strip().lower() in SKIP_WORDS
 
+
+# ---------------------------------------------------------------------------
+# Help-Request detection (KIS-1163)
+# ---------------------------------------------------------------------------
+# Natural-language hints that tell us the user is asking for clarification
+# rather than answering. Previously only the explicit "__HELP_REQUEST__"
+# sentinel (injected by the frontend help button) fired this path, so
+# sentences like "welche gibt es denn?" fell through to the generic
+# Haiku-skip path and Sonnet drifted onto the broadest related topic
+# (DSGVO → EU AI Act). When any hint matches, event_stream routes through
+# build_help_context, which pins the currently-asked field in the prompt.
+_HELP_REQUEST_HINTS: frozenset[str] = frozenset({
+    "welche gibt es",
+    "welche möglichkeiten",
+    "was meinst du",
+    "was meinen sie",
+    "wie meinst du das",
+    "wie meinen sie das",
+    "was bedeutet",
+    "was heißt das",
+    "erkläre mir",
+    "erklär mir",
+    "kannst du erklären",
+    "können sie erklären",
+    "gib mir beispiele",
+    "nenne mir beispiele",
+})
+
+
+def is_natural_help_request(message: str) -> bool:
+    """True when *message* reads like a clarification request in natural
+    German — used in addition to the explicit ``__HELP_REQUEST__`` sentinel
+    so free-form rückfragen also trigger the field-specific help flow."""
+    if not message:
+        return False
+    msg_lower = message.strip().lower()
+    return any(h in msg_lower for h in _HELP_REQUEST_HINTS)
+
+
 # ---------------------------------------------------------------------------
 # KIS-1124 Sprint 2: Hybrid Conversation Model — Phase & Block Definitions
 # ---------------------------------------------------------------------------
@@ -600,7 +639,13 @@ async def chat_message(req: ChatMessageRequest, db: Session = Depends(get_db)):
         _is_low_quality_input = False
 
         _is_qr_click = bool(req.quick_reply_field and req.quick_reply_value)
-        _is_help_request = "__HELP_REQUEST__" in req.message
+        # KIS-1163: Sentinel from the frontend help button + natural-language
+        # rückfragen both route through the help-context flow so Sonnet pins
+        # the currently-asked field and cannot drift onto unrelated topics.
+        _is_help_request = (
+            "__HELP_REQUEST__" in req.message
+            or (not _is_qr_click and is_natural_help_request(req.message))
+        )
 
         # Edit-mode detection: check if user wants to change a field after summary
         _is_in_edit_mode = bool(_draft_state_snapshot.get("edit_mode"))

--- a/services/chat_conversation.py
+++ b/services/chat_conversation.py
@@ -562,11 +562,31 @@ FIELD_DESCRIPTIONS: dict[str, str] = {
     "vision_prioritaet": "Wichtigster strategischer Hebel (KI-Services, Kundenservice, Datenprodukte, etc.)",
     "innovationsprozess": "Wie entstehen Innovationen (Team, Mitarbeitende, Kunden, Berater, etc.)",
     # Sektion 6
-    "datenschutzbeauftragter": "Datenschutzbeauftragter vorhanden (Ja / Nein / Teilweise)",
-    "technische_massnahmen": "Technische Schutzmaßnahmen (Alle / Teilweise / Keine)",
-    "folgenabschaetzung": "Datenschutz-Folgenabschätzung durchgeführt (Ja / Nein / In Planung)",
-    "meldewege": "Meldewege bei Sicherheitsvorfällen definiert (Ja / Teilweise / Nein)",
-    "loeschregeln": "Lösch- und Anonymisierungsrichtlinien (Ja / Teilweise / Nein)",
+    # Sektion 6
+    # KIS-1163: DSGVO-spezifische Anker in den Beschreibungen, damit Sonnet
+    # bei Help-Requests und generellen Block-D-Turns nicht auf EU AI Act
+    # abdriftet. Artikelnummern dienen NUR als interner Kontext — die
+    # BLOCK_D_PROMPT-Regel verbietet sie in user-facing Fragen.
+    "datenschutz": "Strategischer Stellenwert von Datenschutz im Unternehmen "
+        "(DSGVO-Konformität, Datenminimierung, Informationspflichten, "
+        "Betroffenenrechte nach Art. 15-22 DSGVO)",
+    "datenschutzbeauftragter": "Datenschutzbeauftragter vorhanden — Benennungspflicht "
+        "nach Art. 37 DSGVO / § 38 BDSG (Ja / Nein / Teilweise)",
+    "technische_massnahmen": "Technische und organisatorische Schutzmaßnahmen (TOMs) "
+        "nach Art. 32 DSGVO — Pseudonymisierung, Verschlüsselung, Zugangs- und "
+        "Zugriffskontrolle, Backup-/Wiederherstellungsstrategien, Rollen- und "
+        "Rechtekonzepte (Alle / Teilweise / Keine)",
+    "folgenabschaetzung": "Datenschutz-Folgenabschätzung (DSFA) nach Art. 35 DSGVO — "
+        "verpflichtend bei Verarbeitungen mit voraussichtlich hohem Risiko für "
+        "Betroffene (Ja / Nein / In Planung)",
+    "meldewege": "Meldewege bei Datenschutzvorfällen nach Art. 33-34 DSGVO — "
+        "interne Eskalation, Meldung an Aufsichtsbehörde binnen 72 Stunden, "
+        "bei hohem Risiko Benachrichtigung betroffener Personen "
+        "(Ja / Teilweise / Nein)",
+    "loeschregeln": "Lösch-, Aufbewahrungs- und Anonymisierungsrichtlinien "
+        "nach Art. 17 DSGVO — dokumentierte Aufbewahrungsfristen pro "
+        "Datenkategorie, Löschkonzepte, Pseudonymisierung bei Erreichen der "
+        "Frist (Ja / Teilweise / Nein)",
     "ai_act_kenntnis": "Kenntnisse zum EU AI Act (Sehr gut / Gut / Gehört / Unbekannt)",
     "regulierte_branche": "Regulierte Branche (Gesundheit, Finanzen, Öffentlich, Recht, etc.)",
     "ki_hemmnisse": "Was bremst aktuell beim KI-Einsatz? "
@@ -1551,12 +1571,24 @@ lange Einleitung.
 - QR-Buttons bei Ja/Nein-Feldern und Auswahl-Feldern.
 - Max 2 Sätze pro Antwort.
 - Bei Beratungsbranche: Nur 1–2 Fragen, dann Block abschließen.
+- KIS-1163 THEMA-TRENNUNG (STRIKT): Dieser Block fragt DSGVO-Themen ab \
+(TOMs, DSB, Meldewege, DSFA, Löschkonzepte). Der EU AI Act ist ein \
+EIGENES Feld ("ai_act_kenntnis") und wird NUR dann erklärt, wenn \
+dieses Feld als aktives NÄCHSTES FELD vorgegeben ist. Bei \
+Rückfragen zu anderen DSGVO-Feldern NIEMALS auf AI Act ausweichen — \
+bleib bei der DSGVO.
+- KIS-1163 ARTIKEL-REGEL (STRIKT): Erwähne DSGVO-Artikelnummern \
+(z.B. "Art. 32 DSGVO", "Art. 35 DSGVO") NIEMALS in user-facing \
+Fragen oder Antworten. Die Artikelnummern in den Feld-Beschreibungen \
+sind NUR dein interner Kontext-Anker. Formuliere User-Fragen immer \
+in klarer Alltagssprache ("Wie sichern Sie Kundendaten technisch \
+ab?" statt "Welche TOMs nach Art. 32 DSGVO haben Sie?").
 
 BEISPIEL-FRAGEN:
-- Beratung: "Haben Sie einen DSB, und wie gut kennen Sie den \
-EU AI Act?"
-- Andere: "Wie ist Ihr Datenschutz aufgestellt — vom DSB bis \
-zu technischen Maßnahmen?"
+- Beratung: "Gibt es einen Datenschutzbeauftragten, und wie sind \
+Mandantendaten abgesichert?"
+- Andere: "Wie ist Ihr Datenschutz aufgestellt — vom DSB bis zu \
+technischen und organisatorischen Maßnahmen (TOMs)?"
 
 NÄCHSTES FELD:
 {next_field_info}

--- a/tests/test_kis_1163_topic_drift.py
+++ b/tests/test_kis_1163_topic_drift.py
@@ -1,0 +1,254 @@
+# -*- coding: utf-8 -*-
+"""
+KIS-1163 — Topic-drift DSGVO → EU AI Act.
+
+Three cooperating scopes:
+
+  1. ``BLOCK_D_PROMPT`` — AI Act no longer primed in example questions;
+     new THEMA-TRENNUNG and ARTIKEL-REGEL rules keep Sonnet on DSGVO and
+     out of user-facing article numbers.
+  2. ``FIELD_DESCRIPTIONS`` — DSGVO-specific anchors (Art. 32 / 35 / 33-34 /
+     17, TOMs, DSFA, 72 h deadline) in the five Block-D data-protection
+     field descriptions so ``build_help_context`` has concrete vocabulary.
+  3. ``_is_help_request`` — natural-language hints ("welche gibt es",
+     "gib mir beispiele" …) now route through the help-context flow in
+     addition to the explicit ``__HELP_REQUEST__`` sentinel.
+"""
+
+from __future__ import annotations
+
+import inspect
+import re
+
+import pytest
+
+from routes.chat import (
+    _HELP_REQUEST_HINTS,
+    is_natural_help_request,
+)
+from services.chat_conversation import (
+    BLOCK_D_PROMPT,
+    FIELD_DESCRIPTIONS,
+    _BLOCK_PROMPTS,
+)
+
+
+# ---------------------------------------------------------------------------
+# Tier 1 — unit-level is_natural_help_request
+# ---------------------------------------------------------------------------
+
+class TestIsNaturalHelpRequest:
+    """Each hint must actually fire; normal answers must not."""
+
+    @pytest.mark.parametrize("msg", [
+        "welche gibt es denn?",
+        "Welche gibt es überhaupt?",
+        "welche möglichkeiten gibt es hier",
+        "was meinst du damit?",
+        "Was meinen Sie damit genau?",
+        "wie meinst du das?",
+        "Wie meinen Sie das?",
+        "was bedeutet das konkret?",
+        "Was heißt das für mich?",
+        "erkläre mir bitte mal",
+        "Erklär mir das kurz",
+        "kannst du erklären, was gemeint ist",
+        "können sie erklären, was DSB bedeutet",
+        "Gib mir Beispiele!",
+        "Nenne mir Beispiele dafür.",
+    ])
+    def test_hints_fire(self, msg):
+        assert is_natural_help_request(msg), f"should fire: {msg!r}"
+
+    @pytest.mark.parametrize("msg", [
+        "",
+        " ",
+        "ja",
+        "nein",
+        "Wir haben einen DSB und Verschlüsselung auf allen Systemen.",
+        "Unsere Lösch-Fristen sind in der Richtlinie dokumentiert.",
+        "siehe oben",
+        "5",
+        "2000_10000",
+    ])
+    def test_normal_answers_do_not_fire(self, msg):
+        assert not is_natural_help_request(msg), f"false positive: {msg!r}"
+
+    def test_hint_set_covers_all_patterns(self):
+        # The 12 patterns from the diagnosis + 2 new (gib/nenne Beispiele).
+        expected = {
+            "welche gibt es",
+            "welche möglichkeiten",
+            "was meinst du",
+            "was meinen sie",
+            "wie meinst du das",
+            "wie meinen sie das",
+            "was bedeutet",
+            "was heißt das",
+            "erkläre mir",
+            "erklär mir",
+            "kannst du erklären",
+            "können sie erklären",
+            "gib mir beispiele",
+            "nenne mir beispiele",
+        }
+        missing = expected - set(_HELP_REQUEST_HINTS)
+        assert not missing, f"missing hints: {missing}"
+        assert isinstance(_HELP_REQUEST_HINTS, frozenset)
+
+
+# ---------------------------------------------------------------------------
+# Tier 2 — content assertions on prompt templates + descriptions
+# ---------------------------------------------------------------------------
+
+def _block_d_example_section() -> str:
+    """Return the ``BEISPIEL-FRAGEN`` block only — isolating it lets us
+    assert "no AI Act in the examples" without clashing with legitimate
+    AI-Act mentions in the new rule lines."""
+    m = re.search(
+        r"BEISPIEL-FRAGEN:(.*?)NÄCHSTES FELD:",
+        BLOCK_D_PROMPT, flags=re.DOTALL,
+    )
+    assert m, "BEISPIEL-FRAGEN block missing from BLOCK_D_PROMPT"
+    return m.group(1)
+
+
+class TestBlockDPrompt:
+    """BLOCK_D_PROMPT changes keep Sonnet on DSGVO."""
+
+    def test_ai_act_removed_from_examples(self):
+        example_block = _block_d_example_section()
+        lower = example_block.lower()
+        assert "ai act" not in lower, (
+            "Example block still primes AI Act — KIS-1163 regression:\n"
+            + example_block
+        )
+        assert "eu ai act" not in lower
+
+    def test_new_beratung_example_is_dsgvo(self):
+        example_block = _block_d_example_section()
+        # Stem-match so declension ("Datenschutzbeauftragten") passes too.
+        assert "Datenschutzbeauftragte" in example_block, (
+            "Beratung example lost its DSB anchor."
+        )
+        assert "Mandantendaten" in example_block, (
+            "Beratung example lost the Mandantendaten scope."
+        )
+
+    def test_thema_trennung_rule_present(self):
+        assert "THEMA-TRENNUNG" in BLOCK_D_PROMPT, (
+            "BLOCK_D_PROMPT lost the DSGVO/AI-Act separation rule."
+        )
+        # The rule must be explicit about where AI Act IS allowed.
+        assert "ai_act_kenntnis" in BLOCK_D_PROMPT
+
+    def test_artikel_regel_present(self):
+        assert "ARTIKEL-REGEL" in BLOCK_D_PROMPT, (
+            "BLOCK_D_PROMPT lost the article-number rule."
+        )
+        # Rule must forbid article numbers in user-facing output.
+        for phrase in ("NIEMALS", "Alltagssprache"):
+            assert phrase in BLOCK_D_PROMPT, (
+                f"ARTIKEL-REGEL is incomplete: {phrase!r} missing"
+            )
+
+    def test_prompt_is_still_registered_for_block_d(self):
+        # Defensive: registry lookup still maps "D" to this template.
+        assert _BLOCK_PROMPTS.get("D") is BLOCK_D_PROMPT
+
+
+class TestFieldDescriptions:
+    """Enriched DSGVO anchors on the five Block-D data-protection fields."""
+
+    def test_datenschutz_exists_and_mentions_dsgvo(self):
+        desc = FIELD_DESCRIPTIONS.get("datenschutz")
+        assert desc, "datenschutz has no FIELD_DESCRIPTION — was missing before"
+        assert "DSGVO" in desc
+
+    def test_technische_massnahmen_has_art_32_plus_concrete_tom_terms(self):
+        desc = FIELD_DESCRIPTIONS["technische_massnahmen"]
+        assert "Art. 32" in desc, "Art. 32 anchor missing"
+        concrete = {
+            "Pseudonymisierung",
+            "Verschlüsselung",
+            "Zugangs",        # Zugangs- / Zugriffskontrolle
+            "Backup",
+        }
+        present = {t for t in concrete if t in desc}
+        assert len(present) >= 3, (
+            f"Need at least 3 concrete TOM terms, only got {present}"
+        )
+
+    def test_folgenabschaetzung_has_art_35_and_dsfa(self):
+        desc = FIELD_DESCRIPTIONS["folgenabschaetzung"]
+        assert "Art. 35" in desc
+        assert "DSFA" in desc
+
+    def test_meldewege_has_72h_and_art_33(self):
+        desc = FIELD_DESCRIPTIONS["meldewege"]
+        assert "72" in desc, "72-hour deadline anchor missing"
+        assert "Art. 33" in desc
+
+    def test_loeschregeln_has_art_17_and_aufbewahrung(self):
+        desc = FIELD_DESCRIPTIONS["loeschregeln"]
+        assert "Art. 17" in desc
+        assert "Aufbewahrungsfrist" in desc
+
+    def test_datenschutzbeauftragter_has_art_37(self):
+        # Benennungspflicht in der neuen Description.
+        desc = FIELD_DESCRIPTIONS["datenschutzbeauftragter"]
+        assert "Art. 37" in desc
+
+    def test_ai_act_kenntnis_description_intact(self):
+        # Existing AI-Act field stays unchanged — we must not accidentally
+        # drop it while enriching neighbours.
+        desc = FIELD_DESCRIPTIONS["ai_act_kenntnis"]
+        assert "EU AI Act" in desc
+
+
+# ---------------------------------------------------------------------------
+# Tier 3 — wire-up regression via inspect.getsource
+# ---------------------------------------------------------------------------
+
+class TestWireUp:
+    """Catch accidental removal of the KIS-1163 integration points."""
+
+    def test_routes_chat_consumes_natural_help_detector(self):
+        import routes.chat as chat_module
+        src = inspect.getsource(chat_module)
+        # Must be defined at module scope and referenced in event_stream.
+        assert "_HELP_REQUEST_HINTS:" in src
+        assert "def is_natural_help_request(" in src
+        assert "is_natural_help_request(req.message)" in src, (
+            "event_stream no longer consults the natural help detector."
+        )
+
+    def test_sentinel_backcompat_preserved(self):
+        # Frontend help button still works after KIS-1163 extension.
+        import routes.chat as chat_module
+        src = inspect.getsource(chat_module)
+        assert '"__HELP_REQUEST__" in req.message' in src
+
+    def test_is_help_request_assignment_is_single_unconditional(self):
+        # Lessons from KIS-1161 v2: every ASGI-local flag must be defined
+        # on every code path. _is_help_request lives at the top of the
+        # turn-init block, before any branch. Guard by asserting the
+        # assignment text appears exactly once in event_stream.
+        import routes.chat as chat_module
+        src = inspect.getsource(chat_module)
+        # Count lines that start the assignment. Allow indentation.
+        occurrences = re.findall(
+            r"\b_is_help_request\s*=\s*\(",
+            src,
+        )
+        assert len(occurrences) == 1, (
+            f"Expected exactly 1 assignment to _is_help_request, "
+            f"found {len(occurrences)}. Multiple conditional branches would "
+            f"re-introduce UnboundLocalError risk."
+        )
+
+    def test_help_request_hints_is_frozenset(self):
+        # Frozenset prevents accidental mutation at import time.
+        assert isinstance(_HELP_REQUEST_HINTS, frozenset)
+        # And it has the 14 documented patterns.
+        assert len(_HELP_REQUEST_HINTS) == 14


### PR DESCRIPTION
Smoke test 2026-04-19 showed Sonnet drifting from a DSGVO rückfrage onto EU AI Act territory: the user asked "welche gibt es denn?" on the datenschutz field, extractor returned no tool call, dialog_mode kicked in — and the BLOCK_D_PROMPT example (which primed "EU AI Act" as a Beratung default) plus the missing FIELD_DESCRIPTION for the datenschutz field gave Sonnet no DSGVO anchor. Three cooperating changes close the drift; each lives in the minimal place possible.

Scope 1 — BLOCK_D_PROMPT
  - Beratung example rewritten to a pure DSGVO prompt ("Gibt es einen Datenschutzbeauftragten, und wie sind Mandantendaten abgesichert?").
  - New THEMA-TRENNUNG rule: AI Act is only explained when ai_act_kenntnis is the currently active next field, never as a fallback topic for DSGVO fields.
  - New ARTIKEL-REGEL rule: DSGVO article numbers are an *internal* context anchor; the user always hears everyday language.

Scope 2 — FIELD_DESCRIPTIONS (services/chat_conversation.py)
  - Previously-missing `datenschutz` entry added (DSGVO-Konformität, Datenminimierung, Art. 15-22 Betroffenenrechte).
  - `technische_massnahmen` now anchors Art. 32 plus concrete TOMs (Pseudonymisierung, Verschlüsselung, Zugangs-/Zugriffskontrolle, Backup, Rollen-/Rechtekonzepte).
  - `folgenabschaetzung` anchors Art. 35 + DSFA.
  - `meldewege` anchors Art. 33-34 + the 72 h deadline.
  - `loeschregeln` anchors Art. 17 + Aufbewahrungsfristen + Pseudonymisierung.
  - `datenschutzbeauftragter` gains Art. 37 / § 38 BDSG anchor.
  - `ai_act_kenntnis` intentionally unchanged — it remains the one field where AI Act is the right topic.

Scope 3 — _is_help_request (routes/chat.py)
  - New module-level frozenset _HELP_REQUEST_HINTS and helper is_natural_help_request(): 14 patterns covering rückfragen like "welche gibt es", "was meinst du", "erkläre mir", "gib mir beispiele".
  - _is_help_request stays a single unconditional assignment (lesson from KIS-1161 v2) — just extended with an or-branch, guarded by not _is_qr_click so QR clicks never accidentally trigger help mode.
  - Backwards-compat: the "__HELP_REQUEST__" sentinel from the frontend help button still fires as before.

Tests — tiers 1-3
  Tier 1: every hint fires on natural rückfragen, substantive answers
    (including "siehe oben" KIS-1161 input, numeric QR values, "ja" / "nein") never fire, hint set is a frozenset of the documented 14 patterns. Tier 2: BLOCK_D_PROMPT carries both new rules; BEISPIEL-FRAGEN block contains no "AI Act" mention; FIELD_DESCRIPTIONS for the five DSGVO fields contain their DSGVO-article anchors plus the required concrete vocabulary. Tier 3: inspect.getsource proves routes/chat.py defines the hint set + helper AND calls is_natural_help_request from event_stream, and that _is_help_request remains exactly one unconditional assignment (no UnboundLocalError risk).

A fourth tier — a real FastAPI TestClient integration test with a mocked Anthropic client — is filed in docs/MINI_TICKETS_OPEN.md for KW 17/18; it would exercise the SSE path end-to-end and become the canonical shared harness for future chat-flow changes.

KIS-1163.

https://claude.ai/code/session_01VfiRYYLYWWdTKptF1eLV8g