### PR TITLE
diag(r1): always-on [FIX-EXEC-DECISION-DIAG] marker for decision sections

### DIFF
--- a/services/report_healer.py
+++ b/services/report_healer.py
@@ -3662,6 +3662,39 @@ def apply_segment_budget(
         _open_count = len(_li_open_pattern.findall(_exec_content))
         _close_count = len(_li_close_pattern.findall(_exec_content))
 
+        # Sprint 1026.5a: Always-on diagnostic marker. Inventory the section's
+        # tag distribution and tail before the detection branches so we can
+        # tell from production logs whether [FIX-EXEC-DECISION-CLEAN]'s silence
+        # means "ran with truncated=0" or "section shape doesn't match any
+        # detection pass at all". No behavior change.
+        try:
+            from collections import Counter as _Counter
+
+            _diag_p_blocks = _p_pattern.findall(_exec_content)
+            _diag_p_total = len(_diag_p_blocks)
+            _diag_p_strong = sum(
+                1 for _body in _diag_p_blocks if _bullet_prefix_re.search(_body)
+            )
+            _diag_tags = dict(_Counter(re.findall(r'<(\w+)\b', _exec_content)))
+            try:
+                from bs4 import BeautifulSoup as _BS
+                _diag_text = _BS(_exec_content, "html.parser").get_text(" ", strip=True)
+            except Exception:
+                _diag_text = re.sub(r'<[^>]+>', ' ', _exec_content)
+                _diag_text = re.sub(r'\s+', ' ', _diag_text).strip()
+            _diag_last_chars = _diag_text[-30:].replace('\n', ' ').replace('\r', ' ')
+            log.info(
+                "[FIX-EXEC-DECISION-DIAG] section=%s len=%d open_li=%d close_li=%d "
+                "p_total=%d p_strong_prefix=%d last_chars=%r tags=%s",
+                _exec_key, len(_exec_content), _open_count, _close_count,
+                _diag_p_total, _diag_p_strong, _diag_last_chars, _diag_tags,
+            )
+        except Exception as _diag_err:
+            log.info(
+                "[FIX-EXEC-DECISION-DIAG] section=%s diag_error=%r",
+                _exec_key, _diag_err,
+            )
+
         if _open_count == 0:
             _new_content, _total, _truncated = _exec_heal_p_bullets(_exec_content)
             _bullet_tag = "p"

--- a/tests/test_exec_decision_clean.py
+++ b/tests/test_exec_decision_clean.py
@@ -301,3 +301,69 @@ class TestValidatorExecDecisionClean10261:
         )
         warnings = self._validate({"executive_decision": html})
         assert not any("TRUNCATED_LI" in w for w in warnings), f"False positive: {warnings}"
+
+
+class TestExecDecisionDiagMarker:
+    """Sprint 1026.5a — always-on [FIX-EXEC-DECISION-DIAG] marker emits for
+    every decision-section pass through apply_segment_budget regardless of
+    detection outcome. Pure observability, no behavior change."""
+
+    def _heal_with_logs(self, sections, caplog):
+        from services.report_healer import apply_segment_budget
+        import logging
+        caplog.set_level(logging.INFO, logger="services.report_healer")
+        result, _ = apply_segment_budget(sections, "solo")
+        return result, caplog.records
+
+    def test_diag_marker_emitted_on_truncated_section(self, caplog):
+        """KIS-1186-style truncated <li> must trigger both the existing
+        [FIX-EXEC-DECISION-CLEAN] warning AND the new diagnostic marker
+        with the expected fields."""
+        sections = {
+            "executive_decision": (
+                '<div class="exec-decision-box">'
+                '<p><strong>Ihre Entscheidung in 3 Punkten</strong></p>'
+                '<ul>'
+                '<li><strong>Tun:</strong> Einen verbindlichen Standard-Arbeitsablauf '
+                'einführen, bei dem jede Beratungsleistung den Ablauf Input</li>'
+                '<li><strong>Lassen:</strong> Tool-Zoo und Ad-hoc-Prompts ohne Standards.</li>'
+                '<li><strong>Risiko:</strong> Nach 14 Tagen ohne Effekt stoppen.</li>'
+                '</ul></div>'
+            ),
+        }
+        _, records = self._heal_with_logs(sections, caplog)
+        diag = [r for r in records if "[FIX-EXEC-DECISION-DIAG]" in r.getMessage()]
+        assert diag, "DIAG marker must emit even when detection repairs the section"
+        msg = diag[0].getMessage()
+        assert "section=executive_decision" in msg
+        assert "open_li=3" in msg
+        assert "close_li=3" in msg
+        assert "p_total=" in msg
+        assert "p_strong_prefix=" in msg
+        assert "last_chars=" in msg
+        assert "tags=" in msg
+
+    def test_diag_marker_emitted_on_clean_section(self, caplog):
+        """When the LLM honors the contract and no bullet is truncated, the
+        [FIX-EXEC-DECISION-CLEAN] line is DEBUG-only and effectively silent at
+        production log levels. The DIAG marker must still appear so production
+        runs always show the section's tag inventory."""
+        clean = (
+            '<div class="exec-decision-box">'
+            '<p><strong>Ihre Entscheidung in 3 Punkten</strong></p>'
+            '<ul>'
+            '<li><strong>Tun:</strong> Standardisierung einführen mit klarem Owner.</li>'
+            '<li><strong>Lassen:</strong> Tool-Zoo vermeiden, keine parallelen Initiativen.</li>'
+            '<li><strong>Risiko:</strong> Nach 14 Tagen ohne Effekt stoppen.</li>'
+            '</ul></div>'
+        )
+        _, records = self._heal_with_logs({"executive_decision": clean}, caplog)
+        diag = [r for r in records if "[FIX-EXEC-DECISION-DIAG]" in r.getMessage()]
+        assert diag, "DIAG marker must emit on clean sections too"
+        msg = diag[0].getMessage()
+        assert "section=executive_decision" in msg
+        assert "open_li=3" in msg
+        assert "close_li=3" in msg
+        # Tail must end on the Risiko bullet's terminal punctuation
+        assert "last_chars=" in msg
+        assert msg.rstrip().endswith("}") or "tags={" in msg


