### PR TITLE
feat(submit): persist audit trail (source/ip/ua) + structured log

### DIFF
--- a/routes/briefings.py
+++ b/routes/briefings.py
@@ -28,6 +28,30 @@ _briefing_rate_limiter = RateLimiter(namespace="briefings", limit=10, window_sec
 _idempotency_box = IdempotencyBox(namespace="briefing_submit")
 
 
+def _resolve_client_ip(request: Request) -> Optional[str]:
+    """Resolve the originating client IP.
+
+    Railway routes through Fastly; ``request.client.host`` is the CDN IP, not
+    the user. Prefer the first entry of ``X-Forwarded-For`` (the chain's
+    leftmost address is the original client per RFC 7239).
+    """
+    xff = request.headers.get("x-forwarded-for")
+    if xff:
+        first = xff.split(",")[0].strip()
+        if first:
+            return first
+    if request.client and request.client.host:
+        return request.client.host
+    return None
+
+
+def _truncate(value: Optional[str], limit: int = 500) -> Optional[str]:
+    """Truncate strings for DB columns / log lines."""
+    if not value:
+        return None
+    return value if len(value) <= limit else value[: limit - 1] + "…"
+
+
 class BriefingSubmitIn(BaseModel):
     # Rohdaten durchleiten; Validierung findet in der Analyse statt
     lang: str = "de"
@@ -140,6 +164,18 @@ async def submit_briefing(
         else:
             log.debug("No authentication found - proceeding without authentication")
 
+    # Audit-Felder vor dem INSERT (Hotfix 2026-04-27 Schritt 6).
+    # source ist die Auth-Provenienz, NICHT aus dem Request-Body — User
+    # könnte sonst "service_token:foo" eintragen und Logs verfälschen.
+    if service_principal:
+        audit_source = f"service_token:{service_principal}"
+    elif user_id:
+        audit_source = "jwt"
+    else:
+        audit_source = "anonymous"
+    audit_request_ip = _resolve_client_ip(request)
+    audit_request_ua = _truncate(request.headers.get("user-agent"), limit=500)
+
     # Briefing in Datenbank speichern (DB-Backed Worker: nur speichern, KEIN run_async!)
     try:
         from models import Briefing
@@ -157,6 +193,10 @@ async def submit_briefing(
             # Worker-Queue: Status "accepted" für Worker-Abholung
             status="accepted" if payload.queue_analysis else "skipped",
             accepted_at=now if payload.queue_analysis else None,
+            # Audit-Trail
+            source=audit_source,
+            request_ip=audit_request_ip,
+            request_ua=audit_request_ua,
         )
         db.add(briefing)
         db.commit()
@@ -164,6 +204,16 @@ async def submit_briefing(
 
         log.info("✅ Briefing saved to database: ID=%s, user_id=%s, status=%s, len=%s",
                  briefing.id, user_id, briefing.status, len(json.dumps(payload.answers)))
+
+        # Structured audit log — Wolf kann in Railway-Logs sofort sehen, wer/woher.
+        log.info(
+            "📝 BRIEFING-CREATED id=%d user_email=%s ip=%s ua=%s source=%s",
+            briefing.id,
+            authenticated_user or "(none)",
+            audit_request_ip or "(none)",
+            _truncate(audit_request_ua, limit=80) or "(none)",
+            audit_source,
+        )
 
         # WICHTIG: KEIN gpt_analyze.run_async() mehr hier!
         # Worker-Prozess holt Jobs mit status="accepted" aus der DB.

--- a/tests/test_briefings_audit_helpers.py
+++ b/tests/test_briefings_audit_helpers.py
@@ -1,0 +1,89 @@
+# -*- coding: utf-8 -*-
+"""Unit tests for the audit-trail helpers in routes.briefings (Schritt 6).
+
+Wir testen die zwei reinen Helper, nicht das volle FastAPI-Setup.
+``_resolve_client_ip`` ist die kritische Funktion — Railway routet durch
+Fastly, ohne XFF-Auswertung würde jedes Briefing die CDN-IP loggen.
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from routes.briefings import _resolve_client_ip, _truncate
+
+
+class _FakeRequest:
+    """Minimal Request-Stub: nur ``headers`` (dict-like) und ``client``."""
+
+    def __init__(self, headers: dict | None = None, client_host: str | None = None):
+        self.headers = headers or {}
+        self.client = SimpleNamespace(host=client_host) if client_host else None
+
+
+def test_resolve_client_ip_uses_xff_first_entry() -> None:
+    """X-Forwarded-For: leftmost = ursprünglicher Client (RFC 7239)."""
+    req = _FakeRequest(
+        headers={"x-forwarded-for": "203.0.113.42, 100.64.0.5, 10.0.0.1"},
+        client_host="100.64.0.5",  # CDN-IP
+    )
+    assert _resolve_client_ip(req) == "203.0.113.42"
+
+
+def test_resolve_client_ip_falls_back_to_request_client() -> None:
+    """Ohne XFF: request.client.host."""
+    req = _FakeRequest(client_host="198.51.100.7")
+    assert _resolve_client_ip(req) == "198.51.100.7"
+
+
+def test_resolve_client_ip_returns_none_when_unknown() -> None:
+    """Weder XFF noch request.client → None (statt empty string)."""
+    req = _FakeRequest()
+    assert _resolve_client_ip(req) is None
+
+
+def test_resolve_client_ip_strips_whitespace_in_xff() -> None:
+    """XFF-Liste mit Spaces → erstes IP getrimmt."""
+    req = _FakeRequest(headers={"x-forwarded-for": "  192.0.2.1  ,  10.0.0.1  "})
+    assert _resolve_client_ip(req) == "192.0.2.1"
+
+
+def test_resolve_client_ip_empty_xff_falls_back() -> None:
+    """Leerer XFF-Header → fallback auf request.client."""
+    req = _FakeRequest(
+        headers={"x-forwarded-for": ""},
+        client_host="198.51.100.7",
+    )
+    assert _resolve_client_ip(req) == "198.51.100.7"
+
+
+# --- _truncate ----------------------------------------------------------
+
+
+def test_truncate_keeps_short_strings_unchanged() -> None:
+    assert _truncate("Mozilla/5.0") == "Mozilla/5.0"
+
+
+def test_truncate_returns_none_for_none() -> None:
+    assert _truncate(None) is None
+
+
+def test_truncate_returns_none_for_empty_string() -> None:
+    """Empty UA-Header sollte None loggen, nicht ''."""
+    assert _truncate("") is None
+
+
+def test_truncate_cuts_long_strings_with_ellipsis() -> None:
+    long = "x" * 600
+    out = _truncate(long, limit=500)
+    assert out is not None
+    assert len(out) == 500
+    assert out.endswith("…")
+
+
+def test_truncate_default_limit_is_500() -> None:
+    long = "x" * 1000
+    out = _truncate(long)
+    assert out is not None
+    assert len(out) == 500


### PR DESCRIPTION
## Summary

Schritt 6 vom Master-Briefing — jeder neue `/api/briefings/submit` schreibt ab jetzt den Audit-Trail in die DB-Spalten aus PR #996 (`source`, `request_ip`, `request_ua`) und emittiert eine strukturierte Log-Zeile, die Wolf in den Railway-Logs sofort lesen kann.

**Trigger:** der erste Echt-Test heute hat 12/12 Briefings mit `"user_email": null` zurückgeliefert (`/api/admin/briefings/recent?hours=6`). Bevor Schritt 5 (JWT-Pflicht) die Lücke schließt, wollen wir wissen, **woher** die anonymen Submits kommen — ohne diese Information könnten wir mit Schritt 5 unbekannte legitime Service-Caller brechen.

## What changes in `routes/briefings.py:submit_briefing`

```python
# Audit-Provenienz (nie aus Body — User könnte sonst "service_token:foo" eintragen)
if service_principal:
    audit_source = f"service_token:{service_principal}"
elif user_id:
    audit_source = "jwt"
else:
    audit_source = "anonymous"

audit_request_ip = _resolve_client_ip(request)        # XFF leftmost, fallback request.client
audit_request_ua = _truncate(request.headers.get("user-agent"), limit=500)

briefing = Briefing(
    ...,
    source=audit_source,
    request_ip=audit_request_ip,
    request_ua=audit_request_ua,
)
db.commit()

log.info(
    "📝 BRIEFING-CREATED id=%d user_email=%s ip=%s ua=%s source=%s",
    briefing.id, authenticated_user or "(none)",
    audit_request_ip or "(none)",
    _truncate(audit_request_ua, limit=80) or "(none)",
    audit_source,
)
```

`source` ist server-seitig aus dem Auth-Status abgeleitet, **nicht** aus dem Request-Body — wäre sonst trivial spoofbar.

`request_ip` bevorzugt das **leftmost** Feld von `X-Forwarded-For` (RFC 7239 — der originale Client). Railway routet durch Fastly; ohne XFF-Auswertung würde sonst `100.64.0.x` (CDN-interne IP) geloggt.

`request_ua` wird auf 500 Zeichen truncated (Bots schicken absurde User-Agents).

## What's NOT covered

`routes/chat.py:_complete_r1` und `_complete_strategy` erzeugen ebenfalls Briefings (Chat-Funnel). Die laufen hier **nicht** mit. Wenn die Audit-Daten zeigen, dass Chat einen relevanten Anteil der `source=anonymous`-Submits stellt, mache ich das in einem Folge-PR analog.

## Tests

`tests/test_briefings_audit_helpers.py` — neun Unit-Tests gegen die zwei reinen Helper:

- `_resolve_client_ip` mit XFF (leftmost wins, Whitespace getrimmt, leerer Header → fallback), ohne XFF (request.client), ganz ohne Daten (None).
- `_truncate` mit kurzen/langen Strings, None, leerem String, Default-Limit 500.

Lokal nicht ausführbar (Sandbox-cffi-Bindings), aber `python -m py_compile` clean — CI fährt's live.

## Test plan

- [ ] CI grün
- [ ] Nach Merge + Railway-Deploy: ein neuer Test-Submit (egal über welchen Frontend-Weg) erzeugt eine Zeile `📝 BRIEFING-CREATED ...` im Railway-Log
- [ ] `GET /api/admin/briefings/recent?hours=1` zeigt für die frisch erzeugten Briefings:
  - `source` = `jwt` | `anonymous` | `service_token:<principal>` (nicht mehr `null`)
  - `request_ip` = echte Client-IP (z.B. `203.0.113.42`), nicht `100.64.0.x`
  - `request_ua` = User-Agent-String
- [ ] Wolf beobachtet 1-2 h Echt-Traffic, dann **fundierte Entscheidung für Schritt 5** mit der Quellen-Verteilung in der Hand

## Folge-Schritte

Nach diesem PR + 1-2 h Audit-Daten kommt Schritt 5 — JWT-Pflicht in den sechs Report-Endpoints (`/analyze/run`, `/report/generate`, `/report/solo-compact`, `/report/gamechanger-deep-dive`, `/strategy/generate/{id}`, `/strategy/questions/{id}` + `/chat/start`/`complete`). Vorher schicke ich dir die Per-Endpoint-Diff-Liste zur Vorab-Review.

https://claude.ai/code/session_01TDfvj2V5zAbdB1oH56E4Lq

---
_Generated by [Claude Code](https://claude.ai/code/session_01TDfvj2V5zAbdB1oH56E4Lq)_