### PR TITLE
fix(chat): show QR chips for ki_ziele in Phase 1b (KIS-1142) + impact-scope analysis

### DIFF
--- a/IMPACT_SCOPE_ANALYSIS_2026-04-22.md
+++ b/IMPACT_SCOPE_ANALYSIS_2026-04-22.md
@@ -1,0 +1,335 @@
+# Impact-Scope SQL Analysis — Report Pipeline Changes
+
+**Stand:** 2026-04-22
+**Auftrag:** BRIEFING-10 Task B (Punkt 9 aus Briefing 9)
+**Scope:** PR #967, #968, #969, #971, #972, KIS-1140
+**Zweck:** Grundlage für Entscheidung über Kundenkommunikation bei materiellen Änderungen
+**Status:** Analyse — kein Code-Commit
+
+---
+
+## 1. Database Model Map
+
+### Kern-Tabellen
+
+| Tabelle | Key Columns | Zweck | Relations |
+|---------|-------------|-------|-----------|
+| **users** | `id` (PK), `email`, `created_at` | User-Accounts | FK-Target für `user_id` in briefings, reports, analyses |
+| **briefings** | `id` (PK), `user_id` (FK), `answers` (JSONB), `created_at`, `accepted_at`, `done_at`, `status` | Form-Submissions / Conversation-State | Enthält alle User-Inputs inkl. `ki_ziele`, `investitionsbudget`, `technische_massnahmen`, `meldewege`, `loeschregeln` |
+| **reports** | `id` (PK), `user_id`, `briefing_id` (FK), `analysis_id` (FK), `created_at`, `updated_at`, `status`, `pdf_url` | R1-Reports (Basic Advisory) | Verknüpft Briefing (Input) und Analysis (gerenderter HTML) |
+| **analyses** | `id` (PK), `user_id`, `briefing_id` (FK), `html` (Text), `meta` (JSONB), `created_at` | R1 rendered HTML + Metadaten | Enthält `sections` JSON, calculated scores, labels, AI-Act-Risk |
+| **strategy_reports** | `id` (PK), `briefing_id` (FK, unique), `status`, `sections` (JSONB), `calculated_values` (JSONB), `created_at`, `updated_at` | Report 3 (Strategy Advisory) | Verknüpft nur Briefing; strategy-spezifische Calculations |
+| **reports_history** | `id` (PK), `report_id` (FK), `user_id`, `version`, `scores_json` (JSONB), `bc_json` (JSONB), `ai_act_json` (JSONB), `created_at` | Report-Versionierung (Sprint G11) | Snapshots von Scores, Business Case, AI-Act-Compliance pro Report-Version |
+
+**Report-Type-Bestimmung:**
+- **R1 Reports:** via `reports` Tabelle (hat `analysis_id` gesetzt) — Filter `analysis_id IS NOT NULL`
+- **Report 3 (Strategy):** via `strategy_reports` Tabelle — separate Table, eigener Workflow
+- Keine explizite `report_type`-Spalte in `reports` — Differenzierung via FK-Beziehung
+
+---
+
+## 2. SQL-Queries (zur Ausführung durch Product Owner)
+
+> Alle Queries sind PostgreSQL-Syntax. Nicht ausgeführt — nur geschrieben.
+
+### a) Reports letzte 90 Tage (nach Woche)
+
+```sql
+-- R1 Reports by week
+SELECT
+    DATE_TRUNC('week', r.created_at)::DATE AS week_start,
+    COUNT(DISTINCT r.id) AS r1_report_count,
+    COUNT(DISTINCT r.briefing_id) AS unique_briefings,
+    COUNT(DISTINCT r.user_id) AS unique_users
+FROM reports r
+WHERE r.created_at >= NOW() - INTERVAL '90 days'
+  AND r.analysis_id IS NOT NULL
+GROUP BY DATE_TRUNC('week', r.created_at)
+ORDER BY week_start DESC;
+
+-- Strategy Reports by week
+SELECT
+    DATE_TRUNC('week', sr.created_at)::DATE AS week_start,
+    COUNT(DISTINCT sr.id) AS strategy_report_count,
+    COUNT(DISTINCT sr.briefing_id) AS unique_briefings
+FROM strategy_reports sr
+WHERE sr.created_at >= NOW() - INTERVAL '90 days'
+  AND sr.status IN ('completed', 'emailed')
+GROUP BY DATE_TRUNC('week', sr.created_at)
+ORDER BY week_start DESC;
+```
+
+### b) Eindeutige Kunden (letzte 90 Tage, beide Report-Typen)
+
+```sql
+SELECT
+    COUNT(DISTINCT u.id) AS total_customers
+FROM users u
+WHERE EXISTS (
+    SELECT 1 FROM reports r
+    WHERE r.user_id = u.id
+      AND r.created_at >= NOW() - INTERVAL '90 days'
+      AND r.analysis_id IS NOT NULL
+)
+OR EXISTS (
+    SELECT 1 FROM strategy_reports sr
+    JOIN briefings b ON sr.briefing_id = b.id
+    WHERE b.user_id = u.id
+      AND sr.created_at >= NOW() - INTERVAL '90 days'
+      AND sr.status IN ('completed', 'emailed')
+);
+```
+
+### c) Reports von semantisch veränderten Feldern betroffen
+
+#### c1) Reports mit `ki_ziele` (PR #969 Scoring-Kalibrierung)
+
+```sql
+SELECT
+    COUNT(DISTINCT r.id) AS r1_reports_with_ki_ziele,
+    COUNT(DISTINCT r.user_id) AS unique_customers
+FROM reports r
+JOIN briefings b ON r.briefing_id = b.id
+WHERE b.answers->>'ki_ziele' IS NOT NULL
+  AND b.answers->>'ki_ziele' != ''
+  AND b.answers->>'ki_ziele' != '[]'
+  AND r.created_at >= NOW() - INTERVAL '90 days'
+  AND r.analysis_id IS NOT NULL;
+
+SELECT
+    COUNT(DISTINCT sr.id) AS strategy_reports_with_ki_ziele
+FROM strategy_reports sr
+JOIN briefings b ON sr.briefing_id = b.id
+WHERE b.answers->>'ki_ziele' IS NOT NULL
+  AND b.answers->>'ki_ziele' != ''
+  AND sr.created_at >= NOW() - INTERVAL '90 days'
+  AND sr.status IN ('completed', 'emailed');
+```
+
+#### c2) Reports mit Compliance-Feldern (PR #968 + #969 — Art. 32/33/17)
+
+```sql
+-- R1 Reports where briefing has ANY of: technische_massnahmen, meldewege, loeschregeln
+SELECT
+    COUNT(DISTINCT r.id) AS r1_reports_with_compliance,
+    COUNT(DISTINCT r.user_id) AS unique_customers
+FROM reports r
+JOIN briefings b ON r.briefing_id = b.id
+WHERE (
+    b.answers->>'technische_massnahmen' IS NOT NULL
+    OR b.answers->>'meldewege' IS NOT NULL
+    OR b.answers->>'loeschregeln' IS NOT NULL
+)
+  AND r.created_at >= NOW() - INTERVAL '90 days'
+  AND r.analysis_id IS NOT NULL;
+
+-- Breakdown: Welche Felder sind gesetzt?
+SELECT
+    SUM(CASE WHEN b.answers->>'technische_massnahmen' IS NOT NULL THEN 1 ELSE 0 END) AS has_tech_mas,
+    SUM(CASE WHEN b.answers->>'meldewege' IS NOT NULL THEN 1 ELSE 0 END) AS has_meldewege,
+    SUM(CASE WHEN b.answers->>'loeschregeln' IS NOT NULL THEN 1 ELSE 0 END) AS has_loeschregeln
+FROM reports r
+JOIN briefings b ON r.briefing_id = b.id
+WHERE r.created_at >= NOW() - INTERVAL '90 days'
+  AND r.analysis_id IS NOT NULL;
+```
+
+#### c3) Reports mit `investitionsbudget` (PR #969 Finance-Kalibrierung)
+
+```sql
+SELECT
+    COUNT(DISTINCT r.id) AS r1_reports_with_budget,
+    COUNT(DISTINCT r.user_id) AS unique_customers,
+    b.answers->>'investitionsbudget' AS budget_category
+FROM reports r
+JOIN briefings b ON r.briefing_id = b.id
+WHERE b.answers->>'investitionsbudget' IS NOT NULL
+  AND b.answers->>'investitionsbudget' != ''
+  AND r.created_at >= NOW() - INTERVAL '90 days'
+  AND r.analysis_id IS NOT NULL
+GROUP BY b.answers->>'investitionsbudget'
+ORDER BY COUNT(*) DESC;
+
+SELECT
+    COUNT(DISTINCT sr.id) AS strategy_reports_with_budget,
+    b.answers->>'investitionsbudget' AS budget_category
+FROM strategy_reports sr
+JOIN briefings b ON sr.briefing_id = b.id
+WHERE b.answers->>'investitionsbudget' IS NOT NULL
+  AND b.answers->>'investitionsbudget' != ''
+  AND sr.created_at >= NOW() - INTERVAL '90 days'
+  AND sr.status IN ('completed', 'emailed')
+GROUP BY b.answers->>'investitionsbudget'
+ORDER BY COUNT(*) DESC;
+```
+
+### d) Aggregierte Matrix nach Report-Typ × Feld
+
+```sql
+SELECT 'R1' AS report_type, 'ki_ziele' AS affected_field,
+       COUNT(DISTINCT r.id) AS count
+FROM reports r JOIN briefings b ON r.briefing_id = b.id
+WHERE b.answers->>'ki_ziele' IS NOT NULL
+  AND r.created_at >= NOW() - INTERVAL '90 days'
+  AND r.analysis_id IS NOT NULL
+UNION ALL
+SELECT 'R1', 'compliance (art 32/33/17)', COUNT(DISTINCT r.id)
+FROM reports r JOIN briefings b ON r.briefing_id = b.id
+WHERE (b.answers->>'technische_massnahmen' IS NOT NULL
+       OR b.answers->>'meldewege' IS NOT NULL
+       OR b.answers->>'loeschregeln' IS NOT NULL)
+  AND r.created_at >= NOW() - INTERVAL '90 days'
+  AND r.analysis_id IS NOT NULL
+UNION ALL
+SELECT 'R1', 'investitionsbudget', COUNT(DISTINCT r.id)
+FROM reports r JOIN briefings b ON r.briefing_id = b.id
+WHERE b.answers->>'investitionsbudget' IS NOT NULL
+  AND r.created_at >= NOW() - INTERVAL '90 days'
+  AND r.analysis_id IS NOT NULL
+UNION ALL
+SELECT 'Strategy (R3)', 'ki_ziele', COUNT(DISTINCT sr.id)
+FROM strategy_reports sr JOIN briefings b ON sr.briefing_id = b.id
+WHERE b.answers->>'ki_ziele' IS NOT NULL
+  AND sr.created_at >= NOW() - INTERVAL '90 days'
+  AND sr.status IN ('completed', 'emailed')
+UNION ALL
+SELECT 'Strategy (R3)', 'investitionsbudget', COUNT(DISTINCT sr.id)
+FROM strategy_reports sr JOIN briefings b ON sr.briefing_id = b.id
+WHERE b.answers->>'investitionsbudget' IS NOT NULL
+  AND sr.created_at >= NOW() - INTERVAL '90 days'
+  AND sr.status IN ('completed', 'emailed')
+ORDER BY report_type, affected_field;
+```
+
+---
+
+## 3. Impact-Klassifizierung pro PR
+
+### PR #967 (KIS-1136 rest) — Omit Strategy FT Fields on Skip Signals
+
+**Change:** Chat-Normalizer omittet `vision_3_jahre`, `strategische_ziele`, `ki_guardrails`, `geschaeftsmodell_evolution` aus `briefings.answers`, wenn User Skip signalisiert.
+
+**Impact:** **Minor / Internal Process**
+- Keine user-sichtbare Report-Content-Änderung
+- Affektiert nur Forward-Collection, nicht bestehende Briefings
+- **Action:** Keine Re-Gen nötig
+
+### PR #968 (Bug C) — Block-D Head + QuickReply Descriptions
+
+**Changes:**
+1. Datenschutz-Consent aus Block D Header entfernt (H1 fix)
+2. Kurze User-facing Descriptions auf QuickReply-Options (H3 feature)
+
+**Impact:** **Minor / UX-cosmetic only**
+- Chat-UI/Flow-Änderung, kein Report-Content
+- Historische Reports unaffected
+- **Action:** Keine Re-Gen nötig
+
+### PR #969 (KIS-1153) — Scoring + Finance Kalibrierung
+
+**Changes:**
+1. **Compliance-Feld-Scope** (7fcd90d): `technische_massnahmen`, `meldewege`, `loeschregeln` jetzt für **alle Branchen** gefragt, nicht nur regulierte. Vorher hatten nicht-regulierte User diese Felder nie gesetzt.
+2. **Security-Score-Kalibrierung** (8fbfc2b): `loeschregeln` in Security-Scorer aufgenommen, Gewichte rekalibriert.
+3. **Investment-Konsistenz** (8a50c1b, f8e17cb): Strategy-Report-Investment jetzt kanonische CAPEX-Defaults, Budget-Label-Rendering gefixt.
+
+**Impact:** **MATERIAL / User-sichtbar**
+- Reports vor diesem Fix aus nicht-regulierten Branchen haben **andere Security-Scores** (alt: fehlende Compliance-Inputs → künstlich niedrige Scores; neu: Compliance-Felder jetzt gesammelt → kalibrierte Scores)
+- Strategy-Reports: ROI, Budget-Breakdowns, Phase-Allocations ändern sich
+- **Betroffen:** Alle R1-Reports aus nicht-regulierten Branchen vor 2026-04-22 ~18:51 UTC
+- **Action:** **PROAKTIVE NOTIFICATION** empfohlen; Re-Gen mit klarer "Updated Assessment"-Kommunikation
+
+### PR #971 (KIS-1139) — Chip Filter Bug
+
+**Change:** Inspiration-Chips die User-Vorantwort spiegeln werden gedroppt.
+
+**Impact:** **Kein Report-Impact**
+- Chat-UX only
+- **Action:** Keine Re-Gen
+
+### KIS-1140 — Idempotency Cache + TTL
+
+**Change:** Idempotency-Key-TTL von 5 min auf 30 min erweitert; Full Response statt Stub gecached.
+
+**Impact:** **Kein Report-Impact**
+- Infrastructure / Retry-Handling
+- **Action:** Keine Re-Gen
+
+### PR #972 (KIS-1162) — Executive Decision 3-Point Structure
+
+**Change:** 3-Punkt-Struktur in R1 S.4 (`executive_decision`) erzwungen — frühere Versionen liessen manchmal "Lassen:" und "Risiko & Stop-Signal:" weg.
+
+**Impact:** **Minor / Content Completeness**
+- Reports vor Fix können unvollständige S.4 haben (fehlende Bullets)
+- Content-Semantik identisch, Layout war lückenhaft
+- **Action:** **OPTIONAL Re-Gen** für Cosmetic Completeness; Low Priority
+
+---
+
+## 4. Empfehlung für Kundenkommunikation
+
+### Segmentierung nach Impact-Level
+
+| Impact | PR(s) | Action | Scope |
+|--------|-------|--------|-------|
+| **CRITICAL** | #969 (Compliance + Scoring) | **Proaktive Notification + Re-Gen** | Nicht-regulierte-Branchen-Reports vor 2026-04-22 ~18:51 UTC |
+| **OPTIONAL** | #972 | Silent Re-Gen oder User-Wahl | Cosmetic S.4-Completeness |
+| **LOW** | #968, #971, KIS-1140 | Keine Action | UX/Infra only |
+| **INTERNAL** | #967 | Keine Action | Forward-Collection |
+
+### Decision-Tree pro Report (90-Tage-Window)
+
+1. **Branche-Filter:**
+   ```
+   IF branche ∈ {IT, Manufaktur, Handel, Dienstleistung, Bildung, Medien, ...}  # nicht-reguliert
+   AND created_at < 2026-04-22 18:51:00 UTC:
+       → NOTIFY + OFFER RE-GEN
+   ```
+
+2. **Compliance-Feld-Prüfung:**
+   ```
+   IF (technische_massnahmen ∨ meldewege ∨ loeschregeln) IS NULL:
+       → Report hatte artificially niedrige Security-Scores
+       → **PRIORISIERT notifizieren**
+   ```
+
+3. **Strategy-Report-Investment:**
+   ```
+   IF strategy_reports.status IN ('completed', 'emailed')
+   AND investitionsbudget IS NOT NULL:
+       → ROI/Phase-Budgets können abweichen
+       → Re-Gen anbieten (bei High-Value-Kunden)
+   ```
+
+### Kommunikations-Template (Entwurf, mit Wolf final abstimmen)
+
+**Nicht-regulierte Branchen:**
+
+> Wir haben unsere KI-Advisory-Bewertung erweitert: Compliance-Aspekte (DSGVO Art. 32/33/17) werden jetzt für alle Branchen berücksichtigt, nicht nur explizit regulierte.
+>
+> Ihr Report vom [DATUM] basierte auf einem älteren Modell. **Ihr aktualisierter Report ist verfügbar:** [LINK]
+>
+> Keine Aktion nötig — bei Interesse zeigen wir Ihnen die Unterschiede Seite-an-Seite.
+
+**Regulierte Branchen (Gesundheit, Finanzen, Verwaltung):**
+
+> Keine Aktion nötig. Ihr Report enthielt diese Felder bereits.
+
+---
+
+## 5. Zusammenfassung
+
+- **Materialität:** Nur PR #969 hat **material user-visible impact**
+- **Scope:** ~30–50% der R1-Reports aus nicht-regulierten Branchen im 90-Tage-Fenster (Schätzung)
+- **Re-Gen-Kosten:** Niedrig (Offline-Batch via `briefings.answers` + `reports_history`-Versionierung)
+- **Kommunikations-Risiko:** Moderat (Transparenz nötig), niedrige Churn-Wahrscheinlichkeit (Improvement-Story)
+- **Timeline:** Empfehlung: Notifications + Re-Gens binnen 2 Wochen, um Kundenverwirrung bei Nachfragen zu vermeiden
+
+## Wolf-Touchpoint
+
+Entscheidung liegt bei Wolf:
+1. **Go/No-Go** für proaktive Notification (vs. nur bei Kunden-Nachfrage reaktiv)
+2. **Wording** des Kommunikations-Templates (obiges ist Entwurf)
+3. **Scope:** Alle nicht-regulierten Reports, oder nur Reports mit niedrigen Security-Scores (<60)?
+4. **Kanal:** Email an Briefing-Email, oder nur über bestehende Kundenbetreuung?
+
+Keine Wolf-Antwort nötig, um mit Block 2 weiterzumachen.

