### PR TITLE
fix(r1): 30-day-challenge content honors expertise_level steering (solo branch)

### DIFF
--- a/gpt_analyze.py
+++ b/gpt_analyze.py
@@ -15279,6 +15279,20 @@ Gib NUR das angeforderte HTML-Fragment aus - keine Fragen, keine Hilfsangebote, 
     sections["expertise_label"] = _expertise_label
     log.info("[%s] [KIS-1132] Expertise level: %s (%s)", run_id, _expertise_level, _expertise_label)
 
+    # [FIX-CHALLENGE-EXPERTISE] expose normalized segment so the 30-day-challenge
+    # steering hint can branch on solo vs team/kmu — solo keeps week 1 (P6-C
+    # exemption in sofort_start_generator), so the "Einstiegs-Woche entfällt"
+    # phrasing must not be shown to solo users.
+    try:
+        from services.company_size_normalizer import get_segment as _get_segment
+        sections["company_size"] = _get_segment(str(answers.get("unternehmensgroesse", "") or ""))
+    except Exception:
+        sections["company_size"] = "team"
+    log.info(
+        "[%s] [FIX-CHALLENGE-EXPERTISE] company_size=%s expertise_level=%s",
+        run_id, sections["company_size"], _expertise_level,
+    )
+
     # === PAGE 4 CONTEXT CARDS - User Input Variables for Template ===
     # These variables are needed for the Page 4 emoji-cards and Guardrails box
     # Template uses lowercase keys with {% if variable %} conditionals

--- a/templates/pdf_template_v7.html
+++ b/templates/pdf_template_v7.html
@@ -1473,8 +1473,16 @@ h1, h2, h3, h4 {
        oder Governance allein macht niemanden zum Workflow-Profi) und
        spiegelt das Rendering korrekt wider (Woche 1 wird für Intermediate/
        Expert tatsächlich aus der Challenge entfernt, nicht nur empfohlen). #}
