### PR TITLE
fix(r1): align legacy quick-wins parser+builder to prompt schema + add diagnostic marker

### DIFF
--- a/docs/SPRINT_C1_QUICK_WINS_DIAGNOSE.md
+++ b/docs/SPRINT_C1_QUICK_WINS_DIAGNOSE.md
@@ -1,0 +1,173 @@
+# Sprint C1 — Quick-Wins-Bug: Diagnose + Schema-Fix
+
+**Status:** Diagnose abgeschlossen, trivialer Fix umgesetzt, Diagnose-Marker installiert für Folge-Sprint C1.2
+
+**Auslöser:** R1-PDF zu Briefing 1068 (KIS-1185) zeigt auf Seite 7–8 Quick-Wins mit "Schritt 1./2./3.", leerem "IHR ENGPASS", leerem "Aktuell:", leerem "Mit KI:" und "Zeitersparnis: auf Anfrage" — obwohl der LLM-Output strukturierte JSON liefert.
+
+**Hypothese vor Sprint:** Pipeline-Nullung oder unvollständige LLM-JSON. → **Beides falsch.**
+
+---
+
+## Sektion 1: Diagnose-Befund
+
+### 1.1 Root Cause: Schema-Bruch zwischen Prompt und Legacy-Renderer
+
+Der Quick-Wins-Codepfad hat zwei Renderer:
+
+| Renderer | Position | Erwartetes Schema | Status |
+|---|---|---|---|
+| Premium (Primary) | `services/quickwins_renderer.py:795 render_quickwins_premium_json` | `title, icon, problem, wirkung, umsetzung, hinweis` | **stimmt mit Prompt überein** |
+| Legacy (Fallback) | `gpt_analyze.py:4208 _parse_quick_wins_json` + `gpt_analyze.py:4314 _build_quick_wins_html` | `title, icon, time, engpass, description, mit_ki, steps, zeitersparnis` | **stimmt NICHT mit Prompt überein** |
+
+Der Prompt (`prompts/de/quick_wins.md` Z.12–19, Output-Vertrag v8.3) fordert:
+```
+title, icon, problem, wirkung, umsetzung, hinweis
+```
+
+Der Legacy-Parser (vor Fix) erwartete:
+```python
+required_fields = ['title', 'icon', 'time', 'engpass', 'description', 'mit_ki', 'steps', 'zeitersparnis']
+```
+
+→ 6 von 8 Legacy-Feldern fehlen in **jeder** vom Prompt gelieferten JSON. Der Parser deklariert sie als "fehlend" und füllt mit hardcoded Defaults (`gpt_analyze.py:4291`):
+
+```python
+if field == 'steps':
+    qw[field] = ["Schritt 1", "Schritt 2", "Schritt 3"]
+elif field == 'icon':
+    qw[field] = "◎"
+else:
+    qw[field] = ""
+```
+
+Der Legacy-Builder rendert dann eine Card mit leeren Blöcken plus den Hardcoded-Schritten — exakt das Briefing-1068-Symptom.
+
+### 1.2 Wie die Pipeline tatsächlich Briefing 1068 produziert
+
+1. LLM erzeugt JSON nach Output-Vertrag (`title/icon/problem/wirkung/umsetzung/hinweis`)
+2. `_generate_content_sections` ruft `render_quickwins_premium_json` zuerst (`gpt_analyze.py:13135`) — der Primary-Pfad
+3. Premium-Renderer schlägt aus noch unbekanntem Grund fehl (`return None`) → siehe Sektion 4
+4. Codepfad fällt durch zu `_parse_quick_wins_json` (`gpt_analyze.py:13158`) — der Legacy-Fallback
+5. Legacy-Parser sieht 6/8 erwartete Felder als "missing" → Hardcoded-Defaults greifen
+6. `_build_quick_wins_html` rendert das User-sichtbare Bild aus Briefing 1068
+
+Pristine-HTML enthält damit bereits Platzhalter, kein nachgelagerter Renderer-Bug.
+
+### 1.3 Beobachtbare Lücken im Codepfad
+
+| Code-Stelle | Lücke | Behoben in diesem Sprint |
+|---|---|---|
+| `gpt_analyze.py:4283` | `required_fields` = Legacy-Schema (8 Felder) statt Prompt-Schema (6 Felder) | ✅ Schema angeglichen |
+| `gpt_analyze.py:4291` | Hardcoded `["Schritt 1", "Schritt 2", "Schritt 3"]`-Default | ✅ Entfernt (steps existiert im neuen Schema nicht) |
+| `gpt_analyze.py:4314 ff` | Builder rendert nur Legacy-Felder, ignoriert `problem/wirkung/umsetzung/hinweis` | ✅ Conditional-Blocks für `problem/wirkung/umsetzung/hinweis` (analog Premium-Renderer) |
+| `gpt_analyze.py:4759` | Minimal-QW-Build mit Legacy-Feldern bei Title-Extraction-Fallback | ✅ Auf Prompt-Schema umgestellt |
+| `services/quickwins_renderer.py:795 ff` | Drei `return None`-Punkte ohne Diagnose-Log, kein Insight WARUM Primary fehlschlägt | ✅ `[QW-JSON-DEBUG]`-Marker an allen Failure- und Success-Pfaden |
+
+---
+
+## Sektion 2: Hypothesen für die Premium-Fehler-Ursache (offen für C1.2)
+
+Mit dem Schema-Fix in diesem Sprint wird der Fallback-Pfad gesund. Aber: **warum greift der Fallback überhaupt für Briefing 1068, wenn der Premium-Renderer das richtige Schema versteht?** Diese Frage bleibt offen — der Diagnose-Marker in `render_quickwins_premium_json` wird sie nach Merge mit Production-Daten beantworten.
+
+### H1 — JSON-Truncation durch max_tokens-Limit
+
+Der Prompt setzt eine Höchstlänge von 6500 Zeichen pro JSON-Array. `gpt_analyze.py:1385` setzt `"quick_wins": 5000` als Token-Budget. Bei verbose Branchen-Spezial mit 4–5 Quick Wins à 1200 Zeichen kann der Output am Token-Limit abgeschnitten werden → `json.loads` schlägt fehl → Premium-Renderer returnt `None`.
+
+- **Wahrscheinlichkeit:** hoch
+- **Validierung:** Marker zeigt `status=fail reason=json_decode_error json_raw_chars=...` — wenn raw_chars nahe am 5000-Token-Output-Cap liegt, ist Truncation der Treffer.
+- **Patch-Pfad (Folge-Sprint C1.2):** max_tokens für QW erhöhen, **oder** Streaming-Parse mit Recovery für truncated arrays, **oder** Re-Gen-Logik analog `KI_STACK_SUMMARY` (`gpt_analyze.py:19630ff`).
+
+### H2 — Leeres oder list-loses JSON-Objekt
+
+Wenn das LLM trotz Prompt-Vertrag mit einem Object-Wrapper antwortet (`{"quick_wins": [...]}`), greift der Premium-Renderer's Array-Extract-Regex (`r'(\[[\s\S]*\])'`, Z.829) zwar — aber wenn das LLM komplett aus dem Output-Vertrag fällt (z.B. Markdown-Erklärung statt JSON), returnt der Renderer mit `data isinstance check` failure.
+
+- **Wahrscheinlichkeit:** mittel
+- **Validierung:** Marker zeigt `status=fail reason=not_a_list` oder `empty_array`.
+- **Patch-Pfad:** Prompt-Hardening (Output-Vertrag steht bereits klar in Z.5–10 von `prompts/de/quick_wins.md`, mehr ist schwierig); alternativ Object-Wrapper-Detection wie in `_parse_quick_wins_json:4272`.
+
+### H3 — Validation-Gate `enforce_quickwins_complete` produziert leere cards_html
+
+`enforce_quickwins_complete` (`services/quickwins_renderer.py:611`) füllt leere Felder mit deterministischen Fallbacks. Wenn aber **alle** QWs als `not isinstance(qw, dict)` durchfallen (z.B. wenn LLM ein verschachteltes JSON liefert), endet `cards_html` leer → `return None` (Z.904).
+
+- **Wahrscheinlichkeit:** niedrig
+- **Validierung:** Marker zeigt `status=fail reason=no_valid_cards` und im vorgelagerten Log `status=parsed item_count=N` mit hohem N.
+- **Patch-Pfad:** Defensive Type-Coercion in `enforce_quickwins_complete`.
+
+---
+
+## Sektion 3: Empfehlung
+
+**Diesen Sprint mergen** — er fixt die User-sichtbaren Symptome aus Briefing 1068 sofort (Schema-Angleichung), und der Diagnose-Marker sammelt parallel WHY-Daten für den Folge-Sprint.
+
+**Folge-Sprint C1.2:** Nach 24–48 h Production-Marker-Daten den häufigsten `fail reason` identifizieren und gezielt patchen. Wahrscheinlichkeitsreihenfolge:
+
+1. **H1 (Truncation)** zuerst prüfen — höchste Vermutung, einfacher Patch (max_tokens hoch).
+2. **H3 (Validation-Gate)** zweite Prüfung — Defensive-Coercion ist trivial.
+3. **H2 (LLM-Vertragsbruch)** dritte Prüfung — wenn 1+3 nicht erklären, Prompt-Iteration.
+
+**Optionaler Folge-Sprint C1.3 (Tech-Debt):** Legacy-Parser+Builder komplett entfernen, Premium-Renderer wird Primary und einziger Pfad. Bedingt durch C1.2 (erst wenn Premium-Failover-Rate gegen 0 geht). Tests `tests/test_finalD_quickwins_no_raw_json.py`, `tests/test_finalG_quickwins_hardcorrect.py`, `tests/test_p07_quickwins_canonical.py` müssen dann mitwandern oder gelöscht werden (sie referenzieren `_calculate_quickwin_savings_display` und `_sanitize_quickwin_step`, die nach dem Aufräumen verschwinden).
+
+---
+
+## Sektion 4: Validierung der Diagnose-Marker
+
+### Marker-Format
+
+`render_quickwins_premium_json` loggt auf Level `INFO` mit folgenden Status-Werten:
+
+| `status` | Bedeutung | Felder |
+|---|---|---|
+| `ok` | HTML-Rendering erfolgreich | `json_raw_chars`, `item_count`, `total_words`, `mode` |
+| `parsed` | JSON geparst, Schema-Check abgeschlossen, vor Completeness-Gate | `json_raw_chars`, `item_count`, `fields_missing_per_qw` |
+| `fail reason=empty_input` | `raw_json` war leer oder nur Whitespace | `json_raw_chars` |
+| `fail reason=not_a_list` | Geparstes JSON war kein Array | `json_raw_chars`, `item_count` |
+| `fail reason=empty_array` | Geparstes JSON war leeres Array | `json_raw_chars`, `item_count` |
+| `fail reason=no_valid_cards` | Alle Items waren keine Dicts oder durchgefallen | `json_raw_chars`, `item_count` |
+| `fail reason=json_decode_error` | `json.loads` warf JSONDecodeError | `json_raw_chars`, `err` |
+| `fail reason=exception` | Anderer Fehler im Render-Pfad | `json_raw_chars`, `err_type`, `err` |
+
+`_parse_quick_wins_json` loggt parallel auf Level `INFO`:
+```
+[QW-JSON-DEBUG] parser=legacy qw_count=N json_raw_chars=M fields_missing_per_qw=[...]
+```
+→ Zeigt, ob nach Schema-Fix der Legacy-Pfad noch Felder fehlen sieht. Wenn `fields_missing_per_qw` durchgehend leere Listen sind, deckt der Prompt das neue Schema vollständig ab.
+
+### Keine Roh-JSON-Inhalte
+
+Bewusst KEIN Roh-JSON, KEINE Textfeld-Inhalte gelogged. Nur Counts, Feldnamen, Fehlertypen — datenschutz-tauglich für Production-Logs.
+
+### Validierungs-Plan nach Merge
+
+1. Test-Briefing (Solo + Beratung + `ki_kompetenz=hoch`) absenden, der für Briefing 1068 reproduziert wurde
+2. Production-Logs nach `[QW-JSON-DEBUG]` filtern
+3. Erwartung nach Schema-Fix:
+   - **Best case (Premium greift):** `status=ok` Marker erscheint, R1-PDF S.7–8 zeigt echte QW-Inhalte
+   - **Failover-Fall (Legacy greift):** `status=fail reason=X` Marker zeigt konkreten Premium-Fehler; daraufhin loggt `parser=legacy` den Fall — und R1-PDF S.7–8 zeigt die echten Prompt-Felder (problem als Engpass-Box, wirkung+umsetzung als Body, hinweis als Tipp), weil der Legacy-Pfad jetzt schema-konsistent ist
+4. Häufigsten `fail reason=X` als Treiber für C1.2 identifizieren
+
+---
+
+## Sektion 5: Geänderte Zeilen (für Reviewer)
+
+| Datei | Zeilen | Δ | Beschreibung |
+|---|---:|---:|---|
+| `gpt_analyze.py` | 4283–4316 | +18 / −13 | `required_fields` angeglichen; Hardcoded-Defaults entfernt; `[QW-JSON-DEBUG]` Legacy-Marker |
+| `gpt_analyze.py` | 4361–4438 | +43 / −62 | `_build_quick_wins_html` Render-Body komplett auf Prompt-Schema (Conditional-Blocks für `problem/wirkung/umsetzung/hinweis`) |
+| `gpt_analyze.py` | 4762–4768 | +6 / −2 | Title-Extraction-Fallback nutzt jetzt Prompt-Schema |
+| `services/quickwins_renderer.py` | 795–812 | +1 | `run_id`-Parameter, optional |
+| `services/quickwins_renderer.py` | 812–820 | +7 | Marker für `empty_input` |
+| `services/quickwins_renderer.py` | 835–845 | +9 | Marker für `not_a_list` / `empty_array` |
+| `services/quickwins_renderer.py` | 850–862 | +14 | `[QW-JSON-DEBUG] status=parsed` mit `fields_missing_per_qw` vor Completeness-Gate |
+| `services/quickwins_renderer.py` | 920–925 | +5 | Marker für `no_valid_cards` |
+| `services/quickwins_renderer.py` | 957–975 | +14 | Marker für `ok` und Exception-Branches |
+
+**Helper-Funktionen `_calculate_quickwin_savings_display` und `_sanitize_quickwin_step`** bleiben **unverändert** in `gpt_analyze.py`, obwohl der neue Render-Code sie nicht mehr aufruft. Grund: `tests/test_finalD_quickwins_no_raw_json.py`, `tests/test_finalG_quickwins_hardcorrect.py`, `tests/test_p07_quickwins_canonical.py` importieren sie. Aufräumen erfolgt im optionalen Sprint C1.3 zusammen mit den Tests.
+
+---
+
+## Sektion 6: Out of Scope für diesen Sprint
+
+- **WHY-Diagnose des Premium-Fehlers** — passiert nach Merge via Marker in Production
+- **Re-Gen-Logik bei truncated JSON** — Folge-Sprint C1.2, abhängig von Marker-Befund
+- **Legacy-Code-Entfernung** — Folge-Sprint C1.3 nach Premium-Stabilisierung
+- **Prompt-Iteration** — Output-Vertrag steht bereits klar; Änderungen nur bei H2-Befund

