### PR TITLE
fix(prompts): enforce 3-point structure in executive_decision DE (R1 S.4)

### DIFF
--- a/prompts/de/executive_decision.md
+++ b/prompts/de/executive_decision.md
@@ -77,20 +77,25 @@ INHALTLICHE VERDICHTUNG (nutze nur vorhandene Konzepte):
 - "Tool-Zoo / Ad-hoc-Prompts ohne Standards" = No-Go
 - Stop-Regel: max. 2 parallele Initiativen; nach 14 Tagen ohne messbaren Effekt = vereinfachen oder stoppen
 
-OUTPUT (HTML ONLY, exakt einhalten):
+OUTPUT-FORMAT (HTML ONLY, exakt einhalten):
 
-Genau ein Outer-Container: div.exec-decision-box
+```html
+<div class="exec-decision-box">
+  <p><strong>Ihre Entscheidung in 3 Punkten</strong></p>
+  <ul>
+    <li><strong>Tun:</strong> Ein konkreter Standard-Workflow, der sofort umsetzbar ist (vollständiger Satz).</li>
+    <li><strong>Lassen:</strong> Was ab sofort nicht mehr getan werden sollte (vollständiger Satz).</li>
+    <li><strong>Risiko &amp; Stop-Signal:</strong> Wann gestoppt und vereinfacht werden muss (vollständiger Satz).</li>
+  </ul>
+</div>
+```
 
-Reihenfolge:
-- p > strong: "Ihre Entscheidung in 3 Punkten"
-- ul mit genau 3 li
-
-Jeder li startet mit strong Label und danach ein vollständiger Satz:
-- "Tun:" — ein konkreter Standard-Workflow, der sofort umsetzbar ist
-- "Lassen:" — was Sie ab sofort nicht mehr tun sollten
-- "Risiko & Stop-Signal:" — wann Sie stoppen und vereinfachen müssen
-
-Keine eckigen Klammern, keine geschweiften Klammern, keine Platzhalter-Wörter.
+VOLLSTÄNDIGKEIT (zwingend):
+- Genau 3 <li>-Elemente mit den Labels "Tun:", "Lassen:", "Risiko & Stop-Signal:" — in dieser Reihenfolge.
+- Jedes <li> enthält einen vollständigen Satz mit Satzende (Punkt).
+- Die Platzhaltertexte im Template sind durch konkrete Inhalte zu ersetzen.
+- Keine eckigen Klammern, keine geschweiften Klammern, keine Platzhalter-Wörter.
+- Fehlt eines der drei Elemente, ist die Ausgabe ungültig.
 
 STIL:
 - Distanziert-professionell, wie ein externer Gutachter


### PR DESCRIPTION
## Summary

Fix for Briefing 10 / Punkt 1 — R1 S.4 "Entscheidungsvorlage" Content-Abbruch.

The Entscheidungsvorlage page rendered only the first bullet ("Tun: …") and left the rest of the page empty. The versprochenen "Lassen:" and "Risiko & Stop-Signal:" bullets were missing.

### Diagnose

Hypothese H1 (aus Briefing) bestätigt: Das DE-Prompt (`prompts/de/executive_decision.md`) beschreibt die Output-Struktur nur in natürlicher Sprache ("ul mit genau 3 li"), während das EN-Prompt bereits ein explizites HTML-Code-Block-Template nutzt. Unter dieser schwächeren Strukturvorgabe produziert das LLM gelegentlich nur das erste `<li>`-Element.

- **Nicht Token-Budget (H4):** `executive_decision` ist nicht in `_SECTION_MAX_TOKENS`, fällt auf `OPENAI_MAX_TOKENS_DEFAULT=3000` — weit mehr als für 70–90 Wörter nötig.
- **Nicht Post-Processing (H3):** Das Template (`templates/pdf_template_v7.html:1479-1490`) rendert `EXECUTIVE_DECISION_HTML` verbatim. `_aggressive_text_truncation` wird auf `EXECUTIVE_DECISION_HTML` gar nicht angewendet (nicht in `truncation_targets`).
- **Ursache:** LLM-Output unvollständig wegen schwacher Strukturvorgabe im Prompt.

### Fix

`prompts/de/executive_decision.md`:
- Ersetze die natürlichsprachige OUTPUT-Beschreibung durch ein explizites HTML-Code-Fence-Template mit allen 3 `<li>`-Elementen (Tun / Lassen / Risiko & Stop-Signal).
- Füge eine `VOLLSTÄNDIGKEIT`-Sektion hinzu, die das Vorhandensein aller 3 Bullets explizit als zwingend markiert.
- Labels und Reihenfolge unverändert.
- Keine Auswirkungen auf andere Sections oder das Template.

### Risiko

- Gering. Nur Prompt-Text geändert, keine Code-Pfade.
- Labels/Reihenfolge unverändert → keine Template-Anpassungen nötig.
- Keine anderen Prompts oder Sections betroffen.

## Test plan

- [ ] Manueller Testrun Solo: Entscheidungsvorlage zeigt 3 vollständige Bullets (Tun / Lassen / Risiko & Stop-Signal)
- [ ] Manueller Testrun Team: dto.
- [ ] Manueller Testrun KMU: dto.
- [ ] Content-Check: Bullets 2 & 3 sind inhaltlich sinnvoll und branchenspezifisch
- [ ] Regression: Andere Template-Sections unverändert
- [ ] PDF-Rendering: Keine leere Seitenfläche mehr auf S.4

https://claude.ai/code/session_0138EyNDo5UShvpqxWLs5A2v

---
_Generated by [Claude Code](https://claude.ai/code/session_0138EyNDo5UShvpqxWLs5A2v)_