### PR TITLE
hotfix: admin-cancel + audit columns + whitelist extract (Schritte 1–4)

### DIFF
--- a/core/migrate.py
+++ b/core/migrate.py
@@ -163,6 +163,13 @@ DDL = [
     text("CREATE INDEX IF NOT EXISTS idx_chat_sessions_status ON chat_sessions(status)"),
     text("CREATE INDEX IF NOT EXISTS idx_chat_sessions_user ON chat_sessions(user_id)"),
     text("CREATE INDEX IF NOT EXISTS idx_chat_sessions_activity ON chat_sessions(last_activity_at)"),
+    # Hotfix 2026-04-27: Admin-Cancel + Audit (briefings)
+    text("ALTER TABLE briefings ADD COLUMN IF NOT EXISTS cancel_reason TEXT"),
+    text("ALTER TABLE briefings ADD COLUMN IF NOT EXISTS cancelled_at  TIMESTAMPTZ"),
+    text("ALTER TABLE briefings ADD COLUMN IF NOT EXISTS source        TEXT"),
+    text("ALTER TABLE briefings ADD COLUMN IF NOT EXISTS request_ip    TEXT"),
+    text("ALTER TABLE briefings ADD COLUMN IF NOT EXISTS request_ua    TEXT"),
+    text("CREATE INDEX IF NOT EXISTS ix_briefings_cancelled_at ON briefings (cancelled_at)"),
 ]
 
 def migrate_all(engine: Engine) -> None:

--- a/core/whitelist.py
+++ b/core/whitelist.py
@@ -1,0 +1,84 @@
+# -*- coding: utf-8 -*-
+"""
+core.whitelist — Single source of truth for the test-phase E-Mail-Whitelist.
+
+Imported by routes/auth.py (gate /auth/request-code) and by report-pipeline
+endpoints that need to verify the JWT subject is allowed to trigger LLM work.
+Keep the canonical list here; do not duplicate it elsewhere.
+"""
+from __future__ import annotations
+
+from fastapi import HTTPException, status
+
+# Canonical whitelist. Synchron mit setup_database.py TESTUSERS halten.
+# Alle Adressen werden case-insensitive verglichen (lower).
+EMAIL_WHITELIST: frozenset[str] = frozenset(
+    email.lower()
+    for email in [
+        "j.hohl@freenet.de",
+        "kerstin.geffert@gmail.com",
+        "daniel.effinger@web.de",
+        "post@zero2.de",
+        "giselapeter@peter-partner.de",
+        "wolf.hohl@web.de",
+        "geffertj@mac.com",
+        "geffertkilian@gmail.com",
+        "berndemhart46@gmail.com",
+        "po@wbs-slg.de",
+        "trailerman01@outlook.de",
+        "hilfe@ki-sicherheit.jetzt",
+        "levent.graef@posteo.de",
+        "birgit.cook@ulitzka-partner.de",
+        "alexander.luckow@icloud.com",
+        "frank.beer@kabelmail.de",
+        "patrick@silk-relations.com",
+        "marc@trailerhaus-onair.de",
+        "norbert@trailerhaus.de",
+        "sonia-souto@mac.com",
+        "christian.ulitzka@ulitzka-partner.de",
+        "srack@gmx.net",
+        "buss@maria-hilft.de",
+        "w.beestermoeller@web.de",
+        "bewertung@ki-sicherheit.jetzt",  # Admin
+        "test@example.com",  # CI/CD
+        "test-v7-final@ki-sicherheit.jetzt",
+        "test-v7-1@ki-sicherheit.jetzt",
+        "test-v7-400@ki-sicherheit.jetzt",
+    ]
+)
+
+# Admin-Mails (Untermenge der Whitelist) — wer Cancel/List-Endpoints nutzen darf.
+ADMIN_EMAILS: frozenset[str] = frozenset({"bewertung@ki-sicherheit.jetzt"})
+
+
+def is_whitelisted(email: str | None) -> bool:
+    """Return True iff the given email is in the test-phase whitelist."""
+    if not email:
+        return False
+    return email.strip().lower() in EMAIL_WHITELIST
+
+
+def require_whitelisted(email: str | None) -> str:
+    """
+    Raise HTTPException 403 if the email is not whitelisted.
+    Returns the normalised (lowercased, stripped) email on success.
+    """
+    if not email:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Diese E-Mail-Adresse ist nicht für die Testphase freigeschaltet.",
+        )
+    normalised = email.strip().lower()
+    if normalised not in EMAIL_WHITELIST:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Diese E-Mail-Adresse ist nicht für die Testphase freigeschaltet.",
+        )
+    return normalised
+
+
+def is_admin(email: str | None) -> bool:
+    """Return True iff the given email is an admin."""
+    if not email:
+        return False
+    return email.strip().lower() in ADMIN_EMAILS

