### PR TITLE
security(deps): SEC-H2 — FastAPI 0.120 (Starlette CVE-2025-54121, CVE-2025-62727)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # Production-ready minimal requirements for the backend (pinned, Pydantic v2 compatible)
 # --- Web & Settings ---
-fastapi>=0.111,<0.116
+fastapi>=0.120,<0.121
 uvicorn[standard]>=0.30,<0.32
 pydantic[email]>=2.9,<3.0
 pydantic-settings>=2.4,<3.0


### PR DESCRIPTION
## Summary

SEC-H2 follow-up zu PR #983: FastAPI auf `>=0.120,<0.121` bumpen, um die zwei Starlette-CVEs **CVE-2025-54121** (Multipart-DoS) und **CVE-2025-62727** (Multipart-CRLF) in einem Schritt zu schließen.

**Wolf-Decision:** Option A (kein expliziter Starlette-Pin — KISS, Drift-Schutz via `pip-audit --strict` Workflow + Dependabot ist ausreichend).

```diff
- fastapi>=0.111,<0.116
+ fastapi>=0.120,<0.121
```

## Warum Option A der einzige Weg ist

Recherche per `wheel`-Metadaten von PyPI:

| FastAPI | erlaubt Starlette | beide CVEs gefixt? |
|---|---|---|
| 0.111–0.115 (alt) | `>=0.40.0,<0.47.0` | ❌ |
| 0.116–0.119 | `>=0.40.0,<0.49.0` | ❌ (nur 54121) |
| **0.120.x** | `>=0.40.0,<0.50.0` | ✅ |

Es gibt **keine FastAPI-Version <0.120, deren Starlette-Constraint die Fix-Version 0.49.1 zulässt**. Direkter Starlette-Pin ohne FastAPI-Bump funktioniert nicht.

## Pre-Flight-Check

- **`app.on_event(...)` Audit:** kein Vorkommen im Codebase. `main.py:130` benutzt schon `lifespan=lifespan` → FastAPI 0.120 preferred Path.
- **Pydantic-Compat:** `pydantic !=1.8,!=2.0.0,!=2.0.1,!=2.1.0,<3.0.0,>=1.7.4` — identisch in FastAPI 0.111 und 0.120. Pydantic-Pin (`>=2.9,<3.0`) bleibt.

## Lokale Validierung

Mit `fastapi 0.120.4` + `starlette 0.49.3` + `pydantic 2.13.3`:

| Check | Ergebnis |
|---|---|
| `from main import app` | ✅ — 93 Routen mounten cleanly |
| `Settings.from_env()` + `field_validator` | ✅ — positiv & negativ-Case |
| `core.security` JWT round-trip | ✅ |
| `lifespan` async-context-manager | ✅ |
| `pip-audit --strict` auf `requirements.txt` | ✅ **0 Vulnerabilities** (war: 4) |
| `pytest -k "auth or jwt or settings or admin_retest or security or token or cors"` | ✅ **70 passed, 1 skipped** |
| `pytest -k "validator or pydantic or model or endpoint or route"` | ✅ **331 passed, 1 skipped** |

## CI-Test-Plan

- [ ] **Security Scan** Workflow (neu in #983 gemerged) → `pip-audit --strict` muss 0 Prod-Vulns reporten
- [ ] **CI / Unit tests (Python 3.10 + 3.11)** → grün
- [ ] **Type check (mypy)** → grün
- [ ] **PLATIN++ Quality Suite** → grün
- [ ] **Smoke + Auto QA Regression** → grün

## Wenn etwas fällt

Wolfs Vorgabe: bei **Pydantic-Validation-Errors** (`field_validator`/`model_validator`/`computed_field`) — Stack-Trace zurück, **nicht** autonom fixen.

https://claude.ai/code/session_01KMizP3QQaM9nYb8A2rh3KA

---
_Generated by [Claude Code](https://claude.ai/code/session_01KMizP3QQaM9nYb8A2rh3KA)_