### PR TITLE
fix(coach): drop temperature for Anthropic reasoning models in streaming endpoint

### DIFF
--- a/services/coach_service.py
+++ b/services/coach_service.py
@@ -417,14 +417,28 @@ async def stream_coach_response(
     buffer = ""
     inside_thinking = False
 
+    # FIX-COACH-TEMP: Effort-capable Anthropic models (Opus 4.6/4.7, Sonnet 4.6)
+    # reject temperature with 400 ("temperature is deprecated for this model").
+    # Route streaming kwargs through the same helper used for messages.create
+    # (PR #1018/#1020) so the gating is identical and reasoning_effort is wired.
+    from services.anthropic_client import build_anthropic_create_kwargs
+    stream_kwargs = build_anthropic_create_kwargs(
+        model=COACH_MODEL,
+        max_tokens=COACH_MAX_TOKENS,
+        temperature=COACH_TEMPERATURE,
+        system=system_prompt,
+        messages=messages,
+    )
+    log.info(
+        "[FIX-COACH-TEMP] model=%s max_tokens=%d temperature=%s output_config=%s",
+        COACH_MODEL,
+        COACH_MAX_TOKENS,
+        stream_kwargs.get("temperature", "<dropped>"),
+        stream_kwargs.get("output_config", "<none>"),
+    )
+
     try:
-        async with client.messages.stream(
-            model=COACH_MODEL,
-            max_tokens=COACH_MAX_TOKENS,
-            temperature=COACH_TEMPERATURE,
-            system=system_prompt,
-            messages=messages,
-        ) as stream:
+        async with client.messages.stream(**stream_kwargs) as stream:
             async for text in stream.text_stream:
                 buffer += text
 


### PR DESCRIPTION
## Bug-Reproduktion

Coach-Service hat in Production zwischen **12:42–12:49 UTC heute** 27× HTTP 400 von Anthropic erhalten, jeweils nach `POST /api/coach/init` + `/api/coach/message`. Fehler-Body:

```
`temperature` is deprecated for this model.
```

Frontend zeigt dadurch generisches `[Fehler beim Laden der Coach-Antwort]`, Coach-UI komplett unbenutzbar.

## Root-Cause

`services/coach_service.py:421` rief `client.messages.stream(...)` mit `temperature=COACH_TEMPERATURE` (0.4) auf — bei effort-fähigen Anthropic-Modellen (Opus 4.6/4.7, Sonnet 4.6) lehnt Anthropic den Parameter mit 400 ab. Production hat `ANTHROPIC_MODEL_COACH=claude-opus-4-7` gesetzt.

PR #1018 hat dieses Gating für **non-streaming** Calls via `build_anthropic_create_kwargs()` (services/anthropic_client.py) eingeführt — der Coach-Streaming-Pfad hat den Helper bisher umgangen.

## Diagnose-Tabelle

| Frage | Antwort | Evidenz |
|---|---|---|
| Temperature in `coach_service.py:421`? | `temperature=COACH_TEMPERATURE` (default `0.4`) | `coach_service.py:424` (pre-fix) |
| Greift `build_anthropic_create_kwargs` auf Streaming? | Ja — Anthropic SDK akzeptiert dieselben kwargs für `messages.stream()` wie `messages.create()` | `services/anthropic_client.py:53–81` |
| Welches Modell triggert? | `COACH_MODEL = ANTHROPIC_MODEL_COACH \|\| ANTHROPIC_MODEL_OPUS` (Production: `claude-opus-4-7`) | `coach_service.py:59–61` |
| Effort-Gating für claude-opus-4-7 vorhanden? | Ja, `_EFFORT_MODEL_MARKERS = ("opus-4-6", "opus-4-7", "sonnet-4-6")` | `anthropic_client.py:39` |
| Weitere ungetatete Stream-/Create-Calls? | `chat_conversation.py:1859` (stream) und `chat_extractor.py:545, 903` (create) — **alle ohne `temperature`-Arg**, daher nicht betroffen | grep + visuelle Inspektion |

## Implementierungswahl

**Option A — Helper-Wiederverwendung** statt Inline-Gating: identisches Verhalten zu PR #1018/#1020, DRY, kein Drift-Risiko zwischen create- und stream-Codepfad. Der Helper droppt `temperature` für effort-fähige Modelle und ergänzt automatisch `output_config={"effort": …}`.

## Geänderte Stelle

`services/coach_service.py:420–438` (vorher 421–427)

```python
from services.anthropic_client import build_anthropic_create_kwargs
stream_kwargs = build_anthropic_create_kwargs(
    model=COACH_MODEL,
    max_tokens=COACH_MAX_TOKENS,
    temperature=COACH_TEMPERATURE,
    system=system_prompt,
    messages=messages,
)
log.info(
    "[FIX-COACH-TEMP] model=%s max_tokens=%d temperature=%s output_config=%s",
    COACH_MODEL, COACH_MAX_TOKENS,
    stream_kwargs.get("temperature", "<dropped>"),
    stream_kwargs.get("output_config", "<none>"),
)
async with client.messages.stream(**stream_kwargs) as stream:
```

Marker `[FIX-COACH-TEMP]` loggt model, max_tokens und Gating-Effekt (temperature dropped? output_config gesetzt?) — **ohne** Prompt-Content zu leaken.

## Validierungsschritte (Production-Smoke)

1. Nach Deploy: neues Test-Briefing absenden
2. Aus zugestellter R1-/KPA-/Strategy-Mail Coach-Link klicken
3. Test-Message an Coach senden
4. Erwartet:
   - Coach antwortet erfolgreich (Streaming kommt durch)
   - Keine HTTP 400 in Logs
   - Log-Marker `[FIX-COACH-TEMP] model=claude-opus-4-7 … temperature=<dropped> output_config={'effort': 'high'}` erscheint

## Was nicht in diesem Sprint
- Frontend-Error-Handling (generisches `[Fehler beim Laden…]` → spezifischere Message)
- Coach-CTA-Dramaturgie (separate vierte Mail) — Sprint B
- Display-ID vs. DB-ID Verwechslungsgefahr (Coach-URL nutzt DB-ID, Mail-Subject Display-ID) — eigener UX-Sprint

## Erinnerung an gestern festgestellten Befund
Der ursprünglich vermutete Coach-URL-Bug (Mail zu KIS-1185 → /coach/1068) ist **kein Bug**: KIS-1185 ist die Display-ID, 1068 die DB-ID. `REPORT_DISPLAY_OFFSET=117`. Routing korrekt, kein Code-Change nötig. Branch wurde von `claude/fix-coach-url-briefing-id` umbenannt zu `claude/fix-coach-anthropic-temperature`.

https://claude.ai/code/session_01UWV1XBaNB39jy3VQRMiT9X

---
_Generated by [Claude Code](https://claude.ai/code/session_01UWV1XBaNB39jy3VQRMiT9X)_