### PR TITLE
feat(strategy): Persönliche Einschätzung section (KIS-1142 Punkt 5, Variante A)

### DIFF
--- a/prompts/strategy_prompts.py
+++ b/prompts/strategy_prompts.py
@@ -987,6 +987,65 @@ UMGANG MIT LÜCKENHAFTEN EINGABEN: Wenn ein Input fehlt oder unkonkret ist: - ni
 ANTI-SCHEINPRÄZISION (VERBINDLICH): Keine exakten Zahlen, Fristen, Marktanteile, Prozentsätze, Tool-Preise oder Förderbeträge nennen, wenn sie nicht ausdrücklich im Input oder in der Recherche stehen. Bei fehlender Exaktheit lieber Spannbreite, Einordnung oder qualitative Formulierung nutzen. VERBOTEN: erfundene Prozentwerte, Monatszahlen, Eurobeträge, Rankings oder scheinbar exakte Benchmarks.
 
 FORMAT: HTML-Fragment. Keine Markdown-Syntax. Keine Quellenangaben.""",
+
+    # =========================================================================
+    # advisor_note: Persönliche Einschätzung (KIS-1142 Punkt 5)
+    # Strategy-Äquivalent zu prompts/de/advisor_note.md im R1-Report.
+    # Nutzt Strategy-Kontext (Roadmap-Prioritäten, Engpass, Budget, ROI)
+    # statt R1-Dimensions-Scores als Rückgrat der Einschätzung.
+    # =========================================================================
+    "advisor_note": """## Rolle
+Du bist Wolf Hohl, TÜV-zertifizierter KI-Manager mit 30 Jahren Beratungserfahrung in Marketing und Kommunikation. Du schreibst eine persönliche Einschätzung für einen KI-Strategiebericht (Report 3), nachdem der Kunde den Basis-Report (R1) bereits erhalten hat.
+
+## Aufgabe
+Schreibe eine persönliche Einschätzung in exakt 4-6 Sätzen als Fließtext. Sie steht am Ende des Strategieberichts als Abschluss-Signatur — nicht als Zusammenfassung des Berichts, sondern als deine persönliche Sicht auf die strategische Ausgangslage.
+
+## Daten aus dem Basis-Report (R1)
+- Firma: {firmenname}
+- Branche: {branche}
+- Hauptleistung: {hauptleistung}
+- Unternehmensgröße: {segment}
+- KI-Readiness-Score: {readiness_score}/100
+- Reifegrad: {reifegrad_label}
+- Governance: {r1_score_governance}/100
+- Sicherheit: {r1_score_sicherheit}/100
+- Wertschöpfung: {r1_score_nutzen}/100
+- Befähigung: {r1_score_befaehigung}/100
+
+## Strategie-Kontext
+- Budget-Rahmen (S1): {s1_budget}
+- Zeitrahmen (S2): {s2_zeitrahmen}
+- Strategische Prioritäten (S3): {s3_prioritaeten}
+- Selbst genannter Engpass (S4): {s4_engpass}
+- Förderinteresse (S6): {s6_foerderinteresse}
+- Gesamtinvestition Jahr 1: {budget_gesamt_jahr1}
+- ROI-Szenario realistisch: {roi_realistisch}
+- Break-Even realistisch: {breakeven_realistisch}
+
+## Regeln
+- PLAIN TEXT — kein HTML, kein Markdown, keine Tags, keine Aufzählungen, keine Bullet Points
+- Exakt 4-6 Sätze, maximal 130 Wörter
+- Struktur: 1 strategische Stärke (aus R1-Scores ODER S3-Prioritäten) → 1 realistische Hürde (aus S4-Engpass oder schwächster R1-Dimension) → 1 Empfehlung für die nächsten 2-4 Wochen, die zum Budget/Zeitrahmen passt
+- Stärke konkret belegen (z.B. "Wertschöpfung mit {r1_score_nutzen}/100" ODER "Ihre klar benannten Prioritäten {s3_prioritaeten}")
+- Empfehlung mit konkretem Zeitrahmen ("in den nächsten 14 Tagen", "bis Ende Monat")
+- SIEZEN (Sie/Ihr/Ihnen)
+- KEINE Emojis, KEINE Floskeln, KEINE Marketing-Sprache
+- KEINE Begrüßung, KEINE Fragen, KEIN Gesprächsangebot
+- NICHT "Ich empfehle" — stattdessen direkt formulieren
+- Wiederholt NICHT Inhalte, die in S1-S8 bereits stehen
+- Antworte NUR mit dem Fließtext, sonst nichts
+
+BRANCHENBEZEICHNUNG-REGEL:
+"{branche}" maximal 1x verwenden. Danach: "Ihr Unternehmen".
+
+VERBOTEN:
+- "Herzlichen Glückwunsch", "Ich freue mich", "Gerne helfe ich"
+- Aufzählungszeichen oder nummerierte Listen
+- Wiederholung des Executive Summarys oder einzelner Section-Inhalte
+- Generische Aussagen, die auf jedes Unternehmen passen würden
+
+## Beispiel (NICHT kopieren — nur als Ton-Orientierung)
+Was mir an Ihrem Profil auffällt: Die Wertschöpfungs-Dimension mit 82/100 zeigt, dass Sie KI bereits operativ einsetzen und nicht aus einer theoretischen Position starten. Gleichzeitig ist der von Ihnen genannte Engpass bei der Teamkapazität ernst zu nehmen — bei 6 Monaten Zeitrahmen entscheidet er darüber, ob Phase 1 und 2 überhaupt parallel laufen können. Für die nächsten 14 Tage würde ich an einer Stelle ansetzen: Holen Sie sich die schriftliche Freigabe für das Jahres-Investitionsbudget — erst dann lohnt sich der Aufwand der Tool-Evaluation. Das Break-Even-Signal bei 9 Monaten ist realistisch, aber nur, wenn Sie jetzt die Entscheidungsgrundlage absichern.""",
 }
 
 

--- a/services/strategy_pipeline.py
+++ b/services/strategy_pipeline.py
@@ -284,6 +284,12 @@ async def generate_strategy_report(
             "readiness_score": _score,
             "reifegrad": _reifegrad_label,
             "reifegrad_label": _reifegrad_label,
+            # KIS-1142 Punkt 5: R1 dimension scores for advisor_note prompt.
+            # _dim_vals order matches [_r1_scores.governance, .security, .value, .enablement].
+            "r1_score_governance": str(int(_dim_vals[0])) if _dim_vals[0] else "",
+            "r1_score_sicherheit": str(int(_dim_vals[1])) if _dim_vals[1] else "",
+            "r1_score_nutzen":     str(int(_dim_vals[2])) if _dim_vals[2] else "",
+            "r1_score_befaehigung": str(int(_dim_vals[3])) if _dim_vals[3] else "",
             # S31-FIX-C: R1 ROI values for bridge explanation
             "r1_roi_pct": str(_r1_roi_12m),
             "r1_capex": str(_r1_capex),
@@ -492,13 +498,24 @@ async def generate_strategy_report(
             base_context.get("breakeven_optimistisch", "EMPTY"),
         )
 
-        sections["exec_summary"] = await _generate_section("EXEC", base_context, {
+        # KIS-1142 Punkt 5: Executive Summary + advisor_note (Persönliche
+        # Einschätzung) run in parallel — both depend on S3/S5/S7 being
+        # finished but are otherwise independent. advisor_note uses
+        # base_context only (R1 dim scores + Strategy questions are already
+        # populated there).
+        exec_task = _generate_section("EXEC", base_context, {
             "top_handlungsfeld": _extract_top_handlungsfeld(sections["S3"]),
             "anzahl_felder": str(len(handlungsfelder)),
             "quick_win": _extract_quick_win(sections["S3"]),
             "summe_foerder": _extract_foerder_summe(sections["S7"]),
             "s5_investition_summary": _extract_summary(sections["S5"], max_words=150),
         }, use_claude=True)
+        advisor_task = _generate_section("advisor_note", base_context, {},
+                                         use_claude=True)
+
+        sections["exec_summary"], sections["advisor_note"] = await asyncio.gather(
+            exec_task, advisor_task,
+        )
 
         # === FIX-SF1: Strategy Fact Sanitizer ===
         # Snapshot raw LLM outputs before sanitizer (for re-render / sanitizer iteration)

--- a/services/strategy_renderer.py
+++ b/services/strategy_renderer.py
@@ -379,6 +379,9 @@ def render_strategy_html(sr: Any, db_session: Any) -> str:
         "section_s7": _strip_prompt_leaks(_strip_funding_total(sections.get("S7", ""))),
         "section_s8": _strip_prompt_leaks(sections.get("S8", "")),
         "section_s_moat": _strip_prompt_leaks(sections.get("s_moat", "")),
+        # KIS-1142 Punkt 5: Persönliche Einschätzung (Strategy-Äquivalent zum
+        # R1 advisor_note). Rendered between s_moat and "Nächste Schritte".
+        "section_advisor_note": _strip_prompt_leaks(sections.get("advisor_note", "")),
         "naechste_schritte": naechste_schritte,
     }
 

--- a/templates/strategy_report.html
+++ b/templates/strategy_report.html
@@ -1186,6 +1186,17 @@ sup.src-ref {
     </div>
     {% endif %}
 
+    <!-- ====== PERSÖNLICHE EINSCHÄTZUNG (KIS-1142 Punkt 5) ====== -->
+    {% if section_advisor_note and section_advisor_note|trim %}
+    <div class="section" id="advisor-note">
+        <div class="advisor-note">
+            <div class="advisor-note-title">Meine Einschätzung für Ihr Unternehmen</div>
+            <div class="advisor-note-text">{{ section_advisor_note | safe }}</div>
+            <div class="advisor-note-sig">Wolf Hohl · TÜV-zertifizierter KI-Manager</div>
+        </div>
+    </div>
+    {% endif %}
+
     <!-- ====== NÄCHSTE SCHRITTE ====== -->
     {{ chapter_banner("Ihre nächsten Schritte") }}
     <div class="section-content">

--- a/tests/test_kis_1142_p5_advisor_note.py
+++ b/tests/test_kis_1142_p5_advisor_note.py
@@ -1,0 +1,172 @@
+# -*- coding: utf-8 -*-
+"""
+KIS-1142 Punkt 5 — Persönliche Einschätzung im Strategy-Report.
+
+Strategy-Äquivalent zum R1-advisor_note. Regression cover for:
+
+  1. STRATEGY_PROMPTS["advisor_note"] exists and references the expected
+     context variables (R1 dim scores + Strategy questions + budget).
+  2. services.strategy_pipeline exposes R1 dimension scores in base_context
+     under the r1_score_* keys the prompt relies on.
+  3. The Strategy renderer wires `sections["advisor_note"]` into the
+     Jinja context as `section_advisor_note`.
+  4. The Strategy HTML template renders the advisor note between S-Moat
+     and "Nächste Schritte", gated by a non-empty value.
+"""
+
+from __future__ import annotations
+
+import inspect
+import re
+
+import pytest
+
+from prompts.strategy_prompts import STRATEGY_PROMPTS
+from services import strategy_pipeline
+
+
+# ---------------------------------------------------------------------------
+# H1 — Prompt is present and wired to the right context keys
+# ---------------------------------------------------------------------------
+
+class TestAdvisorNotePrompt:
+    def test_prompt_exists_in_strategy_prompts(self):
+        assert "advisor_note" in STRATEGY_PROMPTS, (
+            "STRATEGY_PROMPTS['advisor_note'] missing — Strategy-Report "
+            "would render no Persönliche Einschätzung."
+        )
+        assert STRATEGY_PROMPTS["advisor_note"].strip(), (
+            "advisor_note prompt must not be empty."
+        )
+
+    @pytest.mark.parametrize("placeholder", [
+        # R1 dimension scores — must be populated by strategy_pipeline.
+        "r1_score_governance",
+        "r1_score_sicherheit",
+        "r1_score_nutzen",
+        "r1_score_befaehigung",
+        # Strategy context — already in base_context.
+        "firmenname", "branche", "hauptleistung", "segment",
+        "readiness_score", "reifegrad_label",
+        "s1_budget", "s2_zeitrahmen", "s3_prioritaeten", "s4_engpass",
+        "s6_foerderinteresse",
+        "budget_gesamt_jahr1", "roi_realistisch", "breakeven_realistisch",
+    ])
+    def test_placeholder_referenced(self, placeholder):
+        assert "{" + placeholder + "}" in STRATEGY_PROMPTS["advisor_note"], (
+            f"advisor_note prompt does not reference {{{placeholder}}} — "
+            "either the prompt lost a key or the variable was renamed."
+        )
+
+    def test_prompt_enforces_plain_text_contract(self):
+        # The prompt must mirror the R1 advisor_note plain-text rule so the
+        # Strategy renderer can safely wrap the output in its own HTML chrome
+        # without double-styled <p>/<ul> leaking in.
+        src = STRATEGY_PROMPTS["advisor_note"]
+        assert "PLAIN TEXT" in src
+        assert "kein HTML" in src
+        assert "kein Markdown" in src
+
+    def test_prompt_does_not_leak_r1_only_keys(self):
+        # score_gesamt_display and COMPANY_SIZE are R1-specific names that
+        # don't exist in Strategy's base_context. Accidentally using them
+        # would KeyError at format time.
+        src = STRATEGY_PROMPTS["advisor_note"]
+        assert "{score_gesamt_display}" not in src
+        assert "{COMPANY_SIZE}" not in src
+        assert "{BRANCHE_LABEL}" not in src
+
+
+# ---------------------------------------------------------------------------
+# H2 — Pipeline passes the R1 dimension scores into base_context
+# ---------------------------------------------------------------------------
+
+class TestPipelineBaseContextWiring:
+    """Source-level guard — the full pipeline is async/DB-backed and
+    expensive to spin up for a unit check. Inspecting the source of
+    generate_strategy_report catches the three common regressions:
+    dropping a key, renaming it, or accidentally setting str/None to
+    the wrong value."""
+
+    def test_source_defines_r1_score_keys(self):
+        src = inspect.getsource(strategy_pipeline.generate_strategy_report)
+        for key in ("r1_score_governance", "r1_score_sicherheit",
+                    "r1_score_nutzen", "r1_score_befaehigung"):
+            assert f'"{key}"' in src, (
+                f"{key!r} missing from base_context — advisor_note prompt "
+                "would KeyError/format-miss."
+            )
+
+    def test_source_schedules_advisor_note_in_parallel(self):
+        src = inspect.getsource(strategy_pipeline.generate_strategy_report)
+        # The advisor_note generation and the exec_summary generation must
+        # be gathered together so advisor_note always runs (regression
+        # guard against someone removing the gather and leaving only exec).
+        normalized = " ".join(src.split())
+        assert '_generate_section("advisor_note"' in normalized, (
+            "advisor_note section call is missing from the pipeline."
+        )
+        assert 'sections["advisor_note"]' in normalized, (
+            "Pipeline must assign sections['advisor_note'] so the renderer "
+            "can pick it up."
+        )
+
+    def test_advisor_note_extra_context_is_empty(self):
+        # The prompt relies entirely on base_context. Passing extras risks
+        # accidentally overriding a base_context key or masking a missing
+        # base_context key at review time — this guard pins the contract.
+        src = inspect.getsource(strategy_pipeline.generate_strategy_report)
+        normalized = " ".join(src.split())
+        assert '_generate_section("advisor_note", base_context, {},' in normalized, (
+            "advisor_note should be generated with an empty extra_context "
+            "dict — all data flows through base_context."
+        )
+
+
+# ---------------------------------------------------------------------------
+# H3 — Renderer surfaces the section and template renders it
+# ---------------------------------------------------------------------------
+
+class TestRendererAndTemplateWiring:
+    def test_renderer_exposes_section_advisor_note(self):
+        from services import strategy_renderer
+        src = inspect.getsource(strategy_renderer)
+        assert '"section_advisor_note"' in src, (
+            "strategy_renderer must add section_advisor_note to the "
+            "template context."
+        )
+        assert 'sections.get("advisor_note"' in src, (
+            "strategy_renderer should read sections['advisor_note'] "
+            "(matching the key produced by the pipeline)."
+        )
+
+    def test_template_renders_advisor_note_block(self):
+        with open("templates/strategy_report.html", "r", encoding="utf-8") as f:
+            tpl = f.read()
+
+        # The block must be gated — empty strings should not render.
+        assert "{% if section_advisor_note" in tpl, (
+            "Template must conditionally render the advisor note so it "
+            "stays invisible if the section is empty."
+        )
+        # Signature and title strings follow the R1 advisor_note pattern.
+        assert "Meine Einschätzung für Ihr Unternehmen" in tpl
+        assert "Wolf Hohl" in tpl
+
+    def test_template_places_advisor_note_between_s_moat_and_next_steps(self):
+        with open("templates/strategy_report.html", "r", encoding="utf-8") as f:
+            tpl = f.read()
+
+        # Positional regression guard — moving the block up (before exec
+        # summary) or down (after impressum) would break the intended UX.
+        smoat_pos = tpl.find("section_s_moat")
+        advisor_pos = tpl.find("section_advisor_note")
+        next_steps_pos = tpl.find("naechste_schritte")
+
+        assert smoat_pos > 0
+        assert advisor_pos > 0
+        assert next_steps_pos > 0
+        assert smoat_pos < advisor_pos < next_steps_pos, (
+            "advisor_note block must sit between s_moat and "
+            "nächste Schritte in the Strategy template."
+        )


### PR DESCRIPTION
## Summary

Strategy-Äquivalent zum R1-`advisor_note` ("Persönliche Einschätzung"). R1 schließt mit einer Signatur-Einschätzung von Wolf Hohl ab (`prompts/de/advisor_note.md` → `ADVISOR_NOTE_HTML` in `pdf_template_v7.html`); der Strategy-Report hatte kein Pendant, die letzte Seite endete direkt mit "Nächste Schritte".

Variante A aus Briefing 9 (vorentschieden): neuer Prompt, Strategy-Kontext statt R1-Scores als Rückgrat.

## Was geändert wurde

### Neuer Prompt — `STRATEGY_PROMPTS["advisor_note"]`

Parallel-Pendant zu `advisor_note.md`, aber mit Strategy-Kontext:

| R1 advisor_note.md | Strategy advisor_note |
|---|---|
| score_gesamt_display | readiness_score |
| score_governance/sicherheit/nutzen/befaehigung | r1_score_* (gleiche Werte, durch Pipeline weitergereicht) |
| COMPANY_SIZE | segment |
| BRANCHE_LABEL | branche |
| — | **+** s1_budget, s2_zeitrahmen, s3_prioritaeten, s4_engpass, s6_foerderinteresse |
| — | **+** budget_gesamt_jahr1, roi_realistisch, breakeven_realistisch |

Gleiche Kontrakte: 4–6 Sätze, Plain Text, keine HTML/Markdown-Tags, Struktur "Stärke → Hürde → Empfehlung mit Zeitrahmen", Siezen, keine Floskeln. Zielrichtung: eine persönliche Sicht auf die **strategische Ausgangslage**, keine Wiederholung der Section-Inhalte.

### Pipeline (`services/strategy_pipeline.py`)

1. R1-Dimension-Scores werden in `base_context` aufgenommen (`r1_score_governance`, `r1_score_sicherheit`, `r1_score_nutzen`, `r1_score_befaehigung`) — `_dim_vals[0..3]` waren schon berechnet, aber nur für den Overall-Score benutzt.
2. `advisor_note` wird parallel zu `exec_summary` via `asyncio.gather` generiert. Beide hängen nur von S3/S5/S7 ab und sind dann voneinander unabhängig — die Gesamtlaufzeit bleibt identisch.
3. `use_claude=True`, damit die persönliche Tonalität an dasselbe Modell geht wie der Executive Summary (konsistente "Wolf-Stimme").

### Renderer + Template

- `services/strategy_renderer.py` mapped `sections["advisor_note"]` → `section_advisor_note` im Jinja-Context, mit demselben `_strip_prompt_leaks` wie die anderen Sections.
- `templates/strategy_report.html` rendert den Block zwischen S-Moat und "Nächste Schritte" (Position = Signatur-Closing, nicht Intro), wiederverwendet die `advisor-note` CSS-Klassen-Struktur aus `pdf_template_v7.html` (Title / Text / Signatur mit "Wolf Hohl · TÜV-zertifizierter KI-Manager").
- Leer-Gate via `{% if section_advisor_note and section_advisor_note|trim %}` — wenn der LLM-Call fehlschlägt oder leer zurückkommt, verschwindet der gesamte Block inkl. Chrome.

## Test cover

`tests/test_kis_1142_p5_advisor_note.py` — 27 Tests, all green:

- **Prompt**: existiert, referenziert exakt die 19 erwarteten Placeholder, enforced Plain-Text-Kontrakt, leakt keine R1-only-Keys (`{score_gesamt_display}`, `{COMPANY_SIZE}`, `{BRANCHE_LABEL}` würden KeyError beim `str.format(**context)`)
- **Pipeline**: `base_context` enthält alle 4 `r1_score_*`-Keys, `_generate_section("advisor_note", base_context, {}, use_claude=True)` wird aufgerufen, Extra-Context ist bewusst leer
- **Renderer**: mapped `sections.get("advisor_note", "")` auf `section_advisor_note`
- **Template**: Conditional-Gate vorhanden, Position zwischen S-Moat und `naechste_schritte` (Text-Position-Guard)

Regression auf umliegende Strategy-Tests: `test_strategy_sanitizer.py`, `test_n42_language_strategy.py`, `test_strategy_budget_canonical.py` — 100/100 grün.

## Test plan
- [x] `pytest tests/test_kis_1142_p5_advisor_note.py` — 27/27 green
- [x] Regression: `pytest tests/test_strategy_sanitizer.py tests/test_n42_language_strategy.py tests/test_strategy_budget_canonical.py` — 100/100 green
- [ ] E2E: lokaler Strategy-Run mit Fixture-Briefing → HTML enthält `<div class="advisor-note">` nach S-Moat, vor "Nächste Schritte"; Text ist 4–6 Plain-Text-Sätze; Sanitizer lässt den Block unangetastet
- [ ] Wolf: Tonalitäts-Check auf einem generierten Strategy-Report — liest sich als echte persönliche Signatur, nicht als Zusammenfassung?

## Hinweis zum Railway-Build

Der Build-Fehler im aktuellen Railway-Environment (Commit 310b798b, "failed to get temporal client") ist Railway-Infrastruktur-seitig, nicht Code. Bei Retry oder nach Railway-Incident-Resolution baut dieser Branch sauber. Kein Blocker für den PR-Review.

https://claude.ai/code/session_kis-1142-p5

---
_Generated by [Claude Code](https://claude.ai/code/session_01H9uqvfiPt9vo4KR5Zw6NES)_