### PR TITLE
feat(ci): grant ci_runner reports:read + add --download-html for smoke QA

### DIFF
--- a/.github/workflows/report-smoke.yml
+++ b/.github/workflows/report-smoke.yml
@@ -126,7 +126,7 @@ jobs:
           # Note: Do NOT use 2>&1 - keep streams separate for clean JSON
           # Timeout 900s: KMU pipeline >600s observed; Solo/Team ~570s headroom.
           python scripts/submit_fixture.py fixtures/solo_freelancer.json \
-            --poll --timeout 900 --download-pdf ${{ env.ARTIFACTS_DIR }} --output-json \
+            --poll --timeout 900 --download-html ${{ env.ARTIFACTS_DIR }} --output-json \
             > ${{ env.ARTIFACTS_DIR }}/solo_result.json && EXIT_CODE=0 || EXIT_CODE=$?
 
           echo "Exit code: $EXIT_CODE"
@@ -148,7 +148,7 @@ jobs:
           # Wait 10s between reports to let backend stabilize
           sleep 10
           python scripts/submit_fixture.py fixtures/team_startup.json \
-            --poll --timeout 900 --download-pdf ${{ env.ARTIFACTS_DIR }} --output-json \
+            --poll --timeout 900 --download-html ${{ env.ARTIFACTS_DIR }} --output-json \
             > ${{ env.ARTIFACTS_DIR }}/team_result.json && EXIT_CODE=0 || EXIT_CODE=$?
 
           echo "Exit code: $EXIT_CODE"
@@ -167,7 +167,7 @@ jobs:
           echo "::group::Generating KMU Report"
           sleep 10
           python scripts/submit_fixture.py fixtures/kmu_mittelstand.json \
-            --poll --timeout 900 --download-pdf ${{ env.ARTIFACTS_DIR }} --output-json \
+            --poll --timeout 900 --download-html ${{ env.ARTIFACTS_DIR }} --output-json \
             > ${{ env.ARTIFACTS_DIR }}/kmu_result.json && EXIT_CODE=0 || EXIT_CODE=$?
 
           echo "Exit code: $EXIT_CODE"

--- a/core/security.py
+++ b/core/security.py
@@ -169,7 +169,7 @@ def verify_service_token(token: str, required_scope: str = "briefings:submit") -
     # Scope-Mapping pro Principal
     principal_scopes = {
         "golden_reports": ["briefings:submit", "reports:read"],
-        "ci_runner": ["briefings:submit"],
+        "ci_runner": ["briefings:submit", "reports:read"],
         "test_runner": ["briefings:submit", "reports:read"],
     }
 

--- a/scripts/submit_fixture.py
+++ b/scripts/submit_fixture.py
@@ -346,6 +346,41 @@ def download_pdf(
         return None
 
 
+def download_html(
+    client: httpx.Client,
+    briefing_id: int,
+    output_dir: str,
+    fixture_id: str,
+) -> Optional[str]:
+    """
+    Download the rendered HTML for a briefing.
+
+    Returns:
+        Path to downloaded HTML or None if failed
+    """
+    output_path = Path(output_dir)
+    output_path.mkdir(parents=True, exist_ok=True)
+
+    html_filename = f"{fixture_id}_{briefing_id}.html"
+    html_path = output_path / html_filename
+
+    log.info("Downloading HTML to %s...", html_path)
+
+    try:
+        response = client.get(f"/api/report/html/{briefing_id}")
+        response.raise_for_status()
+
+        with open(html_path, "wb") as f:
+            f.write(response.content)
+
+        log.info("HTML saved: %s (%d bytes)", html_path, len(response.content))
+        return str(html_path)
+
+    except Exception as e:
+        log.error("Failed to download HTML: %s", e)
+        return None
+
+
 def get_report_url(briefing_id: int, base_url: str) -> str:
     """Generate the report URL for a briefing."""
     return f"{base_url}/api/report/html/{briefing_id}"
@@ -409,6 +444,12 @@ Environment Variables (with fallback):
         metavar="DIR",
         default=None,
         help="Download PDF to specified directory",
+    )
+    parser.add_argument(
+        "--download-html",
+        metavar="DIR",
+        default=None,
+        help="Download rendered HTML to specified directory",
     )
     parser.add_argument(
         "--output-json",
@@ -501,6 +542,14 @@ Environment Variables (with fallback):
                         if pdf_path:
                             result["pdf_local_path"] = pdf_path
 
+                    # Download HTML if requested
+                    if args.download_html:
+                        html_path = download_html(
+                            client, briefing_id, args.download_html, fixture_id
+                        )
+                        if html_path:
+                            result["html_local_path"] = html_path
+
                     # Get validation summary if available
                     validation = get_validation_summary(client, briefing_id)
                     if validation:
@@ -535,6 +584,8 @@ Environment Variables (with fallback):
                 print(f"PDF URL: {result['pdf_url']}")
             if result.get("pdf_local_path"):
                 print(f"PDF Local: {result['pdf_local_path']}")
+            if result.get("html_local_path"):
+                print(f"HTML Local: {result['html_local_path']}")
             print(f"{'='*50}\n")
 
         return EXIT_SUCCESS


### PR DESCRIPTION
## Summary
- `core/security.py`: add `reports:read` to `ci_runner` `principal_scopes` (1-line dict change).
- `scripts/submit_fixture.py`: new `download_html()` helper + `--download-html` CLI flag, mirroring the existing PDF path.
- `.github/workflows/report-smoke.yml`: switch the three `submit_fixture.py` invocations from `--download-pdf` to `--download-html`.

## Why
The smoke-test pipeline ships rendered report artifacts to `qa-scan` for content validation (`.github/workflows/report-smoke.yml:255-278`). Both `/api/report/pdf/{id}` and `/api/report/html/{id}` use `get_service_or_skip_auth` with `required_scope="reports:read"` (`routes/report.py:35-44`). Until now `ci_runner` only carried `briefings:submit` — so every download returned 403 and the QA-scan silently degraded to a no-op (`No <segment> artifact found to scan`).

Granting `reports:read` to `ci_runner` is the semantically correct fix: CI must be allowed to read its own briefings to validate them. `golden_reports` and `test_runner` already carry this scope.

PDF download is parked until a concrete use case (e.g. visual regression) appears.

## Risk
Low.
- Backend change is a single dict entry; touches no logic.
- New `download_html()` mirrors the existing `download_pdf()` exactly.
- Workflow change is a flag rename in three places.

## Test plan
- [ ] Workflow run on PR: smoke job downloads `*.html` to artifacts; `qa-scan` reports real findings (no more `No <segment> artifact found`).
- [ ] Manual `workflow_dispatch` after merge: all three briefings reach `final_status: done`, three `*.html` files in artifacts, QA-Scan green or with intelligible findings.
- [ ] Post-flight curl: `curl -H "X-Service-Token: ci_runner:<secret>" https://<backend>/api/report/html/<id>` returns 200.
- [ ] Existing `test_step5_auth_helpers.py` still passes (only references `service:ci_runner` identity, not scope contents).

## Out of scope
- Step-5 cutover — separate sprint.
- PDF endpoint access — re-evaluate if visual-regression tests land.

https://claude.ai/code/session_01Qk2Ua2BRCC1X2mMSPpjyeX

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qk2Ua2BRCC1X2mMSPpjyeX)_