--- a/migrations/2026-04-27_add_cancel_and_audit_columns_postgres.sql
+++ b/migrations/2026-04-27_add_cancel_and_audit_columns_postgres.sql
@@ -1,0 +1,11 @@
+-- Migration: Add cancel + audit columns to briefings table (PostgreSQL)
+-- Sprint: Admin-Cancel + Whitelist-Enforcement Hotfix
+-- Idempotent via IF NOT EXISTS.
+
+ALTER TABLE briefings ADD COLUMN IF NOT EXISTS cancel_reason TEXT;
+ALTER TABLE briefings ADD COLUMN IF NOT EXISTS cancelled_at  TIMESTAMP WITH TIME ZONE;
+ALTER TABLE briefings ADD COLUMN IF NOT EXISTS source        TEXT;
+ALTER TABLE briefings ADD COLUMN IF NOT EXISTS request_ip    TEXT;
+ALTER TABLE briefings ADD COLUMN IF NOT EXISTS request_ua    TEXT;
+
+CREATE INDEX IF NOT EXISTS ix_briefings_cancelled_at ON briefings (cancelled_at);

--- a/migrations/2026-04-27_add_cancel_and_audit_columns_sqlite.sql
+++ b/migrations/2026-04-27_add_cancel_and_audit_columns_sqlite.sql
@@ -1,0 +1,12 @@
+-- Migration: Add cancel + audit columns to briefings table (SQLite)
+-- Sprint: Admin-Cancel + Whitelist-Enforcement Hotfix
+-- SQLite 3.35+ unterstützt IF NOT EXISTS für ALTER TABLE ADD COLUMN.
+-- Falls die Ziel-DB älter ist, einzeln ausführen und vorhandene Spalten überspringen.
+
+ALTER TABLE briefings ADD COLUMN cancel_reason TEXT;
+ALTER TABLE briefings ADD COLUMN cancelled_at  DATETIME;
+ALTER TABLE briefings ADD COLUMN source        TEXT;
+ALTER TABLE briefings ADD COLUMN request_ip    TEXT;
+ALTER TABLE briefings ADD COLUMN request_ua    TEXT;
+
+CREATE INDEX IF NOT EXISTS ix_briefings_cancelled_at ON briefings (cancelled_at);

--- a/models.py
+++ b/models.py
@@ -85,6 +85,15 @@ class Briefing(Base):
     worker_id: Mapped[Optional[str]] = mapped_column(String(64), nullable=True)
     replayed_from: Mapped[Optional[int]] = mapped_column(Integer, nullable=True, index=True)
 
+    # Hotfix 2026-04-27: Admin-Cancel + Audit
+    cancel_reason: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    cancelled_at: Mapped[Optional[datetime]] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    source: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    request_ip: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+    request_ua: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
+
     user = relationship("User", lazy="joined")
 
     def __repr__(self) -> str:  # pragma: no cover

