### PR TITLE
fix(auth): grant ci_runner reports:read for smoke-test PDF download

### DIFF
--- a/core/security.py
+++ b/core/security.py
@@ -169,7 +169,7 @@ def verify_service_token(token: str, required_scope: str = "briefings:submit") -
     # Scope-Mapping pro Principal
     principal_scopes = {
         "golden_reports": ["briefings:submit", "reports:read"],
-        "ci_runner": ["briefings:submit"],
+        "ci_runner": ["briefings:submit", "reports:read"],
         "test_runner": ["briefings:submit", "reports:read"],
     }
 


### PR DESCRIPTION
## Summary

Sprint: **KIS-FIX-POLLING-403** — Restbestand-Cleanup für saubere CI-Logs.

After every smoke-test run, Railway logs showed a single stray `403 Forbidden` on `GET /api/report/pdf/{id}`. The smoke-test pipeline itself succeeded, but the trailing 403 was noise.

## Root cause

`scripts/submit_fixture.py:335` (invoked via `--download-pdf` in `.github/workflows/report-smoke.yml`) calls the PDF endpoint with the `ci_runner` service token. The endpoint at `routes/report.py:332` requires scope `reports:read` (via `get_service_or_skip_auth` → `verify_service_token(..., required_scope="reports:read")` at `routes/report.py:44`). However `ci_runner` only had `["briefings:submit"]` in `core/security.py:172`, while peers `golden_reports` and `test_runner` already had `reports:read` for the same reason.

## Diagnosis (4 hypotheses considered)

- **A** — Caller is dead code → ❌ caller is the active smoke-test PDF download path.
- **B** — Redirect to HTML endpoint → rejected (>50 lines, separate sprint).
- **C** — Grant `ci_runner` the `reports:read` scope → ✅ chosen (1-line, aligns with peers).
- **D** — Loosen endpoint scope → rejected (authz weakening).

## Change

```diff
-        "ci_runner": ["briefings:submit"],
+        "ci_runner": ["briefings:submit", "reports:read"],
```

Single-line edit in `core/security.py`. No other files touched. Workflow `--download-pdf` flag intentionally left in place — that path is now correct.

## Test plan

- [ ] Manual curl on Production after merge: submit fixture with `X-Service-Token: ci_runner:$SECRET`, poll until `done`, then `GET /api/report/pdf/$BID` — expect **HTTP 200** (was 403).
- [ ] Verify Railway logs no longer show `403 Forbidden` on `/api/report/pdf/{id}` after subsequent smoke runs.

Refs: KIS-FIX-POLLING-403

https://claude.ai/code/session_01SWxH2NRv5Vjvp5d8nbpi76

---
_Generated by [Claude Code](https://claude.ai/code/session_01SWxH2NRv5Vjvp5d8nbpi76)_