### PR TITLE
ci(smoke): bump polling timeout 600s → 900s

### DIFF
--- a/.github/workflows/report-smoke.yml
+++ b/.github/workflows/report-smoke.yml
@@ -124,9 +124,9 @@ jobs:
           echo "::group::Generating Solo-Compact Report"
           # JSON to file, logs to stderr (visible in CI console)
           # Note: Do NOT use 2>&1 - keep streams separate for clean JSON
-          # Extended timeout to 600s to handle Railway container restarts
+          # Timeout 900s: KMU pipeline >600s observed; Solo/Team ~570s headroom.
           python scripts/submit_fixture.py fixtures/solo_freelancer.json \
-            --poll --timeout 600 --download-pdf ${{ env.ARTIFACTS_DIR }} --output-json \
+            --poll --timeout 900 --download-pdf ${{ env.ARTIFACTS_DIR }} --output-json \
             > ${{ env.ARTIFACTS_DIR }}/solo_result.json && EXIT_CODE=0 || EXIT_CODE=$?
 
           echo "Exit code: $EXIT_CODE"
@@ -148,7 +148,7 @@ jobs:
           # Wait 10s between reports to let backend stabilize
           sleep 10
           python scripts/submit_fixture.py fixtures/team_startup.json \
-            --poll --timeout 600 --download-pdf ${{ env.ARTIFACTS_DIR }} --output-json \
+            --poll --timeout 900 --download-pdf ${{ env.ARTIFACTS_DIR }} --output-json \
             > ${{ env.ARTIFACTS_DIR }}/team_result.json && EXIT_CODE=0 || EXIT_CODE=$?
 
           echo "Exit code: $EXIT_CODE"
@@ -167,7 +167,7 @@ jobs:
           echo "::group::Generating KMU Report"
           sleep 10
           python scripts/submit_fixture.py fixtures/kmu_mittelstand.json \
-            --poll --timeout 600 --download-pdf ${{ env.ARTIFACTS_DIR }} --output-json \
+            --poll --timeout 900 --download-pdf ${{ env.ARTIFACTS_DIR }} --output-json \
             > ${{ env.ARTIFACTS_DIR }}/kmu_result.json && EXIT_CODE=0 || EXIT_CODE=$?
 
           echo "Exit code: $EXIT_CODE"


### PR DESCRIPTION
## Summary
- Bumps `--timeout 600` → `--timeout 900` in the three `submit_fixture.py` invocations in `.github/workflows/report-smoke.yml` (solo, team, kmu).
- CI-config-only; no backend or script changes.

## Why
Run #631 evidence:
- Solo (1052): done in ~576s — only ~30s headroom
- Team (1053): done in ~563s — only ~37s headroom
- KMU (1054): **timeout at 600s, status still `processing`** ❌

KMU pipeline reproducibly exceeds 600s. 900s gives KMU room to finish and absorbs Railway container-restart jitter for all three fixtures. Job-level `timeout-minutes: 45` is unchanged and still bounds total runtime.

## Risk
Null. Pure CI-knob change, value within existing job timeout budget.

## Test plan
- [ ] CI workflow `Report Smoke Tests` runs and the three submit-fixture steps inherit the new timeout
- [ ] Manual `workflow_dispatch` after merge: solo + team + kmu all reach `final_status: done`
- [ ] No regression in Solo/Team durations (they should still finish in ~570s; 900s is just headroom)

## Out of scope (follow-up PR `fix/ci-runner-reports-read-scope`)
PDF-Download still 403s — being addressed in a separate PR that grants `ci_runner` the `reports:read` scope and switches the workflow to `--download-html` for QA-Scan content validation.

https://claude.ai/code/session_01Qk2Ua2BRCC1X2mMSPpjyeX

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qk2Ua2BRCC1X2mMSPpjyeX)_