--- a/gpt_analyze.py
+++ b/gpt_analyze.py
@@ -4280,19 +4280,38 @@ def _parse_quick_wins_json(raw_response: str) -> Optional[List[Dict[str, Any]]]:
             return None
 
         # Validiere jedes Quick Win
-        required_fields = ['title', 'icon', 'time', 'engpass', 'description', 'mit_ki', 'steps', 'zeitersparnis']
+        # [QW-SCHEMA-FIX] Schema angeglichen an prompts/de/quick_wins.md
+        # Output-Vertrag (title, icon, problem, wirkung, umsetzung, hinweis).
+        # Vorher: Legacy-Felder (time, engpass, description, mit_ki, steps,
+        # zeitersparnis) — die wurden vom Prompt nie geliefert, deshalb
+        # markierte der Parser jedes Quick Win als unvollständig und füllte
+        # mit "" bzw. dem Hardcoded "Schritt 1/2/3"-Default, was im PDF
+        # als leere Engpass-Box, leeres "Aktuell:", leeres "Mit KI:" und
+        # generische Schritte sichtbar wurde (Briefing 1068, R1 S.7-8).
+        required_fields = ['title', 'icon', 'problem', 'wirkung', 'umsetzung', 'hinweis']
+        missing_per_qw: List[List[str]] = []
         for i, qw in enumerate(quick_wins):