--- a/ops/cancel_briefings.sql
+++ b/ops/cancel_briefings.sql
@@ -1,0 +1,46 @@
+-- ============================================================
+-- HOTFIX: Briefings sofort canceln (Notfall-Tool)
+--
+-- Voraussetzung: Migration 2026-04-27_add_cancel_and_audit_columns_postgres.sql
+-- ist gelaufen (cancel_reason, cancelled_at-Spalten existieren). Bei Container-
+-- Restart laufen ALTERs aus core/migrate.py automatisch — kein manueller Schritt.
+--
+-- Verwendung (Komma-Liste, KEINE Quotes pro ID):
+--   psql "$DATABASE_URL" -v briefing_ids="1040,1050" -f ops/cancel_briefings.sql
+--
+-- Aktive Status (lt. Worker-Code workers/briefings_worker.py:166,185):
+--   accepted | queued | processing | analyzing
+-- Terminal: done | failed | skipped | error | cancelled
+-- ============================================================
+
+\set ON_ERROR_STOP on
+
+-- 1. Sanity-Check: was würde gecancelt? (vorher anzeigen)
+SELECT b.id,
+       u.email AS user_email,
+       b.status,
+       b.created_at,
+       b.accepted_at,
+       b.processing_at,
+       b.worker_id,
+       b.source,
+       b.request_ip
+  FROM briefings b
+  LEFT JOIN users u ON u.id = b.user_id
+ WHERE b.id = ANY(string_to_array(:'briefing_ids', ',')::int[])
+ ORDER BY b.id;
+
+-- 2. Cancel — nur wenn Job noch aktiv ist
+UPDATE briefings
+   SET status        = 'cancelled',
+       worker_id     = NULL,
+       cancel_reason = 'admin_manual_cancel',
+       cancelled_at  = NOW()
+ WHERE id = ANY(string_to_array(:'briefing_ids', ',')::int[])
+   AND status IN ('accepted', 'queued', 'processing', 'analyzing');
+
+-- 3. Bestätigung
+SELECT id, status, cancel_reason, cancelled_at, worker_id
+  FROM briefings
+ WHERE id = ANY(string_to_array(:'briefing_ids', ',')::int[])
+ ORDER BY id;

--- a/routes/admin.py
+++ b/routes/admin.py
@@ -13,11 +13,21 @@ import logging
 import os
 from typing import Any, Dict, List, Optional
 
+from datetime import datetime, timedelta, timezone
+
 from fastapi import APIRouter, Depends, HTTPException, Query, BackgroundTasks
 from fastapi.responses import StreamingResponse, HTMLResponse
+from pydantic import BaseModel, Field
+
+from core.whitelist import ADMIN_EMAILS as _CANONICAL_ADMIN_EMAILS
 
 log = logging.getLogger("routes.admin")
 router = APIRouter(prefix="/admin", tags=["admin"])
+
+# Aktive Briefing-Status — Quelle: workers/briefings_worker.py:166,185
+# Worker zieht Jobs mit status IN ('accepted','queued'); 'processing' läuft
+# gerade; 'analyzing' wird in routes/admin.py:rerun_generation gesetzt.
+ACTIVE_STATUSES: tuple[str, ...] = ("accepted", "queued", "processing", "analyzing")
 
 # ---------- DB/Auth Dependencies (guarded) ----------
 try:
@@ -53,10 +63,16 @@ def _is_admin(user: Any) -> bool:
     role = getattr(user, "role", None)
     if isinstance(role, str) and role.lower() in {"admin", "owner"}:
         return True
-    allow = os.getenv("ADMIN_EMAILS", "") or getattr(user, "admin_allow", "") or ""
-    allowlist = [e.strip().lower() for e in allow.split(",") if e.strip()]
     email = (getattr(user, "email", "") or "").lower()
-    return bool(email and email in allowlist)
+    if not email:
+        return False
+    # Env override (CSV) — for ad-hoc additions without redeploy.
+    allow = os.getenv("ADMIN_EMAILS", "") or getattr(user, "admin_allow", "") or ""
+    if email in {e.strip().lower() for e in allow.split(",") if e.strip()}:
+        return True
+    # Canonical fallback so the cancel/audit endpoints work even when the env
+    # var is unset.
+    return email in _CANONICAL_ADMIN_EMAILS
 
 def _require_admin(user: Any) -> None:
     if not _is_admin(user):
