### PR TITLE
feat(chat): expose field_examples_for in session state (KIS-1138)

### DIFF
--- a/routes/chat.py
+++ b/routes/chat.py
@@ -3233,6 +3233,7 @@ def _build_session_state(
     # KIS-1138: Default-initialize every new local at function top before any
     # conditional branch sets or reads it (KIS-1161 v2 UnboundLocalError guard).
     field_examples: list[str] | None = None
+    field_examples_for: str | None = None
 
     rt = session.report_type
     sections = get_sections_for_report(rt)
@@ -3266,10 +3267,12 @@ def _build_session_state(
         _remaining_block_fields = _get_block_fields(_cur_blk_for_chips, collected)
         if _remaining_block_fields and _remaining_block_fields[0] in FIELD_EXAMPLES:
             field_examples = list(FIELD_EXAMPLES[_remaining_block_fields[0]])
+            field_examples_for = _remaining_block_fields[0]
     if field_examples is None:
         _next_field = next_fields[0] if next_fields else None
         if _next_field and _next_field in FIELD_EXAMPLES:
             field_examples = list(FIELD_EXAMPLES[_next_field])
+            field_examples_for = _next_field
 
     total = len(registry)
     collected_count = len(collected)
@@ -3384,6 +3387,7 @@ def _build_session_state(
         block_progress=_blk_progress,
         block_total=_blk_total,
         field_examples=field_examples,
+        field_examples_for=field_examples_for,
     )
 
 

--- a/schemas/chat.py
+++ b/schemas/chat.py
@@ -102,6 +102,10 @@ class ChatSessionState(BaseModel):
     # in Block B (geschaeftsmodell_evolution, vision_3_jahre, strategische_ziele,
     # ki_guardrails). None for all other turns.
     field_examples: Optional[list[str]] = None
+    # Field name the chips belong to — needed so the frontend can send the
+    # correct `field` value to /api/chat/inspiration-click even when chips
+    # come from the block-aware path (where next_fields[0] points elsewhere).
+    field_examples_for: Optional[str] = None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_kis_1138_inspiration_chips.py
+++ b/tests/test_kis_1138_inspiration_chips.py
@@ -221,6 +221,7 @@ class TestBlockAwareProjection:
         )
         state = _build_session_state(session)
         assert state.field_examples == FIELD_EXAMPLES["vision_3_jahre"]
+        assert state.field_examples_for == "vision_3_jahre"
         # Defensive copy — mutating state must not touch module dict.
         state.field_examples.append("MUTATION")
         assert "MUTATION" not in FIELD_EXAMPLES["vision_3_jahre"]
@@ -237,6 +238,7 @@ class TestBlockAwareProjection:
         )
         state = _build_session_state(session)
         assert state.field_examples is None
+        assert state.field_examples_for is None
 
     def test_block_b_yields_none_when_all_example_fields_collected(self):
         # All 4 FIELD_EXAMPLES fields already collected → first remaining
@@ -257,6 +259,7 @@ class TestBlockAwareProjection:
         )
         state = _build_session_state(session)
         assert state.field_examples is None
+        assert state.field_examples_for is None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Frontend-Smoke zeigte: Chips rendern korrekt, aber POST /api/chat/inspiration-click antwortet 400 "unknown field", weil das Frontend beim Klick den Feldnamen aus next_fields[0] schickt, die Chips aber über den Block-Pfad für ein anderes Feld erzeugt wurden (z.B. chips für strategische_ziele, next_fields[0] = jahresumsatz).

Fix: Zusätzlich zu field_examples auch field_examples_for in den ChatSessionState schreiben — der Feldname, zu dem die Chips gehören. Frontend kann diesen Wert als field an /inspiration-click übergeben und bekommt so grünes Licht vom Whitelist-Check.

Gesetzt in beiden Pfaden (block-aware zuerst, section-based als Fallback). None, wenn field_examples None ist — gleiche Konvention.

Endpoint-Verifikation:
- schemas/chat.py:208-211 InspirationClickRequest verlangt `field: str` (nicht `field_key`).
- routes/chat.py:2571 prüft req.field gegen FIELD_EXAMPLES.
- Frontend sendet bereits den Key `field` — korrekt. Das 400 kommt also nur vom Wert, nicht vom Key. Keine Backend-Änderung am Endpoint nötig.

Tests: TestBlockAwareProjection um je eine field_examples_for-Zeile erweitert (Block B: "vision_3_jahre"; Block A: None; Block B mit allen Feldern gesammelt: None). Alle 36 KIS-1138 + 5921 Gesamttests grün.

https://claude.ai/code/session_01WNiKKiTPoQ7Zgd9wnKDFAg