### PR DESCRIPTION
## Sprint 1026.5a — Diagnose-Logging (kein Behavior-Change)

KIS-1189 zeigt: PR #1028 ([FIX-EXEC-DECISION-CLEAN]) und PR #1029 ([FIX-C-SKIP]) sind live, FIX-C-SKIP feuert für `EXECUTIVE_DECISION_HTML` und `executive_decision`, aber `[FIX-EXEC-DECISION-CLEAN]` bleibt stumm — Mid-Sentence-Cutoff (`"...den Pfad Input"`) trotzdem auf R1 Seite 4 sichtbar.

Ohne weitere Diagnostik nicht unterscheidbar:
- **A**: Three-Pass-Detection lief, fand nichts (`truncated=0` → DEBUG-only, invisible bei LOG_LEVEL=INFO)
- **B**: Section-Shape matcht keinen der drei Passes (strict-`<li>` / li-salat / `<p>` mit `<strong>(Tun|Lassen|Risiko|Stop)`)

### Change

Ein unbedingter INFO-Marker direkt vor dem Branching in `apply_segment_budget` inventarisiert die Section:

```
[FIX-EXEC-DECISION-DIAG] section=executive_decision len=820
open_li=3 close_li=3 p_total=1 p_strong_prefix=0
last_chars='Nach 14 Tagen ohne Effekt s' tags={'div': 1, 'p': 1, 'strong': 4, 'ul': 1, 'li': 3}
```

- `open_li` / `close_li` zeigen welcher Detection-Branch greift
- `p_total` / `p_strong_prefix` zeigen ob das `<p>`-Bullet-Gate matcht (Hypothese H1: LLM emittiert `<b>` statt `<strong>` → Gate fails)
- `tags={Counter}` zeigt prompt-contract violations (H2: `<h3>` headers; H3: custom `<div>`-bullets)
- `last_chars` zeigt das tatsächliche Section-Tail — visuelle Bestätigung des sichtbaren Cutoffs vs. CSS-Page-Break

`Counter` via `re.findall(r'<(\w+)\b', content)` (stdlib). Text via `BeautifulSoup.get_text(" ", strip=True)` (bereits Dependency in `services/research_clients.py`) mit Regex-Fallback. Try/except wrapper damit Diagnostik nie den Healer brechen kann.

### Out-of-Scope

- Behavior-Change in Detection
- Erweiterung von `_DECISION_DETECTION_OWNED_KEYS`
- Raw-Section-Persistence in R1 (separates Backlog-Item)
- WP4-GUARD

### Validation-Plan

1. PR merge + Railway Deploy
2. Funnel mit identischen Inputs wie KIS-1188 / KIS-1189
3. `railway logs | grep "FIX-EXEC-DECISION-DIAG" | head -20`
4. Daily Report mit Output → Sprint 1026.5b Scope (zielgerichteter Fix nach bestätigter Hypothese)

### Tests

`tests/test_exec_decision_clean.py` wächst von 18 auf 20:
- `test_diag_marker_emitted_on_truncated_section` — Marker erscheint mit allen erwarteten Feldern bei truncated `<li>`
- `test_diag_marker_emitted_on_clean_section` — Marker erscheint auch bei clean section (DEBUG-only [FIX-EXEC-DECISION-CLEAN] wäre sonst stumm in Production)

Lokal: `20 passed in 0.22s`.

---
_Generated by [Claude Code](https://claude.ai/code/session_014P6awbPJ3rUavTYDDG9Lbv)_