### PR TITLE
fix(chat): Bug C — Block-D head + QuickReply descriptions (H1 + H3)

### DIFF
--- a/routes/chat.py
+++ b/routes/chat.py
@@ -193,12 +193,19 @@ PHASE_1_EXTRACTABLE_FIELDS: set[str] = {
 
 
 def _get_datenschutz_block_fields(branche: str) -> list[str]:
-    """Return Block D fields based on branche (Beratung → reduced set)."""
+    """Return Block D fields based on branche (Beratung → reduced set).
+
+    ``datenschutz`` is intentionally NOT part of this list: it's a consent
+    field (``skip_in_chat: True``), captured at session start via
+    ``req.consent_report`` and seeded into ``collected_fields`` there.
+    Including it here caused the Block-D head to ask a question with no
+    QR options (see Bug C diagnosis).
+    """
     if branche == "beratung":
-        return ["datenschutz", "datenschutzbeauftragter", "ai_act_kenntnis",
+        return ["datenschutzbeauftragter", "ai_act_kenntnis",
                 "ki_hemmnisse", "governance_richtlinien"]
     return [
-        "datenschutz", "datenschutzbeauftragter", "technische_massnahmen",
+        "datenschutzbeauftragter", "technische_massnahmen",
         "folgenabschaetzung", "meldewege", "loeschregeln",
         "ai_act_kenntnis", "regulierte_branche", "ki_hemmnisse",
         "governance_richtlinien",
@@ -529,12 +536,20 @@ async def chat_start(
     # Initialize phase_state for R1 sessions (hybrid conversation model)
     phase_state = _init_phase_state() if req.report_type == "r1" else {}
 
+    # Seed consent into collected_fields for r1 so Block D never lands on
+    # the ``datenschutz`` consent bool at the block head (Bug C fix).
+    # The prefill dict takes precedence — tests or form→chat handover may
+    # explicitly (un)set the flag.
+    initial_collected = dict(req.prefill or {})
+    if req.report_type == "r1" and "datenschutz" not in initial_collected:
+        initial_collected["datenschutz"] = True
+
     session = ChatSession(
         report_type=req.report_type,
         lang=req.lang,
         consent_report=True,
         consent_at=now,
-        collected_fields=req.prefill or {},
+        collected_fields=initial_collected,
         field_meta={},
         current_section=0,
         status="active",

--- a/routes/chat.py
+++ b/routes/chat.py
@@ -64,6 +64,7 @@ from services.chat_normalizer import (
     normalize_field,
 )
 from services.field_templates import (
+    FIELD_DESCRIPTIONS_SHORT,
     FIELD_EXAMPLES,
     FIELD_QUESTIONS,
     get_confirmation,
@@ -4152,6 +4153,7 @@ def _build_quick_replies(
             field=field_name, label=label, options=options,
             multi_select=is_multi, max_select=max_sel,
             optional=is_optional,
+            description=FIELD_DESCRIPTIONS_SHORT.get(field_name),
         ))
 
     return replies

--- a/schemas/chat.py
+++ b/schemas/chat.py
@@ -41,6 +41,12 @@ class QuickReply(BaseModel):
     multi_select: bool = False
     max_select: Optional[int] = None
     optional: bool = False
+    # Bug C H3: User-visible short help text rendered under / beside the
+    # buttons. None when a field has no dedicated short description.
+    # The long, DSGVO-article-laden FIELD_DESCRIPTIONS in
+    # services/chat_conversation.py stay Sonnet-internal — BLOCK_D_PROMPT
+    # forbids article numbers in user-facing strings.
+    description: Optional[str] = None
 
 
 # ---------------------------------------------------------------------------

--- a/services/field_templates.py
+++ b/services/field_templates.py
@@ -127,6 +127,45 @@ FIELD_EXAMPLES: dict[str, list[str]] = {
 
 
 # ──────────────────────────────────────────────────────────────────────
+# Bug C H3: Short, user-visible field descriptions surfaced via
+# QuickReply.description.
+#
+# DO NOT add DSGVO article numbers here — BLOCK_D_PROMPT's ARTIKEL-REGEL
+# forbids them in user-facing strings. The long descriptions with article
+# references live in services/chat_conversation.py:FIELD_DESCRIPTIONS and
+# are Sonnet-prompt-internal only.
+#
+# Texts reviewed and signed off by Wolf 2026-04-22. All entries ≤ ~80
+# chars so they fit under a chat bubble on mobile without clipping.
+# ──────────────────────────────────────────────────────────────────────
+
+FIELD_DESCRIPTIONS_SHORT: dict[str, str] = {
+    "datenschutzbeauftragter": (
+        "Ab 20 Mitarbeitenden mit systematischer Datenverarbeitung meist Pflicht."
+    ),
+    "technische_massnahmen": (
+        "Gemeint sind z. B. Verschlüsselung, Zugriffskontrolle, Backups."
+    ),
+    "folgenabschaetzung": (
+        "Nötig bei Verarbeitung sensibler oder umfangreicher personenbezogener Daten."
+    ),
+    "meldewege": (
+        "Wer informiert wen wie schnell bei Datenpannen oder Sicherheitsvorfällen?"
+    ),
+    "loeschregeln": (
+        "Regeln, wann und wie Daten gelöscht oder anonymisiert werden."
+    ),
+    "ai_act_kenntnis": (
+        "EU-Gesetz zur KI-Regulierung, schrittweise wirksam, "
+        "volle Anwendung ab August 2026."
+    ),
+    "ki_hemmnisse": (
+        "Mehrfachauswahl möglich — welche Hürden bremsen den KI-Einsatz?"
+    ),
+}
+
+
+# ──────────────────────────────────────────────────────────────────────
 # KIS-1128B V1-BE-3: Deterministic confirmation sentences
 #
 # Short confirmations prepended to the template question.

--- a/tests/test_bug_c_block_d_head.py
+++ b/tests/test_bug_c_block_d_head.py
@@ -1,0 +1,233 @@
+# -*- coding: utf-8 -*-
+"""
+Bug C — Block-D-Head fix (H1).
+
+Regression coverage for two cooperating changes:
+
+  1. ``_get_datenschutz_block_fields(branche)`` no longer returns
+     ``datenschutz`` at (or anywhere in) the Block-D field list. The
+     ``datenschutz`` entry is a consent boolean (``skip_in_chat: True``),
+     not a survey item, and was previously leaking into the Phase-2 QR
+     flow as the first uncollected Block-D field — producing a question
+     turn with no QR options because ``datenschutz`` has no entry in
+     ``_QR_OPTIONS``.
+
+  2. The ``/api/chat/start`` handler seeds
+     ``collected_fields["datenschutz"] = True`` for R1 sessions. Consent
+     is already captured via ``req.consent_report`` (required to be
+     ``True`` for the endpoint to succeed); mirroring it into
+     ``collected_fields`` keeps the domain model consistent for any
+     downstream consumer that expects the field.
+
+Both changes together ensure that Block D opens directly on
+``datenschutzbeauftragter`` — which *does* have QR options — and that
+the ``block_total`` counter in ``_build_session_state`` no longer
+includes the consent bool.
+"""
+
+from __future__ import annotations
+
+import inspect
+from dataclasses import dataclass, field
+from typing import Any
+from unittest.mock import MagicMock
+from uuid import UUID, uuid4
+
+import pytest
+
+from routes.chat import (
+    _build_quick_replies,
+    _get_block_fields,
+    _get_datenschutz_block_fields,
+    _QR_OPTIONS,
+    chat_start,
+)
+from schemas.chat import ChatStartRequest
+
+
+# ---------------------------------------------------------------------------
+# H1a — Block-D field list no longer contains `datenschutz`
+# ---------------------------------------------------------------------------
+
+ALL_BRANCHES = (
+    "marketing", "beratung", "it", "finanzen", "handel", "bildung",
+    "verwaltung", "gesundheit", "bau", "medien", "industrie",
+    "logistik", "gastronomie",
+    "",  # unknown / missing
+)
+
+
+class TestDatenschutzNotInBlockDList:
+    @pytest.mark.parametrize("branche", ALL_BRANCHES)
+    def test_datenschutz_not_in_list(self, branche):
+        fields = _get_datenschutz_block_fields(branche)
+        assert "datenschutz" not in fields, (
+            f"datenschutz leaked into Block D for branche={branche!r}: {fields}"
+        )
+
+    @pytest.mark.parametrize("branche", ALL_BRANCHES)
+    def test_block_d_head_has_qr_options(self, branche):
+        # The first uncollected field in Block D must have a _QR_OPTIONS
+        # entry — otherwise the block-scoped QR builder returns [].
+        fields = _get_datenschutz_block_fields(branche)
+        assert fields, f"Block D for branche={branche!r} is empty"
+        head = fields[0]
+        assert head in _QR_OPTIONS, (
+            f"Block-D head {head!r} (branche={branche!r}) has no _QR_OPTIONS "
+            "entry — would produce an empty quick_replies list."
+        )
+
+    def test_beratung_reduced_set_still_compact(self):
+        # Reduced set preserved, only shrunk by one (the removed consent).
+        fields = _get_datenschutz_block_fields("beratung")
+        assert fields == [
+            "datenschutzbeauftragter",
+            "ai_act_kenntnis",
+            "ki_hemmnisse",
+            "governance_richtlinien",
+        ]
+
+    def test_default_set_full_without_consent(self):
+        fields = _get_datenschutz_block_fields("industrie")
+        assert fields == [
+            "datenschutzbeauftragter",
+            "technische_massnahmen",
+            "folgenabschaetzung",
+            "meldewege",
+            "loeschregeln",
+            "ai_act_kenntnis",
+            "regulierte_branche",
+            "ki_hemmnisse",
+            "governance_richtlinien",
+        ]
+
+
+# ---------------------------------------------------------------------------
+# H1b — Integration via _get_block_fields + _build_quick_replies
+# ---------------------------------------------------------------------------
+
+class TestBlockDHeadProducesQuickReplies:
+    """Simulate the Phase-2 call chain used in routes/chat.py:2158."""
+
+    @pytest.mark.parametrize("branche", ["beratung", "industrie", ""])
+    def test_first_block_d_turn_builds_buttons(self, branche):
+        # Starting state: consent seeded, branche known, nothing else.
+        collected = {"datenschutz": True, "branche": branche}
+        remaining = _get_block_fields("D", collected)
+        qr_next = remaining[:1]
+        replies = _build_quick_replies(qr_next, report_type="r1",
+                                       collected_fields=collected)
+        assert qr_next, "Block D has no remaining fields at session start"
+        assert replies, (
+            f"_build_quick_replies returned no QuickReply for {qr_next[0]!r} "
+            f"(branche={branche!r}) — regression of Bug C."
+        )
+        assert replies[0].field == qr_next[0]
+        assert replies[0].options, "first Block-D QuickReply has no options"
+
+    def test_block_d_progress_total_excludes_consent(self):
+        # The progress counter in _build_session_state reads the same
+        # list. With the consent removed, the count reflects only real
+        # survey questions.
+        fields = _get_datenschutz_block_fields("industrie")
+        assert len(fields) == 9  # was 10 pre-fix
+
+
+# ---------------------------------------------------------------------------
+# H1c — Session-start seeds `datenschutz=True` into collected_fields (r1)
+#
+# We assert the seeding logic directly against ``chat_start`` by stubbing out
+# the auth and welcome-builder side effects. This keeps the test decoupled
+# from the JWT/crypto stack and the SQLAlchemy layer.
+# ---------------------------------------------------------------------------
+
+class TestSessionStartSeedsConsent:
+    def _run_chat_start(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        *,
+        report_type: str = "r1",
+        prefill: dict | None = None,
+        briefing_id: int | None = None,
+    ) -> "Any":
+        """Invoke ``chat_start`` with enough stubs that we can read back the
+        ChatSession that would have been persisted."""
+        import asyncio
+
+        from routes import chat as chat_mod
+
+        captured: dict[str, Any] = {}
+
+        def _fake_resolve_user(_request, _db):
+            return None, None
+
+        monkeypatch.setattr(chat_mod, "_resolve_user", _fake_resolve_user)
+
+        class _DBMock:
+            def add(self, obj):
+                captured["session"] = obj
+
+            def commit(self):
+                pass
+
+            def refresh(self, obj):
+                if not getattr(obj, "id", None):
+                    obj.id = uuid4()
+
+            def query(self, *_a, **_k):
+                # Strategy sessions pass a briefing_id and the endpoint looks
+                # it up. Return a truthy Briefing-like mock for that path.
+                return MagicMock(
+                    filter=lambda *a, **k: MagicMock(
+                        first=lambda: (MagicMock(id=briefing_id)
+                                       if briefing_id else None)
+                    )
+                )
+
+        request = MagicMock(cookies={}, headers={})
+        req = ChatStartRequest(
+            report_type=report_type,
+            consent_report=True,
+            prefill=prefill,
+            briefing_id=briefing_id,
+        )
+        asyncio.run(chat_start(req, request, db=_DBMock()))
+        return captured["session"]
+
+    def test_r1_seeds_datenschutz_true(self, monkeypatch):
+        session = self._run_chat_start(monkeypatch)
+        assert session.collected_fields.get("datenschutz") is True
+
+    def test_prefill_explicit_false_wins(self, monkeypatch):
+        # If a caller explicitly prefills datenschutz with False (e.g.
+        # form→chat handover surfacing a revoked consent), we don't
+        # overwrite — the seed only fires when the key is absent.
+        session = self._run_chat_start(
+            monkeypatch, prefill={"datenschutz": False},
+        )
+        assert session.collected_fields["datenschutz"] is False
+
+    def test_strategy_session_unaffected(self, monkeypatch):
+        # Strategy has no datenschutz field in its registry — seeding it
+        # would leave a stray key. Skip for non-r1.
+        session = self._run_chat_start(
+            monkeypatch, report_type="strategy", briefing_id=42,
+        )
+        assert "datenschutz" not in session.collected_fields
+
+
+# ---------------------------------------------------------------------------
+# H1d — Wire-up guard: chat_start sources collected_fields from the
+# seeded dict, not directly from req.prefill, so the seed can't be lost
+# by an inline refactor.
+# ---------------------------------------------------------------------------
+
+class TestChatStartWireUp:
+    def test_collected_fields_uses_seeded_dict(self):
+        src = inspect.getsource(chat_start)
+        assert "initial_collected" in src, (
+            "chat_start must construct an ``initial_collected`` dict with "
+            "the datenschutz seed before passing it to ChatSession — "
+            "otherwise the Bug C fix silently regresses."
+        )
+        assert 'collected_fields=initial_collected' in src

--- a/tests/test_bug_c_block_d_head.py
+++ b/tests/test_bug_c_block_d_head.py
@@ -142,6 +142,25 @@ class TestBlockDHeadProducesQuickReplies:
 # ---------------------------------------------------------------------------
 
 class TestSessionStartSeedsConsent:
+    @staticmethod
+    def _run_coro(coro):
+        """Run a coroutine without polluting the thread's event-loop binding.
+
+        Deliberately avoids ``asyncio.run()`` because it calls
+        ``asyncio.set_event_loop(None)`` on exit — that breaks legacy
+        tests elsewhere in the suite which rely on
+        ``asyncio.get_event_loop()`` (deprecated but still in use). A
+        locally-scoped fresh loop leaves the thread's current-loop
+        binding untouched.
+        """
+        import asyncio
+
+        loop = asyncio.new_event_loop()
+        try:
+            return loop.run_until_complete(coro)
+        finally:
+            loop.close()
+
     def _run_chat_start(
         self,
         monkeypatch: pytest.MonkeyPatch,
@@ -152,8 +171,6 @@ class TestSessionStartSeedsConsent:
     ) -> "Any":
         """Invoke ``chat_start`` with enough stubs that we can read back the
         ChatSession that would have been persisted."""
-        import asyncio
-
         from routes import chat as chat_mod
 
         captured: dict[str, Any] = {}
@@ -191,7 +208,7 @@ class TestSessionStartSeedsConsent:
             prefill=prefill,
             briefing_id=briefing_id,
         )
-        asyncio.run(chat_start(req, request, db=_DBMock()))
+        self._run_coro(chat_start(req, request, db=_DBMock()))
         return captured["session"]
 
     def test_r1_seeds_datenschutz_true(self, monkeypatch):

--- a/tests/test_bug_c_field_descriptions.py
+++ b/tests/test_bug_c_field_descriptions.py
@@ -1,0 +1,205 @@
+# -*- coding: utf-8 -*-
+"""
+Bug C — User-visible short field descriptions (H3).
+
+Adds a contract-level ``description`` string on ``QuickReply`` so
+compliance (and optionally other) fields can surface a short, plain-
+language hint underneath their buttons in the chat UI. The long
+DSGVO-article descriptions in ``services/chat_conversation.py``
+intentionally stay Sonnet-prompt-internal — BLOCK_D_PROMPT's
+ARTIKEL-REGEL forbids article numbers in user-facing strings.
+
+Three scopes under test:
+
+  1. ``QuickReply.description`` default is None; accepts string.
+  2. ``FIELD_DESCRIPTIONS_SHORT`` covers exactly the 7 compliance
+     fields, stays short, and contains zero DSGVO article references.
+  3. ``_build_quick_replies`` wires the dict lookup onto the emitted
+     ``QuickReply`` objects, so turns for described fields carry the
+     description and turns for undescribed fields stay None.
+"""
+
+from __future__ import annotations
+
+import inspect
+import re
+
+import pytest
+
+from routes.chat import _build_quick_replies
+from schemas.chat import QuickReply, QuickReplyOption
+from services.field_templates import FIELD_DESCRIPTIONS_SHORT
+
+
+# ---------------------------------------------------------------------------
+# H3a — QuickReply schema accepts the new field
+# ---------------------------------------------------------------------------
+
+class TestQuickReplySchema:
+    def test_description_defaults_to_none(self):
+        qr = QuickReply(
+            field="x", label="X",
+            options=[QuickReplyOption(value="a", label="A")],
+        )
+        assert qr.description is None
+
+    def test_description_accepts_string(self):
+        qr = QuickReply(
+            field="x", label="X",
+            options=[QuickReplyOption(value="a", label="A")],
+            description="Hilfetext.",
+        )
+        assert qr.description == "Hilfetext."
+
+
+# ---------------------------------------------------------------------------
+# H3b — FIELD_DESCRIPTIONS_SHORT contract
+# ---------------------------------------------------------------------------
+
+COMPLIANCE_FIELDS = {
+    "datenschutzbeauftragter",
+    "technische_massnahmen",
+    "folgenabschaetzung",
+    "meldewege",
+    "loeschregeln",
+    "ai_act_kenntnis",
+    "ki_hemmnisse",
+}
+
+
+class TestFieldDescriptionsShort:
+    def test_covers_all_seven_compliance_fields(self):
+        assert set(FIELD_DESCRIPTIONS_SHORT) >= COMPLIANCE_FIELDS, (
+            "All 7 compliance fields must have a short description."
+        )
+
+    def test_all_values_are_strings(self):
+        for key, val in FIELD_DESCRIPTIONS_SHORT.items():
+            assert isinstance(val, str) and val, (
+                f"{key!r} description must be a non-empty string"
+            )
+
+    def test_all_values_stay_short(self):
+        # Briefing cap: "Alle unter ~80 Zeichen". Keep the bar there
+        # so mobile rendering doesn't clip.
+        for key, val in FIELD_DESCRIPTIONS_SHORT.items():
+            assert len(val) <= 120, (
+                f"{key!r} description too long ({len(val)} chars): {val!r}"
+            )
+
+    @pytest.mark.parametrize("forbidden", [
+        "Art.",       # "Art. 32 DSGVO"
+        "Artikel",    # "Artikel 35"
+        "DSGVO",      # raw acronym in user-facing text
+        "BDSG",
+    ])
+    def test_no_statute_references(self, forbidden):
+        offenders = [
+            (k, v) for k, v in FIELD_DESCRIPTIONS_SHORT.items()
+            if re.search(rf"\b{re.escape(forbidden)}\b", v)
+        ]
+        assert not offenders, (
+            f"{forbidden!r} leaked into user-facing short description: {offenders}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# H3c — _build_quick_replies wires descriptions onto QuickReply objects
+# ---------------------------------------------------------------------------
+
+class TestBuildQuickRepliesWires:
+    @pytest.mark.parametrize("field_name", sorted(COMPLIANCE_FIELDS))
+    def test_compliance_field_carries_description(self, field_name):
+        # Profile-neutral empty collected so no option filtering kicks in.
+        replies = _build_quick_replies([field_name], report_type="r1",
+                                       collected_fields={})
+        assert replies, f"no QuickReply produced for {field_name}"
+        qr = replies[0]
+        assert qr.field == field_name
+        assert qr.description == FIELD_DESCRIPTIONS_SHORT[field_name], (
+            f"description for {field_name!r} did not reach the QuickReply"
+        )
+
+    @pytest.mark.parametrize("field_name", [
+        "automatisierungsgrad",    # Block C enum
+        "branche",                 # Section 0 enum
+        "roadmap_vorhanden",       # Block B QR
+        "investitionsbudget",      # Block A / Section 7 QR
+    ])
+    def test_undescribed_fields_stay_none(self, field_name):
+        replies = _build_quick_replies([field_name], report_type="r1",
+                                       collected_fields={})
+        assert replies, f"no QuickReply produced for {field_name}"
+        assert replies[0].description is None, (
+            f"{field_name!r} unexpectedly carries description "
+            f"{replies[0].description!r} — scope of H3 should be opt-in."
+        )
+
+    def test_multi_select_contract_preserved(self):
+        # Tertiary H4 sanity — ki_hemmnisse still signals multi_select.
+        replies = _build_quick_replies(["ki_hemmnisse"], report_type="r1",
+                                       collected_fields={})
+        assert replies
+        qr = replies[0]
+        assert qr.multi_select is True
+        assert qr.description is not None
+
+
+# ---------------------------------------------------------------------------
+# H3d — Contract-level serialization surfaces `description`
+# ---------------------------------------------------------------------------
+
+class TestQuickReplyJsonContract:
+    def test_model_dump_exposes_description_key(self):
+        qr = QuickReply(
+            field="meldewege", label="Meldewege",
+            options=[
+                QuickReplyOption(value="ja", label="Ja"),
+            ],
+            description="Wer informiert wen wie schnell bei Datenpannen?",
+        )
+        data = qr.model_dump()
+        assert "description" in data
+        assert data["description"] == "Wer informiert wen wie schnell bei Datenpannen?"
+
+    def test_model_dump_none_still_present_by_default(self):
+        # Frontend contract guard: the key exists even when value is None
+        # so a typed-frontend client doesn't need a missing-key fallback.
+        qr = QuickReply(
+            field="x", label="X",
+            options=[QuickReplyOption(value="a", label="A")],
+        )
+        assert "description" in qr.model_dump()
+        assert qr.model_dump()["description"] is None
+
+    def test_build_quick_replies_json_contains_description(self):
+        replies = _build_quick_replies(["datenschutzbeauftragter"],
+                                       report_type="r1", collected_fields={})
+        payload = [qr.model_dump() for qr in replies]
+        assert payload[0]["description"]
+        assert payload[0]["description"] == (
+            FIELD_DESCRIPTIONS_SHORT["datenschutzbeauftragter"]
+        )
+
+
+# ---------------------------------------------------------------------------
+# H3e — Wire-up guard (inspect): description lookup uses the shared dict,
+# not an inline literal — so adding fields to FIELD_DESCRIPTIONS_SHORT is
+# enough to surface them, and the import stays live.
+# ---------------------------------------------------------------------------
+
+class TestWireUpGuard:
+    def test_uses_shared_dict_lookup(self):
+        src = inspect.getsource(_build_quick_replies)
+        assert "FIELD_DESCRIPTIONS_SHORT.get(field_name)" in src, (
+            "_build_quick_replies must route description lookups through "
+            "FIELD_DESCRIPTIONS_SHORT — inline string literals per field "
+            "would fragment the description source of truth."
+        )
+
+    def test_import_remains(self):
+        from routes import chat as chat_mod
+        assert hasattr(chat_mod, "FIELD_DESCRIPTIONS_SHORT"), (
+            "FIELD_DESCRIPTIONS_SHORT must be imported into routes.chat; "
+            "otherwise the lookup silently returns None."
+        )


### PR DESCRIPTION
## Summary

Fix for Bug C (Compliance-Block ohne Chips/Hilfe), scoped per Briefing 4. Diagnosis in the prior turn identified two cooperating backend gaps — this PR closes both in two commits that can be reviewed and reverted independently.

**Frontend coordination required before merge** (H3 adds a new optional `QuickReply.description` field that needs a rendering slot).

---

### Commit 1 — H1: Block-D head no longer lands on the consent bool

`_get_datenschutz_block_fields("…")` used to put `datenschutz` at position 0. That field is `type="bool"`, `skip_in_chat=True` and has **no entry in `_QR_OPTIONS`** — so `_get_block_fields("D", collected)` kept returning it as the next field, and `_build_quick_replies(["datenschutz"], …)` returned `[]`. Users saw the Sonnet question without buttons; if Haiku couldn't extract a bool from the free-text reply, the turn looped.

Two changes together:

1. `datenschutz` removed from both variants of the Block-D list (Beratung reduced set + default full set). Other call-sites (`_complete_r1` partial-survey check, `_build_session_state` block progress counter, preview endpoint) already treated it correctly once it's gone — it was never something they should enumerate.
2. `/api/chat/start` now seeds `collected_fields["datenschutz"] = True` for R1 sessions at session creation. `consent_report=True` is already required at the endpoint boundary; mirroring it into `collected_fields` from turn 1 keeps the domain model consistent and makes `block_total` / `block_progress` accurate. Strategy sessions are unaffected.

Tests: `tests/test_bug_c_block_d_head.py` — 38 cases, all pass.

### Commit 2 — H3: User-visible short descriptions on `QuickReply`

Before: the long DSGVO-article descriptions in `services/chat_conversation.py:FIELD_DESCRIPTIONS` are **Sonnet-internal only** (BLOCK_D_PROMPT ARTIKEL-REGEL forbids article numbers in user-facing strings) and had no channel on the response schema. Compliance turns had no hint underneath the buttons.

- `schemas/chat.py`: `QuickReply.description: Optional[str] = None`. Backwards-compatible default.
- `services/field_templates.py`: new `FIELD_DESCRIPTIONS_SHORT` dict — Wolf-signed short hints (≤ ~80 chars, article-free) for the 7 compliance fields: `datenschutzbeauftragter`, `technische_massnahmen`, `folgenabschaetzung`, `meldewege`, `loeschregeln`, `ai_act_kenntnis`, `ki_hemmnisse`.
- `routes/chat.py`: `_build_quick_replies` looks up the dict and populates the new field. Fields without a description carry `None` (opt-in scope).

Tests: `tests/test_bug_c_field_descriptions.py` — 26 cases, all pass. Includes:
- Schema default + accepts-string
- Dict contract (all 7 fields covered, ≤ 120 char guard, **no `Art.`/`Artikel`/`DSGVO`/`BDSG` leaks**)
- Call-site wiring per compliance field + negative regression on undescribed fields
- JSON contract (`description` present in `model_dump()` even when None)
- Wire-up guard via `inspect.getsource` against accidental inline literals / lost import

---

## Explicitly out of scope

- **H4** (frontend rendering of `multi_select=True` on `ki_hemmnisse`) → stays a separate KIS ticket per Briefing 4. Backend contract verified via existing test + the new `test_multi_select_contract_preserved`.
- Generic `skip_in_chat` filter inside `_get_block_fields` (Variante 1) — rejected due to too-broad blast radius; the per-field fix is surgical.
- Long DSGVO descriptions in user-visible strings — stays Sonnet-internal.

## Test plan

- [x] `pytest tests/test_bug_c_block_d_head.py` → 38 passed
- [x] `pytest tests/test_bug_c_field_descriptions.py` → 26 passed
- [x] `pytest tests/test_bug_c_block_d_head.py tests/test_bug_c_field_descriptions.py tests/test_kis_1138_inspiration_chips.py tests/test_kis_1162_display_section_title.py tests/test_kis_1136_ft_omit_on_skip.py tests/test_kis_1161_quality_validator.py` → 203 passed
- [ ] Browser smoke (Wolf): R1 flow through checkpoint → Block D → first question is `datenschutzbeauftragter` with Ja/Nein/Teilweise buttons + short hint
- [ ] `ki_hemmnisse` turn renders multi-select in frontend (covered separately under H4)

## Frontend handoff note

`QuickReply.description` is a new optional string. Please render it as a short hint under or beside the button row when present. A `null` value should render identically to today (no regression for fields without a description).

https://claude.ai/code/session_01RcZvzgb1CGDSuMGoxRhY2y