### PR TITLE
fix(chat): entangle vision_3_jahre from strategische_ziele in Block B [KIS-1155]

### DIFF
--- a/services/chat_conversation.py
+++ b/services/chat_conversation.py
@@ -547,7 +547,7 @@ FIELD_DESCRIPTIONS: dict[str, str] = {
     "zeitersparnis_prioritaet": "Welche Aufgabe kostet im Arbeitsalltag am meisten Zeit oder Nerven? (Freitext)",
     "pilot_bereich": "Bester Bereich für ein Pilotprojekt (Kundenservice, Marketing, Vertrieb, etc.)",
     "geschaeftsmodell_evolution": "Ideen, wie KI das Geschäftsmodell verändern könnte (Freitext)",
-    "vision_3_jahre": "Wie soll das Unternehmen in 2–3 Jahren mit KI arbeiten? (Freitext)",
+    "vision_3_jahre": "Langfrist-Vision: Wo soll das Unternehmen in 2–3 Jahren mit KI stehen? (Freitext)",
     # Sektion 4
     "strategische_ziele": "Was soll KI in 6–12 Monaten konkret verbessern? (Freitext)",
     "ki_guardrails": "No-Gos oder sensible Themen beim KI-Einsatz (Freitext)",
@@ -1491,6 +1491,11 @@ NOCH OFFENE FELDER IN DIESEM BLOCK:
 
 REGELN:
 - Stelle 1–2 offene Fragen zu Vision, Strategie und Governance.
+- FELD-BINDUNG (STRIKT): Deine Frage MUSS sich ausschließlich am \
+NÄCHSTES FELD festmachen. Übernimm KEINEN Zeitrahmen und KEIN Verb \
+aus anderen noch offenen Feldern dieses Blocks. KEIN Mix von \
+Feldsemantiken — auch wenn andere Block-B-Felder thematisch ähnlich \
+klingen, formuliere STRIKT nur zum aktuell gefragten Feld.
 - Bei "weiß nicht" / "kann ich nicht sagen" → Feld SOFORT \
 überspringen. NICHT insistieren, NICHT alternative \
 Formulierung versuchen.

--- a/services/field_templates.py
+++ b/services/field_templates.py
@@ -109,9 +109,9 @@ FIELD_EXAMPLES: dict[str, list[str]] = {
         "KI als eigenständige Leistung vermarkten",
     ],
     "vision_3_jahre": [
-        "KI als fester Teil aller Kernprozesse",
-        "Doppelte Kapazität ohne zusätzliches Personal",
-        "Neue KI-basierte Produkte im Portfolio",
+        "KI ist fester Teil des Geschäftsmodells",
+        "Neue KI-basierte Angebote etabliert",
+        "Organisation arbeitet KI-nativ",
     ],
     "strategische_ziele": [
         "Wiederkehrende Aufgaben automatisieren und Zeit gewinnen",

--- a/tests/test_kis_1155_block_b_field_isolation.py
+++ b/tests/test_kis_1155_block_b_field_isolation.py
@@ -1,0 +1,63 @@
+"""Regression tests for KIS-1155: Strategy-Intro-Duplikat in Block B.
+
+Root cause: vision_3_jahre and strategische_ziele had semantically
+overlapping FIELD_DESCRIPTIONS. Sonnet blended them when formulating
+the vision_3_jahre question, producing a near-duplicate of the
+following strategische_ziele question (both about "6-12 Monaten
+konkret verbessern").
+
+Fix (Kombi A+B+E):
+- FIELD_DESCRIPTIONS["vision_3_jahre"] reworded to long-term vision
+- FIELD_EXAMPLES["vision_3_jahre"] chips reworked to vision framing
+- BLOCK_B_PROMPT gained a strict FELD-BINDUNG rule
+"""
+from services.chat_conversation import BLOCK_B_PROMPT, FIELD_DESCRIPTIONS
+from services.field_templates import FIELD_EXAMPLES
+
+
+class TestVision3JahreDescriptionIsolation:
+    """The vision_3_jahre description must not share wording with
+    strategische_ziele (6-12 Monaten / verbessern)."""
+
+    def test_no_six_to_twelve_months_wording(self):
+        desc = FIELD_DESCRIPTIONS["vision_3_jahre"]
+        assert "6–12" not in desc
+        assert "6-12" not in desc
+        assert "Monaten" not in desc
+
+    def test_no_improvement_verb(self):
+        desc = FIELD_DESCRIPTIONS["vision_3_jahre"].lower()
+        assert "verbessern" not in desc
+
+    def test_keeps_long_term_timeframe(self):
+        desc = FIELD_DESCRIPTIONS["vision_3_jahre"]
+        assert "2–3 Jahren" in desc or "2-3 Jahren" in desc
+
+    def test_contains_vision_keyword(self):
+        desc = FIELD_DESCRIPTIONS["vision_3_jahre"].lower()
+        assert "vision" in desc
+
+
+class TestVision3JahreChipsAreVisionFramed:
+    """Chips must not use operative/short-term wording."""
+
+    def test_three_chips_present(self):
+        assert len(FIELD_EXAMPLES["vision_3_jahre"]) == 3
+
+    def test_no_kernprozesse_chip(self):
+        for chip in FIELD_EXAMPLES["vision_3_jahre"]:
+            assert "Kernprozesse" not in chip
+
+
+class TestBlockBPromptHasFieldBindingRule:
+    """BLOCK_B_PROMPT must pin Sonnet strictly to the next_field to
+    prevent semantic blending of neighbouring open fields."""
+
+    def test_binding_rule_header_present(self):
+        assert "FELD-BINDUNG" in BLOCK_B_PROMPT
+
+    def test_rule_forbids_cross_field_timeframe(self):
+        assert "KEINEN Zeitrahmen" in BLOCK_B_PROMPT
+
+    def test_rule_forbids_semantic_mixing(self):
+        assert "KEIN Mix von Feldsemantiken" in BLOCK_B_PROMPT


### PR DESCRIPTION
## Summary

Fix für **KIS-1155 Strategy-Intro-Duplikat** in Block B („KI-Strategie & Roadmap").

Sonnet hatte die FIELD_DESCRIPTIONS von `vision_3_jahre` (2–3 Jahre Vision) und `strategische_ziele` (6–12 Monate operative Ziele) beim Formulieren der ersten Block-B-Frage semantisch vermischt. Dadurch erschienen zwei aufeinanderfolgende Fragen, die beide nach „6–12 Monaten konkret verbessern" klangen — der Nutzer erlebte das als Duplikat. Beobachtet im Testrun KIS-1155 (briefing_id 1038, Solo/Beratung, 23.04.2026).

Root cause: Sonnet bekommt im `BLOCK_B_PROMPT` **alle 10 offenen Block-B-Felder mit Beschreibungen** in den Kontext, ohne dass der Prompt strikt bindet, nur zum aktuell nächsten Feld zu formulieren. Bei zwei semantisch nahen Feldern blendet das Modell die Phrasing-Elemente zusammen.

## Änderungen (Kombi A + B + E)

**A — FIELD_DESCRIPTIONS["vision_3_jahre"]** (`services/chat_conversation.py:550`)
- Alt: „Wie soll das Unternehmen in 2–3 Jahren mit KI arbeiten?"
- Neu: „Langfrist-Vision: Wo soll das Unternehmen in 2–3 Jahren mit KI stehen?"
- Entfernt „verbessern"/„Monate"-Überlapp mit `strategische_ziele`.

**B — BLOCK_B_PROMPT FELD-BINDUNG-Regel** (`services/chat_conversation.py:1493–1497`)
Neue strikte Regel, die Sonnet zwingt, die Frage ausschließlich am `next_field` festzumachen:
> FELD-BINDUNG (STRIKT): Deine Frage MUSS sich ausschließlich am NÄCHSTES FELD festmachen. Übernimm KEINEN Zeitrahmen und KEIN Verb aus anderen noch offenen Feldern dieses Blocks. KEIN Mix von Feldsemantiken — auch wenn andere Block-B-Felder thematisch ähnlich klingen, formuliere STRIKT nur zum aktuell gefragten Feld.

**E — FIELD_EXAMPLES["vision_3_jahre"] Chips** (`services/field_templates.py:111–115`)
Von operativem Wording auf Vision-Framing umgestellt:
- „KI als fester Teil aller Kernprozesse" → „KI ist fester Teil des Geschäftsmodells"
- „Doppelte Kapazität ohne zusätzliches Personal" → „Neue KI-basierte Angebote etabliert"
- „Neue KI-basierte Produkte im Portfolio" → „Organisation arbeitet KI-nativ"

**Regression-Test** (`tests/test_kis_1155_block_b_field_isolation.py`, neu)
Fixiert alle drei Änderungen per Assertion:
- vision_3_jahre-Description enthält kein „6–12" / „Monaten" / „verbessern", aber „vision" und „2–3 Jahren"
- Chips enthalten kein „Kernprozesse"
- BLOCK_B_PROMPT enthält „FELD-BINDUNG", „KEINEN Zeitrahmen", „KEIN Mix von Feldsemantiken"

## Scope & Risk

- **Reine Prompt-/Description-/Chip-Änderungen** — keine State-Machine-, Scoring-, Canonical- oder DB-Änderungen.
- Canonical-Werte (Solo 15h/80€, Team 25h/95€, KMU 50h/110€) unberührt.
- Keine DB-Migration.
- Kein Impact auf Block A/C/D.
- Rollback = `git revert` des einzelnen Commits.

## Browser-Smoke (Wolf, nach Deploy auf Staging)

1. Neuen Strategy-Run starten (Solo/Beratung-Profil wie KIS-1155).
2. Durch Phase 1 bis zum Checkpoint vordringen, Block B („KI-Strategie & Roadmap") wählen.
3. **Prüfen — Erste Block-B-Frage:** fragt klar nach 2–3-Jahres-Vision (nicht nach „6–12 Monaten verbessern"). Chips unten: „KI ist fester Teil des Geschäftsmodells" / „Neue KI-basierte Angebote etabliert" / „Organisation arbeitet KI-nativ".
4. Chip wählen → Progress-Bar springt 0/10 → 1/10.
5. **Prüfen — Zweite Block-B-Frage:** fragt nach 6–12 Monaten / strategische Ziele — klar abgegrenzt von Frage 1, nicht als gefühltes Duplikat.
6. Block B weiter durchlaufen (s3–s10): keine weiteren Duplikat-Gefühle, kein Skip, kein Hänger.
7. Block B abschließen → Transition-Text korrekt, Übergang zum nächsten Block sauber.

## Pre-Merge-Checkliste (per Master-Plan)

- [x] Diagnose-Ping an Wolf (Root-Cause + Fix-Varianten) ✓
- [x] Diff-Ping an Wolf vor Commit ✓
- [x] Wolf-Freigabe auf Kombi A+B+E ✓
- [x] Regression-Test ergänzt ✓
- [ ] CI grün
- [ ] **Merge-Ping an Wolf (kein Auto-Merge im BE)**
- [ ] Nach Merge: Deploy-Bestätigung → Wolf macht Browser-Smoke gegen Staging

https://claude.ai/code/session_016aLJRf7ZpCC5dEKXwYMSJV

---
_Generated by [Claude Code](https://claude.ai/code/session_016aLJRf7ZpCC5dEKXwYMSJV)_