### PR TITLE
Sprint 1027.1: R1 Customer-Trust-Cluster (4 Fixes)

### DIFF
--- a/gpt_analyze.py
+++ b/gpt_analyze.py
@@ -20614,6 +20614,8 @@ NUR HTML ausgeben. Keine Erklärungen, keine Markdown-Fences."""
             " feen,": " fest,", " feen ": " fest ", " feen.": " fest.",
             "vorraussichtlich": "voraussichtlich",
             "Vorraussichtlich": "Voraussichtlich",
+            # KIS-1190 Sprint-1027.1 Item C: "hempt" → "hemmt" (LLM glitch)
+            "hempt": "hemmt", "Hempt": "Hemmt",
         }
         _pr_canon = str(sections.get("CANON_RATE_EUR", "") or "")
         _pr_rate_int = int(_pr_canon.strip()) if _pr_canon.strip().isdigit() else 0

--- a/services/final_sanitizer.py
+++ b/services/final_sanitizer.py
@@ -118,11 +118,36 @@ def final_sanitize(sections: dict) -> dict:
     except Exception:
         jahresersparnis_fmt = '41.040'
 
+    # KIS-1190 Sprint-1027.1 Item A: Schutz für Fallstudie-Block. Regionen
+    # zwischen <!--NO-SANITIZE-FALLSTUDIE--> Markern werden extrahiert,
+    # F4/F4b laufen drüberhin, dann werden Originale wieder eingesetzt.
+    _NO_SANITIZE_RE = re.compile(
+        r'<!--NO-SANITIZE-FALLSTUDIE-->.*?<!--/NO-SANITIZE-FALLSTUDIE-->',
+        re.DOTALL | re.IGNORECASE,
+    )
+
+    def _shield(val: str):
+        protected = _NO_SANITIZE_RE.findall(val)
+        if not protected:
+            return val, []
+        stripped = _NO_SANITIZE_RE.sub('\x00NOSAN_BLOCK\x00', val)
+        return stripped, protected
+
+    def _unshield(val: str, protected: list) -> str:
+        if not protected:
+            return val
+        out = val
+        for block in protected:
+            out = out.replace('\x00NOSAN_BLOCK\x00', block, 1)
+        return out
+
     for key in list(sections.keys()):
         val = sections.get(key)
         if not isinstance(val, str) or len(val) < 50:
             continue
         original = val
+        # Schutz: Fallstudie-Region rausnehmen, später re-inject
+        val, _protected = _shield(val)
         # "9 Stunden/Woche" oder "X Stunden pro Woche" → Canonical
         val = re.sub(
             r'(?:ca\.?\s*)?\d+\s*Stunden?\s*/\s*Woche',
@@ -140,6 +165,7 @@ def final_sanitize(sections: dict) -> dict:
             f'{jahresersparnis_fmt} € \\2',
             val
         )
+        val = _unshield(val, _protected)
         if val != original:
             sections[key] = val
             fixes_applied.append(f"F4:hours-fix-in-{key[:30]}")
@@ -160,6 +186,8 @@ def final_sanitize(sections: dict) -> dict:
         if not isinstance(val, str) or len(val) < 50:
             continue
         original = val
+        # KIS-1190 Sprint-1027.1 Item A: Fallstudie-Region schützen
+        val, _protected = _shield(val)
         for _pat, _repl in _f4b_patterns:
             def _f4b_replace(m, repl=_repl, canon=_canon_h_str):
                 # Extract the number from the match
@@ -168,6 +196,7 @@ def final_sanitize(sections: dict) -> dict:
                     return repl
                 return m.group(0)  # no change if already correct or out of range
             val = re.sub(_pat, _f4b_replace, val)
+        val = _unshield(val, _protected)
         if val != original:
             sections[key] = val
             fixes_applied.append(f"F4b:hours-prose-fix-{key[:30]}")

--- a/services/report_healer.py
+++ b/services/report_healer.py
@@ -935,7 +935,9 @@ SOLO_TERM_REPLACEMENTS: Dict[str, str] = {
     "enterprise-grade": "professionell",
     # Team/Org terms
     "Team-Meeting": "Besprechung",
-    "Briefing": "Einweisung",
+    # KIS-1190 Sprint-1027.1 Item D: "Briefing" entfernt — bleibt Beratungs-
+    # Standardterm; "Einweisung" klang im Beratungskontext unbeholfen
+    # ("aus einer kurzen Einweisung-Eingabe" auf R1 S.7+8).
     "Onboarding": "Einarbeitung",
     "Change Management": "Veränderungsprozess",
 }

--- a/services/report_renderer.py
+++ b/services/report_renderer.py
@@ -1062,23 +1062,22 @@ def render(briefing_obj: Any,
         log.info("[S2] Persona-leak fix applied for size=%s", _company_size)
 
     # V4 (was U6): Förder-Alignment-Tabelle — leere Tabellen durch Hinweis ersetzen
-    # Improved: Match ANY table, then check if it has only header rows
+    # KIS-1190 Sprint-1027.1 Item B: Killer prüft jetzt <td>-Body-Content statt
+    # Row-Count. Layout-Tabellen (z.B. quickwins-fullwidth-table, SWOT 2×2)
+    # haben volle <td>-Zellen aber wenige <tr>-Rows und wurden mis-klassifiziert.
     def _fix_empty_tables_v4(html_text):
         def _check_table(match):
             t = match.group(0)
-            # FIX-B732-VENDOR: Preserve vendor audit tables from empty-table killer
+            # FIX-B732-VENDOR: Preserve tables explicitly marked
             if "data-preserve" in t:
                 return t
-            all_rows = re.findall(r'<tr[^>]*>(.*?)</tr>', t, re.DOTALL | re.IGNORECASE)
-            if len(all_rows) <= 1:
-                # Only 0 or 1 row (header only) → empty
-                return '<div style="padding:12px;color:#64748b;font-style:italic;">Keine Daten für diese Darstellung verfügbar.</div>'
-            # Check if rows after first have any <td> with actual text content
-            data_rows = all_rows[1:]  # skip header
+            # Extract <td> cells (data cells only; <th> are headers and don't
+            # count as content). Substantive text in any <td> means the table
+            # is a real data/layout table, not a placeholder.
+            td_cells = re.findall(r'<td[^>]*>(.*?)</td>', t, re.DOTALL | re.IGNORECASE)
             has_content = False
-            for row in data_rows:
-                # Strip tags, check for non-whitespace
-                text = re.sub(r'<[^>]+>', '', row).strip()
+            for cell in td_cells:
+                text = re.sub(r'<[^>]+>', '', cell).strip()
                 if len(text) > 5:
                     has_content = True
                     break

--- a/services/sofort_start_generator.py
+++ b/services/sofort_start_generator.py
@@ -3246,16 +3246,23 @@ def generate_fallstudie_html(branche: str, size_key: str = "solo") -> str:
     if size_key in size_overrides:
         fallstudie = {**fallstudie, "unternehmen": size_overrides[size_key]}
     
-    html = f'''
+    # KIS-1190 Sprint-1027.1 Item A: Fallstudie wird als externes Branchen-
+    # Beispiel gekennzeichnet und gegen final_sanitizer F4 (Stunden/Woche →
+    # Stunden/Monat) per NO-SANITIZE-FALLSTUDIE-Marker geschützt. Werte sind
+    # fiktive Beispieldaten und müssen NICHT der User-canonical ROI matchen.
+    html = f'''<!--NO-SANITIZE-FALLSTUDIE-->
     <!-- FALLSTUDIE -->
-    <div class="card-nobreak" style="background: linear-gradient(135deg, #f8fafc 0%, #e2e8f0 100%); border: 1px solid #cbd5e1; border-radius: 12px; padding: 20px; margin-top: 24px;">
-        <div style="display: flex; align-items: center; gap: 8px; margin-bottom: 16px;">
+    <div class="card-nobreak" data-no-sanitize="true" style="background: linear-gradient(135deg, #f8fafc 0%, #e2e8f0 100%); border: 1px solid #cbd5e1; border-radius: 12px; padding: 20px; margin-top: 24px;">
+        <div style="display: flex; align-items: center; gap: 8px; margin-bottom: 8px;">
             <span style="font-size: 24px;">📊</span>
             <h3 style="font-size: 18px; font-weight: 700; margin: 0; color: #1e293b;">
                 Fallstudie: {fallstudie["titel"]}
             </h3>
         </div>
-        
+        <div style="font-size: 11px; color: #64748b; font-style: italic; margin-bottom: 16px; padding: 4px 8px; background: #fff; border-left: 3px solid #94a3b8; border-radius: 0 4px 4px 0;">
+            Branchen-Beispiel · fiktive Beispieldaten zur Veranschaulichung · weicht von Ihrem persönlichen ROI bewusst ab
+        </div>
+
         <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 16px; margin-bottom: 16px;">
             <div>
                 <div style="font-size: 11px; color: #64748b; text-transform: uppercase; margin-bottom: 4px;">Unternehmen</div>
@@ -3300,6 +3307,7 @@ def generate_fallstudie_html(branche: str, size_key: str = "solo") -> str:
             </div>
         </div>
     </div>
+<!--/NO-SANITIZE-FALLSTUDIE-->
 '''
-    
+
     return html


### PR DESCRIPTION
## Summary

Sprint 1027.1 — vertrauensrelevante R1-Fixes für KMU-Leser. Vier Items, jeweils ein eigener Commit. Diagnose-First-Modus mit zwei Wolf-Pings (Items A und D), zwei autonomen Fixes (Items B und C).

Ref: KIS-1190 (Display-ID), Briefing-ID 1073

## Items

### Item A — Fallstudie-Widerspruch (R1 S.6-7) `[Wolf-Ping: Option 1]`
**Problem:** Branchen-Fallstudie zeigte "15 Stunden/Monat" + "4.800 €/Monat" Ersparnis — bei 80€/h ergäbe das 60h, nicht 15h.
**Root cause:** Fallstudie hat fiktive Hardcoded-Daten "12 Stunden/Woche" + "~4.800€/Monat". `final_sanitizer` F4 rewrited "X Stunden/Woche" → "{canon_hours} Stunden/Monat", ohne den Euro-Wert anzupassen.
**Fix:** Fallstudie-Wrapper mit `<!--NO-SANITIZE-FALLSTUDIE-->` Markern + `data-no-sanitize="true"`-Attribut. Neuer Disclaimer-Header: *"Branchen-Beispiel · fiktive Beispieldaten · weicht von Ihrem persönlichen ROI bewusst ab"*. F4/F4b in `final_sanitizer.py` extrahieren markierte Regionen vor Rewrite und re-injecten sie danach.
**Commit:** 6f028a6

### Item B — "Keine Daten"-Tile (R1 S.7+8) `[autonom]`
**Problem:** Drei Quick-Wins-Tiles zeigten Tile-Header "Keine Daten für diese Darstellung verfügbar" trotz vollständigem Body-Content.
**Root cause:** `_fix_empty_tables_v4` in `report_renderer.py` prüfte `len(<tr>-rows) <= 1` als Empty-Signal. Layout-Tabellen (z.B. quickwins-fullwidth-table mit 1 row × 2 voll-bestückten cells) wurden mis-klassifiziert.
**Fix:** Killer prüft jetzt `<td>`-Body-Content (substantieller Text in mindestens einer Data-Zelle) statt Row-Count. Förder-Tabellen mit nur `<th>`-Headers bleiben weiterhin als leer erkannt.
**Commit:** 3e80e5f

### Item C — Tippfehler "hempt" (R1 S.8) `[autonom]`
**Problem:** "Das hempt die Erweiterung..." statt "hemmt".
**Root cause:** Nicht im Code hardcoded → LLM-Halluzination.
**Fix:** Typo-Dict in `FIX-B722-PRERENDER` (`gpt_analyze.py:20608`) um `"hempt": "hemmt"` + `"Hempt": "Hemmt"` erweitert.
**Commit:** d85958e

### Item D — "Einweisung"-Lexicon (R1 S.7+8) `[Wolf-Ping: Option 2]`
**Problem:** "aus einer kurzen Einweisung-Eingabe" — Solo-Lexicon hatte "Briefing" → "Einweisung" rewritet, klang im Beratungskontext unbeholfen.
**Fix:** `"Briefing": "Einweisung"` aus `SOLO_TERM_REPLACEMENTS` in `report_healer.py:938` entfernt. "Briefing" bleibt in Solo-Reports unverändert (Beratungs-Standardterm).
**Commit:** d907aa5

## Test plan

- [x] Smoke-Test `_fix_empty_tables_v4`: 5 Cases (QW fullwidth, leere Tabelle, leere data rows, SWOT 2×2, vendor data-preserve) korrekt klassifiziert
- [x] Smoke-Test `final_sanitize` Shield: Fallstudie-Region bleibt unangetastet, Außerhalb wird weiter normal sanitiert
- [x] Bestehende Tests grün: 155 passed (`test_report_healer`, `test_report_healer_integration`, `test_strategy_sanitizer`, `test_fix528_pipeline_sanitizers`)
- [ ] **Funnel-Lauf** mit identischen Inputs zu KIS-1188/1189/1190 (Beratung, Solo, KI-Kompetenz hoch, Hauptleistung "Beratung")
- [ ] **Visueller Check R1 S.6-8:**
  - [ ] Fallstudie zeigt "Branchen-Beispiel"-Disclaimer; "12 Stunden/Woche" + "~4.800€/Monat" konsistent zueinander
  - [ ] Keine "Keine Daten"-Tile-Header bei Quick-Wins-Tiles mit Body-Content
  - [ ] Kein "hempt" im Text
  - [ ] Kein "Einweisung-Eingabe"; "Briefing" bleibt erhalten
- [ ] **Cross-Report:** Score/ROI/CAPEX unverändert gegenüber KIS-1190

## Out-of-Scope
- WP4-GUARD (explizit gestrichen)
- Sprint 1027.2 (Strukturhygiene) und 1027.3 (Infrastructure) folgen nach Validierung
- Andere Branchen als Beratung (Fallstudie-Markierung gilt aber für ALLE Branchen — Wert bleibt fiktiv)

https://claude.ai/code/session_01NXshYX2FFWLZcwf2Dw3mtu

---
_Generated by [Claude Code](https://claude.ai/code/session_01NXshYX2FFWLZcwf2Dw3mtu)_