### PR TITLE
KIS-1136: Skip force-default for strategy free-text fields

### DIFF
--- a/routes/chat.py
+++ b/routes/chat.py
@@ -265,6 +265,21 @@ _FIELD_DEFAULTS: dict[str, object] = {
 }
 
 
+# KIS-1136 rest-fix: Strategy free-text fields must NOT receive a force-default.
+# Writing "keine_angabe" (or any sentinel) would bypass the partially-surveyed
+# detection (routes/chat.py ~l.3031) and send a meaningless string into the
+# report pipeline. Skipping the write keeps the field absent from `collected`,
+# so Fix 1 marks the block as _chat_partially_surveyed and the section is
+# shortened cleanly. Matches the omit semantic already established in
+# _REPORT_BLOCK_DEFAULTS["B"] (None entries).
+_FORCE_DEFAULT_SKIP: frozenset[str] = frozenset({
+    "strategische_ziele",
+    "vision_3_jahre",
+    "ki_guardrails",
+    "geschaeftsmodell_evolution",
+})
+
+
 # KIS-1124 Sprint 4 S4-BE-2: Conservative defaults for fields in blocks that
 # the user chose NOT to survey.  These are injected at _complete_r1 time so
 # the report pipeline receives plausible, non-hallucinated values.
@@ -1471,6 +1486,18 @@ async def chat_message(req: ChatMessageRequest, db: Session = Depends(get_db)):
                 _force_defaulted = False
                 for _fd_field, _fd_count in list(_field_ask_counts.items()):
                     if _fd_count >= 2 and _fd_field not in collected:
+                        if _fd_field in _FORCE_DEFAULT_SKIP:
+                            # KIS-1136 rest-fix: leave strategy free-text fields
+                            # absent so Fix 1 marks the block as partially
+                            # surveyed and the pipeline omits the section.
+                            log.info(
+                                "[CHAT] Phase 2 field safeguard: %s asked %d× "
+                                "without extraction — skipping force-default "
+                                "(omit via _chat_partially_surveyed)",
+                                _fd_field, _fd_count,
+                            )
+                            _field_ask_counts.pop(_fd_field, None)
+                            continue
                         _default = _FIELD_DEFAULTS.get(_fd_field, "keine_angabe")
                         collected[_fd_field] = _default
                         log.warning(


### PR DESCRIPTION
## Summary
Prevents strategy free-text fields from receiving force-default sentinel values, allowing them to remain absent from collected data so they can be properly marked as partially surveyed and omitted from reports.

## Changes
- Added `_FORCE_DEFAULT_SKIP` frozenset containing four strategy fields that should not receive force-defaults:
  - `strategische_ziele`
  - `vision_3_jahre`
  - `ki_guardrails`
  - `geschaeftsmodell_evolution`

- Modified the force-default logic in `_run_extraction()` to check if a field is in the skip set before applying defaults
  - Fields in the skip set are logged and skipped, allowing them to remain absent from `collected`
  - This triggers the partially-surveyed detection mechanism (Fix 1) which properly marks the block and omits the section from the report pipeline

## Implementation Details
- The fix prevents meaningless sentinel strings ("keine_angabe") from being written to strategy free-text fields, which would bypass the partially-surveyed detection
- Matches the existing omit semantic already established in `_REPORT_BLOCK_DEFAULTS["B"]` with None entries
- Includes informative logging when fields are skipped to aid in debugging and monitoring

https://claude.ai/code/session_01Bk7WMH8jp2UYkEag7zr3kn