### PR TITLE
feat(step5): JWT enforcement in 8 report-pipeline endpoints (flag-gated)

### DIFF
--- a/core/security.py
+++ b/core/security.py
@@ -277,11 +277,11 @@ def step5_principal(
     # Pfad 1: Service-Token
     if x_service_token and s.security.service_token_enabled:
         try:
-            payload = verify_service_token(
+            service_payload = verify_service_token(
                 x_service_token, required_scope="briefings:submit"
             )
             return AuthenticatedPrincipal(
-                service_principal=payload.principal,
+                service_principal=service_payload.principal,
                 is_service=True,
                 is_authenticated=True,
             )
@@ -299,7 +299,7 @@ def step5_principal(
 
     if token:
         try:
-            payload = verify_access_token(token)
+            user_payload = verify_access_token(token)
         except HTTPException:
             if enforced:
                 raise
@@ -311,10 +311,10 @@ def step5_principal(
                 from core.whitelist import is_whitelisted
             except ImportError:  # pragma: no cover
                 is_whitelisted = lambda _e: True  # type: ignore[assignment]
-            if not is_whitelisted(payload.email):
+            if not is_whitelisted(user_payload.email):
                 log.warning(
                     "🚫 Step5: JWT for non-whitelisted email rejected: %s",
-                    payload.email,
+                    user_payload.email,
                 )
                 raise HTTPException(
                     status_code=status.HTTP_403_FORBIDDEN,
@@ -322,7 +322,7 @@ def step5_principal(
                 )
 
         return AuthenticatedPrincipal(
-            email=payload.email,
+            email=user_payload.email,
             is_authenticated=True,
         )
 

--- a/core/security.py
+++ b/core/security.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import hashlib
 import hmac
 import logging
+import os
 import time
 from typing import Optional, Tuple, Union
 
@@ -210,3 +211,157 @@ def get_service_or_user_auth(
 
     # 2. Fallback: normale User-Auth
     return get_current_user(auth_token, authorization)
+
+
+# ---------------------------------------------------------------------------
+# Step 5 — JWT-Pflicht in Report-Pipeline-Endpoints (Wolf E5 Stufe 1)
+#
+# Umschaltbar via Env STEP5_JWT_ENFORCEMENT={1|true|yes}. Default: off
+# (verhalten unverändert). Wenn aktiv:
+#   - Endpoints lehnen unauthentisierte Requests mit 401 ab
+#   - User-JWT muss in core.whitelist.EMAIL_WHITELIST stehen
+#   - X-Service-Token mit Scope 'briefings:submit' bleibt zweiter Auth-Pfad
+#
+# Endpoints inspizieren ``principal.is_authenticated``/``.email``/``.is_service``
+# um Owner-Checks und email-override-Strict-Equality zu fahren.
+# ---------------------------------------------------------------------------
+
+
+class AuthenticatedPrincipal(BaseModel):
+    """Auth-Resultat für Step-5-Endpoints. Höchstens einer von email
+    / service_principal ist gesetzt. ``is_authenticated`` ist False, wenn
+    der Flag aus ist UND keine Auth-Header gefunden wurden — Endpoints
+    fallen dann auf das Legacy-Verhalten zurück."""
+    email: Optional[str] = None
+    service_principal: Optional[str] = None
+    is_service: bool = False
+    is_authenticated: bool = False
+
+    @property
+    def identity(self) -> str:
+        if self.is_service:
+            return f"service:{self.service_principal}"
+        if self.email:
+            return f"user:{self.email}"
+        return "anonymous"
+
+
+def step5_jwt_enforcement_enabled() -> bool:
+    """Read STEP5_JWT_ENFORCEMENT env on every request — Railway-flippable
+    ohne Re-Deploy."""
+    return (os.getenv("STEP5_JWT_ENFORCEMENT") or "").strip().lower() in {
+        "1", "true", "yes", "on",
+    }
+
+
+def step5_principal(
+    auth_token: Optional[str] = Cookie(None, alias="auth_token"),
+    authorization: Optional[str] = Header(None),
+    x_service_token: Optional[str] = Header(None, alias="X-Service-Token"),
+) -> AuthenticatedPrincipal:
+    """Auth-Dependency für Schritt 5.
+
+    Mit STEP5_JWT_ENFORCEMENT=on:
+      - Service-Token vorhanden → muss valide sein, sonst 401/403
+      - User-JWT vorhanden → muss valide UND whitelisted sein, sonst 401/403
+      - Weder noch → 401
+
+    Ohne Flag (Default):
+      - Token wird best-effort ausgewertet, bei Fehler kommen wir mit
+        is_authenticated=False zurück → Endpoints behalten das Legacy-
+        Verhalten (kein Disruptions-Risiko).
+    """
+    enforced = step5_jwt_enforcement_enabled()
+    s = get_settings()
+
+    # Pfad 1: Service-Token
+    if x_service_token and s.security.service_token_enabled:
+        try:
+            payload = verify_service_token(
+                x_service_token, required_scope="briefings:submit"
+            )
+            return AuthenticatedPrincipal(
+                service_principal=payload.principal,
+                is_service=True,
+                is_authenticated=True,
+            )
+        except HTTPException:
+            if enforced:
+                raise
+            # Flag off: schlucken, weiter mit User-Pfad
+
+    # Pfad 2: User-JWT (Cookie ODER Bearer)
+    token = auth_token
+    if not token and authorization:
+        scheme, _, header_token = authorization.partition(" ")
+        if scheme.lower() == "bearer" and header_token:
+            token = header_token
+
+    if token:
+        try:
+            payload = verify_access_token(token)
+        except HTTPException:
+            if enforced:
+                raise
+            return AuthenticatedPrincipal(is_authenticated=False)
+
+        # Whitelist-Check (nur wenn enforced — sonst best-effort durchlassen)
+        if enforced:
+            try:
+                from core.whitelist import is_whitelisted
+            except ImportError:  # pragma: no cover
+                is_whitelisted = lambda _e: True  # type: ignore[assignment]
+            if not is_whitelisted(payload.email):
+                log.warning(
+                    "🚫 Step5: JWT for non-whitelisted email rejected: %s",
+                    payload.email,
+                )
+                raise HTTPException(
+                    status_code=status.HTTP_403_FORBIDDEN,
+                    detail="Email not whitelisted for the test phase.",
+                )
+
+        return AuthenticatedPrincipal(
+            email=payload.email,
+            is_authenticated=True,
+        )
+
+    # Pfad 3: keine Auth
+    if enforced:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail=(
+                "Authentication required (JWT cookie/bearer or X-Service-Token)."
+            ),
+        )
+    return AuthenticatedPrincipal(is_authenticated=False)
+
+
+def resolve_pipeline_email(
+    principal: AuthenticatedPrincipal,
+    body_email: Optional[str],
+) -> Optional[str]:
+    """
+    Welche E-Mail soll die Pipeline als Empfänger nutzen?
+
+    Regeln:
+      - Service-Token (Golden Reports, CI): body_email zählt — Service darf
+        die Empfänger-Email frei setzen.
+      - User-JWT: body_email muss case-insensitive == principal.email sein,
+        wenn gesetzt; sonst 403. Returns principal.email (single source of
+        truth, body wird ignoriert).
+      - Unauthenticated (Flag aus): body_email durchreichen (Legacy).
+
+    Raises HTTPException 403 bei mismatch.
+    """
+    if principal.is_service:
+        return body_email
+    if principal.is_authenticated and principal.email:
+        if body_email and body_email.strip().lower() != principal.email.strip().lower():
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="email/email_override must match the token email.",
+            )
+        return principal.email
+    # Legacy passthrough
+    return body_email

--- a/routes/analyze.py
+++ b/routes/analyze.py
@@ -5,6 +5,11 @@ from __future__ import annotations
 from fastapi import APIRouter, Depends, HTTPException, Request, status
 from pydantic import BaseModel, EmailStr, Field
 
+from core.security import (
+    AuthenticatedPrincipal,
+    resolve_pipeline_email,
+    step5_principal,
+)
 from routes._bootstrap import get_db, rate_limiter
 
 router = APIRouter(prefix="/analyze", tags=["analyze"])
@@ -22,22 +27,34 @@ def _get_briefing_model():
         raise HTTPException(status_code=503, detail=f"models_unavailable: {exc}")
 
 @router.post("/run", status_code=status.HTTP_202_ACCEPTED, dependencies=[Depends(rate_limiter("analyze:run", 5, 60))])
-def run(body: RunAnalyze, request: Request, db = Depends(get_db)) -> dict:
+def run(
+    body: RunAnalyze,
+    request: Request,
+    db = Depends(get_db),
+    principal: AuthenticatedPrincipal = Depends(step5_principal),
+) -> dict:
     """
     Manually trigger GPT analysis for a briefing.
 
     Starts the asynchronous analysis process for the specified briefing.
     Supports dry-run mode for CI/smoke tests via x-dry-run header.
 
+    Auth (Wolf E5 Stufe 1, gated by STEP5_JWT_ENFORCEMENT):
+        - JWT-Cookie/Bearer ODER X-Service-Token erforderlich, sonst 401
+        - body.email_override muss == JWT-Email sein (Service-Token darf frei
+          setzen für Golden-Reports-Use-Case)
+
     Args:
         body: Contains briefing_id and optional email_override
         request: FastAPI request for dry-run header check
         db: Database session
+        principal: resolved auth principal (JWT user or service token)
 
     Returns:
         dict: Acceptance status with briefing_id
 
     Raises:
+        HTTPException 401/403: Auth fehlt oder email_override mismatch
         HTTPException 404: Briefing not found
         HTTPException 503: Models or analyzer unavailable
     """
@@ -58,5 +75,6 @@ def run(body: RunAnalyze, request: Request, db = Depends(get_db)) -> dict:
         from gpt_analyze import run_async
     except (ImportError, RuntimeError) as exc:
         raise HTTPException(status_code=503, detail=f"analyzer_unavailable: {exc}")
-    run_async(body.briefing_id, body.email_override)
+    final_email = resolve_pipeline_email(principal, body.email_override)
+    run_async(body.briefing_id, final_email)
     return {"accepted": True, "briefing_id": body.briefing_id}

--- a/routes/chat.py
+++ b/routes/chat.py
@@ -23,6 +23,7 @@ from fastapi.responses import StreamingResponse
 from sqlalchemy.orm import Session
 from sqlalchemy import text as _sa_text
 
+from core.security import AuthenticatedPrincipal, step5_principal
 from models import Briefing, ChatSession, User
 from routes._bootstrap import get_db
 from schemas.chat import (
@@ -2689,8 +2690,19 @@ async def chat_complete(
     req: ChatCompleteRequest,
     request: Request,
     db: Session = Depends(get_db),
+    principal: AuthenticatedPrincipal = Depends(step5_principal),
 ):
-    """Finalize chat session and submit collected data to report pipeline."""
+    """Finalize chat session and submit collected data to report pipeline.
+
+    Auth (Wolf E5 Frage 2: C):
+        /chat/start bleibt offen — anonyme Sessions sind erlaubt (Lead-Funnel).
+        /chat/complete erfordert JWT (oder X-Service-Token), wenn
+        STEP5_JWT_ENFORCEMENT=on: das schließt die anonyme Briefing-Erzeugung
+        am Ende des Chats. Frontend muss vor der Auswertung Login einbauen.
+    """
+    # principal wird aktuell nur für Auth-Gating verwendet; user_id-Auflösung
+    # läuft weiterhin über _resolve_user (Cookie/Header → DB-User).
+    _ = principal
     session = db.query(ChatSession).filter(ChatSession.id == req.session_id).first()
     if not session:
         raise HTTPException(status_code=404, detail="Session nicht gefunden")

--- a/routes/report.py
+++ b/routes/report.py
@@ -17,6 +17,9 @@ from core.security import (
     ServiceTokenPayload,
     TokenPayload,
     get_settings,
+    AuthenticatedPrincipal,
+    resolve_pipeline_email,
+    step5_principal,
 )
 from models import Briefing, Analysis, Report
 from utils.report_display_id import get_report_display_id
@@ -84,7 +87,10 @@ SoloCompactRequest = ReportVariantRequest
 
 
 @router.post("/solo-compact")
-async def generate_solo_compact(payload: ReportVariantRequest) -> Dict[str, Any]:
+async def generate_solo_compact(
+    payload: ReportVariantRequest,
+    principal: AuthenticatedPrincipal = Depends(step5_principal),
+) -> Dict[str, Any]:
     """
     FIX-529: Generate a report with variant selection and auto-detection.
 
@@ -181,7 +187,10 @@ async def fetch_report(id: int) -> Dict[str, Any]:
 
 
 @router.post("/generate")
-async def generate(payload: Dict[str, Any]) -> Dict[str, Any]:
+async def generate(
+    payload: Dict[str, Any],
+    principal: AuthenticatedPrincipal = Depends(step5_principal),
+) -> Dict[str, Any]:
     """
     Generate a report by triggering GPT analysis.
 
@@ -217,7 +226,10 @@ async def generate(payload: Dict[str, Any]) -> Dict[str, Any]:
     briefing_id = payload.get("briefing_id", 0)
     variant = payload.get("variant", "auto")
     company_size = payload.get("company_size")
-    email = payload.get("email")
+    body_email = payload.get("email")
+    # Step 5: token-email is the source of truth; body email must match
+    # (or empty), unless service-token authenticated.
+    email = resolve_pipeline_email(principal, body_email)
 
     # FIX-529: Auto-detect variant based on company_size
     resolved_variant = determine_report_variant(variant, company_size)
@@ -837,6 +849,7 @@ class GamechangerDeepDiveRequest(BaseModel):
 @router.post("/gamechanger-deep-dive")
 async def generate_gamechanger_deep_dive(
     payload: GamechangerDeepDiveRequest,
+    principal: AuthenticatedPrincipal = Depends(step5_principal),
 ) -> Dict[str, Any]:
     """
     Generate a Gamechanger Deep Dive report (standalone 6-8 page product).
@@ -1037,6 +1050,7 @@ def _send_deep_dive_email(
 @router.post("/gamechanger-deep-dive/pdf/{briefing_id}")
 async def generate_deep_dive_pdf(
     briefing_id: int,
+    principal: AuthenticatedPrincipal = Depends(step5_principal),
 ) -> Response:
     """
     Generate the Gamechanger Deep Dive as PDF.

--- a/routes/strategy.py
+++ b/routes/strategy.py
@@ -29,7 +29,43 @@ from pydantic import BaseModel, Field
 from sqlalchemy.orm import Session
 
 from routes._bootstrap import get_db
+from core.security import AuthenticatedPrincipal, step5_principal
+from core.whitelist import is_admin
 from models import Briefing, Analysis, StrategyQuestion, StrategyReport
+
+
+def _enforce_strategy_owner(
+    principal: AuthenticatedPrincipal, briefing: Briefing
+) -> None:
+    """Owner-Check für Strategy-Endpoints (Wolf E5 Frage 1: A).
+
+    Service-Tokens und Admin-Emails dürfen jedes Briefing strategisieren.
+    Nicht-authentifizierte Aufrufer (Flag aus + kein Token) dürfen
+    durchlaufen — Legacy-Verhalten. Sobald ein User-JWT vorliegt, MUSS
+    seine Email == briefing.user.email sein.
+    """
+    if principal.is_service:
+        return
+    if not principal.is_authenticated:
+        return  # Flag aus, Legacy passthrough
+    if is_admin(principal.email):
+        return
+    owner_email = (
+        getattr(briefing.user, "email", None) if briefing.user is not None else None
+    )
+    if not owner_email:
+        # Briefing ohne user_id (anonyme Submits). Wenn Schritt 5 aktiv,
+        # ist der Caller authentisiert; ohne Owner können wir nicht
+        # zuordnen — verweigern.
+        raise HTTPException(
+            status_code=403,
+            detail="Briefing has no owner — strategy generation requires admin or service token.",
+        )
+    if owner_email.strip().lower() != (principal.email or "").strip().lower():
+        raise HTTPException(
+            status_code=403,
+            detail="You can only run strategy on your own briefing.",
+        )
 
 log = logging.getLogger(__name__)
 
@@ -192,15 +228,18 @@ async def save_strategy_questions(
     briefing_id: int,
     questions: StrategyQuestionsCreate,
     db: Session = Depends(get_db),
+    principal: AuthenticatedPrincipal = Depends(step5_principal),
 ):
     """
     Speichert die Zusatzfragen für Report 3.
     Voraussetzung: briefing_id existiert und Report 1 ist abgeschlossen.
+    Auth (Step 5): JWT erforderlich, Owner-Check (eigenes Briefing oder Admin/Service).
     """
     # 1. Prüfe ob Briefing existiert
     briefing = db.query(Briefing).filter(Briefing.id == briefing_id).first()
     if not briefing:
         raise HTTPException(status_code=404, detail="Briefing nicht gefunden")
+    _enforce_strategy_owner(principal, briefing)
 
     # 2. Prüfe ob Report 1 abgeschlossen ist (briefing status = 'done')
     if briefing.status != "done":
@@ -321,10 +360,14 @@ async def generate_strategy_report_endpoint(
     briefing_id: int,
     background_tasks: BackgroundTasks,
     db: Session = Depends(get_db),
+    principal: AuthenticatedPrincipal = Depends(step5_principal),
 ):
     """
     Startet die Generierung des Strategieberichts.
     Läuft als Background-Task.
+
+    Auth (Step 5): JWT erforderlich, Owner-Check (eigenes Briefing oder Admin/Service).
+    Begründung Owner-Check: Strategy-Pipeline kostet 5-10 € LLM pro Run.
 
     Voraussetzungen:
     - Briefing existiert
@@ -336,6 +379,7 @@ async def generate_strategy_report_endpoint(
     briefing = db.query(Briefing).filter(Briefing.id == briefing_id).first()
     if not briefing:
         raise HTTPException(status_code=404, detail="Briefing nicht gefunden")
+    _enforce_strategy_owner(principal, briefing)
 
     # 2. Report 1 abgeschlossen?
     if briefing.status != "done":

--- a/tests/test_step5_auth_helpers.py
+++ b/tests/test_step5_auth_helpers.py
@@ -1,0 +1,194 @@
+# -*- coding: utf-8 -*-
+"""Tests for the Step 5 auth-helpers in core.security.
+
+Schwerpunkt: das Feature-Flag STEP5_JWT_ENFORCEMENT muss live umflippbar
+sein, ohne Re-Deploy. Tests laufen mit/ohne Flag und decken die fünf
+Pfade durch ``step5_principal`` ab.
+"""
+from __future__ import annotations
+
+import os
+from unittest.mock import patch
+
+import pytest
+from fastapi import HTTPException
+
+
+# --- step5_jwt_enforcement_enabled --------------------------------------
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        ("1", True),
+        ("true", True),
+        ("True", True),
+        ("yes", True),
+        ("on", True),
+        ("0", False),
+        ("false", False),
+        ("", False),
+        ("garbage", False),
+    ],
+)
+def test_step5_flag_parsing(value: str, expected: bool) -> None:
+    from core.security import step5_jwt_enforcement_enabled
+    with patch.dict(os.environ, {"STEP5_JWT_ENFORCEMENT": value}):
+        assert step5_jwt_enforcement_enabled() is expected
+
+
+def test_step5_flag_unset_is_false() -> None:
+    from core.security import step5_jwt_enforcement_enabled
+    env = dict(os.environ)
+    env.pop("STEP5_JWT_ENFORCEMENT", None)
+    with patch.dict(os.environ, env, clear=True):
+        assert step5_jwt_enforcement_enabled() is False
+
+
+# --- step5_principal: Flag OFF (legacy passthrough) --------------------
+
+
+def _no_flag_env() -> dict:
+    env = dict(os.environ)
+    env.pop("STEP5_JWT_ENFORCEMENT", None)
+    return env
+
+
+def test_principal_flag_off_no_token_returns_unauthenticated() -> None:
+    from core.security import step5_principal
+    with patch.dict(os.environ, _no_flag_env(), clear=True):
+        result = step5_principal(auth_token=None, authorization=None, x_service_token=None)
+    assert result.is_authenticated is False
+    assert result.is_service is False
+    assert result.email is None
+    assert result.identity == "anonymous"
+
+
+def test_principal_flag_off_invalid_token_swallowed() -> None:
+    """Mit Flag aus: ungültiges Token darf das Verhalten nicht brechen."""
+    from core.security import step5_principal
+    with patch.dict(os.environ, _no_flag_env(), clear=True):
+        result = step5_principal(
+            auth_token="not-a-real-jwt", authorization=None, x_service_token=None,
+        )
+    assert result.is_authenticated is False
+
+
+# --- step5_principal: Flag ON ------------------------------------------
+
+
+def _flag_on_env() -> dict:
+    env = dict(os.environ)
+    env["STEP5_JWT_ENFORCEMENT"] = "1"
+    return env
+
+
+def test_principal_flag_on_no_token_raises_401() -> None:
+    from core.security import step5_principal
+    with patch.dict(os.environ, _flag_on_env(), clear=True):
+        with pytest.raises(HTTPException) as exc:
+            step5_principal(auth_token=None, authorization=None, x_service_token=None)
+    assert exc.value.status_code == 401
+
+
+def test_principal_flag_on_invalid_jwt_raises() -> None:
+    """Ungültiges JWT mit Flag on → 401 (nicht stillschweigend durchwinken)."""
+    from core.security import step5_principal
+    with patch.dict(os.environ, _flag_on_env(), clear=True):
+        with pytest.raises(HTTPException):
+            step5_principal(
+                auth_token="garbage", authorization=None, x_service_token=None,
+            )
+
+
+def test_principal_flag_on_valid_jwt_whitelisted_email_passes() -> None:
+    """Echter Round-Trip: erzeuge Token, dekodiere ihn — whitelisted email akzeptiert."""
+    from core.security import create_access_token, step5_principal
+    from core.whitelist import EMAIL_WHITELIST
+
+    # Pick an email that is in the canonical whitelist
+    email = next(iter(EMAIL_WHITELIST))
+    token = create_access_token(email=email)
+    with patch.dict(os.environ, _flag_on_env(), clear=True):
+        result = step5_principal(
+            auth_token=token, authorization=None, x_service_token=None,
+        )
+    assert result.is_authenticated is True
+    assert result.is_service is False
+    assert result.email == email
+
+
+def test_principal_flag_on_valid_jwt_non_whitelisted_email_403() -> None:
+    """JWT für nicht-whitelisted Email → 403, nicht 200."""
+    from core.security import create_access_token, step5_principal
+
+    token = create_access_token(email="random@stranger.tld")
+    with patch.dict(os.environ, _flag_on_env(), clear=True):
+        with pytest.raises(HTTPException) as exc:
+            step5_principal(
+                auth_token=token, authorization=None, x_service_token=None,
+            )
+    assert exc.value.status_code == 403
+
+
+# --- resolve_pipeline_email --------------------------------------------
+
+
+def test_resolve_email_service_token_passes_body_email_through() -> None:
+    """Service-Tokens dürfen body_email frei setzen (Golden-Reports-Fall)."""
+    from core.security import AuthenticatedPrincipal, resolve_pipeline_email
+    p = AuthenticatedPrincipal(
+        service_principal="golden_reports", is_service=True, is_authenticated=True,
+    )
+    assert resolve_pipeline_email(p, "anywhere@example.com") == "anywhere@example.com"
+    assert resolve_pipeline_email(p, None) is None
+
+
+def test_resolve_email_user_token_match_returns_token_email() -> None:
+    from core.security import AuthenticatedPrincipal, resolve_pipeline_email
+    p = AuthenticatedPrincipal(email="user@a.tld", is_authenticated=True)
+    # Match — token email returned regardless of body
+    assert resolve_pipeline_email(p, "user@a.tld") == "user@a.tld"
+    # Case-insensitive
+    assert resolve_pipeline_email(p, "USER@A.TLD") == "user@a.tld"
+    # No body email — token email returned
+    assert resolve_pipeline_email(p, None) == "user@a.tld"
+
+
+def test_resolve_email_user_token_mismatch_raises_403() -> None:
+    from core.security import AuthenticatedPrincipal, resolve_pipeline_email
+    p = AuthenticatedPrincipal(email="user@a.tld", is_authenticated=True)
+    with pytest.raises(HTTPException) as exc:
+        resolve_pipeline_email(p, "attacker@evil.tld")
+    assert exc.value.status_code == 403
+
+
+def test_resolve_email_unauthenticated_passes_body_through() -> None:
+    """Flag off + kein Token: legacy passthrough."""
+    from core.security import AuthenticatedPrincipal, resolve_pipeline_email
+    p = AuthenticatedPrincipal(is_authenticated=False)
+    assert resolve_pipeline_email(p, "x@y.tld") == "x@y.tld"
+    assert resolve_pipeline_email(p, None) is None
+
+
+# --- AuthenticatedPrincipal.identity ------------------------------------
+
+
+def test_identity_service() -> None:
+    from core.security import AuthenticatedPrincipal
+    p = AuthenticatedPrincipal(
+        service_principal="ci_runner", is_service=True, is_authenticated=True,
+    )
+    assert p.identity == "service:ci_runner"
+
+
+def test_identity_user() -> None:
+    from core.security import AuthenticatedPrincipal
+    p = AuthenticatedPrincipal(email="x@y.tld", is_authenticated=True)
+    assert p.identity == "user:x@y.tld"
+
+
+def test_identity_anonymous() -> None:
+    from core.security import AuthenticatedPrincipal
+    p = AuthenticatedPrincipal(is_authenticated=False)
+    assert p.identity == "anonymous"


### PR DESCRIPTION
## Summary

Implementiert Wolf E5 Stufe 1 nach den Antworten auf PR #1001:

| Frage | Antwort | Umsetzung |
|---|---|---|
| 1 — Owner-Check Strategy | A: drin | `_enforce_strategy_owner` in `routes/strategy.py` |
| 2 — Chat-Anonymous-Flow | C: start offen, complete JWT | nur `/chat/complete` bekommt `Depends(step5_principal)` |
| 3 — Rollout | Feature-Flag | `STEP5_JWT_ENFORCEMENT={1\|true\|yes\|on}` in Railway-Env |
| 4 — Service-Token-Scope | B: `briefings:submit` für alle | `step5_principal` validiert mit diesem Scope |

## Was sich ändert

Acht Endpoints bekommen `Depends(step5_principal)` — **gated by Feature-Flag**. Mit Flag aus (Default) ist das Verhalten unverändert (Disruptions-Risiko = 0). Mit Flag an:

- Kein Token → 401
- JWT nicht in `EMAIL_WHITELIST` → 403
- `body.email`/`email_override` ≠ Token-Email → 403 (außer Service-Token darf frei setzen)
- Strategy ohne Owner-Match (oder Admin/Service) → 403

| Endpoint | Special |
|---|---|
| `POST /api/analyze/run` | + `email_override`-Match |
| `POST /api/report/generate` | + `email`-Match |
| `POST /api/report/solo-compact` | — |
| `POST /api/report/gamechanger-deep-dive` | — |
| `POST /api/report/gamechanger-deep-dive/pdf/{id}` | — |
| `POST /api/strategy/questions/{id}` | + Owner-Check |
| `POST /api/strategy/generate/{id}` | + Owner-Check (5-10 € LLM/Run) |
| `POST /api/chat/complete` | `/chat/start` bleibt offen |

**Nicht betroffen** (Wolf E5 Stufe 2, späterer PR): `/api/appetizer/generate`, `/api/strategy/admin/*`, `/api/admin/testrun/*`.

## Neuer Helper in `core/security.py`

```python
class AuthenticatedPrincipal(BaseModel):
    email: Optional[str] = None
    service_principal: Optional[str] = None
    is_service: bool = False
    is_authenticated: bool = False
    @property
    def identity(self) -> str: ...

def step5_jwt_enforcement_enabled() -> bool:
    """Live-flippbar via Railway-Env, kein Re-Deploy nötig."""

def step5_principal(...) -> AuthenticatedPrincipal:
    """JWT (Cookie/Bearer) ODER X-Service-Token. Mit Flag on:
    Whitelist-pflicht + 401 bei fehlender Auth. Ohne Flag: best-effort
    Resolver, fällt auf Legacy-Passthrough zurück."""

def resolve_pipeline_email(principal, body_email) -> Optional[str]:
    """Token-email = Wahrheit; body-email-Match (User) oder
    body-email-frei (Service) oder passthrough (anonym/Legacy)."""
```

## Tests

`tests/test_step5_auth_helpers.py` — 16 Cases:

- **Flag-Parsing** — alle truthy/falsy Varianten + unset (8 Cases)
- **Flag off** — kein Token → unauthenticated; ungültiges Token → unauthenticated (Legacy-Passthrough)
- **Flag on** — kein Token → 401; ungültiges Token → 401; whitelisted JWT → 200; nicht-whitelisted JWT → 403
- **`resolve_pipeline_email`** — Service-Passthrough, User-Match (case-insensitive), User-Mismatch → 403, Anonym-Passthrough
- **`identity`-Format** — `service:...`, `user:...`, `anonymous`

## Rollout-Plan (du)

1. **Merge** → Railway-Deploy. **Flag default off** — Verhalten unverändert, nichts kann brechen.
2. Audit-Daten aus PR #1000 weiter sammeln (`source`-Verteilung in `/api/admin/briefings/recent`).
3. Wenn `source=anonymous` nur über curl/Skripte (nicht Frontend) → in Railway-Env `STEP5_JWT_ENFORCEMENT=1` setzen. Kein Re-Deploy nötig (Container liest bei jedem Request).
4. **30 min Logs beobachten:** Bei einer 401-Welle → Flag zurück auf `0`, Quelle diagnostizieren (Audit-Trail zeigt IP/UA).
5. Wenn stabil → in einem Folge-PR den Default auf `on` hardcoden.

## Rollback

Killswitch ist die Env-Variable. Pro Endpoint git-revert ist auch möglich, weil jeder Endpoint nur 2-3 Zeilen Diff hat.

## Test plan

- [ ] CI grün (insbesondere `test_step5_auth_helpers.py` 16 Cases)
- [ ] Nach Merge + Deploy: existierender Flow (Frontend, Cancel-Endpoints) funktioniert weiter (Flag aus)
- [ ] `STEP5_JWT_ENFORCEMENT=1` setzen
- [ ] `curl -X POST $API/api/analyze/run -d '{"briefing_id":1051}' -H "content-type: application/json"` ohne Token → **401**
- [ ] Mit deinem Admin-JWT → 200/202
- [ ] `curl -X POST $API/api/strategy/generate/1040 -H "Authorization: Bearer $JWT"` → 403 (du hast Briefing 1040 nicht erstellt — es sei denn du bist Admin, dann 200)
- [ ] Frontend-Flow durchklicken → soll weiter funktionieren (sofern Frontend JWT mitschickt)

https://claude.ai/code/session_01TDfvj2V5zAbdB1oH56E4Lq

---
_Generated by [Claude Code](https://claude.ai/code/session_01TDfvj2V5zAbdB1oH56E4Lq)_