### PR TITLE
fix(r1): detect mid-sentence truncation in decision section bullets

### DIFF
--- a/docs/SPRINT_C2_EXEC_DECISION_TRUNCATION.md
+++ b/docs/SPRINT_C2_EXEC_DECISION_TRUNCATION.md
@@ -1,0 +1,142 @@
+# Sprint C2 — R1 Page 4 Executive-Decision Mid-Sentence Truncation
+
+**Status:** H2/H3 Detect+Drop umgesetzt, Sprint-Constraint "H1 NICHT in diesem Sprint" eingehalten
+
+**Auslöser:** R1-PDF KIS-1186 / Briefing 1069 zeigt auf Seite 4 ("Entscheidungsvorlage") einen Mid-Sentence-Cutoff:
+
+> "Tun: Einen verbindlichen Standard-Arbeitsablauf einführen, bei dem jede Beratungsleistung den Ablauf Input"
+
+Der "Tun"-Bullet endet ohne Punkt, ohne logischen Abschluss. Die nachfolgenden Bullets ("Lassen", "Risiko & Stop-Signal") enden korrekt mit "." — daher passt der Section-Last-Char-Check und der Bug rutschte durch die komplette Pipeline.
+
+---
+
+## Sektion 1: Diagnose-Befund
+
+### 1.1 Production-Log-Signal
+
+```
+[FIX-C] Section 'executive_decision': removed 3 blocks, -801 chars
+[PLATIN+++] Validation PASSED: 0 errors, 1 warnings
+[PLATIN+++] WARNING: TRUNCATED: branch_deep_dive ends with '...'
+```
+
+Markant: **`branch_deep_dive`** wurde als TRUNCATED erkannt, **`executive_decision` NICHT** — obwohl beide mid-sentence enden. Keine `[FIX-G]`-, `[FIX-B38a]`- oder `[FIX-B39]`-Marker für `executive_decision`.
+
+### 1.2 Root-Cause-Analyse: H2/H3 architektonische Lücke
+
+Beide Mechanismen — `FIX-B38a`/`FIX-B39` Clean-Ending-Pass (`services/report_healer.py:3411 ff`) und PLATIN+++ `_check_sentence_completeness` (`services/report_validator.py:3486 ff`) — prüfen **nur das letzte Zeichen der gesamten Sektion**:
+
+```python
+# report_healer.py:3435
+_b39_text = re.sub(r'</?\w+[^>]*>', '', _b39_content).rstrip()
+if _b39_text[-1] not in _terminal_chars:  # checks SECTION terminus only
+    ...
+```
+
+```python
+# report_validator.py:3494
+text = re.sub(r'<[^>]+>', '', html).strip()
+if not text[-1] in '.!?:)"»”*':  # SECTION terminus only
+    ...
+```
+
+Die Decision-Sektionen (`executive_decision`, `roadmap_90d_decision`, `gamechanger_decision`) folgen aber alle dem Output-Vertrag **"genau 3 `<li>`-Bullets, jeder ein vollständiger Satz"** (cf. `prompts/de/executive_decision.md` Z.93–98). Eine Truncation INNERHALB eines `<li>` wird vom Section-Level-Check NICHT erfasst, solange die nachfolgenden `<li>` mit `.` enden.
+
+### 1.3 Wahrscheinliche Pipeline-Ursache (H1, Out-of-Scope dieses Sprints)
+
+Token-Budget-Resolution für `executive_decision` (`gpt_analyze.py:1467 ff`):
+
+| Kette | Wert |
+|---|---|
+| `_SECTION_MAX_TOKENS["executive_decision"]` | nicht definiert |
+| Prompt-Kommentar `<!-- TOKEN-BUDGET: 400 -->` | nicht parser-genutzt |
+| Fallback | `OPENAI_MAX_TOKENS_DEFAULT` = **3000** |
+
+3000 Token reichen für 60–90 Wörter Prompt-Output. Beobachtet: LLM emittiert **>1500 Zeichen** (FIX-C entfernte 801 davon als Duplikate) — Hinweis darauf, dass das LLM den 60–90-Wort-Soft-Cap im Prompt regelmäßig verletzt und in Wiederholungen verfällt, bis `max_tokens` greift und mitten im Satz schneidet. **C2.2** wird über `[FIX-EXEC-DECISION-CLEAN]`-Marker-Daten priorisiert.
+
+---
+
+## Sektion 2: Patch (H2 + H3 kombiniert, Scope per Briefing)
+
+### 2.1 Healer-Side (`services/report_healer.py`, +60 LOC nach FIX-B39-Block)
+
+`[FIX-EXEC-DECISION-CLEAN]` iteriert über die drei Decision-Section-Keys (lower- + uppercase-Form), parst jedes `<li>` per Regex, prüft pro Bullet die letzte Zeichenposition. Truncierter Bullet wird ersetzt durch:
+
+```html
+<li><em>Weitere Punkte siehe Business Case und Roadmap.</em></li>
+```
+
+Marker emittiert pro Decision-Section auf Level `WARNING`:
+
+```
+[FIX-EXEC-DECISION-CLEAN] section=executive_decision total=3 truncated=1 dropped=1
+```
+
+Auf `DEBUG`-Level bei sauberer Sektion (für Sample-Bestätigung). Bewusst KEIN `briefing_id` im Marker — `run_id` ist im Healer-Scope nicht verfügbar; Korrelation läuft via Timestamp + sonstiger Run-Marker im selben Log-Block.
+
+**Bullet-Drop ist intentional eine Vertragsverletzung:** Prompt fordert genau 3 Bullets mit fester Reihenfolge `Tun: / Lassen: / Risiko:`. Der Fallback-Bullet bricht diese Reihenfolge — sauberer als Anzeige eines abgehackten Satzes auf einer customer-facing Seite. Die Re-Gen-Logik in C2.2 wird das eleganter lösen.
+
+**Schwellwert `len(bullet_text) < 25`:** Schützt vor False-Positives bei Mini-Labels wie `<li>Tun</li>` (Header-Pattern in einigen Templates). 25 Zeichen entspricht etwa 4–5 Worten — kürzere `<li>` sind statistisch keine vollständigen Sätze, sondern Labels.
+
+### 2.2 Validator-Side (`services/report_validator.py`, +20 LOC in `_check_sentence_completeness`)
+
+`PlatinValidator` führt vor dem Section-Level-Check einen Per-`<li>`-Check für die Decision-Sektionen durch und emittiert pro defektem Bullet:
+
+```
+TRUNCATED_LI: executive_decision bullet ends with '...jede Beratung den Ablauf Input'
+```
+
+`TRUNCATED_LI` ist absichtlich ein **eigener Warning-Code** (nicht `TRUNCATED`), damit Production-Log-Filter beide Failure-Modi separat zählen können.
+
+### 2.3 Tests (`tests/test_exec_decision_clean.py`, 8 Tests)
+
+| Test | Verifikation |
+|---|---|
+| `test_truncated_bullet_dropped_and_replaced` | KIS-1186-Reproduktion 1:1 |
+| `test_clean_section_unchanged` | Keine Veränderung an sauberen Sektionen |
+| `test_non_decision_section_ignored` | Nur die drei Decision-Sections werden bearbeitet |
+| `test_short_bullet_below_threshold_preserved` | 25-Zeichen-Floor schützt Mini-Labels |
+| `test_all_three_decision_sections_covered` | executive_decision + roadmap_90d_decision + gamechanger_decision |
+| `test_truncated_li_emits_warning_despite_clean_section_end` | Validator-Hauptcase |
+| `test_clean_section_no_truncated_li_warning` | Validator False-Positive-Schutz |
+| `test_non_decision_section_not_checked_per_li` | Validator-Scope korrekt |
+
+---
+
+## Sektion 3: Empfehlung für Folge-Sprint C2.2
+
+Nach Production-Smoke und Sammlung von `[FIX-EXEC-DECISION-CLEAN]`-Marker-Daten (mind. 48 h, ≥10 Briefings):
+
+- **`truncated_rate > 5%`:** Sprint C2.2 anstoßen — Re-Gen-Logik analog `KI_STACK_SUMMARY` (`gpt_analyze.py:19630 ff`), wenn defekter Bullet erkannt → erneute LLM-Generierung mit niedrigerer Temperatur und tight `max_tokens` (z.B. 600).
+- **`truncated_rate < 5%`:** Detect+Drop ist die finale Lösung. Marker bleibt für Monitoring.
+
+Zusätzliche Folge-Themen (Out-of-Scope dieses Sprints):
+
+- `executive_decision` in `_SECTION_MAX_TOKENS` aufnehmen mit explizitem Wert (z.B. 800) — verhindert über-generierung statt sie zu reparieren.
+- `<!-- TOKEN-BUDGET: 400 -->` Prompt-Kommentar als Parser-honoriert implementieren oder entfernen (aktuell irreführend).
+
+---
+
+## Sektion 4: Validierungs-Plan nach Merge
+
+1. Test-Briefing absenden (Solo + Beratung + `ki_kompetenz=hoch`, gleicher Profil-Schnitt wie 1069)
+2. R1-PDF S.4 prüfen:
+   - **Best Case:** Keine `[FIX-EXEC-DECISION-CLEAN]`-Marker → LLM lieferte sauber, Patch ungenutzt
+   - **Healing Case:** Marker mit `truncated≥1`, S.4 zeigt Fallback-Bullet `"Weitere Punkte siehe Business Case und Roadmap"` an Position des defekten Bullets
+3. Production-Logs nach beiden Markern filtern:
+   - `[FIX-EXEC-DECISION-CLEAN]` (Healer)
+   - `TRUNCATED_LI` (Validator-Warnings)
+4. Nach 48 h: Rate berechnen und C2.2-Entscheidung treffen
+
+---
+
+## Sektion 5: Geänderte Dateien
+
+| Datei | Δ |
+|---|---|
+| `services/report_healer.py` | +60 LOC (Per-`<li>`-Pass nach FIX-B39) |
+| `services/report_validator.py` | +25 LOC (Per-`<li>`-Check in `_check_sentence_completeness`) |
+| `tests/test_exec_decision_clean.py` | +144 LOC (8 Tests) |
+| `docs/SPRINT_C2_EXEC_DECISION_TRUNCATION.md` | neu |
+
+**Out-of-Scope:** H1 Re-Gen, S.5 "Fallstudie spart 15h"-Layout, S.11 Kosmetik (per Briefing).

