### PR TITLE
fix(r1): extend decision-section truncation detection to &lt;p&gt; and tag-salat

### DIFF
--- a/docs/SPRINT_1026_1_DECISION_DETECTION_FIX.md
+++ b/docs/SPRINT_1026_1_DECISION_DETECTION_FIX.md
@@ -1,0 +1,192 @@
+# Sprint 1026.1 — Decision-Section Detection-Fix
+
+**Status:** Detection-Pattern erweitert um zwei Failure-Modi (Scenario C + E), Pipeline-Reihenfolge unverändert.
+
+**Auslöser:** KIS-1187 / Briefing 1070 — derselbe Mid-Sentence-Cutoff-Bug auf R1 S.4 wie KIS-1186, obwohl PR #1026 produktiv ist. Bullet endete mit "...dem Schema Input", kein Ellipsis, semantisch eindeutig truncated, aber Detection feuerte nicht.
+
+---
+
+## Sektion 1: Diagnose (Phase 1)
+
+### 1.1 Section-Key-Verhalten — ✅ kein Mismatch
+
+`_DECISION_SECTION_KEYS` in `services/report_healer.py:3514-3518` enthielt bereits beide Varianten:
+```python
+_DECISION_SECTION_KEYS = {
+    "executive_decision", "EXECUTIVE_DECISION_HTML",
+    "roadmap_90d_decision", "ROADMAP_90D_DECISION_HTML",
+    "gamechanger_decision", "GAMECHANGER_DECISION_HTML",
+}
+```
+
+Die Loop `for _exec_key in list(result.keys())` iterierte korrekt über alle Keys. **Hypothese 1 (Section-Key-Mismatch) entkräftet.**
+
+### 1.2 Ausführungsreihenfolge — ✅ kein Root Cause
+
+`heal_report_html` Pipeline (Step-by-Step):
+
+| Step | Fix | Location |
+|---:|---|---|
+| 2 | KEYS normalize | `normalize_section_keys` |
+| 3 | A: Template phrases | `_apply_fix_a_recursive` |
+| 4 | B: Persona language | `_apply_fix_b_recursive` |
+| **5** | **C: Redundancy reduction** | **`reduce_redundancy` (`_extract_blocks`)** |
+| 6 | D: ROI rules | `enforce_roi_rules` |
+| 7 | F: Payback consistency | `enforce_payback_consistency` |
+| **9** | **G: Segment budget** | **`apply_segment_budget` ← `[FIX-EXEC-DECISION-CLEAN]` lebt hier** |
+| 10 | E: Trim incomplete | `trim_incomplete_sentences` |
+
+FIX-C läuft VOR der Detection. Aber FIX-C entfernt nur **Duplikate** (via `_extract_blocks` über `<p>`, `<li>`, `<div class="callout|box|card">`) — keine einzelnen broken Bullets. Synthetic-Test Szenario B (FIX-C entfernt alle Siblings, broken Bullet bleibt als einziger übrig) bestätigt: Detection würde korrekt feuern. **Hypothese 2 (FIX-C räumt broken Bullet weg) entkräftet.**
+
+### 1.3 Detection-Pattern — ⚠️ ROOT CAUSE
+
+PR #1026 nutzte einen strikten Regex:
+```python
+_li_pattern = re.compile(r'<li\b[^>]*>(.*?)</li>', re.DOTALL | re.IGNORECASE)
+```
+
+Synthetic-Test mit 5 Szenarien gegen diesen Regex:
+
+| Szenario | Beschreibung | Detection? | Repair? |
+|---|---|:---:|:---:|
+| A | Proper `<li>...</li>` mit truncated Tun | ✅ | ✅ |
+| B | Nach FIX-C: nur truncated Bullet übrig | ✅ | ✅ |
+| **C** | **LLM emittierte `<p>` statt `<li>`** | **❌** | **❌** |
+| D | Loose `<li>` ohne `<ul>`-Parent | ✅ | ✅ |
+| **E** | **`<li>` mit `</p>` geschlossen (Tag-Salat)** | **❌** | **❌** |
+
+**Scenario C** (KIS-1187 vermutete Variante): Prompt-Vertrag-Violation — LLM emittierte `<p><strong>Tun:</strong>...</p>`-Bullets. Strict-Regex matcht 0× `<li>` → keine Detection.
+
+**Scenario E:** LLM emittierte `<li><strong>Tun:</strong>...</p><li>...</li><li>...</li>` (mismatched closing). Non-greedy `(.*?)</li>` matcht vom ersten `<li>` bis zum nächsten echten `</li>` — schluckt also bis "Lassen: ... Standards." als EINEN Bullet, dessen letztes Zeichen `.` ist → kein Trigger.
+
+**Hypothese 3 (Detection-Pattern unzureichend) = ROOT CAUSE.**
+
+---
+
+## Sektion 2: Patch (Phase 2)
+
+### 2.1 Drei-Pass-Detection in `services/report_healer.py`
+
+Detection-Block in `apply_segment_budget` (Position unverändert, **kein Reorder gegen FIX-C**) entscheidet anhand der `<li>`-Tag-Balance, welcher Pass läuft:
+
+```python
+_open_count = len(_li_open_pattern.findall(_exec_content))
+_close_count = len(_li_close_pattern.findall(_exec_content))
+
+if _open_count == 0:
+    # Pass 3: <p>-fallback (Scenario C)
+    _new_content, _total, _truncated = _exec_heal_p_bullets(_exec_content)
+    _bullet_tag = "p"
+elif _open_count == _close_count:
+    # Pass 1: strict <li>...</li> (existing PR #1026 logic)
+    _new_content, _total, _truncated = _exec_heal_strict_li(_exec_content)
+    _bullet_tag = "li"
+else:
+    # Pass 2: tag-salat — split on <li>-boundaries (Scenario E)
+    _new_content, _total, _truncated = _exec_heal_tag_salad(_exec_content)
+    _bullet_tag = "li-salad"
+```
+
+#### Pass 2 (`_exec_heal_tag_salad`) — Tag-Salat-Handling
+
+Findet alle `<li[^>]*>`-Öffnungspositionen via `finditer`. Jeder Bullet erstreckt sich von einer `<li>`-Öffnung bis zur nächsten oder zum schließenden `</ul>`/`</ol>`. Wenn der Bullet-Text truncated ist, wird der gesamte Bullet-Span durch `_LI_BULLET_FALLBACK` ersetzt. Andernfalls wird ein well-formed `<li>...</li>` mit dem Original-Open-Tag re-emittiert.
+
+#### Pass 3 (`_exec_heal_p_bullets`) — `<p>`-Fallback
+
+Iteriert über `<p>...</p>`-Matches. **Gate via `_bullet_prefix_re`**:
+```python
+_bullet_prefix_re = re.compile(
+    r'<strong\b[^>]*>\s*(?:Tun|Lassen|Risiko|Stop)', re.IGNORECASE,
+)
+```
+Nur `<p>`-Blöcke deren Body mit `<strong>Tun:|Lassen:|Risiko|Stop` beginnt werden als Bullet behandelt. Verhindert False-Positives auf Header (`<p><strong>Ihre Entscheidung in 3 Punkten</strong></p>`) und Intro-Text.
+
+Bei Detection wird der `<p>` durch `_P_BULLET_FALLBACK = '<p><em>Weitere Punkte siehe Business Case und Roadmap.</em></p>'` ersetzt (struktur-analog).
+
+### 2.2 Marker-Erweiterung
+
+`[FIX-EXEC-DECISION-CLEAN]` bekommt neues Feld `bullet_tag` für Diagnose:
+
+```
+[FIX-EXEC-DECISION-CLEAN] section=executive_decision bullet_tag=p total=3 truncated=1 dropped=1
+[FIX-EXEC-DECISION-CLEAN] section=executive_decision bullet_tag=li-salad total=3 truncated=1 dropped=1
+[FIX-EXEC-DECISION-CLEAN] section=executive_decision bullet_tag=li total=3 truncated=1 dropped=1
+```
+
+Production-Filter können damit pro Bullet-Tag Statistiken bilden und LLM-Prompt-Compliance über die Zeit messen.
+
+### 2.3 Validator-Parität in `services/report_validator.py`
+
+`PlatinValidator._check_sentence_completeness` bekommt dieselbe Drei-Pass-Logik. Emittiert `TRUNCATED_LI`-Warnings für:
+- `<p>-bullet ends with '...{text}'` (Scenario C)
+- `bullet ends with '...{text}'` (Scenario A/E)
+
+---
+
+## Sektion 3: Tests
+
+`tests/test_exec_decision_clean.py` wächst von 8 auf 18 Tests:
+
+### Bestehend (PR #1026, alle weiter grün)
+
+| Test | Verifikation |
+|---|---|
+| `test_truncated_bullet_dropped_and_replaced` | KIS-1186 strict `<li>` Reproduktion |
+| `test_clean_section_unchanged` | No-Op auf sauberen Sektionen |
+| `test_non_decision_section_ignored` | Scope-Isolation |
+| `test_short_bullet_below_threshold_preserved` | 25-char Floor |
+| `test_all_three_decision_sections_covered` | Alle 3 Sektionen |
+| `test_truncated_li_emits_warning_despite_clean_section_end` | Validator strict |
+| `test_clean_section_no_truncated_li_warning` | Validator False-Positive-Schutz |
+| `test_non_decision_section_not_checked_per_li` | Validator-Scope |
+
+### Neu (Sprint 1026.1)
+
+| Test | Verifikation |
+|---|---|
+| `test_kis1187_p_bullets_scenario_c` | KIS-1187 Reproduktion — `<p>`-Bullets |
+| `test_tag_salad_scenario_e` | Tag-Salat `<li>...</p><li>...` |
+| `test_non_decision_p_bullets_not_repaired` | Scope-Isolation für `<p>`-Pass |
+| `test_p_bullets_all_clean_no_repair` | No-Op `<p>`-only sauber |
+| `test_p_bullets_only_non_bullet_p_unchanged` | Header-`<p>` ohne Prefix |
+| `test_tag_salad_all_clean_no_repair` | Tag-Salat aber alle terminal |
+| `test_p_bullet_truncation_emits_warning` | Validator Scenario C |
+| `test_tag_salad_truncation_emits_warning` | Validator Scenario E |
+| `test_p_bullet_clean_section_no_warning` | Validator False-Positive |
+| `test_non_bullet_p_in_decision_section_not_flagged` | Validator Scope |
+
+Local full suite: **6410 passed, 10 skipped, 0 failed.**
+
+---
+
+## Sektion 4: Validierungsplan (Production-Smoke)
+
+1. Test-Briefing absenden (Solo + Beratung + `ki_kompetenz=hoch`)
+2. R1-PDF S.4 prüfen:
+   - **Best Case (LLM hält Vertrag):** kein Marker, saubere Bullets
+   - **Healing Case Scenario A/B (well-formed):** `bullet_tag=li` + Fallback an Position des truncated Bullet
+   - **Healing Case Scenario C (`<p>`-Bullets):** `bullet_tag=p` + Fallback als `<p>`-Element analog
+   - **Healing Case Scenario E (Tag-Salat):** `bullet_tag=li-salad` + Fallback + re-emittierte well-formed Siblings
+3. Production-Logs nach `[FIX-EXEC-DECISION-CLEAN]` filtern, `bullet_tag`-Distribution prüfen
+4. Nach 48 h / ≥10 Briefings: wenn `bullet_tag=p` oder `bullet_tag=li-salad` > 10% → LLM-Compliance-Issue → C2.2 (Re-Gen) priorisieren
+
+---
+
+## Sektion 5: Geänderte Dateien
+
+| Datei | Δ |
+|---|---|
+| `services/report_healer.py` | +112 / −44 LOC (3-Pass-Detection + Helper-Funktionen) |
+| `services/report_validator.py` | +43 / −6 LOC (Validator-Parität) |
+| `tests/test_exec_decision_clean.py` | +148 LOC (10 neue Tests, 8 bestehende unverändert) |
+| `docs/SPRINT_1026_1_DECISION_DETECTION_FIX.md` | +160 (neu) |
+
+---
+
+## Sektion 6: Out-of-Scope (bestätigt aus Briefing)
+
+- KEINE C2.2 H1 Re-Gen Logik (separates Sprint)
+- KEINE Quick-Wins-Tile-Header-Bugs
+- KEINE Compact-Engine-Effizienz
+- KEINE TRANSPARENCY_BOX Email-Leak-Refinement
+- Fokus ausschließlich auf executive_decision Detection-Robustheit