@@ -338,3 +354,190 @@ def export_briefing_zip(
         media_type="application/zip",
         headers={"Content-Disposition": f'attachment; filename="briefing-{briefing_id}.zip"'}
     )
+
+
+# ============================================================
+# Cancel + Audit Endpoints (Hotfix 2026-04-27)
+# ============================================================
+
+class CancelRequest(BaseModel):
+    reason: Optional[str] = Field(
+        default="admin_manual_cancel",
+        max_length=200,
+        description="Frei wählbarer Grund (wird in briefings.cancel_reason persistiert)",
+    )
+
+
+def _briefing_summary(b: Any) -> Dict[str, Any]:
+    """Serialise a Briefing row for admin listings (joined user.email)."""
+    answers = getattr(b, "answers", None) or {}
+    user_email = None
+    if getattr(b, "user", None) is not None:
+        user_email = getattr(b.user, "email", None)
+    return {
+        "id": b.id,
+        "user_email": user_email,
+        "status": b.status,
+        "lang": getattr(b, "lang", "de"),
+        "branche": answers.get("branche") if isinstance(answers, dict) else None,
+        "unternehmensgroesse": (
+            answers.get("unternehmensgroesse") if isinstance(answers, dict) else None
+        ),
+        "created_at": _iso(getattr(b, "created_at", None)),
+        "accepted_at": _iso(getattr(b, "accepted_at", None)),
+        "processing_at": _iso(getattr(b, "processing_at", None)),
+        "worker_id": getattr(b, "worker_id", None),
+        "source": getattr(b, "source", None),
+        "request_ip": getattr(b, "request_ip", None),
+    }
+
+
+@router.get("/briefings/active", response_model=None)
+def list_active_briefings(
+    db=Depends(get_db),
+    user=Depends(get_current_user()),
+):
+    """
+    Alle Briefings, die gerade laufen oder in der Queue stehen.
+    Aktive Status: accepted | queued | processing | analyzing.
+    Sortierung: created_at DESC (jüngste zuerst).
+    """
+    _require_admin(user)
+    log.info("👤 Admin %s requested active briefings", getattr(user, "email", "?"))
+    _, Briefing, _, _ = _models()
+    rows = (
+        db.query(Briefing)
+        .filter(Briefing.status.in_(ACTIVE_STATUSES))
+        .order_by(Briefing.created_at.desc())
+        .all()
+    )
+    return {"ok": True, "count": len(rows), "rows": [_briefing_summary(b) for b in rows]}
+
+
+@router.get("/briefings/recent", response_model=None)
+def list_recent_briefings(
+    hours: int = Query(24, ge=1, le=720, description="Zeitfenster in Stunden (1–720, Default 24)"),
+    db=Depends(get_db),
+    user=Depends(get_current_user()),
+):
+    """
+    Briefings der letzten N Stunden — schneller Drüberschau-Endpoint.
+    """
+    _require_admin(user)
+    log.info(
+        "👤 Admin %s requested briefings from last %dh",
+        getattr(user, "email", "?"), hours,
+    )
+    _, Briefing, _, _ = _models()
+    cutoff = datetime.now(timezone.utc) - timedelta(hours=hours)
+    rows = (
+        db.query(Briefing)
+        .filter(Briefing.created_at >= cutoff)
+        .order_by(Briefing.created_at.desc())
+        .all()
+    )
+    return {"ok": True, "count": len(rows), "hours": hours, "rows": [_briefing_summary(b) for b in rows]}
+
+
+@router.post("/briefings/{briefing_id}/cancel", response_model=None)
+def cancel_briefing(
+    briefing_id: int,
+    payload: Optional[CancelRequest] = None,
+    db=Depends(get_db),
+    user=Depends(get_current_user()),
+):
+    """
+    Cancelt ein einzelnes Briefing.
+
+    Setzt status='cancelled', leert worker_id, schreibt cancel_reason +
+    cancelled_at. Wirkt nur "weich": ein bereits laufender Worker-Job läuft
+    durch (siehe Wolf-OK E6); der Cancel verhindert nur, dass der Worker das
+    Briefing erneut aufnimmt, und blockt anstehende /report/generate-Aufrufe
+    aus dem Frontend.
+    """
+    _require_admin(user)
+    reason = (payload.reason if payload else None) or "admin_manual_cancel"
+    log.warning(
+        "🛑 Admin %s cancels briefing %d (reason: %s)",
+        getattr(user, "email", "?"), briefing_id, reason,
+    )
+
+    _, Briefing, _, _ = _models()
+    b = db.get(Briefing, briefing_id)
+    if not b:
+        raise HTTPException(status_code=404, detail="briefing_not_found")
+
+    if b.status not in ACTIVE_STATUSES:
+        return {
+            "ok": False,
+            "briefing_id": briefing_id,
+            "current_status": b.status,
+            "message": "briefing_not_active",
+        }
+
+    previous_status = b.status
+    user_email = getattr(b.user, "email", None) if b.user else None
+
+    b.status = "cancelled"
+    b.worker_id = None
+    b.cancel_reason = reason
+    b.cancelled_at = datetime.now(timezone.utc)
+    db.commit()
+
+    log.warning(
+        "🛑 Briefing %d cancelled (was: %s, user_email=%s)",
+        briefing_id, previous_status, user_email,
+    )
+    return {
+        "ok": True,
+        "briefing_id": briefing_id,
+        "previous_status": previous_status,
+        "user_email": user_email,
+        "cancel_reason": reason,
+    }
+
+
+@router.post("/briefings/cancel-all-active", response_model=None)
+def cancel_all_active_briefings(
+    db=Depends(get_db),
+    user=Depends(get_current_user()),
+):
+    """
+    EMERGENCY-STOP: Cancelt ALLE aktiven Briefings (accepted/queued/processing/analyzing).
+    Nur für Notfälle (Worker-Loop, Missbrauch, runaway costs).
+    """
+    _require_admin(user)
+    admin_email = getattr(user, "email", "?")
+    log.warning("🚨 EMERGENCY-STOP triggered by %s", admin_email)
+
+    _, Briefing, _, _ = _models()
+    rows = (
+        db.query(Briefing)
+        .filter(Briefing.status.in_(ACTIVE_STATUSES))
+        .all()
+    )
+    now = datetime.now(timezone.utc)
+    cancelled: List[Dict[str, Any]] = []
+    for b in rows:
+        cancelled.append({
+            "id": b.id,
+            "previous_status": b.status,
+            "user_email": getattr(b.user, "email", None) if b.user else None,
+        })
+        b.status = "cancelled"
+        b.worker_id = None
+        b.cancel_reason = "emergency_stop"
+        b.cancelled_at = now
+    if cancelled:
+        db.commit()
+
+    log.warning(
+        "🚨 Emergency-Stop cancelled %d briefings: ids=%s",
+        len(cancelled), [c["id"] for c in cancelled],
+    )
+    return {
+        "ok": True,
+        "cancelled_count": len(cancelled),
+        "cancelled": cancelled,
+        "triggered_by": admin_email,
+    }