--- a/services/report_healer.py
+++ b/services/report_healer.py
@@ -3498,6 +3498,68 @@ def apply_segment_budget(
             _b39_applied, _b39_skipped
         )
 
+    # =========================================================================
+    # [FIX-EXEC-DECISION-CLEAN] Per-<li> mid-sentence detection for the three
+    # decision sections (executive_decision, roadmap_90d_decision,
+    # gamechanger_decision). FIX-B38a/B39 only inspect the section's terminal
+    # character — when a single <li> is truncated mid-sentence ("...den Ablauf
+    # Input") but later <li> elements end cleanly with "." the section-level
+    # check is satisfied and the broken bullet slips through (KIS-1186 / R1
+    # page 4 customer-facing). Root cause is most likely H1 (LLM emits more
+    # than max_tokens and the response is cut), tracked separately as
+    # potential sprint C2.2. This pass is the deterministic last-line of
+    # defense: detect the broken bullet, drop it, replace with a neutral
+    # status marker that respects the prompt-required 3-bullet shape.
+    # =========================================================================
+    _DECISION_SECTION_KEYS = {
+        "executive_decision", "EXECUTIVE_DECISION_HTML",
+        "roadmap_90d_decision", "ROADMAP_90D_DECISION_HTML",
+        "gamechanger_decision", "GAMECHANGER_DECISION_HTML",
+    }
+    _EXEC_TERMINAL_CHARS = {'.', '!', '?', ':', ')', '"', '»', '”', '*'}
+    _EXEC_BULLET_FALLBACK = (
+        '<li><em>Weitere Punkte siehe Business Case und Roadmap.</em></li>'
+    )
+    _li_pattern = re.compile(r'<li\b[^>]*>(.*?)</li>', re.DOTALL | re.IGNORECASE)
+
+    for _exec_key in list(result.keys()):
+        if _exec_key not in _DECISION_SECTION_KEYS:
+            continue
+        _exec_content = result[_exec_key]
+        if not isinstance(_exec_content, str) or len(_exec_content) < 50:
+            continue
+
+        _exec_bullets_total = 0
+        _exec_bullets_truncated = 0
+        _exec_bullets_dropped = 0
+
+        def _exec_replace(match: 're.Match[str]') -> str:
+            nonlocal _exec_bullets_total, _exec_bullets_truncated, _exec_bullets_dropped
+            _exec_bullets_total += 1
+            _inner = match.group(1)
+            _bullet_text = re.sub(r'</?\w+[^>]*>', '', _inner).strip()
+            if len(_bullet_text) < 25:
+                return match.group(0)
+            if _bullet_text[-1] in _EXEC_TERMINAL_CHARS:
+                return match.group(0)
+            _exec_bullets_truncated += 1
+            _exec_bullets_dropped += 1
+            return _EXEC_BULLET_FALLBACK
+
+        _exec_new = _li_pattern.sub(_exec_replace, _exec_content)
+
+        if _exec_bullets_truncated > 0:
+            result[_exec_key] = _exec_new
+            log.warning(
+                "[FIX-EXEC-DECISION-CLEAN] section=%s total=%d truncated=%d dropped=%d",
+                _exec_key, _exec_bullets_total, _exec_bullets_truncated, _exec_bullets_dropped,
+            )
+        else:
+            log.debug(
+                "[FIX-EXEC-DECISION-CLEAN] section=%s total=%d truncated=0",
+                _exec_key, _exec_bullets_total,
+            )
+
     return result, sections_trimmed
 
 