-            missing = [f for f in required_fields if f not in qw]
+            missing = [f for f in required_fields if not qw.get(f)]
+            missing_per_qw.append(missing)
             if missing:
                 log.warning(f"Quick Win {i+1} fehlt Felder: {missing}")
-                # Setze Defaults für fehlende Felder
+                # Sinnvolle Defaults: leere Strings (Renderer skipt leere
+                # Blöcke). 'icon' bekommt einen Marker-Default, 'hinweis'
+                # bekommt den Standard-Verweis aus dem Output-Vertrag.
                 for field in missing:
-                    if field == 'steps':
-                        qw[field] = ["Schritt 1", "Schritt 2", "Schritt 3"]
-                    elif field == 'icon':
+                    if field == 'icon':
                         qw[field] = "◎"
+                    elif field == 'hinweis':
+                        qw[field] = "siehe Business Case"
                     else:
                         qw[field] = ""
+
+        # [QW-JSON-DEBUG] Marker für Folge-Sprint: zeigt pro Briefing wie
+        # vollständig die LLM-JSON tatsächlich ist. Bewusst KEIN Roh-JSON.
+        log.info(
+            "[QW-JSON-DEBUG] parser=legacy qw_count=%d json_raw_chars=%d fields_missing_per_qw=%s",
+            len(quick_wins), len(cleaned), missing_per_qw,
+        )
 
         log.info(f"✅ Quick Wins JSON erfolgreich geparst: {len(quick_wins)} Items")
         return cast(List[Dict[str, Any]], quick_wins)