--- a/routes/auth.py
+++ b/routes/auth.py
@@ -18,42 +18,7 @@ from services.rate_limit import RateLimiter
 from services.redis_utils import RedisBox
 from utils.idempotency import IdempotencyBox
 from core.security import create_access_token, get_current_user, TokenPayload
-
-# Whitelist für erlaubte E-Mail-Adressen (Testphase)
-# Diese Liste muss synchron mit setup_database.py TESTUSERS gehalten werden
-# Alle Emails sind lowercase für case-insensitive Vergleich
-#Jochen, Bernd,Steffi, Wilhelm 020426
-EMAIL_WHITELIST = {email.lower() for email in [
-    "j.hohl@freenet.de",
-    "kerstin.geffert@gmail.com",
-    "daniel.effinger@web.de",
-    "post@zero2.de",
-    "giselapeter@peter-partner.de",
-    "wolf.hohl@web.de",
-    "geffertj@mac.com",
-    "geffertkilian@gmail.com",
-    "berndemhart46@gmail.com",
-    "po@wbs-slg.de",
-    "trailerman01@outlook.de",
-    "hilfe@ki-sicherheit.jetzt",
-    "levent.graef@posteo.de",
-    "birgit.cook@ulitzka-partner.de",
-    "alexander.luckow@icloud.com",
-    "frank.beer@kabelmail.de",
-    "patrick@silk-relations.com",
-    "marc@trailerhaus-onair.de",
-    "norbert@trailerhaus.de",
-    "sonia-souto@mac.com",
-    "christian.ulitzka@ulitzka-partner.de",
-    "srack@gmx.net",
-    "buss@maria-hilft.de",
-    "w.beestermoeller@web.de",
-    "bewertung@ki-sicherheit.jetzt",  # Admin
-    "test@example.com",  # Für CI/CD Tests
-    # v7.0 Production Testing
-    "test-v7-final@ki-sicherheit.jetzt",
-    "test-v7-1@ki-sicherheit.jetzt",
-    "test-v7-400@ki-sicherheit.jetzt",]}
+from core.whitelist import EMAIL_WHITELIST, is_whitelisted
 
 router = APIRouter(prefix="/auth", tags=["auth"])
 log = logging.getLogger(__name__)