--- a/services/report_validator.py
+++ b/services/report_validator.py
@@ -3469,11 +3469,40 @@ class PlatinValidator:
         'THEME_CSS_VARS',
     }
 
+    # [FIX-EXEC-DECISION-CLEAN] Decision sections share the prompt contract
+    # "exactly 3 <li> bullets, each a complete sentence" (cf.
+    # prompts/de/executive_decision.md). The section-level last-char check
+    # below misses truncations INSIDE a single <li> when later bullets end
+    # cleanly with "." - KIS-1186 / R1 page 4 surfaced this on briefing
+    # 1069 as "...den Ablauf Input" inside the "Tun" bullet while the
+    # "Risiko" bullet's terminal "." satisfied the section-level check.
+    DECISION_SECTIONS_PER_LI_CHECK = {
+        "executive_decision", "EXECUTIVE_DECISION_HTML",
+        "roadmap_90d_decision", "ROADMAP_90D_DECISION_HTML",
+        "gamechanger_decision", "GAMECHANGER_DECISION_HTML",
+    }
+    _DECISION_TERMINAL_CHARS = '.!?:)"»”*'
+
     def _check_sentence_completeness(self) -> None:
         """No truncated sentences. FIX-B24-P3: Improved false-positive filtering."""
         for section_key, html in self.sections.items():
             if not isinstance(html, str) or section_key.startswith("_"):
                 continue
