### PR TITLE
fix(admin): get_db must be a generator function (yield from)

### DIFF
--- a/routes/admin.py
+++ b/routes/admin.py
@@ -39,9 +39,17 @@ except (ImportError, RuntimeError) as exc:  # pragma: no cover
     log.warning("Admin: DB not ready at import: %s", exc)
 
 def get_db():
+    """FastAPI dependency: yield a SQLAlchemy session.
+
+    core.db.get_session is itself a generator (yields the session, closes
+    on cleanup). We MUST ``yield from`` it — returning ``_get_session()``
+    hands FastAPI the bare generator, the endpoint then receives it as
+    ``db``, and ``db.query(...)`` raises AttributeError because generators
+    have no ``query`` attribute.
+    """
     if not DB_READY or _get_session is None:  # pragma: no cover
         raise HTTPException(status_code=503, detail="admin_db_unavailable")
-    return _get_session()
+    yield from _get_session()
 
 def _auth_dep():
     """

--- a/tests/test_admin_db_dep.py
+++ b/tests/test_admin_db_dep.py
@@ -1,0 +1,63 @@
+# -*- coding: utf-8 -*-
+"""Regression: ``routes.admin.get_db`` must yield a SQLAlchemy Session.
+
+Hintergrund (Hotfix 2026-04-27):
+``get_db`` lieferte vorher ``return _get_session()`` — also das Generator-
+Objekt, das ``core.db.get_session`` (yield-pattern) zurückgibt. FastAPI
+erkennt eine Dependency als Generator-Funktion daran, dass die Funktion
+selbst yields (oder ``yield from`` nutzt). Ein normales ``return`` mit
+einem Generator als Wert reicht nicht — der Endpoint bekommt dann das
+nackte Generator-Objekt als ``db``, und ``db.query(...)`` knallt mit
+AttributeError ('generator' object has no attribute 'query').
+
+Bug war pre-existing, aber durch ENABLE_ADMIN_ROUTES=0 und einen
+zweiten kaputten Auth-Resolver maskiert; im ersten Echt-Test nach den
+Hotfixes #997/#998 wurde er sichtbar.
+"""
+from __future__ import annotations
+
+import inspect
+
+import pytest
+
+
+def test_get_db_is_generator_function() -> None:
+    """``routes.admin.get_db`` muss eine Generator-Funktion sein.
+
+    FastAPI braucht Generator-Funktionen für Dependencies mit Cleanup
+    (``yield``-Pattern). Eine normale Funktion mit ``return`` würde den
+    Endpoint mit dem rohen Generator-Objekt versorgen, statt mit der
+    Session.
+    """
+    from routes.admin import get_db
+
+    assert inspect.isgeneratorfunction(get_db), (
+        "routes.admin.get_db must yield (generator function), not return — "
+        "otherwise FastAPI hands the bare generator to the endpoint and "
+        "db.query(...) raises AttributeError."
+    )
+
+
+def test_get_db_yields_session_with_query_attr() -> None:
+    """Beim Iterieren der Generator-Dependency darf nur ein SQLAlchemy-
+    Session-Objekt rauskommen, kein verschachtelter Generator."""
+    from routes.admin import get_db
+
+    gen = get_db()
+    try:
+        first = next(gen)
+    except StopIteration:
+        pytest.fail("get_db() yielded nothing")
+
+    # SQLAlchemy 2.x Session has .query (legacy API) und .execute (Core API)
+    assert hasattr(first, "query") or hasattr(first, "execute"), (
+        f"get_db() yielded {type(first).__name__!r}, expected SQLAlchemy Session"
+    )
+
+    # Cleanup: drain and close the generator (mirrors FastAPI's behaviour
+    # after the request).
+    try:
+        next(gen)
+    except StopIteration:
+        pass
+    gen.close()


### PR DESCRIPTION
## Summary

Echt-Test (PR #997 + #998 deployed) deckte einen pre-existing Bug in `routes/admin.py:get_db()` auf:

```
File "/app/routes/admin.py", line 224, in list_active_briefings
    db.query(Briefing)
AttributeError: 'generator' object has no attribute 'query'
```

**Root cause:** `get_db()` machte `return _get_session()`. `core.db.get_session` ist selbst ein Generator (yield-Pattern). FastAPI erkennt eine Dependency als Generator-Funktion daran, dass die Funktion **selbst** yields. Mit `return` bekommt der Endpoint den nackten Generator als `db`, dann knallt `db.query(...)`.

**Bug war pre-existing** in `routes/admin.py`, aber durch zwei vorgelagerte Schichten maskiert:
1. `ENABLE_ADMIN_ROUTES=0` in Production — Router gar nicht gemountet
2. Der kaputte Auth-Resolver (PR #997 fixed) — Requests starben am Auth-Dep, bevor `get_db` überhaupt ausgewertet wurde

Im ersten Echt-Test nach den Hotfixes #997 + #998 kam der Request zum ersten Mal durch Auth + Routing — und scheiterte hier.

## Fix

```python
# routes/admin.py — vorher
def get_db():
    if not DB_READY or _get_session is None:
        raise HTTPException(status_code=503, detail="admin_db_unavailable")
    return _get_session()      # ← Generator als Wert returned

# nachher
def get_db():
    if not DB_READY or _get_session is None:
        raise HTTPException(status_code=503, detail="admin_db_unavailable")
    yield from _get_session()  # ← Funktion ist selbst Generator
```

Selber Pattern wie `routes/_bootstrap.py:get_db` (das die Bestands-Routes verwenden — deshalb hatten sie das Problem nicht).

## Tests

`tests/test_admin_db_dep.py` — zwei Regressions:

1. `inspect.isgeneratorfunction(get_db)` muss `True` sein.
2. `next(get_db())` muss ein Objekt mit `.query`/`.execute` yielden (also eine echte SQLAlchemy-Session, kein verschachtelter Generator).

Lokal in der Sandbox nicht ausführbar (jwt-Bindings kaputt), aber `python -m py_compile` clean — CI fährt's live.

## Test plan

- [ ] CI grün (insbesondere die zwei neuen Tests in `test_admin_db_dep.py`)
- [ ] Nach Merge + Railway-Deploy: Wolf wiederholt Test A (`GET /api/admin/briefings/active`)
- [ ] Erwartet: HTTP 200 mit `{"ok": true, "count": N, "rows": [...]}`, nicht mehr 500
- [ ] Test B (`/recent?hours=6`) genauso
- [ ] Test D1/D2 (401 ohne Token) bleiben grün

## Mea culpa

Dritter Bug-Fix in `routes/admin.py` in Folge — aber alle drei waren pre-existing. Bisheriger Score:
- PR #996: neue Endpoints in falscher Reihenfolge (mein Fehler) → #998 fixed
- PR #997: vorgefundener Auth-Resolver-Bug → fixed
- jetzt: vorgefundener `get_db()`-Generator-Bug → dieser PR

Die existierenden Admin-Endpoints (`/overview`, `/briefings`, `/rerun`, …) hätten alle dasselbe 500 produziert, sobald jemand sie mit gültigem Admin-JWT aufgerufen hätte. Wir haben sie nur jetzt zum ersten Mal aufgerufen.

https://claude.ai/code/session_01TDfvj2V5zAbdB1oH56E4Lq

---
_Generated by [Claude Code](https://claude.ai/code/session_01TDfvj2V5zAbdB1oH56E4Lq)_