--- a/routes/chat.py
+++ b/routes/chat.py
@@ -2131,8 +2131,12 @@ async def chat_message(req: ChatMessageRequest, db: Session = Depends(get_db)):
             # KIS-1124 Testrun 3 Bugs 16+17: Show QR buttons for fields that
             # need structured input (digitalisierungsgrad, ki_kompetenz) to
             # prevent Doppelfrage and unclear free text answers.
+            # KIS-1142: ki_ziele added — multi-select with 8 canonical options
+            # in _QR_OPTIONS. Freetext answers still accepted via
+            # _FREETEXT_EXTRACTION_FIELDS (extractor preserves user wording).
             _p1b_qr_fields = [f for f in next_fields
-                              if f in ("digitalisierungsgrad", "ki_kompetenz")]
+                              if f in ("digitalisierungsgrad", "ki_kompetenz",
+                                       "ki_ziele")]
             quick_replies = _build_quick_replies(
                 _p1b_qr_fields, rt, collected, _profile_ctx,
             ) if _p1b_qr_fields else []

--- a/tests/test_kis_1142_ki_ziele_qr.py
+++ b/tests/test_kis_1142_ki_ziele_qr.py
@@ -1,0 +1,134 @@
+# -*- coding: utf-8 -*-
+"""
+KIS-1142 — ``ki_ziele`` must render QR buttons in Phase 1b.
+
+Symptom: during the R1 open-conversation phase (Phase 1b), the bot asks
+about ``ki_ziele`` (Sektion 3 — "Ihre wichtigsten Ziele beim KI-Einsatz")
+without any quick-reply chips. Users end up typing freetext, which is
+accepted by the extractor but defeats the UX goal of guiding users to
+the 7 canonical goal categories.
+
+Root cause: the Phase 1b branch in ``routes.chat`` only enumerated
+``digitalisierungsgrad`` and ``ki_kompetenz`` in its QR allowlist
+(see KIS-1124 Testrun 3 Bugs 16+17). ``ki_ziele`` has a ``_QR_OPTIONS``
+entry and ``chat_mode="QR"`` in the registry, but the Phase 1b guard
+filtered it out before ``_build_quick_replies`` ever saw it.
+
+Regression coverage under test:
+
+  1. ``_build_quick_replies(["ki_ziele"])`` produces a multi-select
+     QuickReply with the 8 canonical options.
+  2. The Phase 1b allowlist in ``routes/chat.py`` includes ``ki_ziele``
+     (source-level inspect guard so a future refactor can't silently
+     drop it again).
+  3. Coexistence invariant: ``ki_ziele`` also remains in
+     ``_FREETEXT_EXTRACTION_FIELDS`` — freetext answers are still
+     accepted, the QR chips are an additional path, not a replacement.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+import pytest
+
+from routes import chat as chat_module
+from routes.chat import _build_quick_replies, _QR_OPTIONS
+from services.chat_normalizer import FIELD_REGISTRY
+
+
+# ---------------------------------------------------------------------------
+# H1 — canonical QR build works for ki_ziele
+# ---------------------------------------------------------------------------
+
+class TestKiZieleQuickReplyBuild:
+    def test_has_qr_options_entry(self):
+        # Sanity: the entry added in an earlier sprint must still exist.
+        assert "ki_ziele" in _QR_OPTIONS, (
+            "_QR_OPTIONS is missing the ki_ziele entry — QR rendering "
+            "cannot work without it."
+        )
+        # Eight canonical options (7 goals + keine_angabe escape hatch).
+        assert len(_QR_OPTIONS["ki_ziele"]) == 8
+
+    def test_registered_as_multi_qr(self):
+        reg = FIELD_REGISTRY["ki_ziele"]
+        assert reg["type"] == "multi"
+        assert reg["chat_mode"] == "QR"
+        assert reg["required"] is True
+
+    def test_build_quick_replies_emits_multi_select(self):
+        replies = _build_quick_replies(
+            ["ki_ziele"], report_type="r1", collected_fields={},
+        )
+        assert replies, "no QuickReply produced for ki_ziele"
+        qr = replies[0]
+        assert qr.field == "ki_ziele"
+        assert qr.multi_select is True, (
+            "ki_ziele is a multi field — QuickReply must expose "
+            "multi_select=True so the FE renders checkboxes."
+        )
+        assert len(qr.options) == 8
+
+    def test_build_quick_replies_skips_when_already_collected(self):
+        # Defensive: once ki_ziele is in collected_fields, no QR is emitted.
+        replies = _build_quick_replies(
+            ["ki_ziele"],
+            report_type="r1",
+            collected_fields={"ki_ziele": ["effizienz"]},
+        )
+        assert replies == []
+
+
+# ---------------------------------------------------------------------------
+# H2 — Phase 1b guard must whitelist ki_ziele
+# ---------------------------------------------------------------------------
+
+class TestPhase1bAllowlistIncludesKiZiele:
+    """Source-level guard for the Phase 1b QR allowlist.
+
+    The Phase 1b branch in the main chat handler is deeply nested inside
+    the streaming coroutine and hard to reach via a unit-level call.
+    Instead we inspect the module source to assert the allowlist tuple
+    contains ``ki_ziele`` — cheap and regression-proof.
+    """
+
+    def test_source_contains_ki_ziele_in_phase_1b_tuple(self):
+        src = inspect.getsource(chat_module)
+        # The Phase 1b allowlist sits immediately after the "Phase 1b: open
+        # conversation" comment. Collapse whitespace before matching so
+        # reflowed formatting doesn't break the test.
+        normalized = " ".join(src.split())
+        needle = (
+            '_p1b_qr_fields = [f for f in next_fields '
+            'if f in ("digitalisierungsgrad", "ki_kompetenz", "ki_ziele")]'
+        )
+        assert needle in normalized, (
+            "Phase 1b QR allowlist in routes/chat.py must include "
+            "'ki_ziele' alongside 'digitalisierungsgrad' and "
+            "'ki_kompetenz' (KIS-1142)."
+        )
+
+
+# ---------------------------------------------------------------------------
+# H3 — Freetext coexistence invariant
+# ---------------------------------------------------------------------------
+
+class TestFreetextCoexistence:
+    """QR rendering and freetext extraction must coexist for ki_ziele.
+
+    The Phase 1b multi-field extractor keeps ki_ziele in
+    ``_FREETEXT_EXTRACTION_FIELDS`` so users who ignore the chips and
+    type their own words still have their wording preserved (see
+    KIS-1124 Testrun 3). Dropping ki_ziele from that set as part of the
+    KIS-1142 fix would silently regress that behaviour.
+    """
+
+    def test_freetext_extraction_fields_literal_still_mentions_ki_ziele(self):
+        src = inspect.getsource(chat_module)
+        normalized = " ".join(src.split())
+        assert '_FREETEXT_EXTRACTION_FIELDS = {"ki_ziele"}' in normalized, (
+            "ki_ziele must remain in _FREETEXT_EXTRACTION_FIELDS so the "
+            "Phase 1b extractor keeps using the user's own wording when "
+            "they type freetext instead of clicking a chip."
+        )


### PR DESCRIPTION
## Summary

Two independent deliverables on one branch — clean cherry-pick boundary if you want to split.

### 1. KIS-1142 — `ki_ziele` ohne QR-Buttons (Bug-Fix)

**Symptom:** R1 chat asks "Was sind Ihre wichtigsten Ziele beim KI-Einsatz?" without quick-reply chips. User got a freetext prompt where 8 canonical multi-select options should appear.

**Root cause refuted H1.** The `_QR_OPTIONS["ki_ziele"]` entry, the `chat_mode="QR"` registry record, and the 8 enum values in `ENUM_VALUES["ki_ziele"]` were all already present. The actual bug is one layer up: the Phase 1b QR allowlist (`routes/chat.py:2134`, introduced in KIS-1124 Testrun 3 for Bugs 16+17) only enumerated `digitalisierungsgrad` and `ki_kompetenz`. Any other Phase 1b field — `ki_ziele`, `hauptleistung` — fell through to the `else []` branch and got rendered without chips.

**Fix:** add `ki_ziele` to that tuple.

```diff
- _p1b_qr_fields = [f for f in next_fields
-                   if f in ("digitalisierungsgrad", "ki_kompetenz")]
+ _p1b_qr_fields = [f for f in next_fields
+                   if f in ("digitalisierungsgrad", "ki_kompetenz",
+                            "ki_ziele")]
```

**Coexistence invariant preserved.** `ki_ziele` stays in `_FREETEXT_EXTRACTION_FIELDS` (line 968) so users who type their own goals — "Effizienzsteigerung im Marketing" — still get their wording preserved by the multi-field extractor (KIS-1124 Testrun 3). The QR chips are an *additional* path, not a replacement: users who click get canonical values, users who type get their own words.

**Regression cover** (`tests/test_kis_1142_ki_ziele_qr.py`, 6 tests, all green):

- `_build_quick_replies(["ki_ziele"])` returns multi_select QuickReply with 8 options
- `_QR_OPTIONS` and `FIELD_REGISTRY` invariants
- Source-level guard on the Phase 1b allowlist tuple (so a future refactor can't silently drop `ki_ziele` again)
- Source-level guard on `_FREETEXT_EXTRACTION_FIELDS` (coexistence invariant)
- "Already collected" skip behavior

Related: PR #968 (Bug C — same root-cause class: missing entry in a QR allowlist), PR #971 (KIS-1139 chip filter — same code region).

### 2. Impact-Scope SQL Analysis (Track C, no app code)

`IMPACT_SCOPE_ANALYSIS_2026-04-22.md` — read-only research artifact for the product owner. Maps customer reports affected by recent fixes (PR #967, #968, #969, #971, #972, KIS-1140) and provides PostgreSQL queries to estimate communication scope.

**Headline finding:** only PR #969 (compliance-field scope + scoring recalibration) has *material* user-visible impact. Reports from non-regulated branches generated before 2026-04-22 ~18:51 UTC will produce different security scores after re-generation. All other recent fixes are UX/infra/forward-collection only — no historical reports affected.

**Wolf-touchpoints in the doc** (no blocking question on this PR):
- Go/no-go on proactive notification vs. reactive on inquiry
- Wording of customer email template
- Scope filter — all non-regulated reports, or only those with security score < 60?

## Test plan
- [x] `pytest tests/test_kis_1142_ki_ziele_qr.py` — 6/6 green
- [x] `pytest tests/test_bug_c_block_d_head.py tests/test_bug_c_field_descriptions.py tests/test_kis_1138_inspiration_chips.py tests/test_kis_1139_chip_filter.py` — 108/108 green (regression sanity on adjacent code regions)
- [ ] Browser smoke (Wolf): start a fresh R1 session, answer through Phase 1a (branche / size / bundesland / budget), then in Phase 1b answer `digitalisierungsgrad` via slider chip. The next bot turn ("Was sind Ihre wichtigsten Ziele beim KI-Einsatz?") should now render 8 multi-select chips
- [ ] Verify a freetext answer like "Effizienz steigern, neue Produkte" is still accepted and extracted (coexistence invariant)

https://claude.ai/code/session_kis-1142

---
_Generated by [Claude Code](https://claude.ai/code/session_01H9uqvfiPt9vo4KR5Zw6NES)_