+
+            # [FIX-EXEC-DECISION-CLEAN] Per-<li> check for the three decision
+            # sections. Runs BEFORE the section-level safe-sections skip so
+            # the warning surfaces even when the section's terminal char
+            # looks clean (the common failure mode for these sections).
+            if section_key in self.DECISION_SECTIONS_PER_LI_CHECK:
+                for _li_match in re.finditer(r'<li\b[^>]*>(.*?)</li>', html, re.DOTALL | re.IGNORECASE):
+                    _li_text = re.sub(r'<[^>]+>', '', _li_match.group(1)).strip()
+                    if len(_li_text) < 25:
+                        continue
+                    if _li_text[-1] not in self._DECISION_TERMINAL_CHARS:
+                        self.warnings.append(
+                            f"TRUNCATED_LI: {section_key} bullet ends with '...{_li_text[-30:]}'"
+                        )
+
             # FIX-B24-P3: Skip sections that commonly end without punctuation
             if section_key in self.TRUNCATED_SAFE_SECTIONS:
                 continue

--- a/tests/test_exec_decision_clean.py
+++ b/tests/test_exec_decision_clean.py
@@ -1,0 +1,139 @@
+"""
+[FIX-EXEC-DECISION-CLEAN] Tests for per-<li> mid-sentence detection
+in the three decision sections (executive_decision, roadmap_90d_decision,
+gamechanger_decision).
+
+Reproduces KIS-1186 / R1 page 4: briefing 1069 emitted
+'<li><strong>Tun:</strong> ... den Ablauf Input</li>' inside
+executive_decision, while the "Risiko" bullet's terminal "." satisfied
+the section-level last-char check used by FIX-B38a / FIX-B39 / the
+PLATIN+++ validator. The broken bullet slipped through the entire
+healing+validation pipeline.
+
+Test contract:
+- Healer (apply_segment_budget): truncated <li> is dropped and replaced
+  with the neutral fallback, other bullets are preserved.
+- Validator (ReportValidator._check_sentence_completeness): emits
+  TRUNCATED_LI warning for the offending bullet even when the section
+  ends cleanly.
+"""
+import pytest
+
+
+class TestHealerExecDecisionClean:
+    def _heal(self, sections):
+        from services.report_healer import apply_segment_budget
+        result, _ = apply_segment_budget(sections, "solo")
+        return result
+
+    def test_truncated_bullet_dropped_and_replaced(self):
+        """KIS-1186 reproduction: mid-sentence <li> in executive_decision."""
+        sections = {
+            "executive_decision": (
+                '<div class="exec-decision-box">'
+                '<p><strong>Ihre Entscheidung in 3 Punkten</strong></p>'
+                '<ul>'
+                '<li><strong>Tun:</strong> Einen verbindlichen Standard-Arbeitsablauf '
+                'einführen, bei dem jede Beratungsleistung den Ablauf Input</li>'
+                '<li><strong>Lassen:</strong> Tool-Zoo und Ad-hoc-Prompts ohne Standards.</li>'
+                '<li><strong>Risiko:</strong> Nach 14 Tagen ohne Effekt stoppen.</li>'
+                '</ul></div>'
+            ),
+        }
+        out = self._heal(sections)
+        assert "den Ablauf Input" not in out["executive_decision"]
+        assert "Weitere Punkte siehe Business Case und Roadmap" in out["executive_decision"]
+        assert "Lassen:" in out["executive_decision"]
+        assert "Risiko:" in out["executive_decision"]
+
+    def test_clean_section_unchanged(self):
+        clean = (
+            '<ul>'
+            '<li>Tun: Standardisierung einführen mit klarem Owner.</li>'
+            '<li>Lassen: Tool-Zoo vermeiden, keine parallelen Initiativen.</li>'
+            '<li>Risiko: Nach 14 Tagen ohne Effekt stoppen.</li>'
+            '</ul>'
+        )
+        out = self._heal({"executive_decision": clean})
+        assert "Weitere Punkte siehe Business Case" not in out["executive_decision"]
+        assert "Standardisierung einführen" in out["executive_decision"]
+
+    def test_non_decision_section_ignored(self):
+        """The cleaner must only target the three decision sections."""
+        truncated_summary = (
+            '<ul>'
+            '<li>Punkt 1: Eine längere Aussage die mitten im Satz endet bei Input</li>'
+            '<li>Punkt 2: Vollständiger Satz hier.</li>'
+            '</ul>'
+        )
+        out = self._heal({"executive_summary": truncated_summary})
+        # executive_summary is NOT a decision section - bullet must survive
+        assert "bei Input" in out["executive_summary"]
+        assert "Weitere Punkte siehe Business Case" not in out["executive_summary"]
+
+    def test_short_bullet_below_threshold_preserved(self):
+        """Bullets shorter than 25 chars (likely meta-labels) are skipped."""
+        short = '<ul><li>Tun</li><li>Sonstiges hier.</li></ul>'
+        out = self._heal({"executive_decision": short})
+        # "Tun" (3 chars) is well below the 25-char floor - must be preserved
+        assert "<li>Tun</li>" in out["executive_decision"]
+
+    def test_all_three_decision_sections_covered(self):
+        """The fix targets executive_decision, roadmap_90d_decision,
+        gamechanger_decision (per prompt structure)."""
+        truncated_li = (
+            '<ul>'
+            '<li>Eine Aussage die mitten im Wort endet bei Input</li>'
+            '<li>Sauberes Ende hier mit Punkt.</li>'
+            '</ul>'
+        )
+        for key in ("executive_decision", "roadmap_90d_decision", "gamechanger_decision"):
+            out = self._heal({key: truncated_li})
+            assert "bei Input" not in out[key], f"{key} not cleaned"
+            assert "Weitere Punkte siehe Business Case" in out[key], f"{key} missing fallback"
+
+
+class TestValidatorExecDecisionClean:
+    def _validate(self, sections):
+        from services.report_validator import PlatinValidator
+        v = PlatinValidator(sections=sections)
+        v._check_sentence_completeness()
+        return v.warnings
+
+    def test_truncated_li_emits_warning_despite_clean_section_end(self):
+        """KIS-1186: section ends with '.' (Risiko bullet) but middle <li>
+        is mid-sentence. Section-level check passes; per-<li> check must
+        catch it."""
+        html = (
+            '<ul>'
+            '<li>Tun: Einen verbindlichen Standard einführen, bei dem '
+            'jede Beratung den Ablauf Input</li>'
+            '<li>Lassen: Tool-Zoo ohne Standards vermeiden.</li>'
+            '<li>Risiko: Nach 14 Tagen stoppen.</li>'
+            '</ul>'
+        )
+        warnings = self._validate({"executive_decision": html})
+        assert any(
+            "TRUNCATED_LI" in w and "executive_decision" in w
+            for w in warnings
+        ), f"Expected TRUNCATED_LI warning, got: {warnings}"
+
+    def test_clean_section_no_truncated_li_warning(self):
+        html = (
+            '<ul>'
+            '<li>Tun: Standardisierung mit klarem Owner einführen.</li>'
+            '<li>Lassen: Tool-Zoo vermeiden, keine Parallelinitiativen.</li>'
+            '<li>Risiko: Nach 14 Tagen ohne Effekt stoppen.</li>'
+            '</ul>'
+        )
+        warnings = self._validate({"executive_decision": html})
+        assert not any("TRUNCATED_LI" in w for w in warnings), f"Unexpected warning: {warnings}"
+
+    def test_non_decision_section_not_checked_per_li(self):
+        html = (
+            '<ul>'
+            '<li>Lange Aussage die mitten endet bei Input</li>'
+            '</ul>'
+        )
+        warnings = self._validate({"executive_summary": html})
+        assert not any("TRUNCATED_LI" in w for w in warnings), f"False positive: {warnings}"