@@ -118,9 +83,8 @@ async def request_code(payload: RequestCodeIn, request: Request):
     limiter = RateLimiter(namespace="request_code", limit=s.rate.max_request_code, window_sec=s.rate.window_sec)
     limiter.hit(key=str(payload.email))
 
-    # Whitelist-Prüfung (Testphase)
-    email_lower = str(payload.email).lower()
-    if email_lower not in EMAIL_WHITELIST:
+    # Whitelist-Prüfung (Testphase) — Quelle: core.whitelist
+    if not is_whitelisted(str(payload.email)):
         log.warning("🚫 Login-Code verweigert für nicht-whitelisted E-Mail: %s", payload.email)
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,


### PR DESCRIPTION
## Summary

Erste vier Schritte des Admin-Cancel + Audit-Logging + Whitelist-Enforcement-Hotfix gemäß Master-Briefing. **Vor dem disruptiven Schritt 5** (JWT-Pflicht in 6 Report-Endpoints) angehalten — Wolf-Ping zur Validierung.

## Commits

1. `refactor(whitelist)` — `EMAIL_WHITELIST` aus `routes/auth.py` nach `core/whitelist.py` extrahiert. Helpers: `is_whitelisted`, `require_whitelisted`, `is_admin`, `ADMIN_EMAILS`. `routes/auth.py` importiert jetzt von dort. **Kein Verhaltensänderung** für `/auth/request-code`.
2. `feat(db)` — Briefings-Tabelle bekommt 5 neue Spalten (`cancel_reason`, `cancelled_at`, `source`, `request_ip`, `request_ua`) + Index. ALTER-Statements idempotent in `core/migrate.py` → laufen automatisch beim nächsten Container-Restart. SQL-Files in `migrations/` für Archiv & manuelle Ops-Runs (Postgres + SQLite). `models.Briefing` um die Felder erweitert. **NOT NULL auf `user_id` bewusst NICHT in dieser Migration** (Wolf E2 — Phase 2).
3. `ops(cancel)` — `ops/cancel_briefings.sql` für Notfall-Cancel via psql. Aktive Status sind die echten aus dem Worker-Code (`accepted | queued | processing | analyzing`), nicht die `pending`-Variante aus dem Master-Briefing.
4. `feat(admin)` — `routes/admin.py` erweitert um vier Endpoints, alle hinter `_require_admin` (JWT + `ADMIN_EMAILS` env oder `core.whitelist.ADMIN_EMAILS`-Fallback):
   - `GET  /api/admin/briefings/active`
   - `GET  /api/admin/briefings/recent?hours=24`
   - `POST /api/admin/briefings/{id}/cancel`
   - `POST /api/admin/briefings/cancel-all-active` (Emergency-Stop)

   Cancel ist **weich** (Wolf E6): laufender Worker-Job läuft durch, aber kein Pickup mehr; `worker_id` wird geleert; `cancel_reason` + `cancelled_at` persistiert. `gpt_analyze.py` bleibt unangetastet.

