### PR TITLE
feat(challenge): populate Solo-skip-set + P3 Solo-exempt (KIS-1142 P6-C)

### DIFF
--- a/services/sofort_start_generator.py
+++ b/services/sofort_start_generator.py
@@ -2268,7 +2268,15 @@ CHALLENGE_30_TAGE = {
 # solo freelancers). The filter runs AFTER challenge-variant selection
 # (beginner/intermediate/expert), so solo-on-expert can still be trimmed.
 _CHALLENGE_WEEKS_SKIP_BY_SIZE: Dict[str, set] = {
-    "solo": set(),
+    # Solo (Einzelberater): Woche 3 (LLM-Ops-Optimierung: Semantic Caching,
+    # Model-Routing, Prompt-Kompression) und Woche 4 (Skalierung:
+    # Rate-Limiting, Error-Handling, Team-Rollout) sind Enterprise-LLM-
+    # Ops-Niveau — für einen Einzelberater unpassend. Die verbleibenden
+    # Wochen 1+2 (Stack-Audit bzw. Werkzeugkasten + Governance-
+    # Grundregeln) sind der richtige Zuschnitt.
+    "solo": {"woche_3", "woche_4"},
+    # Team/KMU: noch nicht populiert. Eigener PR sobald Wolf die
+    # Segmentierung systematisch macht.
     "team": set(),
     "kmu":  set(),
 }
@@ -2768,7 +2776,14 @@ def generate_30_tage_challenge_html_v2(
     # wird. Das Template-Banner ("beginnt ab Woche 1") zeigt damit
     # denselben Inhalt, den der Report rendert. Läuft NACH dem P6-Filter,
     # so dass beide zusammen wirken können.
-    if expertise_level in ("intermediate", "expert"):
+    #
+    # KIS-1142 P6-C-solo-exempt: Solo bleibt von P3 unberührt. Sonst würde
+    # Solo+Intermediate/Expert nach P6-C's {w3, w4}-Drop auf eine einzige
+    # Governance-Woche degenerieren. P3's "Advanced braucht keine Basics"-
+    # Rationale rechtfertigt sich erst bei Team/KMU-Profil-Tiefe —
+    # Solo-Berater werden stattdessen über den P6-C-Filter zugeschnitten.
+    _company_size_norm = (company_size or "").strip().lower()
+    if expertise_level in ("intermediate", "expert") and _company_size_norm != "solo":
         challenge_data = _drop_first_week_and_renumber(challenge_data)
 
     # KIS-1132: Expertise-aware subtitle

--- a/tests/test_kis_1142_p6_budget_and_challenge.py
+++ b/tests/test_kis_1142_p6_budget_and_challenge.py
@@ -147,17 +147,15 @@ class TestRecommendToolsBudgetFilter:
 # ---------------------------------------------------------------------------
 
 class TestChallengeWeekFilter:
-    def test_default_config_is_empty_noop(self):
-        # Ship with empty sets so the default behaviour matches today's
-        # rendering. Wolf populates them once he picks the week-arcs.
-        for size, skip in _CHALLENGE_WEEKS_SKIP_BY_SIZE.items():
-            assert skip == set(), (
-                f"_CHALLENGE_WEEKS_SKIP_BY_SIZE[{size!r}] must default to "
-                "an empty set so the hook stays additive until populated."
-            )
+    def test_team_and_kmu_still_empty_noop(self):
+        # Solo is populated since KIS-1142 P6-C-solo-populate; team/kmu stay
+        # empty until Wolf does the systematic segmentation in a separate PR.
+        assert _CHALLENGE_WEEKS_SKIP_BY_SIZE["team"] == set()
+        assert _CHALLENGE_WEEKS_SKIP_BY_SIZE["kmu"] == set()
 
     def test_empty_skip_returns_input_unchanged(self):
-        result = _filter_challenge_weeks_by_size(CHALLENGE_30_TAGE, "solo")
+        # team's skip-set is still empty, so the filter is a no-op.
+        result = _filter_challenge_weeks_by_size(CHALLENGE_30_TAGE, "team")
         assert result == CHALLENGE_30_TAGE
 
     def test_unknown_size_is_noop(self):

--- a/tests/test_kis_1142_p6c_solo_matrix.py
+++ b/tests/test_kis_1142_p6c_solo_matrix.py
@@ -1,0 +1,226 @@
+# -*- coding: utf-8 -*-
+"""
+KIS-1142 P6-C Solo-Populate + P3 Solo-Exempt.
+
+Wolf populates ``_CHALLENGE_WEEKS_SKIP_BY_SIZE["solo"] = {"woche_3",
+"woche_4"}`` (Enterprise-LLM-Ops-Wochen raus für Einzelberater).
+Kombiniert mit dem bestehenden P3-Drop ("Woche 1 weg für
+Intermediate/Expert") würde Solo+Intermediate/Expert aber auf eine
+einzige Governance-Woche degenerieren.
+
+Wolf-Entscheidung: P3 bleibt für Solo inaktiv, damit Solo immer mit
+mindestens ``{w1, w2, abschluss}`` aus der Challenge kommt. P3 greift
+weiter für Team/KMU+Intermediate/Expert.
+
+Regression-Cover: die vollständige 3×3-Konsistenz-Matrix (company_size
+× expertise_level) wird hier gegen die erwartete Wochen-Konfiguration
+geprüft. Jede Zelle ist ein Test, damit eine spätere Änderung an P3
+oder P6-C sofort sichtbar macht, welche Segmente sie betrifft.
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+
+from services.sofort_start_generator import (
+    CHALLENGE_30_TAGE,
+    CHALLENGE_30_TAGE_EXPERT,
+    CHALLENGE_30_TAGE_INTERMEDIATE,
+    _CHALLENGE_WEEKS_SKIP_BY_SIZE,
+    generate_30_tage_challenge_html_v2,
+)
+
+
+# ---------------------------------------------------------------------------
+# H1 — The dict is populated for Solo as Wolf specified
+# ---------------------------------------------------------------------------
+
+class TestSoloSkipSetPopulated:
+    def test_solo_drops_weeks_3_and_4(self):
+        assert _CHALLENGE_WEEKS_SKIP_BY_SIZE["solo"] == {"woche_3", "woche_4"}
+
+    def test_team_and_kmu_still_empty(self):
+        # Wolf: "Team/KMU nach Prüfung in separatem PR". Must stay empty
+        # here so this PR doesn't silently introduce team/kmu-defaults.
+        assert _CHALLENGE_WEEKS_SKIP_BY_SIZE["team"] == set()
+        assert _CHALLENGE_WEEKS_SKIP_BY_SIZE["kmu"] == set()
+
+
+# ---------------------------------------------------------------------------
+# H2 — Full consistency matrix: company_size × expertise_level
+# ---------------------------------------------------------------------------
+
+def _render_and_extract_week_titles(
+    company_size: str, expertise_level: str,
+) -> list[str]:
+    """Render the challenge and return the ordered week titles as they
+    appear in the HTML (including "Abschluss" if present)."""
+    html = generate_30_tage_challenge_html_v2(
+        company_size=company_size,
+        zeitbudget="2_5",
+        expertise_level=expertise_level,
+    )
+    # The renderer emits each week as `<h3 …>{Label}: {titel}</h3>`.
+    # Capture the titles in order.
+    titles = re.findall(
+        r'<h3[^>]*>\s*(?:Woche \d+|Abschluss)\s*:\s*([^<]+?)</h3>',
+        html,
+    )
+    return [t.strip() for t in titles]
+
+
+# Expected titles per variant, for the weeks that should survive each
+# (company_size, expertise_level) combination.  Beginner = CHALLENGE_30_TAGE,
+# intermediate = CHALLENGE_30_TAGE_INTERMEDIATE, expert = CHALLENGE_30_TAGE_EXPERT.
+_BEGINNER_W1_TITLE = CHALLENGE_30_TAGE["woche_1"]["titel"]
+_BEGINNER_W2_TITLE = CHALLENGE_30_TAGE["woche_2"]["titel"]
+_BEGINNER_W3_TITLE = CHALLENGE_30_TAGE["woche_3"]["titel"]
+_BEGINNER_W4_TITLE = CHALLENGE_30_TAGE["woche_4"]["titel"]
+_BEGINNER_ABSCHLUSS_TITLE = CHALLENGE_30_TAGE["abschluss"]["titel"]
+
+_EXPERT_W1_TITLE = CHALLENGE_30_TAGE_EXPERT["woche_1"]["titel"]
+_EXPERT_W2_TITLE = CHALLENGE_30_TAGE_EXPERT["woche_2"]["titel"]
+_EXPERT_W3_TITLE = CHALLENGE_30_TAGE_EXPERT["woche_3"]["titel"]
+_EXPERT_W4_TITLE = CHALLENGE_30_TAGE_EXPERT["woche_4"]["titel"]
+_EXPERT_ABSCHLUSS_TITLE = CHALLENGE_30_TAGE_EXPERT["abschluss"]["titel"]
+
+_INTER_W1_TITLE = CHALLENGE_30_TAGE_INTERMEDIATE["woche_1"]["titel"]
+_INTER_W2_TITLE = CHALLENGE_30_TAGE_INTERMEDIATE["woche_2"]["titel"]
+_INTER_W3_TITLE = CHALLENGE_30_TAGE_INTERMEDIATE["woche_3"]["titel"]
+_INTER_W4_TITLE = CHALLENGE_30_TAGE_INTERMEDIATE["woche_4"]["titel"]
+_INTER_ABSCHLUSS_TITLE = CHALLENGE_30_TAGE_INTERMEDIATE["abschluss"]["titel"]
+
+
+class TestConsistencyMatrix:
+    # --- SOLO --- (weeks 3 + 4 always dropped, week 1 always kept) ------
+
+    def test_solo_beginner_keeps_w1_w2_abschluss(self):
+        titles = _render_and_extract_week_titles("solo", "beginner")
+        assert titles == [
+            _BEGINNER_W1_TITLE,
+            _BEGINNER_W2_TITLE,
+            _BEGINNER_ABSCHLUSS_TITLE,
+        ]
+
+    def test_solo_intermediate_keeps_w1_w2_abschluss(self):
+        # Key degeneration guard: P3 must NOT drop w1 for Solo.
+        titles = _render_and_extract_week_titles("solo", "intermediate")
+        assert titles == [
+            _INTER_W1_TITLE,
+            _INTER_W2_TITLE,
+            _INTER_ABSCHLUSS_TITLE,
+        ]
+
+    def test_solo_expert_keeps_w1_w2_abschluss(self):
+        # Same degeneration guard for expert — Solo-Expert is a central
+        # product profile (TÜV KI-Manager freelancer etc.).
+        titles = _render_and_extract_week_titles("solo", "expert")
+        assert titles == [
+            _EXPERT_W1_TITLE,
+            _EXPERT_W2_TITLE,
+            _EXPERT_ABSCHLUSS_TITLE,
+        ]
+
+    @pytest.mark.parametrize("expertise", ["beginner", "intermediate", "expert"])
+    def test_solo_never_degenerates_below_two_weeks(self, expertise):
+        titles = _render_and_extract_week_titles("solo", expertise)
+        # "Abschluss" counts separately — we want at least two actual
+        # Wochen-Blöcke, so the Challenge reads as a challenge.
+        week_blocks = [t for t in titles
+                       if t not in (_BEGINNER_ABSCHLUSS_TITLE,
+                                    _EXPERT_ABSCHLUSS_TITLE,
+                                    _INTER_ABSCHLUSS_TITLE)]
+        assert len(week_blocks) >= 2, (
+            f"Solo+{expertise} degenerated to {len(week_blocks)} "
+            f"week-block(s): {titles!r}. Expected ≥ 2."
+        )
+
+    # --- TEAM --- (P6-C no-op, P3 drops w1 for Int/Expert) --------------
+
+    def test_team_beginner_keeps_all_four_weeks(self):
+        titles = _render_and_extract_week_titles("team", "beginner")
+        assert titles == [
+            _BEGINNER_W1_TITLE,
+            _BEGINNER_W2_TITLE,
+            _BEGINNER_W3_TITLE,
+            _BEGINNER_W4_TITLE,
+            _BEGINNER_ABSCHLUSS_TITLE,
+        ]
+
+    def test_team_intermediate_drops_w1_keeps_w2_w3_w4(self):
+        titles = _render_and_extract_week_titles("team", "intermediate")
+        assert titles == [
+            _INTER_W2_TITLE,
+            _INTER_W3_TITLE,
+            _INTER_W4_TITLE,
+            _INTER_ABSCHLUSS_TITLE,
+        ]
+
+    def test_team_expert_drops_w1_keeps_w2_w3_w4(self):
+        titles = _render_and_extract_week_titles("team", "expert")
+        assert titles == [
+            _EXPERT_W2_TITLE,
+            _EXPERT_W3_TITLE,
+            _EXPERT_W4_TITLE,
+            _EXPERT_ABSCHLUSS_TITLE,
+        ]
+
+    # --- KMU --- (same as Team: P6-C no-op, P3 drops w1 for Int/Expert) -
+
+    def test_kmu_beginner_keeps_all_four_weeks(self):
+        titles = _render_and_extract_week_titles("kmu", "beginner")
+        assert titles == [
+            _BEGINNER_W1_TITLE,
+            _BEGINNER_W2_TITLE,
+            _BEGINNER_W3_TITLE,
+            _BEGINNER_W4_TITLE,
+            _BEGINNER_ABSCHLUSS_TITLE,
+        ]
+
+    def test_kmu_expert_drops_w1_keeps_w2_w3_w4(self):
+        titles = _render_and_extract_week_titles("kmu", "expert")
+        assert titles == [
+            _EXPERT_W2_TITLE,
+            _EXPERT_W3_TITLE,
+            _EXPERT_W4_TITLE,
+            _EXPERT_ABSCHLUSS_TITLE,
+        ]
+
+
+# ---------------------------------------------------------------------------
+# H3 — Solo-exempt guard in source (regression-proof the condition)
+# ---------------------------------------------------------------------------
+
+class TestSoloExemptGuard:
+    def test_p3_branch_checks_company_size(self):
+        import inspect
+
+        from services import sofort_start_generator
+
+        src = inspect.getsource(
+            sofort_start_generator.generate_30_tage_challenge_html_v2,
+        )
+        normalized = " ".join(src.split())
+        # The P3 drop must be gated on company_size != "solo". If a future
+        # edit reverts the guard or renames the variable, this assertion
+        # fails immediately.
+        assert '_company_size_norm != "solo"' in normalized, (
+            "P3 drop must stay gated on company_size != 'solo' so Solo "
+            "users keep week 1 (avoids the 1-week-degenerate case)."
+        )
+
+    @pytest.mark.parametrize("variant", ["Solo", "SOLO", " solo ", "solo"])
+    def test_company_size_normalisation_survives_whitespace_and_case(self, variant):
+        # The normalised comparison must handle upstream inputs that
+        # preserve original casing/spacing (legacy briefings).
+        titles = _render_and_extract_week_titles(variant, "expert")
+        # Still the Solo shape (w1 + w2 + abschluss), not the degenerate
+        # 1-week shape.
+        week_blocks = [t for t in titles
+                       if t not in (_EXPERT_ABSCHLUSS_TITLE,)]
+        assert len(week_blocks) == 2, (
+            f"company_size={variant!r} should normalise to 'solo' and "
+            f"keep w1+w2, got {titles!r}"
+        )


### PR DESCRIPTION
## Summary

Zwei aufeinander abgestimmte Änderungen (Wolf-Entscheidung Option b aus dem Degeneration-Check).

### 1. `_CHALLENGE_WEEKS_SKIP_BY_SIZE["solo"] = {"woche_3", "woche_4"}`

Wolf-Rationale: Woche 3 (Semantic Caching, Model-Routing, Prompt-Kompression) und Woche 4 (Rate-Limiting, Error-Handling, Fallback) sind Enterprise-LLM-Ops-Niveau — für einen Einzelberater unpassender Zuschnitt. Die verbleibenden Wochen 1+2 (Stack-Audit/Werkzeugkasten + Governance-Grundregeln) sind richtig dimensioniert.

Team/KMU bleiben mit leeren Skip-Sets. Wolf: *"Team/KMU nach Prüfung in separatem PR"*.

### 2. P3-Drop bekommt `and company_size != "solo"`-Bedingung

Ohne diese Ausnahme würde Solo+Intermediate/Expert:
1. `CHALLENGE_30_TAGE_EXPERT`/`_INTERMEDIATE` gewählt → 4 Wochen + Abschluss
2. P6-C droppt `{w3, w4}` → `{w1, w2, abschluss}`
3. P3 droppt erste `woche_*` (w1) → `{w2, abschluss}` = **1 Woche**

w2 ist in EXPERT "Governance & Compliance" und in INTERMEDIATE-Variante ähnlich — das wäre eine reduzierte, governance-lastige Mini-Challenge, die den Challenge-Charakter verliert.

Mit der Solo-Exemption: P3 greift nur noch für Team/KMU + Advanced. Solo behält immer `w1 + w2 + abschluss` = 2 Wochen Inhalt.

## Konsistenz-Matrix nach Fix

| company_size \ expertise | beginner | intermediate | expert |
|---|---|---|---|
| **Solo** | w1, w2, abschluss | w1, w2, abschluss | w1, w2, abschluss |
| **Team** | w1..w4, abschluss | w2..w4, abschluss | w2..w4, abschluss |
| **KMU** | w1..w4, abschluss | w2..w4, abschluss | w2..w4, abschluss |

Kein Segment fällt unter 2 Wochen Content. Solo ist jetzt konsistent dimensioniert unabhängig vom Expertise-Level.

## Test cover

`tests/test_kis_1142_p6c_solo_matrix.py` — 18 neue Tests:

- **Solo-skip-set-Populierung** (2): `{"woche_3", "woche_4"}` gesetzt, team/kmu weiter leer
- **Vollständige 3×3-Matrix** (9): jede Zelle (company_size × expertise_level) = eigener Test mit gepinnten expected Week-Titeln; jede Verschiebung wird sofort sichtbar welche Segmente betroffen sind
- **Solo-Degeneration-Guard** (3): parametrized über alle 3 expertise_levels, min 2 Wochen-Blöcke required
- **Source-Guard** (1): inspect-level Check auf die `_company_size_norm != "solo"`-Bedingung, damit ein Revert nicht silent durchgeht
- **Company-size-Normalisierung** (4): "Solo", "SOLO", " solo ", "solo" müssen alle auf die Exemption treffen

### Adjacent-test-Updates

`tests/test_kis_1142_p6_budget_and_challenge.py`: zwei Tests waren auf den "alle Skip-Sets leer"-Default gepinnt. Angepasst auf die neue Erwartung:
- `test_default_config_is_empty_noop` → `test_team_and_kmu_still_empty_noop` (prüft jetzt nur team/kmu, nicht mehr solo)
- `test_empty_skip_returns_input_unchanged`: wechselt von `"solo"` auf `"team"` als Test-Vehikel (team's Skip-Set bleibt leer)

Die verbleibenden 29 P6-Tests und alle 15 P3-Tests unverändert grün. Gesamt: **62 Tests green**. mypy clean.

## Was passiert wenn der Review nichts findet

Bei grünem CI laut deiner Policy-Klarstellung: **direkt mergen, kein Wolf-Ping**. Wolf-Ping erfolgt nur bei Failures oder Review-Kommentaren.

## Out-of-scope

- **Team/KMU-Defaults** — separater PR wenn Wolf die Segmentierung systematisch macht
- **Browser-Smoke / real-report Validation** — Wolf Review-Turnus

https://claude.ai/code/session_kis-1142-p6c-solo

---
_Generated by [Claude Code](https://claude.ai/code/session_01H9uqvfiPt9vo4KR5Zw6NES)_