### PR TITLE
fix(vendor-audit): relativise R1 framing to match Strategy S8 (KIS-1142 P2)

### DIFF
--- a/services/vendor_audit_engine.py
+++ b/services/vendor_audit_engine.py
@@ -1099,16 +1099,19 @@ def _generate_recommendations(
     us_no_dpa = [e for e in entries if e.jurisdiction == "US" and not e.has_dpa]
     if us_no_dpa:
         names = ", ".join([e.name for e in us_no_dpa[:2]])
+        # KIS-1142 P2: "abschliessen" → "prüfen und ggf. nachholen"
+        # (konstatieren statt befehlen).
         recommendations.append(
-            f"DPA (Data Processing Agreement) mit US-Anbietern abschliessen: {names}"
+            f"DPA (Data Processing Agreement) mit US-Anbietern prüfen und ggf. nachholen: {names}"
         )
 
     # Check for red vendors
     red_vendors = [e for e in entries if e.overall_category == "red"]
     if red_vendors:
         names = ", ".join([e.name for e in red_vendors[:2]])
+        # KIS-1142 P2: "sicherstellen" → "prüfen" (konstatieren statt befehlen).
         recommendations.append(
-            f"Hochrisiko-Anbieter prüfen, Risikominimierung durch AVV/DPA sicherstellen: {names}. Hinweis: Für LLM-Anbieter (OpenAI, Anthropic) existieren aktuell keine gleichwertigen EU-Alternativen — Fokus auf vertragliche Absicherung und Datenminimierung."
+            f"Hochrisiko-Anbieter prüfen, Risikominimierung durch AVV/DPA einordnen: {names}. Hinweis: Für LLM-Anbieter (OpenAI, Anthropic) existieren aktuell keine gleichwertigen EU-Alternativen — Fokus auf vertragliche Absicherung und Datenminimierung."
         )
 
     # Check for unknown data locations
@@ -1174,19 +1177,36 @@ def _generate_summary(
     red = sum(1 for e in entries if e.overall_category == "red")
     eu_compliant = sum(1 for e in entries if e.is_eu_compliant)
 
+    # KIS-1142 P2: Tonalität angeglichen an Strategy S8 (konstatieren statt
+    # befehlen). Summary schließt mit einem Kontextualisierungs-Satz ab, der
+    # klarmacht, dass der Audit-Status die Tools bewertet, nicht das
+    # Unternehmen (wörtlich aus strategy_prompts.py L101-108 übernommen).
     if lang == "en":
+        status = (
+            "Review required for high-risk vendors." if red > 0
+            else "No critical findings."
+        )
         return (
             f"Vendor audit completed for {total} tools/vendors. "
             f"Result: {green} green (low risk), {yellow} yellow (medium risk), {red} red (high risk). "
             f"{eu_compliant} vendors are EU-compliant. "
-            f"{'Immediate action required for high-risk vendors.' if red > 0 else 'No critical findings.'}"
+            f"{status} "
+            f"The audit status reflects the compliance posture of the listed "
+            f"tools only, not the overall AI-readiness status of your company."
         )
     else:
+        status = (
+            "Prüfbedarf bei Hochrisiko-Anbietern." if red > 0
+            else "Keine kritischen Befunde."
+        )
         return (
             f"Vendor-Audit für {total} Tools/Anbieter abgeschlossen. "
             f"Ergebnis: {green} grün (niedriges Risiko), {yellow} gelb (mittleres Risiko), {red} rot (hohes Risiko). "
             f"{eu_compliant} Anbieter sind EU-konform. "
-            f"{'Sofortiger Handlungsbedarf bei Hochrisiko-Anbietern.' if red > 0 else 'Keine kritischen Befunde.'}"
+            f"{status} "
+            f"Der Audit-Status bezieht sich auf den Konformitätsstatus der "
+            f"gelisteten Tools, nicht auf den Gesamt-KI-Readiness-Status "
+            f"Ihres Unternehmens."
         )
 
 

--- a/tests/test_kis_1142_p2_vendor_framing.py
+++ b/tests/test_kis_1142_p2_vendor_framing.py
@@ -1,0 +1,176 @@
+# -*- coding: utf-8 -*-
+"""
+KIS-1142 Punkt 2 — Vendor-Audit-Framing-Inkonsistenz.
+
+R1 war imperativ, Strategy S8 bereits relativierend. Ziel: R1 an Strategy
+angleichen — konstatieren statt befehlen, plus der Kontextualisierungs-
+Satz aus Strategy S8 (dass der Audit-Status die Tools bewertet, nicht
+das Unternehmen).
+
+Regression cover:
+
+  1. Summary enthält **nicht** mehr "Sofortiger Handlungsbedarf" /
+     "Immediate action required" — stattdessen "Prüfbedarf" / "Review
+     required".
+  2. Summary schließt mit einem Kontextualisierungs-Satz, der klarmacht
+     dass der Status die Tools bewertet, nicht das Unternehmen.
+  3. Recommendations schreiben "prüfen und ggf. nachholen" statt
+     "abschliessen" und "einordnen" statt "sicherstellen".
+  4. Der "Keine kritischen Befunde"-Pfad bleibt intakt (kein Regress
+     auf der grünen Seite).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from services.vendor_audit_engine import (
+    VendorAuditEntry,
+    _generate_summary,
+    _generate_recommendations,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+def _make_entry(
+    name: str,
+    overall: str = "green",
+    jurisdiction: str = "EU",
+    has_dpa: bool = True,
+    data_location: str = "EU-only",
+    security_posture: str = "strong",
+    ai_act_relevance: str = "low",
+    has_certifications: bool = True,
+) -> VendorAuditEntry:
+    # ``is_eu_compliant`` and ``has_certifications`` are computed properties,
+    # not dataclass fields — seed the underlying attrs (certifications list,
+    # jurisdiction + has_dpa) so the properties evaluate as intended.
+    certifications = ["ISO 27001"] if has_certifications else []
+    return VendorAuditEntry(
+        name=name,
+        category="LLM",
+        overall_category=overall,
+        jurisdiction=jurisdiction,
+        has_dpa=has_dpa,
+        data_location=data_location,
+        security_posture=security_posture,
+        ai_act_relevance=ai_act_relevance,
+        certifications=certifications,
+    )
+
+
+# ---------------------------------------------------------------------------
+# H1 — Summary tonality
+# ---------------------------------------------------------------------------
+
+class TestSummaryTonality:
+    def test_de_red_vendor_says_pruefbedarf_not_handlungsbedarf(self):
+        entries = [_make_entry("X", overall="red", jurisdiction="US", has_dpa=False)]
+        summary = _generate_summary(entries, lang="de")
+        assert "Sofortiger Handlungsbedarf" not in summary, (
+            "Hartes 'Sofortiger Handlungsbedarf' muss durch 'Prüfbedarf' "
+            "ersetzt sein (konstatieren statt befehlen)."
+        )
+        assert "Prüfbedarf" in summary
+
+    def test_en_red_vendor_says_review_required_not_immediate_action(self):
+        entries = [_make_entry("X", overall="red", jurisdiction="US", has_dpa=False)]
+        summary = _generate_summary(entries, lang="en")
+        assert "Immediate action required" not in summary
+        assert "Review required" in summary
+
+    def test_de_green_only_keeps_keine_kritischen_befunde(self):
+        # Guard the green-path — softening must not erase the no-findings
+        # message.
+        entries = [_make_entry("X", overall="green")]
+        summary = _generate_summary(entries, lang="de")
+        assert "Keine kritischen Befunde" in summary
+
+    def test_en_green_only_keeps_no_critical_findings(self):
+        entries = [_make_entry("X", overall="green")]
+        summary = _generate_summary(entries, lang="en")
+        assert "No critical findings" in summary
+
+
+# ---------------------------------------------------------------------------
+# H2 — Contextualising sentence from Strategy S8
+# ---------------------------------------------------------------------------
+
+class TestSummaryContextualisation:
+    def test_de_summary_ends_with_tool_vs_company_clarification(self):
+        entries = [_make_entry("X", overall="red", jurisdiction="US", has_dpa=False)]
+        summary = _generate_summary(entries, lang="de")
+        # Exakte Formulierung aus strategy_prompts.py L105 (gekürzt).
+        assert "bezieht sich auf den Konformitätsstatus der" in summary
+        assert "nicht auf den Gesamt-KI-Readiness-Status" in summary
+        assert "Ihres Unternehmens" in summary
+
+    def test_en_summary_ends_with_tool_vs_company_clarification(self):
+        entries = [_make_entry("X", overall="red", jurisdiction="US", has_dpa=False)]
+        summary = _generate_summary(entries, lang="en")
+        assert "compliance posture of the listed" in summary
+        assert "not the overall AI-readiness status" in summary
+
+    def test_clarification_present_on_green_path_too(self):
+        # Context clarification is about what the audit *measures*, so it
+        # must be consistent regardless of red count.
+        entries = [_make_entry("X", overall="green")]
+        de_summary = _generate_summary(entries, lang="de")
+        en_summary = _generate_summary(entries, lang="en")
+        assert "nicht auf den Gesamt-KI-Readiness-Status" in de_summary
+        assert "not the overall AI-readiness status" in en_summary
+
+
+# ---------------------------------------------------------------------------
+# H3 — Recommendations: "abschliessen" → "prüfen und ggf. nachholen"
+# ---------------------------------------------------------------------------
+
+class TestRecommendationsTonality:
+    def test_us_no_dpa_no_longer_says_abschliessen(self):
+        entries = [
+            _make_entry("USTool", jurisdiction="US", has_dpa=False,
+                        overall="yellow"),
+        ]
+        recs = _generate_recommendations(entries, size_label="team")
+        us_recs = [r for r in recs if "USTool" in r]
+        assert us_recs, "Expected a DPA recommendation for US-no-DPA vendor"
+        for r in us_recs:
+            assert "abschliessen" not in r, (
+                f"'abschliessen' lingers in: {r!r}"
+            )
+            assert "prüfen und ggf. nachholen" in r
+
+    def test_red_vendor_recommendation_no_sicherstellen(self):
+        # Keep the entry DPA-complete so the US-no-DPA recommendation path
+        # doesn't fire — we want to isolate the "Hochrisiko-Anbieter" path.
+        entries = [_make_entry("Red1", overall="red", jurisdiction="EU",
+                               has_dpa=True)]
+        recs = _generate_recommendations(entries, size_label="team")
+        red_recs = [r for r in recs if "Hochrisiko-Anbieter" in r]
+        assert red_recs, f"No Hochrisiko recommendation in {recs!r}"
+        for r in red_recs:
+            # "sicherstellen" was the hard imperative. "einordnen" is the
+            # softer constatative replacement.
+            assert "sicherstellen" not in r, (
+                f"'sicherstellen' lingers in: {r!r}"
+            )
+            assert "einordnen" in r
+
+
+# ---------------------------------------------------------------------------
+# H4 — No regression on empty inputs
+# ---------------------------------------------------------------------------
+
+class TestEmptyInput:
+    def test_empty_entries_returns_stable_message_de(self):
+        assert _generate_summary([], lang="de") == (
+            "Keine Anbieter zur Prüfung vorhanden."
+        )
+
+    def test_empty_entries_returns_stable_message_en(self):
+        assert _generate_summary([], lang="en") == (
+            "No vendors to audit."
+        )


### PR DESCRIPTION
## Summary

R1 und Strategy framten denselben Vendor-Status unterschiedlich hart — R1 imperativ (*"Sofortiger Handlungsbedarf"*, *"DPA abschließen"*, *"Risikominimierung sicherstellen"*), Strategy S8 bereits relativierend (*"priorisiere"*, *"Mitigationsstrategie"*). Kunden lasen die R1-Version dringender als die Strategy-Version, obwohl beide auf denselben Scores basieren. Ziel: konstatieren statt befehlen, und zusätzlich den Kontextualisierungs-Satz aus Strategy S8 auch in R1 einziehen.

Wolf-Entscheidung: Empfehlung (a) — Scope bleibt auf `services/vendor_audit_engine.py` beschränkt (kein Eingriff in `advisor_note.md` oder andere R1-Prompts).

## Was geändert wurde

### `_generate_summary()` — Tonalität + Kontext

**DE:**
| vorher | nachher |
|---|---|
| `Sofortiger Handlungsbedarf bei Hochrisiko-Anbietern.` | `Prüfbedarf bei Hochrisiko-Anbietern.` |
| — | **+** `Der Audit-Status bezieht sich auf den Konformitätsstatus der gelisteten Tools, nicht auf den Gesamt-KI-Readiness-Status Ihres Unternehmens.` |

**EN:**
| vorher | nachher |
|---|---|
| `Immediate action required for high-risk vendors.` | `Review required for high-risk vendors.` |
| — | **+** `The audit status reflects the compliance posture of the listed tools only, not the overall AI-readiness status of your company.` |

Der Kontextualisierungs-Satz ist wörtlich an `prompts/strategy_prompts.py:105` angelehnt — die exakte Stelle, wo Strategy-Kunden bisher schon diese Klarstellung bekamen. Er erscheint sowohl auf dem roten als auch auf dem grünen Pfad (das Missverständnis über "was der Status misst" ist statusunabhängig).

### `_generate_recommendations()` — zwei Imperativ-Softenings

| vorher | nachher |
|---|---|
| `DPA (…) mit US-Anbietern abschliessen: {names}` | `DPA (…) mit US-Anbietern prüfen und ggf. nachholen: {names}` |
| `Hochrisiko-Anbieter prüfen, Risikominimierung durch AVV/DPA sicherstellen` | `Hochrisiko-Anbieter prüfen, Risikominimierung durch AVV/DPA einordnen` |

Die restlichen Recommendations (`klären`, `anfordern`, `durchführen`, `evaluieren`) waren bereits neutral-konstatativ und bleiben unverändert.

## Test cover

`tests/test_kis_1142_p2_vendor_framing.py` — 11 Tests, all green:
- **Summary-Tonalität** (4): DE+EN red-vendor verwendet `Prüfbedarf`/`Review required`, grün-Pfad hält `Keine kritischen Befunde`/`No critical findings`
- **Kontext-Satz** (3): DE+EN enden mit exakt der Strategy-S8-Klarstellung, Kontext erscheint auf rot UND grün
- **Recommendations-Tonalität** (2): `abschliessen`→`prüfen und ggf. nachholen`, `sicherstellen`→`einordnen` greifen am richtigen Pfad
- **Empty-Input** (2): `_generate_summary([])` verhält sich unverändert

Regression: `tests/test_g35_vendor_audit_engine.py` — 62 Tests unverändert grün (keine Asserts auf die geänderten Strings).

## Test plan
- [x] `pytest tests/test_kis_1142_p2_vendor_framing.py` — 11/11 green
- [x] `pytest tests/test_g35_vendor_audit_engine.py` — 62/62 unchanged
- [x] `mypy services/vendor_audit_engine.py` — clean
- [ ] Wolf: Lies dir auf einem real generierten R1-Report die Vendor-Audit-Summary durch — klingt sie jetzt konsistent mit dem Strategy-S8-Pendant und nicht mehr alarmierender als der Rest?

## Kontext — sequenzielle PR-Kette

Dieser PR ist der erste der drei sequenziellen Follow-ups aus dem Wolf-Batch (P2 → P3 → P4). P3 (Challenge Woche 1 für int/expert weglassen) folgt als separater PR sobald die "überspringbar"-Quelle in Summary-Prompt/Generator lokalisiert ist. P4 (KPA-Prompt entschlacken mit 2–3 alt/neu-Beispielen) danach.

https://claude.ai/code/session_kis-1142-p2

---
_Generated by [Claude Code](https://claude.ai/code/session_01H9uqvfiPt9vo4KR5Zw6NES)_