### PR TITLE
fix(chat): restore KIS-1138 word count for vision_3_jahre chip [KIS-1155]

### DIFF
--- a/services/field_templates.py
+++ b/services/field_templates.py
@@ -111,7 +111,7 @@ FIELD_EXAMPLES: dict[str, list[str]] = {
     "vision_3_jahre": [
         "KI ist fester Teil des Geschäftsmodells",
         "Neue KI-basierte Angebote etabliert",
-        "Organisation arbeitet KI-nativ",
+        "Gesamte Organisation arbeitet KI-nativ",
     ],
     "strategische_ziele": [
         "Wiederkehrende Aufgaben automatisieren und Zeit gewinnen",

--- a/tests/test_kis_1155_block_b_field_isolation.py
+++ b/tests/test_kis_1155_block_b_field_isolation.py
@@ -48,6 +48,12 @@ class TestVision3JahreChipsAreVisionFramed:
         for chip in FIELD_EXAMPLES["vision_3_jahre"]:
             assert "Kernprozesse" not in chip
 
+    def test_all_chips_have_at_least_four_words(self):
+        for chip in FIELD_EXAMPLES["vision_3_jahre"]:
+            assert len(chip.split()) >= 4, (
+                f"Chip '{chip}' violates KIS-1138 4-8 word rule"
+            )
+
 
 class TestBlockBPromptHasFieldBindingRule:
     """BLOCK_B_PROMPT must pin Sonnet strictly to the next_field to


### PR DESCRIPTION
## Summary

Hotfix für gebrochenen main nach Merge von PR #980 (KIS-1155).

Der KIS-1155 Chip-Rework hat versehentlich einen 3-Wort-Chip eingeführt, der die in KIS-1138 etablierte **4–8-Wort-Regel** (half-sentence rule) verletzt. Test `tests/test_kis_1138_inspiration_chips.py::test_word_count_between_four_and_eight[vision_3_jahre]` schlug fehl.

## Änderung

**FIELD_EXAMPLES["vision_3_jahre"]** (`services/field_templates.py:114`)
- Alt: „Organisation arbeitet KI-nativ" (3 Worte ✗)
- Neu: „Gesamte Organisation arbeitet KI-nativ" (4 Worte ✓)

„Gesamte" als Scope-Marker passt zum Vision-Framing der beiden anderen Chips und erfüllt die KIS-1138-Untergrenze.

## Regression-Guard

`tests/test_kis_1155_block_b_field_isolation.py` ergänzt um `test_all_chips_have_at_least_four_words`, damit dieser Fehler bei zukünftigen Chip-Änderungen nicht wieder unbemerkt durchrutscht. Ergänzt die KIS-1138-Suite auf der Seite des neuen Regression-Tests.

## Scope & Risk

- **Ein-Wort-Erweiterung eines einzelnen Chip-Strings + 6 Zeilen Test.** Kein Impact auf Prompts, Descriptions, Scoring oder Canonical-Werte.
- Unabhängig vom Inhalt: beide Worte-Tests (KIS-1138 und neuer KIS-1155-Guard) prüfen strukturelle Regeln, kein LLM-Verhalten.

## Browser-Smoke

Unverändert zum ursprünglichen KIS-1155-Plan. Nach Deploy: Block B erste Frage Vision 2–3 Jahre, Chip #3 jetzt „Gesamte Organisation arbeitet KI-nativ".

## Pre-Merge

- [x] Wolf-Freigabe für Chip-Variante (a) ✓
- [x] Lokaler Smoke-Check (3 Chips, alle 4–8 Worte) ✓
- [ ] CI grün (muss KIS-1138- UND KIS-1155-Tests grün zeigen)
- [ ] Merge-Ping an Wolf

## Selbstkritik / Arbeitsprinzip-Update

Hätte vor KIS-1155-Commit existierende Tests greppen sollen, die `FIELD_EXAMPLES` prüfen (`grep -rn FIELD_EXAMPLES tests/`). Gilt ab sofort auch ohne lokal installiertes Pytest als festes Arbeitsprinzip vor Prompt-/Template-/Registry-Änderungen.

https://claude.ai/code/session_016aLJRf7ZpCC5dEKXwYMSJV

---
_Generated by [Claude Code](https://claude.ai/code/session_016aLJRf7ZpCC5dEKXwYMSJV)_