### PR TITLE
KIS-1138: Block-aware inspiration chips for Phase 2 hybrid flow

### DIFF
--- a/routes/chat.py
+++ b/routes/chat.py
@@ -3245,13 +3245,31 @@ def _build_session_state(
     # Always 1 field at a time (Smart Grouping disabled, KIS-1122)
     next_fields = get_next_fields(collected, section_idx, max_fields=1, report_type=rt)
 
+    # Phase tracking (hybrid conversation model, KIS-1124) — hoisted above
+    # the field_examples block so the chip trigger can consult current_block.
+    ps = _get_phase_state(session)
+
     # KIS-1138: Surface inspiration chips for the 4 strategic-imaginative
     # Block-B freetext fields. Defensive copy so callers can't mutate the
     # module-level dict. Concrete-experiential fields are deliberately absent
     # from FIELD_EXAMPLES and therefore always yield None here.
-    _next_field = next_fields[0] if next_fields else None
-    if _next_field and _next_field in FIELD_EXAMPLES:
-        field_examples = list(FIELD_EXAMPLES[_next_field])
+    #
+    # Two cooperating paths:
+    #   1. Block-aware (Phase 2 hybrid): when current_block is set, read the
+    #      first uncollected field of that block. In the real hybrid flow
+    #      section_idx stays pinned (checkpoint) while blocks advance, so the
+    #      section pipeline never surfaces Block-B fields as next_fields[0].
+    #   2. Section-based (fallback): next_fields[0] from the section pipeline.
+    #      Still correct when callers set current_section directly (tests).
+    _cur_blk_for_chips = ps.get("current_block")
+    if _cur_blk_for_chips:
+        _remaining_block_fields = _get_block_fields(_cur_blk_for_chips, collected)
+        if _remaining_block_fields and _remaining_block_fields[0] in FIELD_EXAMPLES:
+            field_examples = list(FIELD_EXAMPLES[_remaining_block_fields[0]])
+    if field_examples is None:
+        _next_field = next_fields[0] if next_fields else None
+        if _next_field and _next_field in FIELD_EXAMPLES:
+            field_examples = list(FIELD_EXAMPLES[_next_field])
 
     total = len(registry)
     collected_count = len(collected)
@@ -3270,9 +3288,6 @@ def _build_session_state(
 
     # Draft-Pattern state (backward-compatible: old sessions without column → {})
     draft = getattr(session, 'draft_state', None) or {}
-
-    # Phase tracking (hybrid conversation model, KIS-1124)
-    ps = _get_phase_state(session)
 
     # is_completable: after summary has been sent.
     # KIS-1124-HOTFIX: In the hybrid Phase 2 model, unsurveyed blocks have

--- a/tests/test_kis_1138_inspiration_chips.py
+++ b/tests/test_kis_1138_inspiration_chips.py
@@ -200,6 +200,65 @@ class TestBuildSessionStateProjection:
         assert state.field_examples is None
 
 
+class TestBlockAwareProjection:
+    """Block-aware field_examples path (KIS-1138 block-aware fix).
+
+    In the real hybrid flow section_idx stays pinned at the checkpoint while
+    Phase 2 blocks advance, so the Block-B fields never reach next_fields[0]
+    via the section pipeline. These tests pin current_section=0 (realistic
+    Phase 2 state) and exercise the block-aware branch.
+    """
+
+    def test_block_b_active_surfaces_first_uncollected_block_field(self):
+        # Block B order starts with vision_3_jahre → chips for that field.
+        session = _make_session(
+            current_section=0,
+            phase_state={
+                "conversation_phase": "phase_2",
+                "current_block": "B",
+                "selected_blocks": ["B"],
+            },
+        )
+        state = _build_session_state(session)
+        assert state.field_examples == FIELD_EXAMPLES["vision_3_jahre"]
+        # Defensive copy — mutating state must not touch module dict.
+        state.field_examples.append("MUTATION")
+        assert "MUTATION" not in FIELD_EXAMPLES["vision_3_jahre"]
+
+    def test_block_a_active_yields_none(self):
+        # Block A contains no FIELD_EXAMPLES fields.
+        session = _make_session(
+            current_section=0,
+            phase_state={
+                "conversation_phase": "phase_2",
+                "current_block": "A",
+                "selected_blocks": ["A"],
+            },
+        )
+        state = _build_session_state(session)
+        assert state.field_examples is None
+
+    def test_block_b_yields_none_when_all_example_fields_collected(self):
+        # All 4 FIELD_EXAMPLES fields already collected → first remaining
+        # Block-B field is roadmap_vorhanden (not in FIELD_EXAMPLES).
+        session = _make_session(
+            current_section=0,
+            collected_fields={
+                "vision_3_jahre": "x",
+                "strategische_ziele": "x",
+                "ki_guardrails": "x",
+                "geschaeftsmodell_evolution": "x",
+            },
+            phase_state={
+                "conversation_phase": "phase_2",
+                "current_block": "B",
+                "selected_blocks": ["B"],
+            },
+        )
+        state = _build_session_state(session)
+        assert state.field_examples is None
+
+
 # ---------------------------------------------------------------------------
 # Tier 3 — Wire-up regression via inspect.getsource
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Implement block-aware field_examples projection to surface inspiration chips for Block-B strategic-imaginative fields in the Phase 2 hybrid conversation model. The section pipeline cannot surface these fields when section_idx is pinned at a checkpoint, so a parallel block-aware path is needed.

## Key Changes
- **Block-aware chip trigger**: When `current_block` is set (Phase 2 hybrid mode), read the first uncollected field from that block's field order instead of relying on the section pipeline's `next_fields[0]`
- **Fallback to section-based path**: If the block-aware path yields no FIELD_EXAMPLES match, fall back to the original section-based logic for backward compatibility with direct `current_section` usage
- **Phase state hoisting**: Move `_get_phase_state()` call earlier in `_build_session_state()` so the chip trigger can consult `current_block`
- **Comprehensive test coverage**: Add `TestBlockAwareProjection` class with three test cases:
  - Block B active surfaces first uncollected block field with defensive copy
  - Block A active yields None (no FIELD_EXAMPLES fields in Block A)
  - Block B yields None when all example fields already collected

## Implementation Details
- The block-aware path uses `_get_block_fields()` to retrieve the field order for the active block
- Defensive copying (`list()`) prevents callers from mutating the module-level `FIELD_EXAMPLES` dictionary
- The dual-path approach maintains correctness for both the real hybrid flow (section_idx pinned, blocks advancing) and test scenarios (direct section_idx manipulation)

https://claude.ai/code/session_01WNiKKiTPoQ7Zgd9wnKDFAg