### PR TITLE
chore(deps): tighten anthropic SDK pin to >=0.78,<1.0 (pre-PR-2 gate)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,6 +52,10 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
           if [ -f requirements-test.txt ]; then pip install -r requirements-test.txt; fi
+      - name: Show resolved SDK versions (anthropic, openai)
+        run: |
+          pip show anthropic | grep -E '^(Name|Version):'
+          pip show openai    | grep -E '^(Name|Version):'
       - name: Run unit tests (ignore E2E file)
         env:
           JWT_SECRET: ${{ secrets.JWT_SECRET || 'ci-test-secret-not-for-production' }}

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,7 +26,7 @@ resend>=2.0,<3.0
 
 # --- Optional: LLM / Research clients ---
 openai>=1.51,<2.0
-anthropic>=0.25,<1.0
+anthropic>=0.78,<1.0
 tavily-python>=0.3,<0.4
 beautifulsoup4>=4.11,<5.0
 markdownify>=0.11,<1.0


### PR DESCRIPTION
## Sprint: ENV-Audit Implementation — SDK Pre-PR (gates PR 2)

Pre-flight gate for [PR #1018 (PR 2/4)](https://github.com/Wolf-Achtung/api-ki-backend-neu/pull/1018). Without this pin, PR 2's Anthropic effort wiring (`output_config={"effort": ...}`) would risk 400 errors against a pre-Claude-4 SDK.

### Changes

**1. `requirements.txt`** — `anthropic>=0.25,<1.0` → `anthropic>=0.78,<1.0`

- `v0.78` of the anthropic Python SDK is the first version with both the **`output_config` parameter** required for effort routing AND full **Claude Opus 4.6** support.
- `v0.75` would be the strict minimum for `output_config["effort"]`, but pinning to `0.78` guarantees the full Claude-4-generation surface area the rest of the codebase relies on.
- The old pin (`>=0.25,<1.0`) silently allowed pre-Claude-4 versions (e.g. `0.25.x` from mid-2024) that lack `output_config` entirely → would have caused **400 errors on every Anthropic call** once PR 2 lands.

Source for SDK feature timeline:
https://github.com/anthropics/anthropic-sdk-python/blob/main/CHANGELOG.md

**2. `.github/workflows/test.yml`** — print resolved SDK versions

Added a small step right after `pip install -r requirements.txt` in the unit-tests job:

```yaml
- name: Show resolved SDK versions (anthropic, openai)
  run: |
    pip show anthropic | grep -E '^(Name|Version):'
    pip show openai    | grep -E '^(Name|Version):'
```

Makes the actually-resolved version visible in every CI run's logs without needing a Railway shell session. The mypy and e2e jobs already install requirements but their logs are noisier — keeping this step scoped to the unit-tests job to avoid log churn.

### Not done (worth a follow-up sprint)

- **No lockfile** yet (`requirements.lock` / pip-tools / `pip freeze`). Without one, every fresh Railway build resolves to the latest PyPI version matching the pin — reproducible *enough* with the tighter pin, but not bit-exact. Proper lockfile generation is a small but separate sprint (needs CI integration, a lock-update workflow, and a doc note for contributors).
- No SDK upgrade beyond what the pin requires; if the project wants to commit to a specific minor (e.g. exactly `0.78.x`), that's a one-character edit.

### Validation

- [x] `grep -n anthropic requirements.txt` → `anthropic>=0.78,<1.0` (single line).
- [x] `git diff` confined to the two intended files; no collateral edits.
- [ ] CI green (lets the new `Show resolved SDK versions` step prove which version resolves on the runner).

### Merge plan

After this merges:
1. Rebase [PR #1018](https://github.com/Wolf-Achtung/api-ki-backend-neu/pull/1018) on the new `main`.
2. PR #1018 merges normally.
3. Wolf deploys to Railway and runs the live smoke.
4. After live smoke confirms a clean Anthropic + OpenAI call, PR 3 (`OPUS_SECTIONS` startup mapping log) starts.


---
_Generated by [Claude Code](https://claude.ai/code/session_015ff12N9zfwNvMgz4fTZZLY)_