### PR TITLE
feat: tool-budget-filter + challenge-opt-in hook (KIS-1142 P6, B+C)

### DIFF
--- a/services/sofort_start_generator.py
+++ b/services/sofort_start_generator.py
@@ -2259,6 +2259,38 @@ CHALLENGE_30_TAGE = {
     }
 }
 
+# =============================================================================
+# KIS-1142 Punkt 6 Variante C: Challenge-Wochen-Opt-in per company size
+# =============================================================================
+# Maps company_size → set of week-keys that should NOT be rendered. Empty
+# sets act as no-ops. Populate when Wolf decides which week arcs feel
+# out-of-scale for the target profile (e.g. governance-heavy weeks for
+# solo freelancers). The filter runs AFTER challenge-variant selection
+# (beginner/intermediate/expert), so solo-on-expert can still be trimmed.
+_CHALLENGE_WEEKS_SKIP_BY_SIZE: Dict[str, set] = {
+    "solo": set(),
+    "team": set(),
+    "kmu":  set(),
+}
+
+
+def _filter_challenge_weeks_by_size(
+    challenge_data: Dict[str, Any], company_size: str,
+) -> Dict[str, Any]:
+    """Drop week-keys flagged as out-of-scale for the given company size.
+
+    No-op unless _CHALLENGE_WEEKS_SKIP_BY_SIZE has entries for the size.
+    The challenge-variant selection runs before this filter, so the input
+    is always one of CHALLENGE_30_TAGE / _INTERMEDIATE / _EXPERT / _LIGHT.
+    """
+    skip_keys = _CHALLENGE_WEEKS_SKIP_BY_SIZE.get(
+        (company_size or "").strip().lower(), set(),
+    )
+    if not skip_keys:
+        return challenge_data
+    return {k: v for k, v in challenge_data.items() if k not in skip_keys}
+
+
 KATEGORIE_ICONS = {
     "Setup": "⚙️",
     "Praxis": "💪",
@@ -2673,6 +2705,11 @@ def generate_30_tage_challenge_html_v2(
         show_prio = True
     else:
         challenge_data = CHALLENGE_30_TAGE
+
+    # KIS-1142 Punkt 6 Variante C: trim weeks flagged as out-of-scale for
+    # the user's company size. No-op until _CHALLENGE_WEEKS_SKIP_BY_SIZE
+    # is populated; wired now so the opt-in hook ships with the branch.
+    challenge_data = _filter_challenge_weeks_by_size(challenge_data, company_size)
 
     # KIS-1132: Expertise-aware subtitle
     if expertise_level == "expert":

--- a/services/tools_recommender.py
+++ b/services/tools_recommender.py
@@ -19,6 +19,7 @@ import json
 import logging
 import math
 import os
+import re
 import statistics
 from dataclasses import dataclass, field, asdict
 from datetime import datetime, timedelta
@@ -554,6 +555,88 @@ def get_segment_weight(
 
 
 # =============================================================================
+# KIS-1142 Punkt 6 Variante B: Budget-aware tool filter
+# =============================================================================
+
+# investitionsbudget enum → max monthly entry-level cost (€/month) per tool.
+# None = no cap (don't filter). "ueber_50000" and "unklar" also bypass the
+# filter — never penalise enterprise buyers or users with missing data.
+_BUDGET_BAND_MAX_MONTHLY: Dict[str, Optional[int]] = {
+    "unter_2000":     30,
+    "2000_10000":    100,
+    "10000_50000":   500,
+    "ueber_50000":  None,
+    "unklar":       None,
+}
+
+
+def _parse_price_min_monthly(price: str) -> Optional[int]:
+    """Extract the minimum monthly €-amount a user would pay for the tool.
+
+    Returns None when the price string is usage-based or otherwise
+    unparseable — callers should treat None as "unknown, keep the tool"
+    rather than "free, keep the tool".
+
+    Examples:
+        '0–29 €/Monat'         → 0
+        '0–10 €/Monat'         → 0
+        'Free / ab 18 €/Monat' → 0   (free tier available)
+        'Kostenlos'            → 0
+        'ab 9 €/Monat'         → 9
+        'ab ~5 € (Nutzung)'    → 5
+        'Usage-basiert'        → None
+        'Usage'                → None
+    """
+    if not price:
+        return None
+    s = price.strip().lower()
+    if "kostenlos" in s or s.startswith("free"):
+        # "Free / ab 18 …" → users can start at €0.
+        return 0
+    if s.startswith("usage") or "usage" in s and "€" not in s:
+        return None
+    # Ranges like "0–29 €/Monat" or "0-10 €/Monat" — take the low end.
+    range_match = re.match(r"\s*(\d+)\s*[–-]\s*(\d+)", s)
+    if range_match:
+        try:
+            return int(range_match.group(1))
+        except ValueError:
+            pass
+    # Open-ended like "ab 9 €" or "ab ~5 €".
+    ab_match = re.search(r"ab\s*~?\s*(\d+)", s)
+    if ab_match:
+        try:
+            return int(ab_match.group(1))
+        except ValueError:
+            pass
+    # Last resort: first integer anywhere in the string.
+    num_match = re.search(r"(\d+)", s)
+    if num_match:
+        try:
+            return int(num_match.group(1))
+        except ValueError:
+            pass
+    return None
+
+
+def _fits_budget(tool: Dict[str, Any], budget_band: str) -> bool:
+    """True if the tool's minimum monthly entry cost fits the budget band.
+
+    Tools with unparseable ("Usage-basiert") prices are always kept — we'd
+    rather show an unknown-cost tool than drop a potentially critical
+    recommendation because of a price-string edge case.
+    """
+    cap = _BUDGET_BAND_MAX_MONTHLY.get(budget_band)
+    if cap is None:
+        return True
+    price = tool.get("price", "")
+    min_monthly = _parse_price_min_monthly(str(price))
+    if min_monthly is None:
+        return True
+    return min_monthly <= cap
+
+
+# =============================================================================
 # MAIN RECOMMENDATION ENGINE
 # =============================================================================
 
@@ -589,6 +672,20 @@ def recommend_tools(
     groesse = (b.get("unternehmensgroesse") or b.get("groesse") or "").lower()
     hauptleistung = (b.get("hauptleistung") or "").lower()
     ai_act_risk = (b.get("ai_act_risk_level") or b.get("risk_level") or "minimal").lower()
+
+    # KIS-1142 Punkt 6 Variante B: budget-aware pre-filter.
+    # Drops tools whose minimum monthly entry cost exceeds what the user's
+    # budget band can reasonably absorb per tool. Applied before scoring so
+    # segment weighting doesn't silently rank an unaffordable tool to the top.
+    _budget_band = (b.get("investitionsbudget") or "").strip().lower()
+    if _budget_band and _BUDGET_BAND_MAX_MONTHLY.get(_budget_band) is not None:
+        _before = len(tools)
+        tools = [t for t in tools if _fits_budget(t, _budget_band)]
+        if _before != len(tools):
+            logger.info(
+                "[tools_recommender] budget filter (%s): %d → %d tools",
+                _budget_band, _before, len(tools),
+            )
 
     # Normalize size
     if "solo" in groesse or "1" in groesse or "freiberuf" in groesse:

--- a/services/tools_recommender.py
+++ b/services/tools_recommender.py
@@ -682,7 +682,7 @@ def recommend_tools(
         _before = len(tools)
         tools = [t for t in tools if _fits_budget(t, _budget_band)]
         if _before != len(tools):
-            logger.info(
+            log.info(
                 "[tools_recommender] budget filter (%s): %d → %d tools",
                 _budget_band, _before, len(tools),
             )

--- a/tests/test_kis_1142_p6_budget_and_challenge.py
+++ b/tests/test_kis_1142_p6_budget_and_challenge.py
@@ -1,0 +1,207 @@
+# -*- coding: utf-8 -*-
+"""
+KIS-1142 Punkt 6 — Enterprise-Content-Bias mitigations (Varianten B + C).
+
+Wolf pre-decided B+C (vs Variante A, a full content-matrix rewrite).
+
+**Variante B — Tool-Budget-Filter**
+Pre-filter the tool-recommender's seed list by the user's
+`investitionsbudget` band so enterprise-priced tools (e.g.
+"ab 500 €/Monat") never reach the scorer when a solo freelancer has
+stated "unter_2000" as their budget cap. Tools with unparseable prices
+("Usage-basiert") are always kept — we'd rather show an unknown-cost
+tool than silently drop a potentially critical recommendation.
+
+**Variante C — Challenge-Wochen-Opt-in**
+Add an infrastructure hook so specific weeks of the 30-day challenge
+can be dropped based on `company_size`. Populates empty by default;
+once Wolf calls out which week-arcs feel too enterprise-heavy for solo
+(governance-heavy content, team-scaling exercises), those keys drop
+into `_CHALLENGE_WEEKS_SKIP_BY_SIZE`.
+
+Both variants ship as **additive, non-breaking changes** — the default
+(empty skip-set / unknown budget band) reproduces today's behavior.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+import pytest
+
+from services.sofort_start_generator import (
+    CHALLENGE_30_TAGE,
+    CHALLENGE_30_TAGE_EXPERT,
+    _CHALLENGE_WEEKS_SKIP_BY_SIZE,
+    _filter_challenge_weeks_by_size,
+)
+from services.tools_recommender import (
+    _BUDGET_BAND_MAX_MONTHLY,
+    _fits_budget,
+    _parse_price_min_monthly,
+    recommend_tools,
+)
+
+
+# ---------------------------------------------------------------------------
+# Variante B — price parsing
+# ---------------------------------------------------------------------------
+
+class TestParsePriceMinMonthly:
+    @pytest.mark.parametrize("price, expected", [
+        ("0–29 €/Monat",         0),
+        ("0-29 €/Monat",         0),
+        ("0–10 €/Monat",         0),
+        ("Free / ab 18 €/Monat", 0),
+        ("Kostenlos",            0),
+        ("ab 9 €/Monat",         9),
+        ("ab ~5 € (Nutzung)",    5),
+    ])
+    def test_parses_known_seed_formats(self, price, expected):
+        assert _parse_price_min_monthly(price) == expected
+
+    @pytest.mark.parametrize("price", [
+        "Usage-basiert", "Usage", "Usage/Pro", "",
+    ])
+    def test_unparseable_returns_none(self, price):
+        assert _parse_price_min_monthly(price) is None
+
+    def test_none_input_is_none(self):
+        assert _parse_price_min_monthly(None) is None  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# Variante B — budget gate
+# ---------------------------------------------------------------------------
+
+class TestFitsBudget:
+    def test_unter_2000_drops_expensive_tool(self):
+        tool = {"name": "Expensive SaaS", "price": "ab 100 €/Monat"}
+        assert _fits_budget(tool, "unter_2000") is False
+
+    def test_unter_2000_keeps_cheap_tool(self):
+        tool = {"name": "Tally.so", "price": "0–29 €/Monat"}
+        assert _fits_budget(tool, "unter_2000") is True
+
+    def test_2000_10000_keeps_mid_tier(self):
+        tool = {"name": "HubSpot", "price": "Free / ab 18 €/Monat"}
+        assert _fits_budget(tool, "2000_10000") is True
+
+    def test_ueber_50000_bypass_filter(self):
+        # Enterprise buyers should not be filtered — cap is None.
+        tool = {"name": "Expensive", "price": "ab 9999 €/Monat"}
+        assert _fits_budget(tool, "ueber_50000") is True
+
+    def test_unklar_bypass_filter(self):
+        # Missing data → never penalise.
+        tool = {"name": "Expensive", "price": "ab 9999 €/Monat"}
+        assert _fits_budget(tool, "unklar") is True
+
+    def test_unknown_budget_band_bypasses(self):
+        tool = {"name": "Expensive", "price": "ab 9999 €/Monat"}
+        assert _fits_budget(tool, "some_new_band") is True
+
+    def test_usage_based_tool_always_kept(self):
+        # "Usage-basiert" → unparseable → keep as conservative default.
+        tool = {"name": "OpenAI API", "price": "Usage-basiert"}
+        for band in _BUDGET_BAND_MAX_MONTHLY:
+            assert _fits_budget(tool, band) is True, (
+                f"Usage-based tool was dropped under budget band {band!r}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Variante B — end-to-end recommender
+# ---------------------------------------------------------------------------
+
+class TestRecommendToolsBudgetFilter:
+    def test_no_budget_returns_baseline_count(self):
+        # Empty briefing → filter skipped, we still get some recommendations.
+        result = recommend_tools({})
+        assert isinstance(result, list)
+        assert len(result) > 0
+
+    def test_unter_2000_drops_fewer_or_equal_than_baseline(self):
+        # The filter can only drop, never add.
+        baseline = recommend_tools({})
+        filtered = recommend_tools({
+            "investitionsbudget": "unter_2000",
+            "unternehmensgroesse": "solo",
+        })
+        assert len(filtered) <= len(baseline)
+        # Every remaining tool must pass the budget gate.
+        for tool in filtered:
+            assert _fits_budget(tool, "unter_2000")
+
+    def test_ueber_50000_matches_baseline_length(self):
+        baseline = recommend_tools({})
+        unfiltered = recommend_tools({
+            "investitionsbudget": "ueber_50000",
+        })
+        # ueber_50000 bypasses the filter, so length should match.
+        assert len(unfiltered) == len(baseline)
+
+
+# ---------------------------------------------------------------------------
+# Variante C — challenge filter
+# ---------------------------------------------------------------------------
+
+class TestChallengeWeekFilter:
+    def test_default_config_is_empty_noop(self):
+        # Ship with empty sets so the default behaviour matches today's
+        # rendering. Wolf populates them once he picks the week-arcs.
+        for size, skip in _CHALLENGE_WEEKS_SKIP_BY_SIZE.items():
+            assert skip == set(), (
+                f"_CHALLENGE_WEEKS_SKIP_BY_SIZE[{size!r}] must default to "
+                "an empty set so the hook stays additive until populated."
+            )
+
+    def test_empty_skip_returns_input_unchanged(self):
+        result = _filter_challenge_weeks_by_size(CHALLENGE_30_TAGE, "solo")
+        assert result == CHALLENGE_30_TAGE
+
+    def test_unknown_size_is_noop(self):
+        result = _filter_challenge_weeks_by_size(CHALLENGE_30_TAGE, "unknown_size")
+        assert result == CHALLENGE_30_TAGE
+
+    def test_missing_size_is_noop(self):
+        result = _filter_challenge_weeks_by_size(CHALLENGE_30_TAGE, "")
+        assert result == CHALLENGE_30_TAGE
+
+    def test_populated_skip_drops_matching_keys(self, monkeypatch):
+        # Simulate Wolf adding "woche_1" to solo's skip-set.
+        monkeypatch.setitem(
+            _CHALLENGE_WEEKS_SKIP_BY_SIZE, "solo", {"woche_1"},
+        )
+        result = _filter_challenge_weeks_by_size(CHALLENGE_30_TAGE, "solo")
+        assert "woche_1" not in result
+        # Other weeks survive.
+        assert "woche_2" in result
+        assert "abschluss" in result
+
+    def test_filter_does_not_mutate_source(self, monkeypatch):
+        monkeypatch.setitem(
+            _CHALLENGE_WEEKS_SKIP_BY_SIZE, "solo", {"woche_1"},
+        )
+        _filter_challenge_weeks_by_size(CHALLENGE_30_TAGE, "solo")
+        # Guard against someone swapping to pop() and breaking the shared
+        # module-level dict for every subsequent caller.
+        assert "woche_1" in CHALLENGE_30_TAGE
+
+
+# ---------------------------------------------------------------------------
+# Variante C — wiring into the renderer
+# ---------------------------------------------------------------------------
+
+class TestChallengeFilterWiredIntoRenderer:
+    def test_renderer_calls_filter_after_variant_selection(self):
+        from services import sofort_start_generator
+        src = inspect.getsource(
+            sofort_start_generator.generate_30_tage_challenge_html_v2
+        )
+        # The call must appear in the renderer so the hook is live.
+        assert "_filter_challenge_weeks_by_size(" in src, (
+            "generate_30_tage_challenge_html_v2 must invoke "
+            "_filter_challenge_weeks_by_size — otherwise Variante C is a "
+            "dead config."
+        )


### PR DESCRIPTION
## Summary

Enterprise-Content-Bias mitigations, Wolf vorentschieden: **B+C** (vs Variante A = volle Content-Matrix-Überarbeitung).

Beide Varianten sind **additiv und non-breaking**: Default-Verhalten (leere Skip-Sets, unbekannte Budget-Band, `Usage-basiert` Preis) reproduziert das heutige Rendering 1:1.

### Variante B — Tool-Budget-Filter

`services/tools_recommender.py`: Pre-Filter des Tool-Seeds **vor** Scoring. Wenn `briefings.investitionsbudget` gesetzt ist, werden Tools gedroppt, deren minimale Monatsgebühr die Budget-Band-Kappe überschreitet.

| Band | Max €/Monat pro Tool |
|---|---|
| `unter_2000` | 30 |
| `2000_10000` | 100 |
| `10000_50000` | 500 |
| `ueber_50000` | **— kein Filter —** |
| `unklar` | **— kein Filter —** |

**Robust gegen Preis-String-Varianten:** der Parser deckt alle heutigen `data/tools_seed.json` Formate ab:
- `0–29 €/Monat`, `0-29 €/Monat`, `0–10 €/Monat` → min = 0
- `Free / ab 18 €/Monat`, `Kostenlos` → min = 0
- `ab 9 €/Monat`, `ab ~5 € (Nutzung)` → min = 9 / 5
- `Usage`, `Usage-basiert`, `Usage/Pro`, `""` → **None → Tool bleibt** (konservativ: kein Silent-Drop bei unbekannter Preisstruktur)

Current-seed-Impact: Da alle seed-Tools im €0–30/mo-Range sind, filtert der Code heute praktisch nichts — der Hook greift erst sichtbar, wenn neue teurere Tools im Seed landen. Wichtiger Effekt: **kein enterprise-priced Tool kann jemals unbemerkt einen Solo-Report dominieren**.

### Variante C — Challenge-Wochen-Opt-in

`services/sofort_start_generator.py`: Neues Config-Dict `_CHALLENGE_WEEKS_SKIP_BY_SIZE` + Helper `_filter_challenge_weeks_by_size()`. Läuft **nach** der Challenge-Variant-Selection (beginner/intermediate/expert/light), so dass auch `solo + expertise=expert` trimmbar ist.

```python
_CHALLENGE_WEEKS_SKIP_BY_SIZE: Dict[str, set] = {
    "solo": set(),   # ← Wolf populiert
    "team": set(),
    "kmu":  set(),
}
```

**Warum leer shipped:** Die aktuellen `CHALLENGE_30_TAGE` / `_INTERMEDIATE` / `_EXPERT` Dicts haben keinen `woche_X`-Key der eindeutig als "Governance-heavy" oder "Team-scaling-heavy" durchbricht — jede Entscheidung wäre subjektiv. Wolf kriegt den wired+tested Hook und trifft in der nächsten Runde eine scharfe Produkt-Entscheidung, welche Wochen für Solo raus müssen. Das vermeidet einen Silent-Downscope, den Wolf später nicht gesehen hat.

Beispiel-Usage (einmal populiert):
```python
_CHALLENGE_WEEKS_SKIP_BY_SIZE["solo"] = {"woche_3"}  # z.B. "Team-Rollout-Woche"
```

## Test cover

`tests/test_kis_1142_p6_budget_and_challenge.py` — 29 Tests, all green:

- **Price parser** (12): alle seed-Formate + unparseable → None + None-Input
- **Budget gate** (7): drop-expensive, keep-cheap, bypass für ueber_50000/unklar/unknown-band, usage-based tools always kept
- **End-to-end recommender** (3): filter kann nur droppen, niemals hinzufügen; ueber_50000 matcht baseline
- **Challenge filter** (6): leerer Default ist No-Op, unknown/empty size No-Op, populiertes Skip-Set droppt richtige Keys, Source-Dict wird nicht mutiert
- **Wiring guard** (1): inspect-level Check, dass der Renderer `_filter_challenge_weeks_by_size` tatsächlich aufruft

Regression-Check auf 148 adjacent tests in tools/challenge-Files — 0 broken.

## Test plan
- [x] `pytest tests/test_kis_1142_p6_budget_and_challenge.py` — 29/29 green
- [x] Regression: 148 tests (tools_recommender, sofort_start, challenge, tools_engine) — 0 broken
- [ ] Wolf populiert `_CHALLENGE_WEEKS_SKIP_BY_SIZE["solo"]` mit den spezifischen `woche_X`-Keys, die er für Solo aus Strategic-/Governance-Gründen rausziehen will. Ist ein 2-Zeilen-Commit.

## Kontext — was als nächstes kommt

Parallel zu diesem PR habe ich die Diagnosen für **Punkte 2, 3, 4** des Master-Plans abgeschlossen. Die sind alle *blockiert auf Wolf-Produkt-Entscheidungen*, daher kein Code-Commit in diesem PR. Batch-Ping als nächste Message an Wolf:

- **P2 Vendor-Audit-Framing** — welche R1-Strings sollen relativiert werden (nur `advisor_note.md:40`, oder auch `vendor_audit_engine.py:_generate_summary`)?
- **P3 30-Tage-Challenge-Widerspruch** — die literale Phrase "Woche 1 überspringbar" ist nicht im Codebase. Screenshot oder Zitat nötig, um die Quelle zu lokalisieren.
- **P4 KPA Jargon-Dichte** — Variante A (Prompt-Tone rewrite in `gc_strategic_analysis.md:84-102`) oder B (Jinja-Conditional per `EXPERTISE_LEVEL` — die Infra existiert schon für R1)?

https://claude.ai/code/session_kis-1142-p6

---
_Generated by [Claude Code](https://claude.ai/code/session_01H9uqvfiPt9vo4KR5Zw6NES)_