### PR DESCRIPTION
## Bug C2 — KIS-1186 / Briefing 1069 (R1 S.4 Executive Decision)

R1-PDF zeigt auf Seite 4 ("Entscheidungsvorlage"):

> "Tun: Einen verbindlichen Standard-Arbeitsablauf einführen, bei dem jede Beratungsleistung den Ablauf Input"

Der "Tun"-Bullet endet mid-sentence ohne Punkt. Die anderen Bullets ("Lassen", "Risiko") enden korrekt mit `.` — Section-Last-Char-Check war zufrieden, Bug rutschte durch.

## Root Cause — architektonische Lücke in Section-Level-Checks

Beide existierenden Mechanismen prüfen **nur das letzte Zeichen der gesamten Sektion**:

| Mechanismus | Datei:Zeile | Scope |
|---|---|---|
| `FIX-B38a` / `FIX-B39` Clean-Ending-Pass | `services/report_healer.py:3411 ff` | Section-Terminus |
| PLATIN+++ `_check_sentence_completeness` | `services/report_validator.py:3486 ff` | Section-Terminus |

Die drei Decision-Sektionen (`executive_decision`, `roadmap_90d_decision`, `gamechanger_decision`) folgen aber alle dem Prompt-Vertrag **"genau 3 `<li>`-Bullets, jeder ein vollständiger Satz"** (cf. `prompts/de/executive_decision.md` Z.93–98). Truncation INNERHALB eines `<li>` rutscht durch, solange spätere `<li>` mit `.` enden — exakt das KIS-1186-Symptom.

