### PR TITLE
feat(audit): extend audit trail to chat + admin replay (6B)

### DIFF
--- a/core/audit.py
+++ b/core/audit.py
@@ -53,3 +53,10 @@ def anonymize_ip(ip: Optional[str]) -> Optional[str]:
             return str(net.network_address)
     except ValueError:
         return ip  # leave malformed IPs untouched
+
+
+def _truncate(value: Optional[str], limit: int = 500) -> Optional[str]:
+    """Truncate strings for DB columns / log lines."""
+    if not value:
+        return None
+    return value if len(value) <= limit else value[: limit - 1] + "…"

--- a/routes/admin_testrun.py
+++ b/routes/admin_testrun.py
@@ -16,10 +16,11 @@ import os
 import time
 from typing import Any, Dict, List, Optional
 
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
+from core.audit import _resolve_client_ip, _truncate, anonymize_ip
 from routes._bootstrap import get_db
 
 router = APIRouter(prefix="/admin/testrun", tags=["admin-testrun"])
@@ -61,6 +62,7 @@ _REPLAY_DEDUP_WINDOW_MINUTES = 30
 @router.post("/replay/{briefing_id}")
 def replay_testrun(
     briefing_id: int,
+    request: Request,
     admin_key: str = Query(..., description="Admin API Key"),
     force: bool = Query(False, description="Bypass duplicate guard"),
     body: Optional[ReplayRequest] = None,
@@ -181,6 +183,9 @@ def replay_testrun(
     cleaned_answers = clean_briefing_data(answers)
     now = datetime.now(timezone.utc)
 
+    audit_request_ip = anonymize_ip(_resolve_client_ip(request))
+    audit_request_ua = _truncate(request.headers.get("user-agent"), limit=500)
+
     new_briefing = Briefing(
         user_id=source.user_id,
         lang=source.lang,
@@ -188,6 +193,9 @@ def replay_testrun(
         status="accepted",
         accepted_at=now,
         replayed_from=briefing_id,
+        source="admin_replay",
+        request_ip=audit_request_ip,
+        request_ua=audit_request_ua,
     )
     db.add(new_briefing)
     db.commit()

--- a/routes/briefings.py
+++ b/routes/briefings.py
@@ -14,7 +14,7 @@ from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
 from core.security import bearer_token, verify_access_token, verify_service_token, ServiceTokenPayload
-from core.audit import _resolve_client_ip, anonymize_ip
+from core.audit import _resolve_client_ip, anonymize_ip, _truncate
 from settings import get_settings
 from services.rate_limit import RateLimiter
 from utils.idempotency import IdempotencyBox
@@ -27,13 +27,6 @@ log = logging.getLogger(__name__)
 # Rate limiter and idempotency box as module-level variables to persist state across requests
 _briefing_rate_limiter = RateLimiter(namespace="briefings", limit=10, window_sec=300)
 _idempotency_box = IdempotencyBox(namespace="briefing_submit")
-
-
-def _truncate(value: Optional[str], limit: int = 500) -> Optional[str]:
-    """Truncate strings for DB columns / log lines."""
-    if not value:
-        return None
-    return value if len(value) <= limit else value[: limit - 1] + "…"
 
 
 class BriefingSubmitIn(BaseModel):

--- a/routes/chat.py
+++ b/routes/chat.py
@@ -23,6 +23,7 @@ from fastapi.responses import StreamingResponse
 from sqlalchemy.orm import Session
 from sqlalchemy import text as _sa_text
 
+from core.audit import _resolve_client_ip, _truncate, anonymize_ip
 from core.security import AuthenticatedPrincipal, step5_principal
 from models import Briefing, ChatSession, User
 from routes._bootstrap import get_db
@@ -601,7 +602,11 @@ async def chat_start(
 # ===========================================================================
 
 @router.post("/message")
-async def chat_message(req: ChatMessageRequest, db: Session = Depends(get_db)):
+async def chat_message(
+    req: ChatMessageRequest,
+    request: Request,
+    db: Session = Depends(get_db),
+):
     """Process user message, extract fields, stream AI response via SSE."""
     session = db.query(ChatSession).filter(ChatSession.id == req.session_id).first()
     if not session:
@@ -2289,7 +2294,7 @@ async def chat_message(req: ChatMessageRequest, db: Session = Depends(get_db)):
                 if rt == "strategy":
                     _briefing_id = await _complete_strategy(session, collected, db, now)
                 else:
-                    _briefing_id = _complete_r1(session, collected, db, now)
+                    _briefing_id = _complete_r1(session, collected, db, now, request)
                 _redirect_url = _complete_redirect(rt, _briefing_id)
                 log.info("[CHAT] Report triggered: briefing_id=%s, session=%s", _briefing_id, session.id)
                 yield f"event: report_started\ndata: {json.dumps({'briefing_id': _briefing_id, 'redirect_url': _redirect_url})}\n\n"
@@ -3115,12 +3120,20 @@ def _complete_r1(
         answers["email"] = user_email
     log.info("[CHAT] Complete R1: user_email=%s, user_id=%s", user_email, user_id)
 
+    audit_request_ip = anonymize_ip(_resolve_client_ip(request)) if request else None
+    audit_request_ua = (
+        _truncate(request.headers.get("user-agent"), limit=500) if request else None
+    )
+
     briefing = Briefing(
         user_id=user_id,
         lang=session.lang,
         answers=answers,
         status="accepted",
         accepted_at=now,
+        source="chat",
+        request_ip=audit_request_ip,
+        request_ua=audit_request_ua,
     )
     db.add(briefing)
     db.flush()
@@ -3130,6 +3143,13 @@ def _complete_r1(
     session.briefing_id = briefing.id
     session.updated_at = now
     db.commit()
+    log.info(
+        "📝 BRIEFING-CREATED id=%d user_email=%s ip=%s ua=%s source=chat",
+        briefing.id,
+        user_email or "(none)",
+        audit_request_ip or "(none)",
+        _truncate(audit_request_ua, limit=80) or "(none)",
+    )
     return briefing.id
 
 

--- a/tests/test_audit_extended.py
+++ b/tests/test_audit_extended.py
@@ -1,0 +1,182 @@
+"""
+Audit-trail extension tests (KIS-AUDIT-6B-EXTEND).
+
+Verifies that briefings created via:
+  - routes/chat.py:_complete_r1   → source="chat"
+  - routes/admin_testrun.py:replay → source="admin_replay"
+persist the same audit fields (source / request_ip / request_ua) as 6A's
+/submit, with IP anonymized via core.audit.anonymize_ip.
+"""
+from __future__ import annotations
+
+import os
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.pool import StaticPool
+
+os.environ.setdefault("STRATEGY_ADMIN_KEY", "test-admin-key-6b")
+
+from models import Base, Briefing, ChatSession  # noqa: E402
+from routes._bootstrap import get_db  # noqa: E402
+from routes.admin_testrun import router as admin_testrun_router  # noqa: E402
+from routes.chat import _complete_r1  # noqa: E402
+
+
+# --------------------------------------------------------------------------
+# DB / app fixtures
+# --------------------------------------------------------------------------
+
+@pytest.fixture()
+def db_session() -> Session:
+    engine = create_engine(
+        "sqlite:///:memory:",
+        future=True,
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(engine)
+    SessionLocal = sessionmaker(bind=engine, autoflush=False, expire_on_commit=False)
+    session = SessionLocal()
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+@pytest.fixture()
+def fastapi_app(db_session: Session) -> FastAPI:
+    app = FastAPI()
+    app.include_router(admin_testrun_router, prefix="/api")
+    app.dependency_overrides[get_db] = lambda: db_session
+    return app
+
+
+@pytest.fixture()
+def client(fastapi_app: FastAPI) -> TestClient:
+    return TestClient(fastapi_app)
+
+
+# --------------------------------------------------------------------------
+# Mock request helper
+# --------------------------------------------------------------------------
+
+def _mock_request(xff: str | None = "203.0.113.42, 10.0.0.1", ua: str = "Mozilla/5.0 test-agent"):
+    """Build a duck-typed Request good enough for _resolve_client_ip / _resolve_user."""
+    req = MagicMock()
+    headers = {}
+    if xff:
+        headers["x-forwarded-for"] = xff
+    if ua:
+        headers["user-agent"] = ua
+    headers["authorization"] = ""  # so _resolve_user can't extract a token
+    req.headers = headers
+    req.cookies = {}
+    req.client = SimpleNamespace(host="100.64.0.1")
+    return req
+
+
+# --------------------------------------------------------------------------
+# 1) chat.py:_complete_r1 — unit test
+# --------------------------------------------------------------------------
+
+def test_complete_r1_persists_audit_trail(db_session: Session) -> None:
+    """_complete_r1 with a request must write source='chat' + anonymized IP + UA."""
+    session = ChatSession(
+        report_type="r1",
+        lang="de",
+        collected_fields={},
+        messages=[],
+        phase_state={"selected_blocks": ["A", "B", "C", "D"], "completed_blocks": ["A", "B", "C", "D"]},
+    )
+    db_session.add(session)
+    db_session.flush()
+
+    request = _mock_request(xff="203.0.113.42")
+    now = datetime.now(timezone.utc)
+
+    briefing_id = _complete_r1(session, {"branche": "it"}, db_session, now, request)
+
+    briefing = db_session.get(Briefing, briefing_id)
+    assert briefing is not None
+    assert briefing.source == "chat"
+    assert briefing.request_ip == "203.0.113.0"  # /24 anonymized
+    assert briefing.request_ua == "Mozilla/5.0 test-agent"
+
+
+def test_complete_r1_without_request_writes_source_only(db_session: Session) -> None:
+    """When request is None (legacy path), source='chat' is still written; IP/UA are None."""
+    session = ChatSession(
+        report_type="r1",
+        lang="de",
+        collected_fields={},
+        messages=[],
+        phase_state={"selected_blocks": ["A", "B", "C", "D"], "completed_blocks": ["A", "B", "C", "D"]},
+    )
+    db_session.add(session)
+    db_session.flush()
+
+    now = datetime.now(timezone.utc)
+    briefing_id = _complete_r1(session, {"branche": "it"}, db_session, now, None)
+
+    briefing = db_session.get(Briefing, briefing_id)
+    assert briefing.source == "chat"
+    assert briefing.request_ip is None
+    assert briefing.request_ua is None
+
+
+# --------------------------------------------------------------------------
+# 2) admin_testrun.py:replay — integration test via TestClient
+# --------------------------------------------------------------------------
+
+def test_admin_replay_persists_audit_trail(
+    client: TestClient, db_session: Session
+) -> None:
+    """POST /api/admin/testrun/replay/<id> creates a new briefing with
+    source='admin_replay' and an anonymized IP / UA."""
+    # Seed a source briefing with replayable answers
+    source = Briefing(
+        user_id=None,
+        lang="de",
+        answers={"branche": "it", "bundesland": "be", "email": "src@example.com"},
+        status="done",
+        accepted_at=datetime.now(timezone.utc),
+        source="jwt",
+        request_ip="198.51.100.0",
+        request_ua="orig-agent",
+    )
+    db_session.add(source)
+    db_session.commit()
+    source_id = source.id
+
+    response = client.post(
+        f"/api/admin/testrun/replay/{source_id}",
+        params={"admin_key": "test-admin-key-6b"},
+        headers={
+            "X-Forwarded-For": "203.0.113.99, 10.0.0.1",
+            "User-Agent": "replay-test-agent",
+        },
+        json={"trigger_kpa": False, "trigger_strategy": False},
+    )
+
+    assert response.status_code == 200, response.text
+    new_id = response.json()["new_briefing_id"]
+    assert new_id != source_id
+
+    new_briefing = db_session.get(Briefing, new_id)
+    assert new_briefing is not None
+    assert new_briefing.source == "admin_replay"
+    assert new_briefing.request_ip == "203.0.113.0"  # /24 anonymized
+    assert new_briefing.request_ua == "replay-test-agent"
+    assert new_briefing.replayed_from == source_id
+
+    # Original briefing's audit fields must be untouched
+    refreshed_source = db_session.get(Briefing, source_id)
+    assert refreshed_source.source == "jwt"
+    assert refreshed_source.request_ip == "198.51.100.0"

--- a/tests/test_audit_extended.py
+++ b/tests/test_audit_extended.py
@@ -21,7 +21,7 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import Session, sessionmaker
 from sqlalchemy.pool import StaticPool
 
-os.environ.setdefault("STRATEGY_ADMIN_KEY", "test-admin-key-6b")
+os.environ.setdefault("STRATEGY_ADMIN_KEY", "test-admin-key-123")
 
 from models import Base, Briefing, ChatSession  # noqa: E402
 from routes._bootstrap import get_db  # noqa: E402
@@ -157,7 +157,7 @@ def test_admin_replay_persists_audit_trail(
 
     response = client.post(
         f"/api/admin/testrun/replay/{source_id}",
-        params={"admin_key": "test-admin-key-6b"},
+        params={"admin_key": os.environ["STRATEGY_ADMIN_KEY"]},
         headers={
             "X-Forwarded-For": "203.0.113.99, 10.0.0.1",
             "User-Agent": "replay-test-agent",


### PR DESCRIPTION
## Sprint
KIS-AUDIT-6B-EXTEND — Extend audit trail (source/request_ip/request_ua)
to two more briefing-creating paths beyond /submit.

## Approach
Two new paths now persist audit fields matching the 6A pattern:

- **`routes/chat.py:_complete_r1`** — briefings created via chat flow
  → `source="chat"` (no sub-classification, consistent with 6A)
- **`routes/admin_testrun.py:replay_testrun`** — admin-triggered replays
  → `source="admin_replay"` on the new row; original briefing unchanged
  (replayed_from links them)

IP anonymization via `core.audit.anonymize_ip` (default /24, AUDIT_FULL_IP=1
override). User-Agent truncated to 500 chars via `core.audit._truncate`
(moved from routes/briefings.py for DRY across audit sites).

## Commits
1. `76345693` refactor(audit): move _truncate to core/audit.py
2. `725f6df3` feat(audit): instrument chat.py:_complete_r1 with audit trail
3. `b6c8619a` feat(audit): instrument admin_testrun.py:replay with audit trail
4. `37684ac7` test(audit): add coverage for chat + replay audit-trail instrumentation

## Architecture Notes
- `chat_message` signature gained `request: Request` param (FastAPI auto-injects).
  Pre-commitment grep verified no test calls the function directly with old sig.
- `replay_testrun` is INSERT-only (creates new row linked via `replayed_from`),
  so source-overwrite question doesn't apply — Option A is structurally clean.
- `_truncate` joined `_resolve_client_ip` and `anonymize_ip` in core/audit.py
  to give all audit sites a single import path.

## Tests
- `tests/test_audit_extended.py`: 3 new tests
  - chat with request → source/IP/UA persisted
  - chat without request → graceful None fallback
  - replay → new row with source="admin_replay", original unchanged
- Existing audit tests (test_audit.py, test_briefings_audit_helpers.py): unchanged,
  18 still green
- Combined regression: 26 passed, 0 failed

## Schema/Migration
None. DB columns from PR #1000 (6A) reused.

## Verification (manual, post-merge)
```bash
SECRET=""
TOKEN=""
ADMIN_KEY=""
BASE="https://api-ki-backend-neu-production.up.railway.app"

# Test chat path (anonymous):
# Trigger via frontend chat-flow oder via TestClient

# Test replay path:
curl -X POST "$BASE/api/admin/testrun/replay/1065?admin_key=$ADMIN_KEY"

# Verify in DB:
SELECT id, source, request_ip, request_ua, replayed_from
  FROM briefings
 WHERE source IN ('chat', 'admin_replay')
 ORDER BY id DESC LIMIT 5;
```

Expected:
- Chat row: `source='chat'`, `request_ip` ends with `.0`, `request_ua` ≤ 500 chars
- Replay row: `source='admin_replay'`, `replayed_from=<original_id>`, original row unchanged

## Refs
Builds on:
- PR #1000 (6A) — original /submit instrumentation
- PR #1007 (6C) — IP anonymization + _resolve_client_ip helper

Closes the audit-trail extension series. All three briefing-creating paths
(submit/chat/replay) now persist source/request_ip/request_ua.

https://claude.ai/code/session_01SWxH2NRv5Vjvp5d8nbpi76

---
_Generated by [Claude Code](https://claude.ai/code/session_01SWxH2NRv5Vjvp5d8nbpi76)_