### PR TITLE
fix(env): temperature-Gating für Reasoning- + Effort-Modelle (P0 hotfix)

### DIFF
--- a/gpt_analyze.py
+++ b/gpt_analyze.py
@@ -2302,13 +2302,16 @@ def _call_openai(
         log.debug("OpenAI request headers: %s", safe_headers)
 
         # Payload base: model, messages, temperature
+        # Reasoning models (gpt-5.x, o1/o3/o4) reject the temperature parameter
+        # with HTTP 400; only ship it for models that accept it.
+        from services.llm_client import maybe_openai_temperature
         payload = {
             "model": model,
             "messages": [
                 {"role": "system", "content": system_prompt},
                 {"role": "user", "content": prompt},
             ],
-            "temperature": float(temperature),
+            **maybe_openai_temperature(model, temperature),
         }
 
         # v14.35.22: Set correct token limit parameter based on model

--- a/services/anthropic_client.py
+++ b/services/anthropic_client.py
@@ -60,11 +60,15 @@ def build_anthropic_create_kwargs(
     stop_sequences: Optional[List[str]] = None,
 ) -> dict:
     """Assemble kwargs for client.messages.create(), including conditional
-    output_config={"effort": ...} for models that support it."""
+    output_config={"effort": ...} for models that support it.
+
+    Effort-capable models (Opus 4.6/4.7, Sonnet 4.6) reject ``temperature``
+    with 400 ("temperature is deprecated for this model") — for those we
+    omit the parameter and let the provider use its default.
+    """
     kwargs: dict = {
         "model": model,
         "max_tokens": max_tokens,
-        "temperature": temperature,
         "system": system,
         "messages": messages,
     }
@@ -72,6 +76,8 @@ def build_anthropic_create_kwargs(
         kwargs["stop_sequences"] = stop_sequences
     if _model_supports_effort(model):
         kwargs["output_config"] = {"effort": get_anthropic_effort()}
+    else:
+        kwargs["temperature"] = temperature
     return kwargs
 
 # --- RUN-622 P2: Opus Routing ------------------------------------------------

--- a/services/llm_client.py
+++ b/services/llm_client.py
@@ -292,6 +292,24 @@ def get_reasoning_effort() -> str:
         return os.getenv("OPENAI_REASONING_EFFORT", "high")
 
 
+_OPENAI_REASONING_MODEL_PREFIXES = ("gpt-5", "o1", "o3", "o4")
+
+
+def is_openai_reasoning_model(model: str) -> bool:
+    """gpt-5.x and o-series models only accept the default temperature (1)
+    and reject any explicit temperature value with 400."""
+    m = (model or "").lower()
+    return any(m.startswith(p) for p in _OPENAI_REASONING_MODEL_PREFIXES)
+
+
+def maybe_openai_temperature(model: str, value: float) -> dict:
+    """Return ``{"temperature": value}`` only when the model accepts it.
+    Reasoning models (gpt-5.x, o1/o3/o4) reject the parameter outright."""
+    if is_openai_reasoning_model(model):
+        return {}
+    return {"temperature": float(value)}
+
+
 # =============================================================================
 # STABILITY PATCH v1: OpenAI Call Wrapper with Retry & Semaphore
 # =============================================================================

--- a/services/openai_retry.py
+++ b/services/openai_retry.py
@@ -519,13 +519,15 @@ def openai_request_simple(
 
     base = api_base or os.getenv("OPENAI_API_BASE", "https://api.openai.com")
 
+    # Reasoning models (gpt-5.x, o-series) reject temperature with 400.
+    from services.llm_client import maybe_openai_temperature
     payload = {
         "model": model,
         "messages": [
             {"role": "system", "content": system_prompt},
             {"role": "user", "content": prompt},
         ],
-        "temperature": temperature,
+        **maybe_openai_temperature(model, temperature),
     }
 
     # Set token parameter based on model

--- a/services/strategy_pipeline.py
+++ b/services/strategy_pipeline.py
@@ -759,14 +759,15 @@ async def _call_openai(prompt: str, system_prompt: str, section: str, max_tokens
 
         client = openai.OpenAI(api_key=api_key, timeout=180.0)
 
+        from services.llm_client import maybe_openai_temperature
         create_kwargs: Dict[str, Any] = {
             "model": model,
             "messages": [
                 {"role": "system", "content": system_prompt},
                 {"role": "user", "content": prompt},
             ],
-            "temperature": 0.3,
             "max_completion_tokens": max_tokens,
+            **maybe_openai_temperature(model, 0.3),
         }
         _m = model.lower()
         if any(_m.startswith(p) for p in ("gpt-5", "o1", "o3", "o4")):


### PR DESCRIPTION
## Summary

Hotfix für die rote Live-Smoke nach PR #1018-Deploy (Briefing 1067 hat die Pipeline gerissen). PR 2 selbst war sauber — Root Cause ist ein latenter Bug, der durch `OPENAI_MODEL=gpt-5.5-2026-04-23` und Opus-4-7-Sections aktiv geworden ist:

- **OpenAI** (gpt-5.x, o1/o3/o4): `400 Bad Request — temperature does not support X with this model. Only the default (1) value is supported`
- **Anthropic** (Opus 4.6/4.7, Sonnet 4.6): `400 Bad Request — temperature is deprecated for this model`

Pipeline-Killer war der `KI_STACK_SUMMARY_HTML`-Strict-Regen mit hardcoded `temperature=0.5` (fail-closed, 2 attempts → `RuntimeError` → Briefing abort).

## Changes

**Neuer Helper** in `services/llm_client.py`:

- `is_openai_reasoning_model(model)` — prefix-based check (`gpt-5`, `o1`, `o3`, `o4`)
- `maybe_openai_temperature(model, value)` — gibt `{"temperature": value}` zurück, nur wenn das Modell sie akzeptiert; sonst `{}`. Greift automatisch auch für `OPENAI_MODEL_FALLBACK="gpt-5.4-mini-…"`.

**OpenAI-Call-Sites** auf Helper umgestellt (analog `_maybe_reasoning_effort` aus PR #1018):

- `gpt_analyze.py:_call_openai` — entfernt das unkonditionale `"temperature": float(temperature)` aus dem Payload. Deckt damit automatisch alle Helpers ab, die durch diese Funktion laufen: `_repair_html` (`temperature=0.0`), N4.6-Regen, `_expand_short_section` (`0.4`), one_liner (`0.1`), roadmap_12m-Regen (`0.4`) und vor allem die drei hardcoded `temperature=0.5` Strict-Regen-Pfade (ROADMAP_90D, **KI_STACK_SUMMARY** ← Pipeline-Killer, GAMECHANGER).
- `services/strategy_pipeline.py:_call_openai` — ersetzt hardcoded `"temperature": 0.3`.
- `services/openai_retry.py:openai_request_simple` — bedient `services/html_contract.py:_attempt_llm_repair` und `services/news_researcher.py`.
- `services/gamechanger_deep_dive.py` — bereits korrekt gegated über `_is_new_model`-Check; unverändert.

**Anthropic-Seite** — `build_anthropic_create_kwargs` in `services/anthropic_client.py` erweitert:

- Effort-fähige Modelle (`opus-4-6`, `opus-4-7`, `sonnet-4-6`, gleicher Marker wie für `output_config`): `temperature` wird **weggelassen** → Provider-Default.
- Alle anderen (Haiku 4.5, Sonnet 4.5, ältere): `temperature` wird wie bisher gesetzt → `ANTHROPIC_TEMPERATURE` bleibt für diese Modelle wirksam.
- `routes/appetizer.py` nutzt den Helper schon aus PR #1018 — Anpassung wirkt dort transparent.

## Verification

`py_compile` über alle geänderten Files. Lokale Smoke-Tests:

```
OK  maybe_openai_temperature('gpt-5.5-2026-04-23', 0.25) -> {}
OK  maybe_openai_temperature('gpt-4o', 0.25)             -> {'temperature': 0.25}
OK  maybe_openai_temperature('o3-mini', 0.25)            -> {}
OK  maybe_openai_temperature('gpt-5.4-mini-2026-03-17', 0.25) -> {}    # FALLBACK
OK  maybe_openai_temperature('o1-preview', 0.0)          -> {}
OK  maybe_openai_temperature('o4-mini', 0.7)             -> {}

OK  build_anthropic_create_kwargs('claude-opus-4-7',           …) → KEIN temperature, output_config gesetzt
OK  build_anthropic_create_kwargs('claude-opus-4-6',           …) → KEIN temperature, output_config gesetzt
OK  build_anthropic_create_kwargs('claude-sonnet-4-6',         …) → KEIN temperature, output_config gesetzt
OK  build_anthropic_create_kwargs('claude-haiku-4-5-20251001', …) → temperature wie bisher
OK  build_anthropic_create_kwargs('claude-sonnet-4-5-20250929',…) → temperature wie bisher
```

## Test plan (Live-Smoke nach Deploy)

- [ ] Test-Briefing auf make.ki-sicherheit.jetzt durchläuft komplett
- [ ] Keine 400er von `api.openai.com` mit "temperature"-Message in den Railway-Logs
- [ ] Keine 400er von `api.anthropic.com` mit "temperature deprecated"
- [ ] Keine `[FIX-511][SG-REGEN][FAIL] section=KI_STACK_SUMMARY_HTML`-Fehler
- [ ] Keine Häufung von `LLM content too short → using PLATIN fallback` für Sections, die vorher betroffen waren (`prompt_framework`, `score_interpretation`, `branch_deep_dive`, `advisor_note`)
- [ ] Status-Seite zeigt fertigen Report mit PDF-Link

## Nicht im Scope

Siehe P2/P3-Findings aus dem Sprint-Briefing (`DEBUG_LOG_PROMPTS`, `PROMPT_TUNER_ENABLED`, `ANTHROPIC_MODEL` vs `ANTHROPIC_MODEL_DEFAULT`, OPUS_SECTIONS-Visibility = PR 3, strategy-pipeline Section-Naming, ki_stack_summary_strict Graceful-Degradation).

Bonus (Wolf, Railway-UI): `ANTHROPIC_SECTIONS` um `advisor_note` ergänzen.

https://claude.ai/code/session_015hm3nCi7R6xYJyTszdACGL

---
_Generated by [Claude Code](https://claude.ai/code/session_015hm3nCi7R6xYJyTszdACGL)_