H1 (LLM emittiert >max_tokens, Output cut) ist wahrscheinlichste Ursache: Token-Budget für `executive_decision` ist `OPENAI_MAX_TOKENS_DEFAULT=3000` (kein expliziter Wert in `_SECTION_MAX_TOKENS`), Prompt-Soft-Cap 60–90 Wörter wird vom LLM regelmäßig verletzt (FIX-C-Log: 801 char duplicates removed → LLM emittete ~1500+ chars). **H1 ist bewusst Out-of-Scope dieses Sprints**, Re-Gen-Logik wird via Marker-Volumen in C2.2 priorisiert.

## Patch — H2/H3 kombiniert per Briefing

### 1. `services/report_healer.py` — `[FIX-EXEC-DECISION-CLEAN]` (~60 LOC)

Nach dem FIX-B39-Block: iteriert über die drei Decision-Section-Keys (lower- + uppercase-Form), parst jedes `<li>` per Regex, prüft pro Bullet das terminale Zeichen. Truncierter Bullet wird ersetzt durch:

```html
<li><em>Weitere Punkte siehe Business Case und Roadmap.</em></li>
```

Marker auf `WARNING`-Level:
```
[FIX-EXEC-DECISION-CLEAN] section=executive_decision total=3 truncated=1 dropped=1
```