--- a/services/report_healer.py
+++ b/services/report_healer.py
@@ -3499,17 +3499,33 @@ def apply_segment_budget(
         )
 
     # =========================================================================
-    # [FIX-EXEC-DECISION-CLEAN] Per-<li> mid-sentence detection for the three
+    # [FIX-EXEC-DECISION-CLEAN] Per-bullet mid-sentence detection for the three
     # decision sections (executive_decision, roadmap_90d_decision,
     # gamechanger_decision). FIX-B38a/B39 only inspect the section's terminal
-    # character — when a single <li> is truncated mid-sentence ("...den Ablauf
-    # Input") but later <li> elements end cleanly with "." the section-level
-    # check is satisfied and the broken bullet slips through (KIS-1186 / R1
-    # page 4 customer-facing). Root cause is most likely H1 (LLM emits more
-    # than max_tokens and the response is cut), tracked separately as
-    # potential sprint C2.2. This pass is the deterministic last-line of
-    # defense: detect the broken bullet, drop it, replace with a neutral
-    # status marker that respects the prompt-required 3-bullet shape.
+    # character — when a single bullet is truncated mid-sentence ("...den Ablauf
+    # Input") but later bullets end cleanly with "." the section-level check
+    # is satisfied and the broken bullet slips through.
+    #
+    # Sprint 1026.1 (KIS-1187): The strict `<li>...</li>` regex from PR #1026
+    # missed two LLM-output-quality failure modes:
+    #
+    #   - Scenario C: LLM emitted `<p>` instead of `<li>` (prompt-contract
+    #     violation). The strict regex matched zero bullets and skipped the
+    #     section entirely.
+    #   - Scenario E: Tag-salat — LLM emitted `<li>...<li>` without `</li>`,
+    #     or closed `<li>` with `</p>`. The greedy `(.*?)</li>` then captured
+    #     multiple bullets as one; the last sibling's terminal "." satisfied
+    #     the check and the broken bullet slipped through.
+    #
+    # Detection now runs three passes:
+    #   1. Strict `<li>...</li>` (unchanged, well-formed LLM output)
+    #   2. Tag-salat: open/close `<li>` count mismatch → split on `<li>`
+    #      boundaries and treat each segment as one bullet
+    #   3. `<p>`-fallback: no `<li>` at all → look for `<p>` blocks whose
+    #      content starts with `<strong>Tun:|Lassen:|Risiko|Stop` and treat
+    #      each as a bullet
+    #
+    # Out of scope (per sprint briefing): H1 re-gen, queue C2.2 separately.
     # =========================================================================
     _DECISION_SECTION_KEYS = {
         "executive_decision", "EXECUTIVE_DECISION_HTML",
@@ -3517,10 +3533,100 @@ def apply_segment_budget(
         "gamechanger_decision", "GAMECHANGER_DECISION_HTML",
     }
     _EXEC_TERMINAL_CHARS = {'.', '!', '?', ':', ')', '"', '»', '”', '*'}
-    _EXEC_BULLET_FALLBACK = (
+    _LI_BULLET_FALLBACK = (
         '<li><em>Weitere Punkte siehe Business Case und Roadmap.</em></li>'
     )
-    _li_pattern = re.compile(r'<li\b[^>]*>(.*?)</li>', re.DOTALL | re.IGNORECASE)
+    _P_BULLET_FALLBACK = (
+        '<p><em>Weitere Punkte siehe Business Case und Roadmap.</em></p>'
+    )
+    _li_strict_pattern = re.compile(r'<li\b[^>]*>(.*?)</li>', re.DOTALL | re.IGNORECASE)
+    _li_open_pattern = re.compile(r'<li\b[^>]*>', re.IGNORECASE)
+    _li_close_pattern = re.compile(r'</li>', re.IGNORECASE)
+    _list_close_pattern = re.compile(r'</(?:ul|ol)>', re.IGNORECASE)
+    _p_pattern = re.compile(r'<p\b[^>]*>(.*?)</p>', re.DOTALL | re.IGNORECASE)
+    _bullet_prefix_re = re.compile(
+        r'<strong\b[^>]*>\s*(?:Tun|Lassen|Risiko|Stop)', re.IGNORECASE,
+    )
+
+    def _exec_text_truncated(_text: str) -> bool:
+        """True iff bullet text is long enough to evaluate AND ends mid-sentence."""
+        if not _text or len(_text) < 25:
+            return False
+        return _text[-1] not in _EXEC_TERMINAL_CHARS
+
+    def _exec_heal_strict_li(_content: str) -> Tuple[str, int, int]:
+        """Pass 1: well-formed `<li>...</li>` (existing PR #1026 logic)."""
+        _total = 0
+        _truncated = 0
+
+        def _li_replace(match: 're.Match[str]') -> str:
+            nonlocal _total, _truncated
+            _total += 1
+            _text = re.sub(r'</?\w+[^>]*>', '', match.group(1)).strip()
+            if _exec_text_truncated(_text):
+                _truncated += 1
+                return _LI_BULLET_FALLBACK
+            return match.group(0)
+
+        _new = _li_strict_pattern.sub(_li_replace, _content)
+        return _new, _total, _truncated
+
+    def _exec_heal_tag_salad(_content: str) -> Tuple[str, int, int]:
+        """Pass 2: `<li>` open/close count mismatch.
+
+        Splits at each `<li>` opening regardless of `</li>` presence. Each
+        bullet spans from one `<li>` opening to the next `<li>` opening or
+        to the closing `</ul>`/`</ol>` (or end-of-content).
+        """
+        _opens = list(_li_open_pattern.finditer(_content))
+        if not _opens:
+            return _content, 0, 0
+
+        # Locate the list-closing tag after the last <li>
+        _list_close_match = _list_close_pattern.search(_content, _opens[-1].end())
+        _list_close_at = _list_close_match.start() if _list_close_match else len(_content)
+
+        _parts = [_content[: _opens[0].start()]]
+        _total = 0
+        _truncated = 0
+
+        for _idx, _open_match in enumerate(_opens):
+            _total += 1
+            _body_start = _open_match.end()
+            _body_end = _opens[_idx + 1].start() if _idx + 1 < len(_opens) else _list_close_at
+            _body = _content[_body_start:_body_end]
+            # Strip any trailing </li> the LLM produced
+            _body_clean = re.sub(r'</li>\s*$', '', _body, flags=re.IGNORECASE).rstrip()
+            _text = re.sub(r'<[^>]+>', '', _body_clean).strip()
+            if _exec_text_truncated(_text):
+                _truncated += 1
+                _parts.append(_LI_BULLET_FALLBACK)
+            else:
+                # Re-emit a well-formed <li>...</li> using the original opening tag
+                _parts.append(f'{_open_match.group(0)}{_body_clean}</li>')
+
+        _parts.append(_content[_list_close_at:])
+        return ''.join(_parts), _total, _truncated
+
+    def _exec_heal_p_bullets(_content: str) -> Tuple[str, int, int]:
+        """Pass 3: no `<li>` at all — `<p><strong>Tun:|Lassen:|Risiko:` bullets."""
+        _total = 0
+        _truncated = 0
+
+        def _p_replace(match: 're.Match[str]') -> str:
+            nonlocal _total, _truncated
+            _body = match.group(1)
+            if not _bullet_prefix_re.search(_body):
+                return match.group(0)  # not a decision bullet, leave it
+            _total += 1
+            _text = re.sub(r'<[^>]+>', '', _body).strip()
+            if _exec_text_truncated(_text):
+                _truncated += 1
+                return _P_BULLET_FALLBACK
+            return match.group(0)
+
+        _new = _p_pattern.sub(_p_replace, _content)
+        return _new, _total, _truncated
 
     for _exec_key in list(result.keys()):
         if _exec_key not in _DECISION_SECTION_KEYS:
@@ -3529,35 +3635,30 @@ def apply_segment_budget(
         if not isinstance(_exec_content, str) or len(_exec_content) < 50:
             continue
 
-        _exec_bullets_total = 0
-        _exec_bullets_truncated = 0
-        _exec_bullets_dropped = 0
+        _open_count = len(_li_open_pattern.findall(_exec_content))
+        _close_count = len(_li_close_pattern.findall(_exec_content))
 
-        def _exec_replace(match: 're.Match[str]') -> str:
-            nonlocal _exec_bullets_total, _exec_bullets_truncated, _exec_bullets_dropped
-            _exec_bullets_total += 1
-            _inner = match.group(1)
-            _bullet_text = re.sub(r'</?\w+[^>]*>', '', _inner).strip()
-            if len(_bullet_text) < 25:
-                return match.group(0)
-            if _bullet_text[-1] in _EXEC_TERMINAL_CHARS:
-                return match.group(0)
-            _exec_bullets_truncated += 1
-            _exec_bullets_dropped += 1
-            return _EXEC_BULLET_FALLBACK
+        if _open_count == 0:
+            _new_content, _total, _truncated = _exec_heal_p_bullets(_exec_content)
+            _bullet_tag = "p"
+        elif _open_count == _close_count:
+            _new_content, _total, _truncated = _exec_heal_strict_li(_exec_content)
+            _bullet_tag = "li"
+        else:
+            _new_content, _total, _truncated = _exec_heal_tag_salad(_exec_content)
+            _bullet_tag = "li-salad"
 
-        _exec_new = _li_pattern.sub(_exec_replace, _exec_content)
-
-        if _exec_bullets_truncated > 0:
-            result[_exec_key] = _exec_new
+        if _truncated > 0:
+            result[_exec_key] = _new_content
             log.warning(
-                "[FIX-EXEC-DECISION-CLEAN] section=%s total=%d truncated=%d dropped=%d",
-                _exec_key, _exec_bullets_total, _exec_bullets_truncated, _exec_bullets_dropped,
+                "[FIX-EXEC-DECISION-CLEAN] section=%s bullet_tag=%s "
+                "total=%d truncated=%d dropped=%d",
+                _exec_key, _bullet_tag, _total, _truncated, _truncated,
             )
         else:
             log.debug(
-                "[FIX-EXEC-DECISION-CLEAN] section=%s total=%d truncated=0",
-                _exec_key, _exec_bullets_total,
+                "[FIX-EXEC-DECISION-CLEAN] section=%s bullet_tag=%s total=%d truncated=0",
+                _exec_key, _bullet_tag, _total,
             )
 
     return result, sections_trimmed

--- a/services/report_validator.py
+++ b/services/report_validator.py
@@ -3489,19 +3489,62 @@ class PlatinValidator:
             if not isinstance(html, str) or section_key.startswith("_"):
                 continue
 
-            # [FIX-EXEC-DECISION-CLEAN] Per-<li> check for the three decision
-            # sections. Runs BEFORE the section-level safe-sections skip so
-            # the warning surfaces even when the section's terminal char
-            # looks clean (the common failure mode for these sections).
+            # [FIX-EXEC-DECISION-CLEAN] Per-bullet check for the three decision
+            # sections. Sprint 1026.1 (KIS-1187): also detects <p>-bullets
+            # (Scenario C, prompt-contract violation) and <li> tag-salat
+            # (Scenario E, mismatched closing tags) — same failure modes the
+            # healer now repairs.
             if section_key in self.DECISION_SECTIONS_PER_LI_CHECK:
-                for _li_match in re.finditer(r'<li\b[^>]*>(.*?)</li>', html, re.DOTALL | re.IGNORECASE):
-                    _li_text = re.sub(r'<[^>]+>', '', _li_match.group(1)).strip()
-                    if len(_li_text) < 25:
-                        continue
-                    if _li_text[-1] not in self._DECISION_TERMINAL_CHARS:
-                        self.warnings.append(
-                            f"TRUNCATED_LI: {section_key} bullet ends with '...{_li_text[-30:]}'"
-                        )
+                _open_count = len(re.findall(r'<li\b', html, re.IGNORECASE))
+                _close_count = len(re.findall(r'</li>', html, re.IGNORECASE))
+
+                if _open_count == 0:
+                    # <p>-fallback path
+                    _bullet_prefix = re.compile(
+                        r'<strong\b[^>]*>\s*(?:Tun|Lassen|Risiko|Stop)',
+                        re.IGNORECASE,
+                    )
+                    for _p_match in re.finditer(
+                        r'<p\b[^>]*>(.*?)</p>', html, re.DOTALL | re.IGNORECASE,
+                    ):
+                        _body = _p_match.group(1)
+                        if not _bullet_prefix.search(_body):
+                            continue
+                        _text = re.sub(r'<[^>]+>', '', _body).strip()
+                        if len(_text) < 25:
+                            continue
+                        if _text[-1] not in self._DECISION_TERMINAL_CHARS:
+                            self.warnings.append(
+                                f"TRUNCATED_LI: {section_key} <p>-bullet ends with '...{_text[-30:]}'"
+                            )
+                elif _open_count != _close_count:
+                    # Tag-salat path — split on <li> openings
+                    _opens = list(re.finditer(r'<li\b[^>]*>', html, re.IGNORECASE))
+                    _list_close = re.search(r'</(?:ul|ol)>', html[_opens[-1].end():], re.IGNORECASE)
+                    _end = (_opens[-1].end() + _list_close.start()) if _list_close else len(html)
+                    for _i, _o in enumerate(_opens):
+                        _bs = _o.end()
+                        _be = _opens[_i + 1].start() if _i + 1 < len(_opens) else _end
+                        _body = re.sub(r'</li>\s*$', '', html[_bs:_be], flags=re.IGNORECASE)
+                        _text = re.sub(r'<[^>]+>', '', _body).strip()
+                        if len(_text) < 25:
+                            continue
+                        if _text[-1] not in self._DECISION_TERMINAL_CHARS:
+                            self.warnings.append(
+                                f"TRUNCATED_LI: {section_key} bullet ends with '...{_text[-30:]}'"
+                            )
+                else:
+                    # Well-formed <li>...</li> — original logic
+                    for _li_match in re.finditer(
+                        r'<li\b[^>]*>(.*?)</li>', html, re.DOTALL | re.IGNORECASE,
+                    ):
+                        _li_text = re.sub(r'<[^>]+>', '', _li_match.group(1)).strip()
+                        if len(_li_text) < 25:
+                            continue
+                        if _li_text[-1] not in self._DECISION_TERMINAL_CHARS:
+                            self.warnings.append(
+                                f"TRUNCATED_LI: {section_key} bullet ends with '...{_li_text[-30:]}'"
+                            )
 
             # FIX-B24-P3: Skip sections that commonly end without punctuation
             if section_key in self.TRUNCATED_SAFE_SECTIONS:

--- a/tests/test_exec_decision_clean.py
+++ b/tests/test_exec_decision_clean.py
@@ -93,6 +93,113 @@ class TestHealerExecDecisionClean:
             assert "Weitere Punkte siehe Business Case" in out[key], f"{key} missing fallback"
 
 
+class TestHealerExecDecisionClean10261:
+    """Sprint 1026.1 — coverage for LLM-output-quality scenarios that PR #1026
+    missed (KIS-1187 reproduction)."""
+
+    def _heal(self, sections):
+        from services.report_healer import apply_segment_budget
+        result, _ = apply_segment_budget(sections, "solo")
+        return result
+
+    def test_kis1187_p_bullets_scenario_c(self):
+        """KIS-1187 root cause: LLM emitted <p> bullets instead of <li>. The
+        strict regex from PR #1026 saw zero <li> and the broken bullet slipped
+        through. Pass 3 (<p>-fallback) must now catch it."""
+        sections = {
+            "executive_decision": (
+                '<div class="exec-decision-box">'
+                '<p><strong>Ihre Entscheidung in 3 Punkten</strong></p>'
+                '<p><strong>Tun:</strong> Einen verbindlichen Standard einführen, '
+                'bei dem jedes Objekt dem Schema Input</p>'
+                '<p><strong>Lassen:</strong> Tool-Zoo ohne Standards.</p>'
+                '<p><strong>Risiko:</strong> Nach 14 Tagen ohne Effekt stoppen.</p>'
+                '</div>'
+            ),
+        }
+        out = self._heal(sections)
+        assert "dem Schema Input" not in out["executive_decision"]
+        assert "Weitere Punkte siehe Business Case und Roadmap" in out["executive_decision"]
+        # Sibling p-bullets preserved
+        assert "Lassen:" in out["executive_decision"]
+        assert "Risiko:" in out["executive_decision"]
+        # Non-bullet <p> (header) preserved
+        assert "Ihre Entscheidung in 3 Punkten" in out["executive_decision"]
+
+    def test_tag_salad_scenario_e(self):
+        """LLM emitted <li>...<li> (no </li>) or closed <li> with </p>. PR #1026
+        regex greedy-matched across bullets and accepted the last sibling's "."
+        as terminal. Pass 2 (tag-salat) splits on <li>-boundaries."""
+        sections = {
+            "executive_decision": (
+                '<ul>'
+                '<li><strong>Tun:</strong> Einen verbindlichen Standard einführen, '
+                'bei dem jedes Objekt dem Schema Input</p>'
+                '<li><strong>Lassen:</strong> Tool-Zoo ohne Standards.</li>'
+                '<li><strong>Risiko:</strong> Nach 14 Tagen stoppen.</li>'
+                '</ul>'
+            ),
+        }
+        out = self._heal(sections)
+        assert "dem Schema Input" not in out["executive_decision"]
+        assert "Weitere Punkte siehe Business Case und Roadmap" in out["executive_decision"]
+        # Siblings preserved with proper <li>...</li>
+        assert "Tool-Zoo ohne Standards." in out["executive_decision"]
+        assert "Nach 14 Tagen stoppen." in out["executive_decision"]
+
+    def test_non_decision_p_bullets_not_repaired(self):
+        """Non-decision sections with similar <p><strong>Tun:</strong> patterns
+        must NOT be touched — Pass 3 is gated on section key."""
+        html = (
+            '<p><strong>Tun:</strong> Eine längere Aussage die mitten endet bei Input</p>'
+        )
+        out = self._heal({"executive_summary": html})
+        # executive_summary is NOT a decision section
+        assert "bei Input" in out["executive_summary"]
+        assert "Weitere Punkte siehe Business Case" not in out["executive_summary"]
+
+    def test_p_bullets_all_clean_no_repair(self):
+        """When all <p>-bullets end cleanly, nothing changes."""
+        clean = (
+            '<p><strong>Tun:</strong> Standardisierung einführen.</p>'
+            '<p><strong>Lassen:</strong> Tool-Zoo vermeiden.</p>'
+            '<p><strong>Risiko:</strong> Nach 14 Tagen stoppen.</p>'
+        )
+        out = self._heal({"executive_decision": clean})
+        assert "Weitere Punkte siehe Business Case" not in out["executive_decision"]
+        assert "Standardisierung einführen" in out["executive_decision"]
+
+    def test_p_bullets_only_non_bullet_p_unchanged(self):
+        """<p> blocks without the Tun:/Lassen:/Risiko prefix must not trigger
+        Pass 3 (prevents false-positives in headers, intro text, etc.)."""
+        html = (
+            '<p>Diese Sektion enthält einen längeren Einleitungstext der mitten endet bei Input</p>'
+        )
+        # Decision-section key but non-bullet <p> with no prefix — must NOT touch
+        out = self._heal({"executive_decision": html})
+        assert "bei Input" in out["executive_decision"]
+        assert "Weitere Punkte siehe Business Case" not in out["executive_decision"]
+
+    def test_tag_salad_all_clean_no_repair(self):
+        """Tag-salat with all bullets ending cleanly: split heuristic must not
+        flag anything and must produce well-formed <li>...</li> output."""
+        sections = {
+            "executive_decision": (
+                '<ul>'
+                '<li><strong>Tun:</strong> Standardisierung einführen mit klarem Owner.'
+                '<li><strong>Lassen:</strong> Tool-Zoo vermeiden, keine Parallelinitiativen.'
+                '<li><strong>Risiko:</strong> Nach 14 Tagen ohne Effekt stoppen.'
+                '</ul>'
+            ),
+        }
+        out = self._heal(sections)
+        assert "Weitere Punkte siehe Business Case" not in out["executive_decision"]
+        # All three sibling texts present
+        assert "Standardisierung einführen" in out["executive_decision"]
+        assert "Tool-Zoo vermeiden" in out["executive_decision"]
+        assert "Nach 14 Tagen ohne Effekt stoppen" in out["executive_decision"]
+
+
 class TestValidatorExecDecisionClean:
     def _validate(self, sections):
         from services.report_validator import PlatinValidator
@@ -136,4 +243,61 @@ class TestValidatorExecDecisionClean:
             '</ul>'
         )
         warnings = self._validate({"executive_summary": html})
+        assert not any("TRUNCATED_LI" in w for w in warnings), f"False positive: {warnings}"
+
+
+class TestValidatorExecDecisionClean10261:
+    """Sprint 1026.1 validator parity for scenarios C and E."""
+
+    def _validate(self, sections):
+        from services.report_validator import PlatinValidator
+        v = PlatinValidator(sections=sections)
+        v._check_sentence_completeness()
+        return v.warnings
+
+    def test_p_bullet_truncation_emits_warning(self):
+        """Scenario C: <p>-only decision section with truncated Tun bullet."""
+        html = (
+            '<p><strong>Ihre Entscheidung in 3 Punkten</strong></p>'
+            '<p><strong>Tun:</strong> Einen Standard einführen, bei dem jedes Objekt dem Schema Input</p>'
+            '<p><strong>Lassen:</strong> Tool-Zoo ohne Standards.</p>'
+            '<p><strong>Risiko:</strong> Nach 14 Tagen stoppen.</p>'
+        )
+        warnings = self._validate({"executive_decision": html})
+        assert any(
+            "TRUNCATED_LI" in w and "executive_decision" in w and "dem Schema Input" in w
+            for w in warnings
+        ), f"Expected TRUNCATED_LI warning for <p>-bullet, got: {warnings}"
+
+    def test_tag_salad_truncation_emits_warning(self):
+        """Scenario E: <li>...<li> tag-salat with truncated Tun bullet."""
+        html = (
+            '<ul>'
+            '<li><strong>Tun:</strong> Einen Standard einführen, bei dem jedes Objekt dem Schema Input</p>'
+            '<li><strong>Lassen:</strong> Tool-Zoo ohne Standards.</li>'
+            '<li><strong>Risiko:</strong> Nach 14 Tagen stoppen.</li>'
+            '</ul>'
+        )
+        warnings = self._validate({"executive_decision": html})
+        assert any(
+            "TRUNCATED_LI" in w and "executive_decision" in w and "dem Schema Input" in w
+            for w in warnings
+        ), f"Expected TRUNCATED_LI warning for tag-salat, got: {warnings}"
+
+    def test_p_bullet_clean_section_no_warning(self):
+        html = (
+            '<p><strong>Tun:</strong> Standardisierung einführen.</p>'
+            '<p><strong>Lassen:</strong> Tool-Zoo vermeiden.</p>'
+            '<p><strong>Risiko:</strong> Nach 14 Tagen stoppen.</p>'
+        )
+        warnings = self._validate({"executive_decision": html})
+        assert not any("TRUNCATED_LI" in w for w in warnings), f"False positive: {warnings}"
+
+    def test_non_bullet_p_in_decision_section_not_flagged(self):
+        """Non-bullet <p> (no Tun:/Lassen:/Risiko prefix) must not flag,
+        prevents false positives on intro text inside decision sections."""
+        html = (
+            '<p>Diese Sektion enthält Einleitungstext der mitten endet bei Input</p>'
+        )
+        warnings = self._validate({"executive_decision": html})
         assert not any("TRUNCATED_LI" in w for w in warnings), f"False positive: {warnings}"


### PR DESCRIPTION
## Bug 1026.1 — KIS-1187 / Briefing 1070 Recurrence

R1-PDF S.4 zeigt den **gleichen** Mid-Sentence-Cutoff-Bug wie KIS-1186 — Bullet endete mit "...dem Schema Input" — obwohl PR #1026 produktiv ist. PR #1026's strikte Regex `<li>...</li>` deckt nur ein Drittel der LLM-Output-Failure-Modi ab.

## Diagnose (Phase 1)

### 1. Section-Keys — ✅ kein Mismatch
`_DECISION_SECTION_KEYS` enthielt bereits beide Varianten (lowercase + uppercase). Loop iteriert korrekt über beide.

### 2. Pipeline-Reihenfolge — ✅ kein Root Cause
FIX-C läuft als Step 5 (`reduce_redundancy`), Detection als Step 9 (in `apply_segment_budget`). FIX-C läuft VOR Detection, **aber FIX-C entfernt nur Duplikate, keine einzelnen broken Bullets** — Hypothese 2 entkräftet. Detection-Position **bleibt unverändert** (Reorder hätte kein Benefit für KIS-1187).

### 3. Detection-Pattern — ⚠️ ROOT CAUSE

Synthetic-Test mit 5 Szenarien:

| # | Szenario | Detection |
|---|---|:---:|
| A | Proper `<li>...</li>` | ✅ |
| B | Nach FIX-C: nur truncated übrig | ✅ |
| **C** | **LLM emittierte `<p>` statt `<li>`** | **❌** |
| D | Loose `<li>` ohne `<ul>` | ✅ |
| **E** | **`<li>` mit `</p>` (Tag-Salat)** | **❌** |

**Scenario C** (vermutete KIS-1187-Variante): LLM brach Prompt-Vertrag und emittierte `<p><strong>Tun:</strong>...</p>`. Strict-Regex matcht 0× `<li>` → keine Detection.

**Scenario E:** LLM emittierte `<li>...</p><li>...</li>`. Non-greedy `(.*?)</li>` matcht greedy über mehrere Pseudo-Bullets, schluckt broken Bullet als Anfang eines größeren Matches → letztes Zeichen `.` aus dem nachfolgenden Sibling satisfies check.

## Patch (Phase 2)

### Three-Pass Detection — Position unverändert

`services/report_healer.py` `[FIX-EXEC-DECISION-CLEAN]`-Block (innerhalb `apply_segment_budget`, **kein Reorder gegen FIX-C**). Branch auf `<li>`-Tag-Balance:

```python
if _open_count == 0:
    # Pass 3: <p>-fallback (Scenario C)
    _bullet_tag = "p"
elif _open_count == _close_count:
    # Pass 1: strict <li>...</li> (unchanged PR #1026)
    _bullet_tag = "li"
else:
    # Pass 2: tag-salat (Scenario E)
    _bullet_tag = "li-salad"
```

- **Pass 1** unverändert (well-formed `<li>...</li>`).
- **Pass 2 Tag-Salat:** splittet an `<li>`-Boundary via `finditer` der Öffnungspositionen. Jeder Bullet erstreckt sich von einer `<li>`-Öffnung bis zur nächsten oder zu `</ul>`/`</ol>`. Healthy Bullets werden als well-formed `<li>...</li>` re-emittiert.
- **Pass 3 `<p>`-Fallback:** gated auf `<strong>Tun:|Lassen:|Risiko|Stop` Prefix-Pattern — verhindert False-Positives auf Header (`Ihre Entscheidung in 3 Punkten`) und Intro-Text. Truncated `<p>` wird durch struktur-analogen `<p><em>Weitere Punkte siehe Business Case und Roadmap.</em></p>` ersetzt.

### Marker-Erweiterung

`[FIX-EXEC-DECISION-CLEAN]` bekommt `bullet_tag`-Feld:
```
[FIX-EXEC-DECISION-CLEAN] section=executive_decision bullet_tag=p total=3 truncated=1 dropped=1
[FIX-EXEC-DECISION-CLEAN] section=executive_decision bullet_tag=li-salad total=3 truncated=1 dropped=1
```

Production-Filter können damit pro Tag-Type Statistiken bilden → LLM-Compliance über die Zeit messen.

### Validator-Parität

`PlatinValidator._check_sentence_completeness` bekommt dieselbe Drei-Pass-Logik. `TRUNCATED_LI`-Warnings für alle drei Cases.

## Tests — 8 → 18 (alle 8 bestehenden PR-#1026-Tests weiter grün)

| Block | Neu in 1026.1 |
|---|---|
| Healer | `test_kis1187_p_bullets_scenario_c` (KIS-1187 Reproduktion), `test_tag_salad_scenario_e`, `test_non_decision_p_bullets_not_repaired`, `test_p_bullets_all_clean_no_repair`, `test_p_bullets_only_non_bullet_p_unchanged`, `test_tag_salad_all_clean_no_repair` |
| Validator | `test_p_bullet_truncation_emits_warning`, `test_tag_salad_truncation_emits_warning`, `test_p_bullet_clean_section_no_warning`, `test_non_bullet_p_in_decision_section_not_flagged` |

```
Local full suite: 6410 passed, 10 skipped, 0 failed
```

## Validierungs-Plan (Production-Smoke)

1. Test-Briefing absenden (Solo + Beratung + `ki_kompetenz=hoch`)
2. R1-PDF S.4 prüfen — kein Marker (best case) oder Fallback an Position des Bugs
3. Production-Logs `[FIX-EXEC-DECISION-CLEAN]` filtern, **`bullet_tag`-Distribution**:
   - `bullet_tag=li` → Strict Pass (well-formed LLM)
   - `bullet_tag=li-salad` → LLM Mismatch
   - `bullet_tag=p` → LLM Vertrag-Violation (`<p>` statt `<li>`)
4. Nach 48h / ≥10 Briefings: wenn `bullet_tag != li` > 10% → LLM-Compliance-Issue → **C2.2 (Re-Gen) priorisieren**

## Geänderte Dateien

| Datei | Δ |
|---|---|
| `services/report_healer.py` | +112 / −44 LOC |
| `services/report_validator.py` | +43 / −6 LOC |
| `tests/test_exec_decision_clean.py` | +148 LOC (10 neue Tests) |
| `docs/SPRINT_1026_1_DECISION_DETECTION_FIX.md` | +160 (neu) |

## Out of Scope (per Sprint-Briefing)

- KEINE C2.2 H1 Re-Gen Logik (separates Sprint)
- KEINE Quick-Wins-Tile-Header-Bugs
- KEINE Compact-Engine-Effizienz (43→43 pages Drop-Bug)
- KEINE TRANSPARENCY_BOX Email-Leak-Refinement
- Fokus ausschließlich auf executive_decision Detection-Robustheit

https://claude.ai/code/session_01UWV1XBaNB39jy3VQRMiT9X

---
_Generated by [Claude Code](https://claude.ai/code/session_01UWV1XBaNB39jy3VQRMiT9X)_