### PR TITLE
fix(idempotency): cache submit response, extend TTL to 30min (KIS-1140)

### DIFF
--- a/routes/briefings.py
+++ b/routes/briefings.py
@@ -61,9 +61,15 @@ async def submit_briefing(
     """
     s = get_settings()
 
-    # Idempotency
-    if _idempotency_box.is_duplicate(request):
-        return {"status": "duplicate_ignored"}
+    # Idempotency — zweiter Call mit gleichem Key liefert die gecachte Response des ersten.
+    idem_result = _idempotency_box.check(request)
+    if idem_result is not None:
+        is_dup, cached = idem_result
+        if is_dup:
+            if cached is not None:
+                return cached
+            # Erster Call noch in-flight oder fehlgeschlagen → Stub
+            return {"status": "duplicate_ignored"}
 
     # Rate-Limit pauschal
     _briefing_rate_limiter.hit(key=request.client.host if request.client else "unknown")
@@ -173,10 +179,14 @@ async def submit_briefing(
         # Service-Principal hinzufügen wenn Service-Token verwendet
         if service_principal:
             response["service_principal"] = service_principal
+        # Response cachen, damit identischer Retry dieselbe Antwort bekommt
+        _idempotency_box.remember(request, response)
         return response
 
     except Exception as e:
         db.rollback()
+        # Key entfernen, damit der Client mit gleichem Key einen sauberen Retry fahren kann
+        _idempotency_box.forget(request)
         log.error("Failed to save briefing: %s", str(e), exc_info=True)
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,

--- a/routes/briefings.py
+++ b/routes/briefings.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 import json
 import logging
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, cast
 
 from fastapi import APIRouter, Depends, HTTPException, Request, status
 from pydantic import BaseModel
@@ -67,7 +67,7 @@ async def submit_briefing(
         is_dup, cached = idem_result
         if is_dup:
             if cached is not None:
-                return cached
+                return cast(Dict[str, Any], cached)
             # Erster Call noch in-flight oder fehlgeschlagen → Stub
             return {"status": "duplicate_ignored"}
 

--- a/tests/test_report_workflow.py
+++ b/tests/test_report_workflow.py
@@ -233,8 +233,8 @@ class TestReportWorkflow:
 
     @patch("gpt_analyze.run_async")
     def test_05_idempotency(self, mock_run_async, client, auth_headers):
-        """Test 5: Idempotenz verhindert doppelte Requests"""
-        # Mock run_async to prevent actual API calls
+        """Test 5: Idempotenter Retry liefert identische Response (inkl. briefing_id),
+        statt einen zweiten DB-Insert zu triggern."""
         mock_run_async.return_value = None
 
         payload = {
@@ -255,11 +255,77 @@ class TestReportWorkflow:
         # Erster Request
         response1 = client.post("/api/briefings/submit", json=payload, headers=headers)
         assert response1.status_code == 202
+        body1 = response1.json()
+        assert body1["status"] == "queued"
+        assert "briefing_id" in body1
 
-        # Zweiter Request mit gleichem Key
+        # Zweiter Request mit gleichem Key → identische Response
         response2 = client.post("/api/briefings/submit", json=payload, headers=headers)
         assert response2.status_code == 202
-        assert response2.json()["status"] == "duplicate_ignored"
+        body2 = response2.json()
+        assert body2 == body1, "Zweiter Call muss gecachte Response zurückliefern"
+        assert body2["briefing_id"] == body1["briefing_id"]
+
+        # Sanity: DB hat nur einen Briefing-Eintrag mit dieser ID, kein zweiter Insert
+        from models import Briefing
+        from routes._bootstrap import get_db
+        db_gen = client.app.dependency_overrides[get_db]()
+        db = next(db_gen)
+        try:
+            count = db.query(Briefing).count()
+            assert count == 1, f"Erwartete genau 1 Briefing-Zeile, gefunden: {count}"
+        finally:
+            db.close()
+
+    @patch("gpt_analyze.run_async")
+    def test_06_idempotency_ttl_expiry(self, mock_run_async, client, auth_headers):
+        """Test 6: Nach TTL-Ablauf darf gleicher Key wieder verarbeitet werden."""
+        mock_run_async.return_value = None
+
+        payload = {
+            "lang": "de",
+            "answers": {
+                "branche": "IT",
+                "bundesland": "Bayern",
+                "jahresumsatz": "1-5M",
+                "unternehmensgroesse": "10-50",
+                "ki_kompetenz": "Anfänger",
+                "hauptleistung": "Software",
+                "antworten": []
+            }
+        }
+
+        headers = auth_headers | {"Idempotency-Key": "ttl-key-67890"}
+
+        # Erster Request
+        response1 = client.post("/api/briefings/submit", json=payload, headers=headers)
+        assert response1.status_code == 202
+        briefing_id_1 = response1.json()["briefing_id"]
+
+        # Box der Route manuell altern lassen (TTL auf 0 setzen + purge erzwingen)
+        import time
+        from routes import briefings as briefings_route
+        box = briefings_route._idempotency_box
+        original_ttl = box.ttl
+        try:
+            box.ttl = 0
+            # Purge triggern durch eine Pseudo-Abfrage mit time-Versatz
+            with box._lock:
+                box._purge_locked(time.time() + 1)
+
+            # Zweiter Request mit gleichem Key → wird neu verarbeitet
+            response2 = client.post("/api/briefings/submit", json=payload, headers=headers)
+            assert response2.status_code == 202
+            briefing_id_2 = response2.json()["briefing_id"]
+            assert briefing_id_2 != briefing_id_1, "Nach TTL-Ablauf muss neuer Briefing-Eintrag entstehen"
+        finally:
+            box.ttl = original_ttl
+
+    def test_07_idempotency_default_ttl_is_30min(self):
+        """Test 7: Default-TTL der IdempotencyBox ist 1800 Sekunden (30 Min)."""
+        from utils.idempotency import IdempotencyBox
+        box = IdempotencyBox(namespace="ttl-default-check")
+        assert box.ttl == 1800
 
 
 class TestReportGeneration:

--- a/utils/idempotency.py
+++ b/utils/idempotency.py
@@ -1,33 +1,84 @@
 
 """
 utils/idempotency.py — Header "Idempotency-Key" auswerten, um doppelte POSTs zu ignorieren.
+
+Zweiter Request mit gleichem Key gibt die gecachte Response des ersten zurück
+(innerhalb der TTL), statt den Handler erneut auszuführen.
 """
 from __future__ import annotations
 
 import threading
 import time
 from collections import OrderedDict
+from typing import Any, Optional, Tuple
+
 
 class IdempotencyBox:
-    def __init__(self, namespace: str, ttl_sec: int = 300, max_size: int = 2000):
+    def __init__(self, namespace: str, ttl_sec: int = 1800, max_size: int = 2000):
         self.ns = namespace
         self.ttl = ttl_sec
         self.max_size = max_size
-        self._box: "OrderedDict[str, float]" = OrderedDict()
+        # key -> (timestamp, cached_response_or_None)
+        self._box: "OrderedDict[str, Tuple[float, Optional[Any]]]" = OrderedDict()
         self._lock = threading.Lock()
 
-    def is_duplicate(self, request) -> bool:
+    def _purge_locked(self, now: float) -> None:
+        for k, (ts, _) in list(self._box.items()):
+            if now - ts > self.ttl:
+                self._box.pop(k, None)
+        while len(self._box) > self.max_size:
+            self._box.popitem(last=False)
+
+    def check(self, request) -> Optional[Tuple[bool, Optional[Any]]]:
+        """Prüfe, ob ein Idempotency-Key vorliegt und schon bekannt ist.
+
+        Returns:
+            None: kein Idempotency-Key-Header → Handler normal ausführen.
+            (False, None): Key zum ersten Mal gesehen; als "in-flight" markiert.
+                           Aufrufer muss am Ende ``remember()`` oder bei Fehlern
+                           ``forget()`` aufrufen.
+            (True, cached): Duplicate, gecachte Response verfügbar.
+            (True, None):   Duplicate, aber erster Call noch in-flight oder fehlgeschlagen.
+        """
         key = request.headers.get("Idempotency-Key")
         if not key:
-            return False
-
+            return None
         with self._lock:
-            now = time.time()
-            # Cleanup
-            for k, ts in list(self._box.items()):
-                if now - ts > self.ttl or len(self._box) > self.max_size:
-                    self._box.pop(k, None)
+            self._purge_locked(time.time())
             if key in self._box:
-                return True
-            self._box[key] = now
+                _, cached = self._box[key]
+                return True, cached
+            self._box[key] = (time.time(), None)
+            return False, None
+
+    def remember(self, request, response: Any) -> None:
+        """Gecachte Response für einen zuvor via ``check()`` markierten Key hinterlegen."""
+        key = request.headers.get("Idempotency-Key")
+        if not key:
+            return
+        with self._lock:
+            if key in self._box:
+                ts, _ = self._box[key]
+                self._box[key] = (ts, response)
+
+    def forget(self, request) -> None:
+        """Key entfernen, damit ein Retry mit gleichem Key erneut verarbeitet wird.
+
+        Sinnvoll, wenn der Handler fehlgeschlagen ist und der Client es mit
+        gleichem Key nochmal versuchen soll.
+        """
+        key = request.headers.get("Idempotency-Key")
+        if not key:
+            return
+        with self._lock:
+            self._box.pop(key, None)
+
+    def is_duplicate(self, request) -> bool:
+        """Legacy-API (boolean). Markiert den Key beim ersten Aufruf als gesehen
+        und liefert bei Folge-Aufrufen True, ohne die ursprüngliche Response
+        zurückzugeben. Für neue Call-Sites bitte ``check()``/``remember()`` nutzen.
+        """
+        result = self.check(request)
+        if result is None:
             return False
+        return result[0]


### PR DESCRIPTION
## Summary

Hardening of backend-side idempotency for `POST /api/briefings/submit` so the FE-PR KIS-1140 (stable Idempotency-Key per page-load) has matching backend semantics.

**Before:** Second call with same `Idempotency-Key` returned `{"status": "duplicate_ignored"}` (without `briefing_id`), and the key lived only 5 minutes.

**After:** Second call returns the original response (incl. `briefing_id`, `analysis_queued`, `service_principal`). TTL raised to 30 minutes. No second DB insert.

## Changes

- `utils/idempotency.py` — new `check()` / `remember()` / `forget()` API; box now stores `(timestamp, cached_response_or_None)`. Default TTL `300 → 1800s`. `is_duplicate()` kept as BC wrapper (still used by `routes/auth.py`).
- `routes/briefings.py:65-71` — use `check()` to fetch cached response; `remember()` before `return`; `forget()` in the `except` path so 5xx-retries with the same key can proceed.
- `tests/test_report_workflow.py` — `test_05_idempotency` now asserts `body2 == body1` and that only one `Briefing` row exists. Added `test_06_idempotency_ttl_expiry` (TTL expiry → new briefing) and `test_07_idempotency_default_ttl_is_30min`.

## Scope notes (from diagnosis)

- Dedup storage remains in-memory (`OrderedDict` + `threading.Lock`). Railway runs 1 replica of the web service and worker is a DB-poller with no HTTP, so cross-process dedup is not required.
- Redis wrapper exists but the `redis` dep is commented out in `requirements.txt` and `REDIS_URL` is not wired into the submit path — intentionally out of scope for this PR.

## Test plan

- [x] `pytest tests/test_report_workflow.py` — 7 pass, 1 skipped (unrelated full-pipeline test)
- [ ] Post-deploy cURL sanity: two `POST /api/briefings/submit` with same `Idempotency-Key`; second returns identical JSON body, `briefings` table has 1 row
- [ ] FE smoke: double-submit, browser-refresh-resubmit within 30 min → same `briefing_id` returned

https://claude.ai/code/session_016vi1oWHkLK71xqQC1Wgopo

---
_Generated by [Claude Code](https://claude.ai/code/session_016vi1oWHkLK71xqQC1Wgopo)_