@@ -4359,37 +4378,58 @@ def _build_quick_wins_html(quick_wins: list, branche: str = "Unbekannt", groesse
 """
 
     # Quick Win Cards - JEDE als eigene Struktur mit Tabellen-Header
+    # [QW-SCHEMA-FIX] Render-Felder umgestellt auf prompts/de/quick_wins.md
+    # Output-Vertrag: problem (Engpass), wirkung (Effekt mit KI),
+    # umsetzung (Schritte), hinweis (Verweis auf Business Case).
+    # Legacy-Felder time/engpass/description/mit_ki/steps/zeitersparnis
+    # wurden vom Prompt nie geliefert → leerer Render im PDF (Briefing 1068).
+    # Hardcoded P0.7-Zeitersparnis-Anzeige entfällt: das neue Schema
+    # verbietet Zahlen/Zeitangaben in Quick Wins (Prompt Z.26: „Keine
+    # Ziffern, keine Euro-Beträge"), Business-Case-Verweis übernimmt das.
     for i, qw in enumerate(quick_wins, 1):
-        # Escape HTML
         title = html_module.escape(str(qw.get('title', 'Ohne Titel')))
         # Fix-Batch G: Aggressively clean Icon: artifacts from icon field
         raw_icon = str(qw.get('icon', '◎'))
-        # Remove "Icon:" prefix and any similar patterns
         icon = re.sub(r'^Icon:\s*', '', raw_icon, flags=re.IGNORECASE).strip()
         icon = re.sub(r'^Symbol:\s*', '', icon, flags=re.IGNORECASE).strip()
         icon = re.sub(r'^Emoji:\s*', '', icon, flags=re.IGNORECASE).strip()
-        # If icon is now empty or still contains "Icon", use default
         if not icon or 'icon' in icon.lower() or len(icon) > 5:
             icon = '◎'
-        time = html_module.escape(str(qw.get('time', 'Unbekannt')))
-        engpass = html_module.escape(str(qw.get('engpass', '')))
-        description = html_module.escape(str(qw.get('description', '')))
-        mit_ki = html_module.escape(str(qw.get('mit_ki', '')))
-        steps = qw.get('steps', [])
-        raw_zeitersparnis = str(qw.get('zeitersparnis', ''))
+        problem = html_module.escape(str(qw.get('problem', '')).strip())
+        wirkung = html_module.escape(str(qw.get('wirkung', '')).strip())
+        umsetzung = html_module.escape(str(qw.get('umsetzung', '')).strip())
+        hinweis = html_module.escape(str(qw.get('hinweis', 'siehe Business Case')).strip())
 
-        # P0.7: Calculate € values from hours using canonical rate
-        zeitersparnis_display = _calculate_quickwin_savings_display(
-            raw_zeitersparnis, canonical_rate
+        # Conditional Blocks: leere Felder werden komplett übersprungen,
+        # nicht als leere Boxen gerendert (analog Premium-Renderer).
+        problem_block = (
+            f'''
+        <div style="background: #fffbeb; border-left: 4px solid #f59e0b; padding: 14px; margin-bottom: 16px; border-radius: 6px;">
+            <div style="font-weight: bold; color: #92400e; font-size: 13px; margin-bottom: 4px;"><span class="icon">◎</span> ENGPASS / PROBLEM:</div>
+            <div style="color: #78350f; font-size: 14px;">{problem}</div>
+        </div>''' if problem else ""
         )
-
-        # Fix-Batch G: Sanitize steps to prevent truncated sentences
-        steps_html = '<ol style="margin: 12px 0 12px 20px; padding: 0; color: #065f46;">'
-        for step in steps:
-            step_clean = _sanitize_quickwin_step(str(step))
-            if step_clean:  # Only add non-empty steps
-                steps_html += f'<li style="margin-bottom: 8px; line-height: 1.6;">{html_module.escape(step_clean)}</li>'
-        steps_html += '</ol>'
+        wirkung_block = (
+            f'''
+        <div style="background: #f0fdf4; border-left: 4px solid #10b981; padding: 14px; margin-bottom: 16px; border-radius: 6px;">
+            <p style="margin: 0; color: #065f46; line-height: 1.6; font-size: 14px;">
+                <strong style="color: #047857;"><span class="icon icon--success">✓</span> Wirkung mit KI:</strong> {wirkung}
+            </p>
+        </div>''' if wirkung else ""
+        )
+        umsetzung_block = (
+            f'''
+        <div style="background: #eff6ff; border-left: 4px solid #3b82f6; padding: 14px; margin-bottom: 14px; border-radius: 6px;">
+            <div style="font-weight: bold; color: #1e40af; font-size: 14px; margin-bottom: 6px;"><span class="icon icon--accent">▸</span> Umsetzung:</div>
+            <p style="margin: 0; color: #1e3a8a; line-height: 1.6; font-size: 14px;">{umsetzung}</p>
+        </div>''' if umsetzung else ""
+        )
+        hinweis_block = (
+            f'''
+        <div style="text-align: left; padding-top: 12px; border-top: 1px solid #e5e7eb; color: #6b7280; font-size: 12px; font-style: italic;">
+            💡 {hinweis}
+        </div>''' if hinweis else ""
+        )
 
         html += f"""
 <div class="quick-win quick-win-card" data-qw-json-rendered="true" style="border: 2px solid #3b82f6; border-radius: 12px; padding: 0; margin-bottom: 30px; page-break-inside: avoid; background: white;">
@@ -4401,50 +4441,13 @@ def _build_quick_wins_html(quick_wins: list, branche: str = "Unbekannt", groesse
                 <div style="font-size: 36px; line-height: 1;">{icon}</div>
             </td>
             <td style="padding: 16px; color: white;">
-                <div style="font-size: 18px; font-weight: bold; margin-bottom: 6px;">{title}</div>
-                <span style="background: #dbeafe; color: #1e40af; padding: 4px 12px; border-radius: 12px; font-size: 13px; font-weight: 600;">
-                    ⏱️ {time}
-                </span>
+                <div style="font-size: 18px; font-weight: bold;">{title}</div>
             </td>
         </tr>
     </table>
 
     <!-- Content Area -->
-    <div style="padding: 20px;">
-
-        <!-- Engpass Box -->
-        <div style="background: #fffbeb; border-left: 4px solid #f59e0b; padding: 14px; margin-bottom: 16px; border-radius: 6px;">
-            <div style="font-weight: bold; color: #92400e; font-size: 13px; margin-bottom: 4px;"><span class="icon">◎</span> IHR ENGPASS:</div>
-            <div style="color: #78350f; font-size: 14px;">"{engpass}"</div>
-        </div>
-
-        <!-- Aktuell -->
-        <div style="margin-bottom: 14px;">
-            <p style="margin: 0; color: #374151; line-height: 1.6; font-size: 14px;">
-                <strong style="color: #1f2937;">Aktuell:</strong> {description}
-            </p>
-        </div>
-
-        <!-- Mit KI Box -->
-        <div style="background: #f0fdf4; border-left: 4px solid #10b981; padding: 14px; margin-bottom: 16px; border-radius: 6px;">
-            <p style="margin: 0; color: #065f46; line-height: 1.6; font-size: 14px;">
-                <strong style="color: #047857;"><span class="icon icon--success">✓</span> Mit KI:</strong> {mit_ki}
-            </p>
-        </div>
-
-        <!-- Steps -->
-        <div style="background: #f0fdf4; padding: 16px; border-radius: 6px; margin-bottom: 14px;">
-            <div style="font-weight: bold; color: #047857; font-size: 14px; margin-bottom: 8px;"><span class="icon icon--accent">▸</span> Umsetzungsschritte:</div>
-            {steps_html}
-        </div>
-
-        <!-- Zeitersparnis Footer (P0.7: Calculated from canonical rate) -->
-        <div style="text-align: right; padding-top: 12px; border-top: 2px solid #e5e7eb;">
-            <span style="background: #d1fae5; color: #065f46; font-weight: bold; font-size: 14px; padding: 6px 14px; border-radius: 12px;">
-                <span class="icon icon--success">◆</span> {zeitersparnis_display}
-            </span>
-        </div>
-
+    <div style="padding: 20px;">{problem_block}{wirkung_block}{umsetzung_block}{hinweis_block}
     </div>
 </div>
 """
@@ -4752,8 +4755,14 @@ def _enforce_quickwins_no_raw_json(qw_html: str, branche: str, groesse: str) -> 
         titles = list(dict.fromkeys(titles))[:5]  # Deduplicate, limit to 5
 
         if len(titles) >= 3:
-            # Build minimal Quick Wins from extracted titles
-            minimal_qw = [{"title": t, "icon": "🎯", "engpass": "", "zeitersparnis": "2-4 Stunden/Woche", "steps": []} for t in titles[:5]]
+            # Build minimal Quick Wins from extracted titles.
+            # [QW-SCHEMA-FIX] Felder umgestellt auf Prompt-Schema; alte
+            # Zeitersparnis-Pauschale entfällt, Hinweis verweist auf den
+            # Business Case wie im Prompt-Output-Vertrag definiert.
+            minimal_qw = [
+                {"title": t, "icon": "🎯", "problem": "", "wirkung": "", "umsetzung": "", "hinweis": "siehe Business Case"}
+                for t in titles[:5]
+            ]
             log.info("[QW-JSON-RENDER] ✅ Built %d Quick Wins from extracted titles", len(minimal_qw))
             return _build_quick_wins_html(minimal_qw, branche=branche, groesse=groesse)
 

--- a/services/quickwins_renderer.py
+++ b/services/quickwins_renderer.py
@@ -792,7 +792,7 @@ def enrich_quickwins_premium(html: str) -> str:
 # Renders FIX-506 JSON format (title, icon, problem, wirkung, umsetzung, hinweis)
 # to rich HTML cards that meet >=30 word requirements.
 
-def render_quickwins_premium_json(raw_json: str, template_mode: str = "FULL") -> Optional[str]:
+def render_quickwins_premium_json(raw_json: str, template_mode: str = "FULL", run_id: str = "") -> Optional[str]:
     """
     FIX-510 CHANGE 2: Premium renderer for FIX-506 QuickWins JSON format.
 
@@ -802,6 +802,7 @@ def render_quickwins_premium_json(raw_json: str, template_mode: str = "FULL") ->
     Args:
         raw_json: JSON string with QuickWins array
         template_mode: "LEFT_ONLY", "FULL", etc.
+        run_id: Optional briefing/run identifier for diagnostic logs.
 
     Returns:
         Rich HTML string or None if parsing fails
@@ -809,7 +810,17 @@ def render_quickwins_premium_json(raw_json: str, template_mode: str = "FULL") ->
     import json
     import html as html_module
 
+    # [QW-JSON-DEBUG] Strukturierter Marker für Diagnose des Premium-Pfades.
+    # Loggt ausschließlich Metriken (keine Roh-JSON-Inhalte), damit nach Merge
+    # in Production sichtbar wird, warum der Premium-Renderer für ein konkretes
+    # Briefing nach None fällt und der Legacy-Pfad greift.
+    raw_chars = len(raw_json or "")
+
     if not raw_json or not raw_json.strip():
+        log.info(
+            "[QW-JSON-DEBUG] run_id=%s renderer=premium status=fail "
+            "reason=empty_input json_raw_chars=%d", run_id, raw_chars,
+        )
         return None
 
     try:
@@ -833,10 +844,34 @@ def render_quickwins_premium_json(raw_json: str, template_mode: str = "FULL") ->
         data = json.loads(cleaned)
 
         if not isinstance(data, list) or len(data) == 0:
+            log.info(
+                "[QW-JSON-DEBUG] run_id=%s renderer=premium status=fail "
+                "reason=%s json_raw_chars=%d item_count=%d",
+                run_id,
+                "not_a_list" if not isinstance(data, list) else "empty_array",
+                raw_chars,
+                len(data) if isinstance(data, list) else 0,
+            )
             return None
 
         # TASK 1 (P0 FINAL): DUMP POINT 1 - Raw JSON after parsing
         dump_raw_json(data, context="render_quickwins_premium_json")
+
+        # [QW-JSON-DEBUG] Pro Quick-Win: welche der vom Prompt geforderten
+        # Felder (title/icon/problem/wirkung/umsetzung/hinweis) fehlen oder
+        # sind leer? Aufschluss darüber, ob das LLM den Output-Vertrag
+        # einhält oder bestimmte Felder systematisch leer lässt. Ausgeführt
+        # VOR enforce_quickwins_complete, damit die Roh-Daten gemessen werden.
+        _required = ("title", "icon", "problem", "wirkung", "umsetzung", "hinweis")
+        _missing_per_qw = [
+            [f for f in _required if not (isinstance(qw, dict) and str(qw.get(f, "")).strip())]
+            for qw in data
+        ]
+        log.info(
+            "[QW-JSON-DEBUG] run_id=%s renderer=premium status=parsed "
+            "json_raw_chars=%d item_count=%d fields_missing_per_qw=%s",
+            run_id, raw_chars, len(data), _missing_per_qw,
+        )
 
         # TASK B (P0): Apply completeness gate - fill empty fields with deterministic fallbacks
         data = enforce_quickwins_complete(data)
@@ -902,6 +937,11 @@ def render_quickwins_premium_json(raw_json: str, template_mode: str = "FULL") ->
             cards_html.append(card_html)
 
         if not cards_html:
+            log.info(
+                "[QW-JSON-DEBUG] run_id=%s renderer=premium status=fail "
+                "reason=no_valid_cards json_raw_chars=%d item_count=%d",
+                run_id, raw_chars, len(data),
+            )
             return None
 
         # FIX-517C: WeasyPrint-safe layout (table instead of CSS Grid)
@@ -936,13 +976,29 @@ def render_quickwins_premium_json(raw_json: str, template_mode: str = "FULL") ->
         # TASK 1 (P0 FINAL): DUMP POINT 2 - Renderer output HTML
         dump_renderer_output(html_out, renderer_name="render_quickwins_premium_json")
 
+        log.info(
+            "[QW-JSON-DEBUG] run_id=%s renderer=premium status=ok "
+            "json_raw_chars=%d item_count=%d total_words=%d mode=%s",
+            run_id, raw_chars, len(cards_html), total_words, template_mode,
+        )
+
         return html_out
 
     except json.JSONDecodeError as e:
         log.debug("[FIX-510-QW] JSON parse failed: %s", e)
+        log.info(
+            "[QW-JSON-DEBUG] run_id=%s renderer=premium status=fail "
+            "reason=json_decode_error json_raw_chars=%d err=%.80s",
+            run_id, raw_chars, str(e),
+        )
         return None
     except Exception as e:
         log.warning("[FIX-510-QW] Premium render failed: %s", e)
+        log.info(
+            "[QW-JSON-DEBUG] run_id=%s renderer=premium status=fail "
+            "reason=exception json_raw_chars=%d err_type=%s err=%.80s",
+            run_id, raw_chars, type(e).__name__, str(e),
+        )
         return None
 
 

--- a/tests/test_finalG_quickwins_hardcorrect.py
+++ b/tests/test_finalG_quickwins_hardcorrect.py
@@ -276,29 +276,31 @@ class TestBatchGIntegration:
             assert "Symbol:" not in result, f"Symbol: found for input: {test_icon}"
             assert "Emoji:" not in result, f"Emoji: found for input: {test_icon}"
 
-    def test_full_pipeline_correct_eur_values(self):
-        """Test full pipeline produces correct EUR values."""
+    def test_full_pipeline_renders_prompt_schema_fields(self):
+        """[QW-SCHEMA-FIX] Builder uses prompt schema (problem/wirkung/
+        umsetzung/hinweis). Prompt v8.3 Z.26 forbids digits/EUR values in
+        Quick Wins, so the builder no longer renders EUR via
+        _calculate_quickwin_savings_display. The helper itself remains
+        unit-tested at TestQuickWinsEURCalculation in this file.
+        """
         from gpt_analyze import _build_quick_wins_html
 
         quick_wins = [{
             "title": "Test",
             "icon": "📧",
-            "time": "2h",
-            "engpass": "X",
-            "description": "Y",
-            "mit_ki": "Z",
-            "steps": ["A"],
-            "zeitersparnis": "20 h/Monat",
+            "problem": "Bottleneck",
+            "wirkung": "Effect with AI",
+            "umsetzung": "Steps to implement",
+            "hinweis": "siehe Business Case",
         }]
 
         result = _build_quick_wins_html(quick_wins, "IT", "team")
 
-        # Should contain calculated EUR values with € symbol
-        # Rate depends on company size (team → ~95€/h)
-        # 20h creates range 16-24h, so values should be in 1000-2500 range
-        assert "€" in result
-        # Check that calculated values are present (not LLM-generated wrong values)
-        assert re.search(r'\d+[–-]\d+ h/Monat = [\d.]+[–-][\d.]+ €', result)
+        # Prompt-schema fields are rendered
+        assert "Bottleneck" in result
+        assert "Effect with AI" in result
+        assert "Steps to implement" in result
+        assert "siehe Business Case" in result
 
     def test_fix_batch_g_comment_exists(self):
         """Test that Fix-Batch G comment block exists."""

--- a/tests/test_p07_quickwins_canonical.py
+++ b/tests/test_p07_quickwins_canonical.py
@@ -129,53 +129,52 @@ class TestQuickWinsCardRendering:
     """Test that Quick Wins render as structured cards."""
 
     def test_quick_wins_render_as_cards(self):
-        """Test that Quick Wins output contains card structure."""
+        """Test that Quick Wins output contains card structure.
+
+        [QW-SCHEMA-FIX] Migrated from legacy schema (engpass/description/
+        mit_ki/steps/zeitersparnis) to current prompt schema (problem/
+        wirkung/umsetzung/hinweis). Cf. prompts/de/quick_wins.md v8.3.
+        """
         from gpt_analyze import _build_quick_wins_html
 
         quick_wins = [{
             'title': 'Card Test',
             'icon': '📋',
-            'time': '1 Woche',
-            'engpass': 'Bottleneck',
-            'description': 'Description text',
-            'mit_ki': 'AI solution',
-            'steps': ['First step', 'Second step'],
-            'zeitersparnis': '8-12 h/Monat',
+            'problem': 'Bottleneck text',
+            'wirkung': 'Effect with AI',
+            'umsetzung': 'How to implement',
+            'hinweis': 'siehe Business Case',
         }]
 
         html = _build_quick_wins_html(quick_wins, branche="Marketing", groesse="kmu")
 
-        # Should contain card CSS class
         assert 'quick-win-card' in html, "Missing quick-win-card class"
-
-        # Should contain all sections
         assert 'Card Test' in html, "Missing title"
         assert '📋' in html, "Missing icon"
-        assert 'ENGPASS' in html.upper(), "Missing engpass section"
-        assert 'Mit KI' in html, "Missing 'Mit KI' section"
-        assert 'Umsetzungsschritte' in html, "Missing steps section"
+        assert 'PROBLEM' in html.upper(), "Missing problem/engpass section"
+        assert 'Wirkung' in html, "Missing wirkung section"
+        assert 'Umsetzung' in html, "Missing umsetzung section"
 
-    def test_quick_wins_contain_calculated_eur(self):
-        """Test that rendered cards contain calculated € values."""
+    def test_quick_wins_skips_empty_blocks(self):
+        """[QW-SCHEMA-FIX] Empty fields produce no rendered block (analog
+        services/quickwins_renderer.py:render_quickwins_premium_json)."""
         from gpt_analyze import _build_quick_wins_html
 
         quick_wins = [{
-            'title': 'EUR Test',
-            'icon': '💰',
-            'time': '2 Tage',
-            'engpass': 'Test',
-            'description': 'Test',
-            'mit_ki': 'Test',
-            'steps': ['Step'],
-            'zeitersparnis': '10-15 h/Monat',
+            'title': 'Sparse Test',
+            'icon': '💡',
+            'problem': 'Only problem set',
+            'wirkung': '',
+            'umsetzung': '',
+            'hinweis': 'siehe Business Case',
         }]
 
-        # Solo rate = 80€/h
         html = _build_quick_wins_html(quick_wins, branche="IT", groesse="Einzelunternehmer")
 
-        # Should contain calculated € values (10*80=800, 15*80=1200)
-        assert '800' in html, f"Missing calculated €800"
-        assert '1.200' in html or '1200' in html, f"Missing calculated €1.200"
+        assert 'Sparse Test' in html
+        assert 'Only problem set' in html
+        assert 'Wirkung mit KI' not in html, "Empty wirkung block should be skipped"
+        assert 'Umsetzung:' not in html, "Empty umsetzung block should be skipped"
 
     def test_quick_wins_context_banner(self):
         """Test that context banner shows branche and groesse."""


### PR DESCRIPTION
## Bug C1 — KIS-1185 / Briefing 1068 (R1 S.7-8 Quick-Wins)

R1-PDF zeigt "Schritt 1./2./3.", leere Engpass-/Aktuell-/Mit-KI-Boxen und "Zeitersparnis: auf Anfrage" — obwohl der LLM-Output strukturierte JSON liefert.

## Root Cause — Schema-Mismatch zwischen Prompt und Legacy-Renderer

| Komponente | Erwartetes Schema |
|---|---|
| **Prompt** `prompts/de/quick_wins.md` v8.3 Output-Vertrag (Z.13-19) | `title, icon, problem, wirkung, umsetzung, hinweis` |
| **Premium-Renderer** `services/quickwins_renderer.py:render_quickwins_premium_json` (Primary) | dito ✅ |
| **Legacy-Parser** `gpt_analyze.py:_parse_quick_wins_json.required_fields` (Fallback) | `title, icon, time, engpass, description, mit_ki, steps, zeitersparnis` ❌ |
| **Legacy-Builder** `gpt_analyze.py:_build_quick_wins_html` (Fallback) | dito ❌ |

Konkrete Pipeline für Briefing 1068:
1. LLM liefert JSON nach Output-Vertrag
2. Premium-Renderer schlägt aus **noch unbekanntem Grund** fehl → `return None`
3. Codepfad fällt zu Legacy-Parser (`gpt_analyze.py:13158`)
4. Legacy-Parser sieht 6/8 erwartete Felder als "fehlend" → setzt `qw['steps'] = ["Schritt 1", "Schritt 2", "Schritt 3"]` (Z.4291) und alle anderen Legacy-Felder auf `""` (Z.4295)
5. Legacy-Builder rendert die kaputten Cards aus R1 S.7-8

Pristine-HTML enthält damit schon Platzhalter — Bug ist vor dem Renderer, im Parser.

## Patch

### 1. Schema-Angleichung — Legacy-Pfad ist jetzt schema-konsistent mit Prompt

- `gpt_analyze.py:4283-4316` — `_parse_quick_wins_json.required_fields` auf `[title, icon, problem, wirkung, umsetzung, hinweis]` umgestellt. Hardcoded `["Schritt 1/2/3"]`-Fallback entfernt. Defaults: leere Strings (Renderer überspringt leere Blöcke); `hinweis` bekommt den Output-Vertrags-Standard "siehe Business Case".
- `gpt_analyze.py:4361-4438` — `_build_quick_wins_html` Render-Body komplett auf `problem/wirkung/umsetzung/hinweis` mit Conditional-Blocks (analog Premium-Renderer): leere Felder erzeugen keine leeren Boxen mehr.
- `gpt_analyze.py:4762-4768` — Title-Extraction-Fallback nutzt jetzt Prompt-Schema.

### 2. `[QW-JSON-DEBUG]` Diagnose-Marker — sammelt WHY-Daten für Folge-Sprint

`services/quickwins_renderer.py:render_quickwins_premium_json` loggt strukturiert auf INFO an allen Failure- und Success-Pfaden:

| Status | Bedeutung |
|---|---|
| `ok` | Render erfolgreich |
| `parsed` | JSON ok, mit `fields_missing_per_qw=[[...],[...],...]` — vor Completeness-Gate |
| `fail reason=empty_input` | Leere oder Whitespace-only Eingabe |
| `fail reason=not_a_list` | Geparstes JSON war kein Array |
| `fail reason=empty_array` | Geparstes JSON war leeres Array |
| `fail reason=no_valid_cards` | Alle Items keine Dicts, Cards-Loop leer |
| `fail reason=json_decode_error` | `json.loads` warf JSONDecodeError (Truncation-Verdacht) |
| `fail reason=exception` | Anderer Fehler |

Optionaler `run_id`-Parameter (default `""`). Logs enthalten **nur Metriken** — keine Roh-JSON-Inhalte, keine Feldwerte (Datenschutz). Legacy-Parser loggt parallel `[QW-JSON-DEBUG] parser=legacy qw_count=N json_raw_chars=M fields_missing_per_qw=[...]`.

### 3. Diagnose-Doku

Neue Datei `docs/SPRINT_C1_QUICK_WINS_DIAGNOSE.md`:
- Sektion 1: Diagnose-Befund (Tabelle, Pipeline-Erklärung, geänderte Stellen)
- Sektion 2: 3 Hypothesen für Premium-Fehler (H1 Truncation hoch, H2 Vertragsbruch mittel, H3 Validation-Gate niedrig)
- Sektion 3: Empfehlung + Folge-Sprints C1.2/C1.3
- Sektion 4: Marker-Format + Validierungs-Plan
- Sektion 5: Geänderte Zeilen
- Sektion 6: Out-of-Scope

## Geänderte Zeilen

| Datei | Δ |
|---|---|
| `gpt_analyze.py` | +67 / −62 |
| `services/quickwins_renderer.py` | +57 / −1 |
| `docs/SPRINT_C1_QUICK_WINS_DIAGNOSE.md` | +183 (neu) |

## Scope-Check

`grep` verifiziert, dass kein anderer Produktions-Codepfad das Legacy-Schema liest:
- `gpt_analyze.py:4374-4379` (eigentlicher `_build_quick_wins_html` Renderer) — **ist Patch-Target**, jetzt auf Prompt-Schema
- `gpt_analyze.py:4939-4944` (`_generate_deterministic_quickwins_fallback`) — **self-contained**: definiert Daten + rendert sie inline, eigenes Schema, keine LLM-Schnittstelle. **Unverändert.**
- Tests `test_finalD_*`, `test_finalG_*`, `test_p07_*` importieren die orphan-gewordenen Helper `_calculate_quickwin_savings_display` + `_sanitize_quickwin_step`. Helper bleiben in der Datei (sind harmlos, fail kein Build). Aufräumen in optionalem C1.3.

## Verifikation (lokal)

```
$ python -c "import ast; ast.parse(open('gpt_analyze.py').read()); ast.parse(open('services/quickwins_renderer.py').read())"
$ # Premium-Renderer Smoke-Tests:
$ # - empty input → None ✅
$ # - valid prompt-schema JSON (3 items) → renders ✅
$ # - empty array → None ✅
$ # Legacy-Parser Schema-Tests:
$ # - prompt-schema JSON parses without "missing fields" warnings ✅
$ # - incomplete JSON: fehlende Felder = ""; KEIN "Schritt 1/2/3" Default; hinweis-Default = "siehe Business Case" ✅
```

## Validierungs-Plan (Production-Smoke nach Merge)

1. Test-Briefing absenden (Solo + Beratung + `ki_kompetenz=hoch`) — gleiches Profil wie Briefing 1068
2. Production-Logs nach `[QW-JSON-DEBUG]` filtern
3. **Best-Case (Premium greift):** `status=ok`, R1 S.7-8 zeigt echte QW-Inhalte
4. **Failover (Legacy greift):** Marker enthüllt konkreten Premium-Fehler-Grund, Legacy-Pfad rendert jetzt schema-konsistent (`problem` als Engpass-Box, `wirkung` als Effekt, `umsetzung` als Body, `hinweis` als Tipp) — keine "Schritt 1/2/3" mehr
5. Häufigsten `fail reason=X` als Treiber für Folge-Sprint C1.2 identifizieren

## Was bewusst NICHT in diesem Sprint

- **WHY-Diagnose des Premium-Fehlers** — Marker liefert das nach Merge in Production
- **Re-Gen-Logik bei truncated JSON** — Folge-Sprint C1.2, abhängig von Marker-Befund
- **Legacy-Code-Entfernung** — optionaler Folge-Sprint C1.3 nach Premium-Stabilisierung; Tests müssen dann mitwandern

https://claude.ai/code/session_01UWV1XBaNB39jy3VQRMiT9X

---
_Generated by [Claude Code](https://claude.ai/code/session_01UWV1XBaNB39jy3VQRMiT9X)_