**Bullet-Drop ist intentional eine Vertragsverletzung** (Prompt fordert genau 3 Bullets in fester `Tun:/Lassen:/Risiko:`-Reihenfolge). Mid-sentence-Cutoff auf customer-facing PDF ist schlimmer als ein neutraler Fallback. Re-Gen wäre der saubere Fix → C2.2.

**Schwellwert `len(bullet_text) < 25`:** schützt vor False-Positives bei Mini-Label-`<li>` (z.B. `<li>Tun</li>` Header-Pattern).

### 2. `services/report_validator.py` — `TRUNCATED_LI` Warning (~25 LOC)

`PlatinValidator._check_sentence_completeness` führt vor dem Section-Level-Check einen Per-`<li>`-Check für die Decision-Sektionen durch:

```
TRUNCATED_LI: executive_decision bullet ends with '...jede Beratung den Ablauf Input'
```

Eigener Warning-Code (nicht `TRUNCATED`) damit Production-Log-Filter beide Failure-Modi separat zählen.

### 3. `tests/test_exec_decision_clean.py` — 8 Tests

| Test | Verifikation |
|---|---|
| `test_truncated_bullet_dropped_and_replaced` | KIS-1186-Reproduktion |
| `test_clean_section_unchanged` | No-Op auf sauberen Sektionen |
| `test_non_decision_section_ignored` | Scope-Isolation |
| `test_short_bullet_below_threshold_preserved` | 25-char Floor |
| `test_all_three_decision_sections_covered` | Alle 3 Sektionen |
| `test_truncated_li_emits_warning_despite_clean_section_end` | Validator-Hauptcase |
| `test_clean_section_no_truncated_li_warning` | Validator False-Positive-Schutz |
| `test_non_decision_section_not_checked_per_li` | Validator-Scope |

## Verifikation

```
Local full suite: 6387 passed, 10 skipped, 0 failed
```

## Validierungs-Plan (Production-Smoke)

1. Test-Briefing absenden (Solo + Beratung + `ki_kompetenz=hoch`, gleicher Profil-Schnitt wie 1069)
2. R1-PDF S.4 prüfen:
   - **Best Case:** Kein Marker → LLM lieferte sauber, Patch ungenutzt
   - **Healing Case:** Marker mit `truncated≥1`, S.4 zeigt Fallback-Bullet an Position des defekten Bullets
3. Production-Logs filtern nach:
   - `[FIX-EXEC-DECISION-CLEAN]` (Healer)
   - `TRUNCATED_LI` (Validator)
4. Nach 48h/≥10 Briefings: Rate für C2.2-Entscheidung

## Geänderte Dateien

| Datei | Δ |
|---|---|
| `services/report_healer.py` | +60 LOC |
| `services/report_validator.py` | +25 LOC |
| `tests/test_exec_decision_clean.py` | +144 (neu) |
| `docs/SPRINT_C2_EXEC_DECISION_TRUNCATION.md` | +147 (neu) |

## Out of Scope

- **H1 Re-Gen-Logik** — Folge-Sprint C2.2, abhängig von Marker-Volumen
- **`_SECTION_MAX_TOKENS["executive_decision"]` explizit setzen** — Folge-Optimierung
- **S.5 "Fallstudie spart 15h" Layout-Bruch** — separate Diagnose
- **S.11 Kosmetik-Findings** — separate

https://claude.ai/code/session_01UWV1XBaNB39jy3VQRMiT9X

---
_Generated by [Claude Code](https://claude.ai/code/session_01UWV1XBaNB39jy3VQRMiT9X)_