### PR TITLE
fix(env): PR 1/4 — remove hardcoded LLM model strings (P0 #1+#2)

### DIFF
--- a/routes/appetizer.py
+++ b/routes/appetizer.py
@@ -99,8 +99,13 @@ class AppetizerRequest(BaseModel):
 def call_claude_sonnet(system_prompt: str, user_prompt: str) -> str:
     """Call Claude Sonnet and return the raw text response."""
     client = anthropic.Anthropic()  # uses ANTHROPIC_API_KEY env var
+    model = (
+        os.getenv("ANTHROPIC_MODEL_APPETIZER")
+        or os.getenv("ANTHROPIC_MODEL")
+        or "claude-sonnet-4-6"
+    )
     message = client.messages.create(
-        model="claude-sonnet-4-20250514",
+        model=model,
         max_tokens=2048,
         system=system_prompt,
         messages=[{"role": "user", "content": user_prompt}],

--- a/services/providers/perplexity.py
+++ b/services/providers/perplexity.py
@@ -5,6 +5,7 @@ import requests
 from typing import List, Dict, Any
 
 PPLX_API_KEY = os.getenv("PPLX_API_KEY", "")
+PPLX_MODEL = os.getenv("PERPLEXITY_MODEL") or os.getenv("PPLX_MODEL") or "sonar-pro"
 
 def perplexity_search(queries: List[str], max_items: int = 8) -> List[Dict[str, Any]]:
     if not PPLX_API_KEY:
@@ -13,7 +14,7 @@ def perplexity_search(queries: List[str], max_items: int = 8) -> List[Dict[str, 
     results: List[Dict[str, Any]] = []
     for q in queries:
         payload = {
-            "model": "sonar-small-online",
+            "model": PPLX_MODEL,
             "messages": [{"role": "system", "content": "Return 5 concise links with single-sentence summaries."},
                          {"role": "user", "content": q}],
             "return_images": False,


### PR DESCRIPTION
## Sprint: ENV-Audit Implementation — PR 1 of 4

Addresses **P0-Findings 1 + 2** from the ENV audit (2026-05-15).

### Changes

**1. `routes/appetizer.py:103`** — hardcoded `claude-sonnet-4-20250514` ignored Railway ENV.
Replaced with the established lookup pattern:
```python
model = (
    os.getenv("ANTHROPIC_MODEL_APPETIZER")
    or os.getenv("ANTHROPIC_MODEL")
    or "claude-sonnet-4-6"
)
```

**2. `services/providers/perplexity.py:16`** — hardcoded `sonar-small-online` (retired model).
Aligned with the pattern already used by the sibling `services/provider_perplexity.py`:
```python
PPLX_MODEL = os.getenv("PERPLEXITY_MODEL") or os.getenv("PPLX_MODEL") or "sonar-pro"
```

### Heals a silent production bug (not just hygiene)

The `sonar-small-online` model in `services/providers/perplexity.py` has been **retired by Perplexity since early 2025**. The call site `requests.post(...)` therefore returned HTTP 400 on every invocation, and the surrounding `if not resp.ok: continue` swallowed the error silently. As a result, `services/research_fetcher.py:59` — the only caller of `perplexity_search()` — has been returning **empty result lists** through this path for months without any log signal. This patch restores actual Perplexity search results to that path by routing through the same `PERPLEXITY_MODEL` / `PPLX_MODEL` ENVs the sibling module already uses (defaulting to `sonar-pro`, which is what Railway already has set).

Note for follow-up (not this PR): `research_fetcher.py` evidently has a redundant/alternative data source, since the broken path has not caused user-visible regressions. Worth a P2 look later to confirm the redundancy is intentional.

### Diagnose-Notes

- Both `services/providers/perplexity.py` (used by `services/research_fetcher.py`) and
  `services/provider_perplexity.py` (used by `live_research.py`, `research_pipeline.py`, `routes/dashboard.py`,
  several tests) are **live**. Not deleting either; patched the duplicate to use the same ENV vars.
- ENV var names (`PERPLEXITY_MODEL` / `PPLX_MODEL`) match what `provider_perplexity.py` already reads.
  Railway-Check (Wolf): `PERPLEXITY_MODEL=sonar-pro` already set; `ANTHROPIC_MODEL_APPETIZER` intentionally
  unset → falls back to global `ANTHROPIC_MODEL` (Sonnet 4.6). **No Railway change needed.**

### Validation

- [x] `grep -rn 'claude-sonnet-4-2025' routes/ services/` → only `chat_conversation.py` + `chat_extractor.py`
      defaults remain (P1 findings #5/#6, handled in PR 4).
- [x] `grep -rn 'sonar-small-online' routes/ services/` → empty.
- [x] `python -m py_compile routes/appetizer.py services/providers/perplexity.py` → both OK.
- [x] CI green (12 success, 1 skipped E2E).

### Out of scope (next PRs)

- PR 2: wire `OPENAI_REASONING_EFFORT` + Anthropic `output_config={"effort": ...}`.
- PR 3: `OPUS_SECTIONS` allowlist consistency + startup logging.
- PR 4: stale defaults in `chat_conversation.py` / `chat_extractor.py`, hardcoded temperatures,
  `OPENAI_TIMEOUT*` consolidation, real `OPENAI_MODEL_FALLBACK` retry path.
