### PR TITLE
Fix: KPA Observability — Logging + Failsafe in _auto_trigger_potenzialanalyse

### DIFF
--- a/gpt_analyze.py
+++ b/gpt_analyze.py
@@ -21435,19 +21435,69 @@ def _auto_trigger_potenzialanalyse(briefing_id: int, run_id: str) -> None:
 
     Generates the Deep Dive HTML, renders PDF, and sends via email.
     Runs in a background thread so Report 1 pipeline is never blocked.
+
+    Observability: emits [KPA-{id}] START / SUCCESS / FAIL log markers and,
+    on FAIL, dispatches an admin-mail notice via the existing Resend helper.
+    No segment gate, no retry. Strategy-Mail is sent before this trigger and
+    remains unaffected by any KPA failure.
     """
     import threading
 
-    def _run(bid: int, rid: str) -> None:
-        _tag = f"AUTO-POTENZIALANALYSE-{bid}"
+    def _send_kpa_fail_admin_notice(bid: int, reason: str) -> None:
+        # Best-effort admin notification. Must never raise.
         try:
-            log.info("[%s] Triggering for briefing_id=%d run=%s", _tag, bid, rid)
+            if os.getenv("DISABLE_EMAILS", "").lower() in ("1", "true", "yes", "on"):
+                return
+            if os.getenv("ENABLE_ADMIN_NOTIFY", "1") not in ("1", "true", "TRUE", "yes", "YES"):
+                return
+            segment = "unknown"
+            try:
+                _db = core_db.SessionLocal()
+                try:
+                    _br = _db.get(Briefing, bid)
+                    if _br is not None:
+                        _answers = getattr(_br, "answers", {}) or {}
+                        segment = str(_answers.get("unternehmensgroesse") or "unknown")
+                finally:
+                    _db.close()
+            except Exception:
+                pass
+            subject = f"KPA-Generierung fehlgeschlagen – Briefing #{bid}"
+            body = (
+                "<p><strong>KI-Potenzial-Analyse konnte nicht erzeugt werden.</strong></p>"
+                f"<ul><li>briefing_id: {bid}</li>"
+                f"<li>segment: {segment}</li>"
+                f"<li>reason: {reason}</li></ul>"
+                "<p>Der KI-Status-Report (Strategy-Mail) wurde regulär versendet."
+                " Es wurde KEIN zweiter User-Mail-Versand ausgelöst.</p>"
+            )
+            for addr in _admin_recipients():
+                try:
+                    time.sleep(0.6)  # Resend Rate Limit: max 2 req/sec
+                    _send_email_via_resend(addr, subject, body, attachments=None)
+                except Exception:
+                    continue
+        except Exception:
+            return
 
+    def _run(bid: int, rid: str) -> None:
+        _tag = f"KPA-{bid}"
+        log.info("[%s] START briefing_id=%d run=%s", _tag, bid, rid)
+        try:
             from services.gamechanger_deep_dive import generate_gamechanger_report
-            result = generate_gamechanger_report(bid)
-            html = result.get("html", "")
+            try:
+                result = generate_gamechanger_report(bid)
+            except Exception as gen_exc:
+                reason = f"generate_exception:{type(gen_exc).__name__}:{str(gen_exc)[:200]}"
+                log.error("[%s] FAIL reason=%s", _tag, reason, exc_info=True)
+                _send_kpa_fail_admin_notice(bid, reason)
+                return
+
+            html = (result or {}).get("html", "")
             if not html:
-                log.warning("[%s] Empty HTML, skipping PDF+email", _tag)
+                reason = "empty_html"
+                log.error("[%s] FAIL reason=%s", _tag, reason)
+                _send_kpa_fail_admin_notice(bid, reason)
                 return
 
             from services.pdf_client import render_pdf_from_html
@@ -21463,20 +21513,33 @@ def _auto_trigger_potenzialanalyse(briefing_id: int, run_id: str) -> None:
                 pdf_options=pdf_options,
             )
 
-            pdf_bytes = pdf_result.get("pdf_bytes")
+            pdf_bytes = (pdf_result or {}).get("pdf_bytes")
             if not pdf_bytes:
-                log.warning("[%s] PDF render failed: %s", _tag, pdf_result.get("error"))
+                err = (pdf_result or {}).get("error", "unknown")
+                reason = f"pdf_render_failed:{str(err)[:200]}"
+                log.error("[%s] FAIL reason=%s", _tag, reason)
+                _send_kpa_fail_admin_notice(bid, reason)
                 return
 
             log.info("[%s] PDF generated: %d bytes", _tag, len(pdf_bytes))
 
-            # Send email using existing helper from routes/report.py
             from routes.report import _send_deep_dive_email
-            _send_deep_dive_email(bid, pdf_bytes)
+            try:
+                _send_deep_dive_email(bid, pdf_bytes)
+            except Exception as mail_exc:
+                reason = f"send_mail_exception:{type(mail_exc).__name__}:{str(mail_exc)[:200]}"
+                log.error("[%s] FAIL reason=%s", _tag, reason, exc_info=True)
+                _send_kpa_fail_admin_notice(bid, reason)
+                return
 
-            log.info("[%s] ✅ Complete for briefing_id=%d", _tag, bid)
+            log.info("[%s] SUCCESS pdf_bytes=%d email_sent=true", _tag, len(pdf_bytes))
         except Exception as exc:
-            log.error("[%s] ❌ Failed: %s", _tag, exc, exc_info=True)
+            reason = f"unexpected_exception:{type(exc).__name__}:{str(exc)[:200]}"
+            log.error("[%s] FAIL reason=%s", _tag, reason, exc_info=True)
+            try:
+                _send_kpa_fail_admin_notice(bid, reason)
+            except Exception:
+                pass
             # Never propagate — Report 1 must not be affected
 
     thread = threading.Thread(target=_run, args=(briefing_id, run_id), daemon=True)


### PR DESCRIPTION
## Befund (Diagnose vor Implementation)

Die ursprüngliche Briefing-Hypothese ("Refactor hat KPA-Trigger entfernt") wurde durch die Forensik **widerlegt**:

- **A1 (KPA fehlt bei KIS-1155 / Solo):** `_auto_trigger_potenzialanalyse()` existiert in `gpt_analyze.py:21432` und wird **unconditional** für alle Segmente aufgerufen (Zeilen 21619 und 21755). Im gesamten Fenster 2026-03-30 bis 2026-05-16 gibt es **keinen Commit**, der diesen Trigger entfernt hätte (`git log -S "gamechanger_deep_dive"` im Window: nur ein unrelated Chat-Validation-Commit). Es gibt **kein Segment-Gate** und **kein ENV-Flag** (`ENABLE_KPA`/`ENABLE_GAMECHANGER_DEEP_DIVE`/`KPA_ENABLED` existieren nicht). Der Bug ist eine **Observability-Lücke**: der Empty-HTML-Pfad bei Zeile 21450 hat ein silent `return` gemacht, ohne Admin-Mail-Notice und ohne strukturierten FAIL-Marker.

- **A2 ("KI-gestützter Wettbewerbsvorteil"-Section im Strategy-PDF):** Section `s_moat` wurde in **Commit 40ad638 (2026-04-19, PR #952, KIS-1160)** regulär als Strategy-Section eingeführt — nicht versehentlich aus der KPA verrutscht. Sie existiert in KIS-1083 nicht (vor diesem Commit) und in KIS-1155 schon (nach). **Out of scope für diesen PR** (eigene Sprint-Entscheidung nötig: Code-Gate für Solo vs. Prompt-Härtung vs. Keep-as-is).

## Ursache des KIS-1155-Symptoms

KPA-Trigger feuert für Solo, der Daemon-Thread crasht oder bekommt leeres HTML aus `generate_gamechanger_report(bid)` zurück, der bisherige Code bricht silent ab (`if not html: return` als `log.warning`, keine Eskalation). Folge: keine KPA-PDF, keine KPA-Mail, keine Spur in der Admin-Mailbox.

## Fix A1 — V1: Observability + Failsafe

**Geänderte Datei:** `gpt_analyze.py` (nur diese eine Datei, +75 / -12)
**Geänderte Funktion:** `_auto_trigger_potenzialanalyse()` (Zeilen 21432–21547)

Eingebaut:
- `[KPA-{id}] START` am Funktionsanfang
- `[KPA-{id}] SUCCESS pdf_bytes=N email_sent=true` nach erfolgreichem Mail-Versand
- `[KPA-{id}] FAIL reason=<konkret>` in **fünf** Failure-Pfaden:
  - `empty_html` (löst den Silent-Return ab, der KIS-1155 versteckt hat)
  - `generate_exception:{Type}:{msg}`
  - `pdf_render_failed:{err}`
  - `send_mail_exception:{Type}:{msg}`
  - `unexpected_exception:{Type}:{msg}` (Outer-Catch als Sicherheitsnetz)
- Try/Except um `generate_gamechanger_report()` und `_send_deep_dive_email()`
- Admin-Mail-Notice bei jedem FAIL via existierendem `_send_email_via_resend` + `_admin_recipients()` — kein neuer Mail-Pfad, kein neues Template. Nutzt bestehende Flags `DISABLE_EMAILS` und `ENABLE_ADMIN_NOTIFY`. Notice enthält `briefing_id`, `segment` (best-effort aus `briefing.answers["unternehmensgroesse"]`) und `reason`.

## Failure-Mode (verbindlich, §5 des Briefings)

- Strategy-Mail wird **vor** dem KPA-Trigger versendet (`_send_emails` bei Zeile 21615) und bleibt unangetastet.
- KPA-Generierung: **1 Versuch, kein Retry**.
- KPA-Fail → strukturierter Log-Marker + Admin-Mail-Notice. **Keine** zweite User-Mail im Fehlerfall.
- KPA-Success → bisheriger User-Mail-Pfad (`_send_deep_dive_email`, unverändert).
- Keine transaktionale Klammer um Strategy+KPA.
- Exceptions propagieren nie aus dem Daemon-Thread heraus.

## Bewusst nicht im Scope

- **Kein Segment-Gate.** KPA bleibt unconditional. Falls Wolf nach dem nächsten Smoke entscheidet, dass KPA für Solo dauerhaft ausgeschlossen werden soll, ist das ein separater PR.
- **Kein Retry-Mechanismus.** Daemon-Thread + leerer LLM-Output ist mit Retry selten zu beheben.
- **Keine Architektur-Änderung.** Daemon-Thread bleibt Daemon-Thread, kein Sync-Refactor.
- **s_moat / "KI-gestützter Wettbewerbsvorteil"** (`services/strategy_pipeline.py`, `prompts/strategy_prompts.py`, `templates/strategy_report.html`) bleibt unangetastet.
- **Keine Änderungen** an `services/llm_client.py` (PR #1020), OPUS_SECTIONS / ANTHROPIC_SECTIONS Routing, `generate_gamechanger_report()` selbst, `_send_deep_dive_email()` selbst, `prompts/`, `templates/`.

## Validation-Checkliste

- [x] `[KPA-{id}] START` Marker am Funktionsanfang
- [x] `[KPA-{id}] SUCCESS` Marker nach erfolgreichem Mail-Versand
- [x] `[KPA-{id}] FAIL` Marker mit `reason=` in allen Failure-Pfaden
- [x] Empty-HTML-Pfad eskaliert jetzt als FAIL (kein Silent-Return mehr)
- [x] Try/Except um `generate_gamechanger_report` und `_send_deep_dive_email`
- [x] Admin-Mail-Notice bei FAIL via existierendem Resend-Helper
- [x] Strategy-Mail-Pfad unverändert
- [x] Keine Segment-Conditional im KPA-Pfad
- [x] Daemon-Thread-Struktur unverändert
- [x] Keine Datei außer `gpt_analyze.py` geändert
- [x] AST + py_compile syntaktisch sauber

## Smoke-Test-Plan (nach Merge, Wolf führt aus)

**Test 1 — Solo-Briefing:** Erwartung in Logs
- `[STRATEGY-MAIL-…]` ✅
- `[ADMIN-BRIEFING-…]` ✅
- `[KPA-…] START` ✅
- Entweder `[KPA-…] SUCCESS pdf_bytes=… email_sent=true` → KPA-Mail im Postfach
- Oder `[KPA-…] FAIL reason=…` → Admin-Notice im Postfach, Strategy-Mail trotzdem da

Der `reason`-String ist konkret genug, um im nächsten Sprint die Root-Cause direkt zu adressieren (Empty-HTML? Welche Exception? Welcher Subsystem-Fehler?).

**Test 2 — Team/KMU-Briefing (Regression-Check):**
- KPA muss weiterhin durchlaufen (Verhalten wie KIS-1083)
- Strategy-PDF unverändert
- Keine Verschlechterung gegenüber heutigem Verhalten

## Diff-Statistik

```
gpt_analyze.py | 87 ++++++++++++++++++++++++++++++++--
1 file changed, 75 insertions(+), 12 deletions(-)
```


---
_Generated by [Claude Code](https://claude.ai/code/session_01Cg8DEMejzudeuUW8B3TVy3)_