### PR TITLE
KIS-1128 Sprint A: Page-break cascade fix + silent-loss guard (R1/Strategy/KPA)

### DIFF
--- a/services/coverage_guard.py
+++ b/services/coverage_guard.py
@@ -1,7 +1,10 @@
 # -*- coding: utf-8 -*-
 from __future__ import annotations
-from typing import Dict, Any
+from typing import Dict, Any, Iterable, List
 import html
+import logging
+
+log = logging.getLogger(__name__)
 
 """
 coverage_guard
@@ -125,6 +128,94 @@ def analyze_coverage(answers: Dict[str, Any]) -> Dict[str, Any]:
         "coverage_pct": coverage,
         "present_count": len(present),
     }
+
+
+# ---------------------------------------------------------------------------
+# KIS-1128 audit M11: Render-Context Coverage
+#
+# Detects silent content loss at template render time. If a generator returns
+# an empty / whitespace-only string for a required key, the corresponding
+# section is suppressed by the template's {% if X and X|trim %} guard. Without
+# logging, these losses are invisible in production. This audit emits a
+# WARNING per missing/empty required key — output is unchanged.
+# ---------------------------------------------------------------------------
+
+# Minimum required top-level context keys per report. Each key lists field names
+# that — if missing or empty — likely represent a silent content loss. Cover
+# only Pflicht-keys (LLM-generated narrative blocks, deterministic engines).
+# Score / metadata keys are excluded (they have their own validators).
+RENDER_REQUIRED_KEYS: Dict[str, List[str]] = {
+    "r1": [
+        "SOFORT_START_HTML",
+        "QUICK_WINS_HTML",
+        "ROADMAP_90D_DECISION_HTML",
+        "BUSINESS_CASE_ENGINE_HTML",
+        "KI_STACK_SUMMARY_HTML",
+        "PROMPT_VORLAGEN_HTML",
+        "CHALLENGE_30_TAGE_HTML",
+        "VENDOR_AUDIT_HTML",
+        "RISK_ENGINE_HTML",
+        "ROADMAP_12M_HTML",
+        "GAMECHANGER_DECISION_HTML",
+        "ADVISOR_NOTE_HTML",
+    ],
+    "strategy": [
+        "exec_summary",
+        "section_s1",
+        "section_s2",
+        "section_s3",
+        "section_s4",
+        "section_s5",
+        "section_s6",
+        "section_s7",
+        "naechste_schritte",
+    ],
+    "kpa": [
+        "GC_BRUCHPUNKT_HTML",
+        "GC_IMPL_PLAN_HTML",
+        "BC_DEEP_DIVE_HTML",
+        "GC_RISK_HTML",
+        "GC_NEXT_STEPS_HTML",
+    ],
+}
+
+
+def audit_render_context(
+    report_type: str,
+    context: Dict[str, Any],
+    *,
+    extra_required: Iterable[str] = (),
+    report_id: str | None = None,
+) -> List[str]:
+    """
+    Audit a Jinja render context for empty required keys.
+
+    Emits one WARNING per missing/empty key. Returns the list of missing keys
+    (caller may forward to telemetry). Output of the renderer is NOT modified.
+
+    Args:
+        report_type: "r1" | "strategy" | "kpa" — selects the required-key list.
+        context: the dict passed to template.render(**context).
+        extra_required: optional caller-specific keys to also check.
+        report_id: optional id to include in log messages for traceability.
+    """
+    base = RENDER_REQUIRED_KEYS.get(report_type, [])
+    required = list(base) + [k for k in extra_required if k not in base]
+    missing: List[str] = [k for k in required if not _is_filled(context.get(k))]
+
+    if missing:
+        prefix = f"[{report_type}"
+        if report_id:
+            prefix += f"/{report_id}"
+        prefix += "]"
+        log.warning(
+            "%s render-context audit: %d/%d required keys empty: %s",
+            prefix,
+            len(missing),
+            len(required),
+            ", ".join(missing),
+        )
+    return missing
 
 
 def build_html_report(result: Dict[str, Any]) -> str:

--- a/services/gamechanger_deep_dive.py
+++ b/services/gamechanger_deep_dive.py
@@ -886,6 +886,13 @@ def render_deep_dive_html(sections: Dict[str, str],
         _bid = context.get('briefing_id', 0)
         template_vars['REPORT_DISPLAY_ID'] = get_report_display_id(int(_bid)) if _bid else ''
 
+        # KIS-1128 audit M11: warn on empty required keys (silent-loss detector).
+        try:
+            from services.coverage_guard import audit_render_context
+            audit_render_context("kpa", template_vars, report_id=str(template_vars.get("REPORT_DISPLAY_ID") or _bid or ""))
+        except Exception as _e:
+            log.debug("audit_render_context failed: %s", _e)
+
         return str(template.render(**template_vars))
 
     except Exception as exc:

--- a/services/report_renderer.py
+++ b/services/report_renderer.py
@@ -1032,6 +1032,14 @@ def render(briefing_obj: Any,
             ctx['FINAL_CHECK_INTRO'] = _fci_new
             log.info("[FIX-FCI-GAP] Fixed empty hauptleistung gap in FINAL_CHECK_INTRO")
 
+    # KIS-1128 audit M11: warn on empty required keys (silent-loss detector).
+    # Output is unchanged; warnings surface in logs / Railway only.
+    try:
+        from services.coverage_guard import audit_render_context
+        audit_render_context("r1", ctx, report_id=str(ctx.get("report_id") or ""))
+    except Exception as _e:  # never break rendering on audit failure
+        log.debug("audit_render_context failed: %s", _e)
+
     html = env.get_template(tpl_name).render(**ctx)
 
     # Q3: Fix Kl→KI globally in final HTML (common OCR/input error)

--- a/services/sofort_start_generator.py
+++ b/services/sofort_start_generator.py
@@ -1848,8 +1848,11 @@ def generate_sofort_start_html(
     </div>
     
     <!-- PROMPTS SECTION – KIS-1132: expertise-aware -->
+    <!-- KIS-1128 audit M3: outer page-break-inside:avoid wrapper removed —
+         it kept H3 + intro + first prompt-box together, which on S.5/S.6
+         pushed the whole block forward and left ~40% whitespace on S.5.
+         Each prompt-box still has its own page-break-inside:avoid below. -->
     <div style="margin-bottom: 24px;">
-        <div style="page-break-inside: avoid; break-inside: avoid;">
 '''
 
     # KIS-1132: Select prompts based on expertise level
@@ -1871,7 +1874,6 @@ def generate_sofort_start_html(
         _expert_prompts = EXPERT_PROMPT_PATTERNS
         for i, prompt_data in enumerate(_expert_prompts, 1):
             _prompt_text = prompt_data["prompt"].replace("{hauptleistung}", _hl_clean or str(branche_data["name"]))
-            close_wrapper = "</div>" if i == 1 else ""
             html += f'''
         <div style="background: #f8fafc; border: 1px solid #e2e8f0; border-radius: 8px; padding: 16px; margin-bottom: 12px; page-break-inside: avoid;">
             <div style="display: flex; justify-content: space-between; align-items: flex-start; margin-bottom: 8px;">
@@ -1886,7 +1888,6 @@ def generate_sofort_start_html(
 {_prompt_text}
             </div>
         </div>
-        {close_wrapper}
 '''
 
     elif expertise_level == "intermediate":
@@ -1903,7 +1904,6 @@ def generate_sofort_start_html(
         _inter_prompts = INTERMEDIATE_PROMPTS
         for i, prompt_data in enumerate(_inter_prompts, 1):
             _prompt_text = prompt_data["prompt"].replace("{hauptleistung}", _hl_clean or str(branche_data["name"]))
-            close_wrapper = "</div>" if i == 1 else ""
             html += f'''
         <div style="background: #f8fafc; border: 1px solid #e2e8f0; border-radius: 8px; padding: 16px; margin-bottom: 12px; page-break-inside: avoid;">
             <div style="display: flex; justify-content: space-between; align-items: flex-start; margin-bottom: 8px;">
@@ -1918,7 +1918,6 @@ def generate_sofort_start_html(
 {_prompt_text}
             </div>
         </div>
-        {close_wrapper}
 '''
 
     else:
@@ -1936,7 +1935,6 @@ def generate_sofort_start_html(
         for i, prompt_data in enumerate(prompts_list, 1):
             _raw_prompt = _hl_context_prefix + prompt_data["prompt"] if _hl_context_prefix else prompt_data["prompt"]
             prompt_text = _raw_prompt
-            close_wrapper = "</div>" if i == 1 else ""
             html += f'''
         <div style="background: #f8fafc; border: 1px solid #e2e8f0; border-radius: 8px; padding: 16px; margin-bottom: 12px; page-break-inside: avoid;">
             <div style="display: flex; justify-content: space-between; align-items: flex-start; margin-bottom: 8px;">
@@ -1951,7 +1949,6 @@ def generate_sofort_start_html(
 {prompt_text}
             </div>
         </div>
-        {close_wrapper}
 '''
         # Lern-Prompt (beginner only)
         _lern_raw = branche_data.get("lern_prompt")

--- a/services/strategy_renderer.py
+++ b/services/strategy_renderer.py
@@ -385,6 +385,14 @@ def render_strategy_html(sr: Any, db_session: Any) -> str:
         "naechste_schritte": naechste_schritte,
     }
 
+    # KIS-1128 audit M11: warn on empty required keys (silent-loss detector).
+    try:
+        from services.coverage_guard import audit_render_context
+        audit_render_context("strategy", context, report_id=str(context.get("report_id") or ""))
+    except Exception as _e:
+        import logging as _logging
+        _logging.getLogger(__name__).debug("audit_render_context failed: %s", _e)
+
     html = str(template.render(**context))
 
     # Post-process LLM HTML to use CSS design classes (KPI cards, timelines, etc.)

--- a/templates/gamechanger_deep_dive_v1.html
+++ b/templates/gamechanger_deep_dive_v1.html
@@ -131,13 +131,15 @@ td.negative { color: var(--c-danger); font-weight: 600; }
     break-inside: auto;
 }
 
-/* ── Chapter Banner (KIS-1127/C4) ─────────────────────── */
+/* ── Chapter Banner (KIS-1127/C4, KIS-1128 audit M1) ──────
+   break-after: avoid removed for family consistency with R1.
+   KPA layout was OK because each section forces break-before:page;
+   removal is risk-neutral but keeps the family aligned. */
 .chapter-banner {
     padding: 20px 32px 16px;
     margin: 0 0 20px 0;
     position: relative;
     break-inside: avoid;
-    break-after: avoid;
     -webkit-print-color-adjust: exact;
     print-color-adjust: exact;
 }

--- a/templates/pdf_template_v7.html
+++ b/templates/pdf_template_v7.html
@@ -1481,7 +1481,7 @@ h1, h2, h3, h4 {
         <strong>Auf einen Blick:</strong> Drei klare Leitplanken für Ihre KI-Strategie – ausdruckbar als Vorlage für die Geschäftsführung.
     </div>
 
-    {% if EXECUTIVE_DECISION_HTML and EXECUTIVE_DECISION_HTML|trim and '<' in EXECUTIVE_DECISION_HTML %}
+    {% if EXECUTIVE_DECISION_HTML and EXECUTIVE_DECISION_HTML|trim %}
     {{ EXECUTIVE_DECISION_HTML|safe }}
     {% elif FINAL_CHECK_DECISIONS %}
     {% for decision in FINAL_CHECK_DECISIONS %}
@@ -1529,7 +1529,7 @@ h1, h2, h3, h4 {
 {% endif %}
 
 <!-- ═══════ QUICK WINS ═══════ -->
-{% if QUICK_WINS_HTML and QUICK_WINS_HTML|trim and '<' in QUICK_WINS_HTML %}
+{% if QUICK_WINS_HTML and QUICK_WINS_HTML|trim %}
 <section class="section" id="quick-wins-section" data-category="action">
     <div class="level-indicator"><span class="level-dot level-dot-action"></span> ACTION GUIDE</div>
     <div class="section-header">
@@ -1554,7 +1554,7 @@ h1, h2, h3, h4 {
 {% endif %}
 
 <!-- ═══════ 90-TAGE-ROADMAP ═══════ -->
-{% if ROADMAP_90D_DECISION_HTML and ROADMAP_90D_DECISION_HTML|trim and '<' in ROADMAP_90D_DECISION_HTML %}
+{% if ROADMAP_90D_DECISION_HTML and ROADMAP_90D_DECISION_HTML|trim %}
 <section class="section" id="roadmap-90d" data-category="action">
     <div class="level-indicator"><span class="level-dot level-dot-action"></span> ACTION GUIDE</div>
     <div class="section-header">
@@ -1596,7 +1596,7 @@ h1, h2, h3, h4 {
 {% endif %}
 
 <!-- ═══════ TOOLS & STARTER-KIT ═══════ -->
-{% if KI_STACK_SUMMARY_HTML and KI_STACK_SUMMARY_HTML|trim and '<' in KI_STACK_SUMMARY_HTML %}
+{% if KI_STACK_SUMMARY_HTML and KI_STACK_SUMMARY_HTML|trim %}
 <section class="section" id="tools-section" data-category="action">
     <div class="level-indicator"><span class="level-dot level-dot-action"></span> ACTION GUIDE</div>
     <div class="section-header">
@@ -1763,7 +1763,7 @@ h1, h2, h3, h4 {
             <div class="funding-card-next">→ {{ FUNDING_PATH_2.next_step }}</div>
         </div>
         {% endif %}
-        {% if not FUNDING_PATH_1 and FOERDERPOTENZIAL_HTML and FOERDERPOTENZIAL_HTML|trim and '<' in FOERDERPOTENZIAL_HTML %}
+        {% if not FUNDING_PATH_1 and FOERDERPOTENZIAL_HTML and FOERDERPOTENZIAL_HTML|trim %}
         {{ FOERDERPOTENZIAL_HTML|safe }}
         {% endif %}
     </div>
@@ -1772,7 +1772,7 @@ h1, h2, h3, h4 {
 {% endif %}
 
 <!-- ═══════ 12-MONATS-AUSBLICK ═══════ -->
-{% if ROADMAP_12M_HTML and ROADMAP_12M_HTML|trim and '<' in ROADMAP_12M_HTML %}
+{% if ROADMAP_12M_HTML and ROADMAP_12M_HTML|trim %}
 <section class="section" id="outlook-section" data-category="strategy">
     <div class="level-indicator"><span class="level-dot level-dot-action"></span> ACTION GUIDE</div>
     <div class="section-header">
@@ -1792,7 +1792,7 @@ h1, h2, h3, h4 {
 {% endif %}
 
 <!-- ═══════ GAMECHANGER ═══════ -->
-{% if GAMECHANGER_DECISION_HTML and GAMECHANGER_DECISION_HTML|trim and '<' in GAMECHANGER_DECISION_HTML %}
+{% if GAMECHANGER_DECISION_HTML and GAMECHANGER_DECISION_HTML|trim %}
 <section class="section {% if 'gamechanger' in skip_pages %}section-optional{% endif %}" id="gamechanger-section" data-category="strategy">
     <div class="chapter-banner chapter-banner--r1 chapter-banner--unnumbered" style="background:linear-gradient(135deg,#1a3a2a 0%,#2a5f3d 100%);-webkit-print-color-adjust:exact;print-color-adjust:exact;">
         <div class="chapter-banner__content">
@@ -1919,7 +1919,7 @@ h1, h2, h3, h4 {
 {% endif %}
 
 <!-- A4: Handlungsempfehlungen (Detail) -->
-{% if RECOMMENDATIONS_ENGINE_HTML and RECOMMENDATIONS_ENGINE_HTML|trim and '<' in RECOMMENDATIONS_ENGINE_HTML %}
+{% if RECOMMENDATIONS_ENGINE_HTML and RECOMMENDATIONS_ENGINE_HTML|trim %}
 <section class="appendix-section" id="appendix-a4" data-category="deep">
     <div class="appendix-header">Anhang A4 · Handlungsempfehlungen (Detail)</div>
     <div class="section-body">{{ RECOMMENDATIONS_ENGINE_HTML|safe }}</div>
@@ -1951,7 +1951,7 @@ h1, h2, h3, h4 {
 {% endif %}
 
 <!-- A7: KI-Skill-Fahrplan -->
-{% if KI_SKILLPLAN_HTML and KI_SKILLPLAN_HTML|trim and '<' in KI_SKILLPLAN_HTML %}
+{% if KI_SKILLPLAN_HTML and KI_SKILLPLAN_HTML|trim %}
 <section class="appendix-section" id="appendix-a7" data-category="deep">
     <div class="appendix-header">Anhang A7 · KI-Skill-Fahrplan 2026</div>
     <div class="section-body">{{ KI_SKILLPLAN_HTML|safe }}</div>
@@ -1959,7 +1959,7 @@ h1, h2, h3, h4 {
 {% endif %}
 
 <!-- A8: Monetarisierung -->
-{% if MONETARISIERUNG_HTML and MONETARISIERUNG_HTML|trim and '<' in MONETARISIERUNG_HTML %}
+{% if MONETARISIERUNG_HTML and MONETARISIERUNG_HTML|trim %}
 <section class="appendix-section" id="appendix-a8" data-category="deep">
     <div class="appendix-header">Anhang A8 · Monetarisierung &amp; Angebotslogik</div>
     <div class="section-body">{{ MONETARISIERUNG_HTML|safe }}</div>
@@ -1995,7 +1995,7 @@ h1, h2, h3, h4 {
 {% endif %}
 
 <!-- A12: Förderpotenzial (Detail) -->
-{% if FOERDERPOTENZIAL_HTML and FOERDERPOTENZIAL_HTML|trim and '<' in FOERDERPOTENZIAL_HTML %}
+{% if FOERDERPOTENZIAL_HTML and FOERDERPOTENZIAL_HTML|trim %}
 <section class="appendix-section" id="appendix-a12" data-category="deep">
     <div class="appendix-header">Anhang A12 · Förderpotenzial (Detail)</div>
     <div class="section-body">

--- a/templates/pdf_template_v7.html
+++ b/templates/pdf_template_v7.html
@@ -147,12 +147,10 @@ tr:last-child td { border-bottom: none; }
     padding: var(--sp-xl) 0 var(--sp-lg);
     break-inside: auto;
 }
-/* KIS-1126 / C3 FIX: Prevent near-empty pages by keeping headings with
-   their following content and avoiding orphaned section starts */
+/* KIS-1126 / C3 FIX: Headings stay with following content (browser default
+   reinforced). KIS-1128 audit M2: glance-box break-after removed — caused
+   cascade banner→glance→h3→content that pushed half-empty pages forward. */
 .section h2, .section h3, .section h4 {
-    break-after: avoid;
-}
-.section .glance-box {
     break-after: avoid;
 }
 /* Phase/roadmap items should not break internally */
@@ -269,13 +267,15 @@ tr:last-child td { border-bottom: none; }
 .section-body p, .section-body li { orphans: 3; widows: 3; }
 .section-body h3 { margin-top: var(--sp-lg); }
 
-/* ── Chapter Banner (KIS-1127/C4) ─────────────────────── */
+/* ── Chapter Banner (KIS-1127/C4, KIS-1128 audit M1) ──────
+   break-after: avoid removed — banners on sections without
+   forced page-break (vendor, funding) caused 70% whitespace
+   on the preceding page when banner+content didn't fit. */
 .chapter-banner {
     padding: 20px 32px 16px;
     margin: 0 0 20px 0;
     position: relative;
     break-inside: avoid;
-    break-after: avoid;
     -webkit-print-color-adjust: exact;
     print-color-adjust: exact;
 }
@@ -1101,8 +1101,8 @@ h1, h2, h3, h4 {
     .scenarios-section, .business-case-engine-v2 { break-inside: auto; }
     /* Small cards stay together */
     .tool-card, .vendor-card, .scenario-card { break-inside: avoid; }
-    /* KIS-1127/C4: Chapter banners */
-    .chapter-banner { break-inside: avoid; break-after: avoid; }
+    /* KIS-1127/C4 + KIS-1128 audit M1: break-after removed (cascade fix) */
+    .chapter-banner { break-inside: avoid; }
 }
     </style>
 </head>

--- a/templates/strategy_report.html
+++ b/templates/strategy_report.html
@@ -449,13 +449,15 @@ h1, h2, h3, h4 { break-after: avoid; }
 /* ══════════════════════════════════════════════════════
    CHAPTER BANNER (compact top-banner, replaces full-page divider)
    ══════════════════════════════════════════════════════ */
-/* KIS-1127 / C4: Compact ~80px banner instead of 100vh full-page divider */
+/* KIS-1127/C4 + KIS-1128 audit M1: Compact ~80px banner.
+   break-after: avoid removed for family consistency with R1+KPA. Each strategy
+   banner already forces page-break via the `page-break` class on the macro,
+   so break-after was redundant and a regression risk. */
 .chapter-banner {
     padding: 20px 32px 16px;
     margin: 0 0 24px 0;
     position: relative;
     break-inside: avoid;
-    break-after: avoid;
     -webkit-print-color-adjust: exact;
     print-color-adjust: exact;
 }


### PR DESCRIPTION
## Summary

Sprint A of the KIS-1128 audit (page-break + silent-loss). Four small, sequential commits, each minimal-invasive and content-preserving. Two prior fix attempts (`c21ea1a` orphans/widows, `9c974c3` break-inside:auto on phase/kit/vendor) failed because they didn't address the **banner-level break-after cascade** — the actual root cause.

### Audit findings (full report in chat thread)

The R1 page-break problem was a **cascaded `break-after: avoid` chain** across `.chapter-banner` → `.section .glance-box` → `.section h2/h3/h4`. Chromium kept these as one virtual block; if it didn't fit at the bottom of a page, it pushed the whole block forward — producing the documented 40–70 % whitespace pages on S.5 (prompt-boxes), S.16 (AI-Act → funding banner), S.15/16 (vendor) and S.13 (challenge end). KPA worked because each KPA section forces `break-before: page`, so its banners always sit at the top.

Additionally found: a **silent content-loss vector** — 11 R1 conditionals gated rendering on `'<' in VAR`, suppressing entire sections if a generator returned valid plain text.

### Commits

1. **`fd62503` — fix(pdf-css): remove break-after:avoid cascade on chapter-banner + glance-box** (M1+M2)
   - `templates/pdf_template_v7.html`: drop `break-after: avoid` on `.chapter-banner` (main + `@media print`) and on `.section .glance-box`
   - `templates/gamechanger_deep_dive_v1.html`: drop `break-after: avoid` on `.chapter-banner` (family consistency, risk-neutral)
   - `templates/strategy_report.html`: drop `break-after: avoid` on `.chapter-banner` (redundant — strategy banners force a page break via the `.page-break` class)

2. **`61be0bf` — fix(sofort-start): remove outer page-break-inside:avoid wrapper around prompts** (M3)
   - `services/sofort_start_generator.py`: drop the outer `<div style="page-break-inside: avoid; break-inside: avoid;">` that grouped H3 + intro + first prompt-box. Each individual prompt-box still has its own `page-break-inside: avoid` (correct, smaller scope).
   - Drops the 3× `close_wrapper = "</div>" if i == 1 else ""` pattern in expert/intermediate/beginner branches.
   - Verified: all 9 permutations (3 expertise_level × 3 company_size) render with balanced `<div>/</div>`.

3. **`2c8e6af` — fix(pdf-template): drop '<' in HTML heuristic that silently swallowed sections** (M4)
   - 11 conditionals in `pdf_template_v7.html` relaxed from `{% if VAR and VAR|trim and '<' in VAR %}` to `{% if VAR and VAR|trim %}`.
   - Net effect: identical for current generators (they all return HTML). Insurance against future regressions.

4. **`8894997` — feat(coverage-guard): warn on empty required render-context keys** (M11)
   - `services/coverage_guard.py`: new `audit_render_context(report_type, ctx, ...)` that emits a single `WARNING` per missing/empty required key. Output unchanged — pure observability.
   - `RENDER_REQUIRED_KEYS` for `r1` (12 keys), `strategy` (9 keys), `kpa` (5 keys).
   - Hooks in all three renderers, directly before `template.render()`. Audit failures are swallowed (debug-logged) — never breaks PDF generation.
   - Existing `tests/test_coverage_guard.py` 10/10 green.

### Content-preservation guarantees

- Pure CSS / Conditional-Logic / Generator-Layout edits.
- No content removed, no fields renamed, no template structure changed beyond CSS rules.
- All generators still emit identical HTML (verified for `sofort_start_generator` × 9 permutations).
- New `audit_render_context` call only logs — never modifies the rendered output.

## Test plan

- [ ] Render R1 PDF (solo / team / kmu × beginner / intermediate / expert) — verify S.5/S.6 prompt-boxes no longer leave >40 % whitespace; S.13 challenge end clean; S.16 AI Act → funding banner without whitespace cascade.
- [ ] Render KPA PDF — verify pixel-stable vs. status quo (KPA was already OK; family-consistency edits must be regression-free).
- [ ] Render Strategy PDF — verify chapter banners still start cleanly on new pages (`.page-break` class still in place).
- [ ] Tail Railway logs during a smoke-test run — confirm no spurious `audit_render_context` WARNINGs (means all required keys are filled in healthy runs).
- [ ] If any generator currently returns empty for a required key, confirm the WARNING surfaces correctly with `report_id`.

## Out of scope (deferred to Sprint B / C)

- M5: KPA body-font 10pt → 11pt (family typography)
- M6: prompt-box monospace 10px → 9pt (readability)
- M7: optional `break-before: page` on `#vendor-section` / `#funding-section`
- M8: Strategy `orphans/widows` 5/5 → 3/3 (family consistency)
- M9: shared `chapter_banner()` macro across R1 + KPA
- M10: archive `.bak` files in `services/`

https://claude.ai/code/session_01Q8pz8oN6sLydrCDo7EDsDH

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q8pz8oN6sLydrCDo7EDsDH)_