+    {# [FIX-CHALLENGE-EXPERTISE] Solo bleibt von P3 (Woche-1-Drop) unberührt:
+       Solo+Intermediate/Expert verlieren nach P6-C ({woche_3, woche_4}-Drop)
+       so viele Wochen, dass Woche 1 erhalten bleiben muss. Der Hinweis muss
+       das widerspiegeln, sonst widerspricht er dem gerenderten Inhalt. #}
+    {% elif expertise_level == "expert" and company_size == "solo" %}
+    <div class="skip-hint"><strong>Für Ihr Kompetenzniveau (fortgeschritten):</strong> Die 30-Tage-Challenge ist auf Solo-Berater zugeschnitten und fokussiert auf Werkzeugkasten-Optimierung und Spielregeln in 3 Wochen. Fokussieren Sie auf: Quick Wins, Vendor-Audit und KI-Potenzial-Analyse.</div>
     {% elif expertise_level == "expert" %}
     <div class="skip-hint"><strong>Für Ihr Kompetenzniveau (fortgeschritten):</strong> Die 30-Tage-Challenge startet direkt mit Stack-Optimierung und Governance — die Einstiegs-Woche entfällt. Fokussieren Sie auf: Quick Wins, Vendor-Audit und KI-Potenzial-Analyse.</div>
+    {% elif expertise_level == "intermediate" and company_size == "solo" %}
+    <div class="skip-hint"><strong>Für Ihr Kompetenzniveau (erfahren):</strong> Die 30-Tage-Challenge ist auf Solo-Berater zugeschnitten und kombiniert Workflow-Analyse mit Automatisierung in 3 Wochen. Fokussieren Sie auf: Quick Wins, 90-Tage-Roadmap und Business Case.</div>
     {% elif expertise_level == "intermediate" %}
     <div class="skip-hint"><strong>Für Ihr Kompetenzniveau (erfahren):</strong> Die 30-Tage-Challenge überspringt die Grundlagen-Woche und startet mit Workflow-Integration. Fokussieren Sie auf: Quick Wins, 90-Tage-Roadmap und Business Case.</div>
     {% endif %}


### PR DESCRIPTION
## Bug C2 — KIS-1185 / Briefing 1068

Solo + Expert (`ki_kompetenz=hoch`, Hauptleistung enthält „Beratung" → expertise_level=expert) sieht in R1-PDF einen Widerspruch zwischen Management-Summary-Hint und Challenge-Content:

- **Seite 3 (Hint):** „Die 30-Tage-Challenge startet direkt mit Systemlandschaft-Optimierung und Spielregeln — die Einstiegs-Woche entfällt."
- **Seite 13 (Content):** Woche 1 = „Werkzeugkasten-Prüfung" (= Stack-Audit nach Solo-Final-Pass-Rename), Woche 2 = „Spielregeln", Woche 3 = „Abschluss".

## Root Cause

`services/sofort_start_generator.py:2783` exemptiert Solo bewusst vom P3-Drop-First-Week (KIS-1142 P6-C — sonst degeneriert Solo+Expert nach `{woche_3, woche_4}`-Drop auf eine einzige Governance-Woche). Der Template-Hint in `templates/pdf_template_v7.html:1477` ignorierte diese Ausnahme und sprach für ALLE Expert-Briefings von „Einstiegs-Woche entfällt".

Generator-Code wusste Bescheid (Inline-Comment Z.2777–2781), Template nicht.

## Diagnose-Tabelle

| Stelle | Vor Fix | Nach Fix |
|---|---|---|
| `pdf_template_v7.html:1477` | Hint für alle Expert | Hint solo-aware: Solo bekommt „auf Solo-Berater zugeschnitten ... in 3 Wochen" |
| `pdf_template_v7.html:1479` | Hint für alle Intermediate | Hint solo-aware (analog) |
| `gpt_analyze.py:15278ff` | `expertise_level` exposed | Zusätzlich `company_size` (canonical solo\|team\|kmu via `get_segment`) exposed |
| `sofort_start_generator.py:2789` | unchanged | unchanged — „in 3 Wochen" passt zu Solo+Expert (woche_1, woche_2, abschluss labeled „Woche 3") |

## Implementierungswahl
Variante X (vom Briefing empfohlen): Template-Hint und Subtitle company_size-aware machen. Subtitle blieb unverändert da Solo+Expert tatsächlich 3 user-sichtbare Wochen rendert. Minimalinvasiv: 1 neue sections-Zuweisung in `gpt_analyze.py`, 2 zusätzliche Jinja-Branches im Template.

## Geänderte Zeilen
- `gpt_analyze.py:15282–15295` (+14): `sections["company_size"] = get_segment(answers["unternehmensgroesse"])` + `[FIX-CHALLENGE-EXPERTISE]`-Log-Marker
- `templates/pdf_template_v7.html:1476–1488` (+8): 2 zusätzliche `{% elif ... and company_size == "solo" %}`-Branches

## Validierungsschritte für Production-Smoke
1. Test-Briefing mit Solo + `ki_kompetenz=hoch` + Hauptleistung mit „Beratung" submitten
2. Log: `[FIX-CHALLENGE-EXPERTISE] company_size=solo expertise_level=expert` muss erscheinen
3. R1-PDF S.3: Hint sagt jetzt „auf Solo-Berater zugeschnitten ... in 3 Wochen" (nicht mehr „Einstiegs-Woche entfällt")
4. R1-PDF S.13: Woche 1/2/3 unverändert — Konsistenz mit Hint
5. Gegenprobe mit Team+Expert: alter Hint („Einstiegs-Woche entfällt") greift nach wie vor

## Was bewusst NICHT in diesem Sprint
- C1 Quick-Wins-Render-Bug — separater Sprint (Diagnose-Doku zuerst)
- Refactor des Solo-Final-Pass-Renames (Stack→Werkzeugkasten, Governance→Spielregeln)
- P6-C-Filter selbst (Hint nutzt sich an den Code an, nicht umgekehrt)

https://claude.ai/code/session_01UWV1XBaNB39jy3VQRMiT9X

---
_Generated by [Claude Code](https://claude.ai/code/session_01UWV1XBaNB39jy3VQRMiT9X)_