## Vorausgesetzte Railway-Env-Setzungen (von Wolf bestätigt)

- `ENABLE_ADMIN_ROUTES=1` — sonst wird `routes.admin` nicht gemountet (`main.py:215`).
- `ADMIN_EMAILS=bewertung@ki-sicherheit.jetzt` — optional, Fallback ist die hardcoded `core.whitelist.ADMIN_EMAILS`.

## Test plan

- [ ] Container-Restart in Staging → Logs zeigen `✓ All database migrations completed (core.migrate)` und keine Fehler durch die neuen ALTERs.
- [ ] `psql "$DATABASE_URL" -c "\d briefings"` zeigt die fünf neuen Spalten + den Index.
- [ ] `curl -H "Authorization: Bearer $WOLF_JWT" $API/api/admin/briefings/active` → JSON-Liste mit aktiven Briefings.
- [ ] `curl -H "Authorization: Bearer $WOLF_JWT" "$API/api/admin/briefings/recent?hours=24"` → letzte 24 h.
- [ ] `curl -X POST -H "Authorization: Bearer $NON_ADMIN_JWT" $API/api/admin/briefings/9999/cancel` → 403.
- [ ] `curl -X POST -H "Authorization: Bearer $WOLF_JWT" -d '{"reason":"test"}' -H "content-type: application/json" $API/api/admin/briefings/<lebende_id>/cancel` → `{"ok":true,"previous_status":...}` und in der DB sind `status='cancelled'`, `cancel_reason='test'`, `cancelled_at` gesetzt.
- [ ] Worker-Log nach Cancel: aktueller Job läuft durch, anschließend kein Pickup mehr (Job ist `cancelled`, nicht in `(accepted, queued)`).
- [ ] `ops/cancel_briefings.sql` mit nicht-existenter ID läuft ohne Crash.
- [ ] `ops/cancel_briefings.sql` mit echter ID setzt korrekt auf `cancelled` und gibt vorher/nachher-Übersicht.

## Wolf-Ping — STOP vor Schritt 5

**STATUS: wolf_ping**
**COMPLETED: Schritte 1–4 implementiert, committet, gepusht.**
**BLOCKED ON: Wolf-OK auf Diff + finale Bestätigung E5-Stufe-1.**
**NEXT (nach OK):**
- Schritt 5 (JWT-Pflicht): `/api/analyze/run`, `/api/report/generate`, `/api/report/solo-compact`, `/api/report/gamechanger-deep-dive`, `/api/strategy/generate/{id}`, `/api/strategy/questions/{id}`, `/api/chat/start`, `/api/chat/complete`. `email`/`email_override` aus Body wird ignoriert oder muss === Token-Email sein. `X-Service-Token` als zweiter Pfad bleibt. **Disruptiv — kann Service-Caller brechen, falls welche existieren, die nicht über `X-Service-Token` laufen.** Vor Merge in einer Staging-Iteration testen?
- Schritt 6 (Audit-Logging im /submit): `source`, `request_ip`, `request_ua` werden beim INSERT gesetzt + per `log.info("📝 BRIEFING-CREATED ...")` ins Railway-Log geschrieben.

## Offene Sub-Frage zu Schritt 5

Sollen `/api/strategy/admin/*` (HMAC-Query-Key) gleich auch auf JWT umgestellt werden, oder bleiben die wie sie sind (Wolf-OK separat)? Der HMAC-Key in der Query-String landet potenziell in Proxy-Logs.

Bitte signalisiere Schritt 5 + ggf. Antwort auf die Sub-Frage, dann mache ich weiter.

https://claude.ai/code/session_01TDfvj2V5zAbdB1oH56E4Lq

---
_Generated by [Claude Code](https://claude.ai/code/session_01TDfvj2V5zAbdB1oH56E4Lq)_