### PR TITLE
fix(chat-normalizer): omit strategy FT fields on skip signals (KIS-1136 rest)

### DIFF
--- a/services/chat_normalizer.py
+++ b/services/chat_normalizer.py
@@ -114,6 +114,23 @@ def is_low_quality_text(raw: str, min_words: int = 3) -> bool:
 
 
 # ===========================================================================
+# KIS-1136 rest-fix (Option 6): strategy freetext fields that must be OMITTED
+# (absent from `collected`/`answers`) on skip signals, never written as "".
+# Writing an empty string would bypass the `_chat_partially_surveyed` marker
+# (routes/chat.py `field not in answers` check) and feed a meaningless empty
+# value into the report pipeline. Mirrors the force-default skip in
+# routes/chat.py (_FORCE_DEFAULT_SKIP) so both safeguards stay in sync.
+# ===========================================================================
+
+_FT_OMIT_ON_SKIP: frozenset[str] = frozenset({
+    "vision_3_jahre",
+    "strategische_ziele",
+    "ki_guardrails",
+    "geschaeftsmodell_evolution",
+})
+
+
+# ===========================================================================
 # Field Registry — PoC Block 1 (Section 0) + full structure for later
 # ===========================================================================
 
@@ -892,6 +909,12 @@ def normalize_field(field_name: str, raw_value: Any, collected: dict, report_typ
         cleaned = str(raw_value).strip()
         # "keine_angabe" is a valid skip for optional text fields
         if cleaned.lower() in ("keine_angabe", "keine angabe"):
+            # KIS-1136 rest-fix: for strategy FT fields the skip must OMIT
+            # the field (not write ""), so the partially-surveyed marker in
+            # routes/chat.py sees `field not in answers` and shortens the
+            # report section cleanly.
+            if field_name in _FT_OMIT_ON_SKIP:
+                return NormResult(None, "low", True)
             return NormResult("", "high", False)
         if len(cleaned) < 3:
             return NormResult(None, "low", True)

--- a/tests/test_kis_1136_ft_omit_on_skip.py
+++ b/tests/test_kis_1136_ft_omit_on_skip.py
@@ -1,0 +1,84 @@
+# -*- coding: utf-8 -*-
+"""
+KIS-1136 rest-fix (Option 6): Omit-Semantik für Strategy-FT-Felder.
+
+Auf Skip-Signale ("keine_angabe") dürfen die vier Strategy-FT-Felder NICHT
+mit einem leeren String in ``collected``/``answers`` landen — sie müssen
+vollständig omitiert werden, damit der ``_chat_partially_surveyed``-Marker
+(routes/chat.py) greift und die Report-Pipeline die Sektion sauber kürzt.
+
+Siehe Briefing 1 — Option 6 Omit-Semantik-Fix.
+"""
+
+import pytest
+
+from services.chat_normalizer import (
+    _FT_OMIT_ON_SKIP,
+    normalize_field,
+)
+
+
+STRATEGY_FT_FIELDS = (
+    "vision_3_jahre",
+    "strategische_ziele",
+    "ki_guardrails",
+    "geschaeftsmodell_evolution",
+)
+
+
+class TestOmitSetIsCanonical:
+    def test_contains_all_four_strategy_fields(self):
+        assert set(_FT_OMIT_ON_SKIP) == set(STRATEGY_FT_FIELDS)
+
+
+class TestSkipSignalOmitsField:
+    """Skip-Signal → low confidence → Caller schreibt nichts in `collected`."""
+
+    @pytest.mark.parametrize("field", STRATEGY_FT_FIELDS)
+    @pytest.mark.parametrize("skip_value", ["keine_angabe", "keine angabe", "KEINE_ANGABE"])
+    def test_skip_returns_low_confidence(self, field, skip_value):
+        r = normalize_field(field, skip_value, {}, "r1")
+        assert r.confidence == "low"
+        assert r.value is None
+        assert r.needs_confirmation is True
+
+    @pytest.mark.parametrize("field", STRATEGY_FT_FIELDS)
+    def test_caller_pattern_keeps_field_absent(self, field):
+        """Simuliert die Call-Site aus routes/chat.py (legacy flow)."""
+        collected: dict = {}
+        r = normalize_field(field, "keine_angabe", collected, "r1")
+        if r.confidence == "low":
+            # Caller-Logik: skip, write nothing.
+            pass
+        else:
+            collected[field] = r.value
+        assert field not in collected
+
+
+class TestRegressionNormalFtInputStored:
+    """Echte Freitext-Antworten werden weiterhin normal akzeptiert."""
+
+    @pytest.mark.parametrize("field,text", [
+        ("vision_3_jahre",
+         "Marktführer für datengetriebene Effizienz im DACH-Raum bis 2029."),
+        ("strategische_ziele",
+         "White-Label-Tool, Branchen-Reports, Proposal-Automation."),
+        ("ki_guardrails",
+         "DSGVO-konform, Human-in-the-Loop bei externen Texten, Audit-Log."),
+        ("geschaeftsmodell_evolution",
+         "Von Beratung zu Produkt-SaaS mit Usage-based Pricing."),
+    ])
+    def test_substantive_answer_stored(self, field, text):
+        r = normalize_field(field, text, {}, "r1")
+        assert r.confidence == "high"
+        assert r.value == text
+
+
+class TestNonOmitFieldsUnaffected:
+    """Generische optionale Text-Felder behalten das Legacy-Skip-Verhalten."""
+
+    @pytest.mark.parametrize("field", ["hauptleistung", "ki_projekte", "zeitersparnis_prioritaet"])
+    def test_non_strategy_ft_still_returns_empty_string(self, field):
+        r = normalize_field(field, "keine_angabe", {}, "r1")
+        assert r.confidence == "high"
+        assert r.value == ""

--- a/tests/test_kis_1161_quality_validator.py
+++ b/tests/test_kis_1161_quality_validator.py
@@ -167,9 +167,19 @@ class TestNormalizeFieldTextFT:
         r = normalize_field("hauptleistung", "Beratung", {}, "r1")
         assert r.confidence == "low"
 
-    def test_keine_angabe_still_passes(self):
-        # KIS-1160 skip path must stay intact.
+    def test_keine_angabe_omits_strategy_ft_field(self):
+        # KIS-1136 rest-fix (Option 6): for the four strategy FT fields
+        # "keine_angabe" must NOT write "" — instead return low confidence
+        # so the caller omits the field from `collected`/`answers` and the
+        # partially-surveyed marker can short-circuit the section.
         r = normalize_field("strategische_ziele", "keine_angabe", {}, "r1")
+        assert r.confidence == "low"
+        assert r.value is None
+
+    def test_keine_angabe_still_passes_for_non_strategy_ft(self):
+        # Generic optional text fields (e.g. hauptleistung) keep the legacy
+        # skip path: "keine_angabe" → empty string with high confidence.
+        r = normalize_field("hauptleistung", "keine_angabe", {}, "r1")
         assert r.confidence == "high"
         assert r.value == ""
 


### PR DESCRIPTION
## Summary

Closes the normalizer-side gap in Option 6 (Strategy-FT-Skip-Logik, live since `b59a3a7`). The force-default path in `routes/chat.py` was already updated via `_FORCE_DEFAULT_SKIP` — but a parallel branch in `services/chat_normalizer.py` still wrote `""` into `collected` when the extractor surfaced `keine_angabe` for one of the four strategy FT fields. The empty string satisfied `field not in answers`, so the section was marked fully surveyed and `""` leaked into the report pipeline.

### Fix

- **`services/chat_normalizer.py`** — new `_FT_OMIT_ON_SKIP` frozenset mirroring `_FORCE_DEFAULT_SKIP`:
  - `vision_3_jahre`
  - `strategische_ziele`
  - `ki_guardrails`
  - `geschaeftsmodell_evolution`
- In the text-type branch at `normalize_field`, for these four fields a `keine_angabe` skip now returns `NormResult(None, "low", True)`. The caller's existing low-confidence guard omits the field from `collected` → `_chat_partially_surveyed` triggers as intended.
- Generic optional text fields (e.g. `hauptleistung`, `ki_projekte`, `zeitersparnis_prioritaet`) keep the legacy `""` skip path.

### Tests

- New `tests/test_kis_1136_ft_omit_on_skip.py` (24 cases):
  - All 4 fields × 3 casing variants of `keine_angabe` → `confidence == "low"`, `value is None`
  - Caller-pattern simulation → `field not in collected`
  - Regression: substantive answers still stored with `confidence == "high"`
  - Non-strategy FT fields still return `""` (unchanged)
- Updated `test_keine_angabe_*` in `tests/test_kis_1161_quality_validator.py` to reflect the new split.

## Test plan

- [x] `pytest tests/test_kis_1136_ft_omit_on_skip.py` — 24 passed
- [x] `pytest tests/test_kis_1161_quality_validator.py` — 51 passed (3 pre-existing `fastapi` import failures in `TestLivePathRegressionGuard` are environment-only and unrelated)
- [ ] Manual smoke (morgen): Strategy-Flow durchlaufen, alle 4 FT-Felder skippen, Admin-Inspect prüfen: `answers` darf die 4 Felder nicht enthalten, `answers._chat_partially_surveyed` muss `true` sein.

https://claude.ai/code/session_01RcZvzgb1CGDSuMGoxRhY2y