### PR TITLE
Sprint 1027.1.1 Hotfix: SOLO-LANGUAGE-Pass auf _QUICK_WINS_PRISTINE

### DIFF
--- a/services/content_quality_enforcer.py
+++ b/services/content_quality_enforcer.py
@@ -402,6 +402,12 @@ def apply_solo_language_normalizer(sections: dict, company_size: str) -> dict:
         "OPEN_INPUTS_HTML", "ROI_HTML", "ROI_TRACKING_HTML",
         "STARTER_KITS_HTML", "TOOLS_BRANCH_ALIGNMENT_HTML",
         "TOOLS_FUNDING_ALIGNMENT_HTML", "TOOLS_SECTION_HTML",
+        # KIS-1191 Sprint-1027.1.1: Include pristine QW snapshot in SOLO-LANGUAGE
+        # pass. Snapshot is taken before enforcer passes to preserve PROBLEM/
+        # WIRKUNG/UMSETZUNG block structure, but pure term substitutions are
+        # safe and required — otherwise validator catches blacklist terms
+        # ("Governance", "Stakeholder", …) on the un-normalized snapshot.
+        "_QUICK_WINS_PRISTINE",
     ]
 
     # Team-specific replacements


### PR DESCRIPTION
## Summary

KIS-1191 (Briefing 1074, Validierung Sprint 1027.1) scheiterte am Quality-Gate mit:
```
[SOLO_TERMINOLOGY] _QUICK_WINS_PRISTINE: Solo-Blacklist: 'Governance' gefunden in _QUICK_WINS_PRISTINE
```

## Diagnose-Korrektur zum Briefing

Das ursprüngliche Briefing schlug vor, Solo-Lexicon-Replacements zu erweitern. **Die Replacements existieren bereits** in `content_quality_enforcer.py`:
- `:132` `Governance → Steuerung`
- `:115` `Stakeholder → Beteiligte`
- `:116` `Audit-Trail → Prüfpfad`
- `:77`  `Stack → Technikpaket` (mit KI-Stack/Stack-Komponente Ausschluss)

**Tatsächliche Lücke:** `apply_solo_language_normalizer` hat eine `check_sections`-Whitelist (`content_quality_enforcer.py:375-405`), die `_QUICK_WINS_PRISTINE` nicht enthält. Der Pristine-Snapshot wird in `gpt_analyze.py:13274` vor allen Enforcer-Passes gespeichert ("Key starts with _ so enforcers skip it"), damit Struktur-Stripping (z.B. PROBLEM/WIRKUNG/UMSETZUNG-Block-Verlust) den Restore-Pfad nicht zerstört. Validator scannt aber auch `_`-prefixed Sections und findet die un-normalisierten LLM-Terms.

## Fix (Wolf-Entscheidung: Option A)

`_QUICK_WINS_PRISTINE` zur `check_sections`-Whitelist hinzugefügt. Term-Substitutionen sind strukturerhaltend, der Pristine-Zweck (Struktur-Restore) bleibt intakt.

## Test plan

- [x] Smoke-Test bestätigt:
  - Governance → Steuerung greift
  - Stakeholder → Beteiligte greift
  - Audit-Trail → Prüfpfad greift
  - Stack → Technikpaket greift (bare, KI-Stack/Stack-Komponente ausgenommen)
  - `data-qw-json-rendered="true"` Marker erhalten
  - `quick-win-card-premium` Klasse erhalten
  - PROBLEM/WIRKUNG/UMSETZUNG-DIVs erhalten
- [x] Bestehende Tests grün: 169 passed (`test_report_healer`, `test_strategy_sanitizer`, `test_fix528_pipeline_sanitizers`, `test_fix512_ki_stack_sanitize`)
- [ ] **Funnel-Lauf KIS-1191 wiederholen** mit identischen Inputs — Quality-Gate sollte passieren
- [ ] **Regression-Check Sprint-1026 + Sprint-1027.1 Fixes** weiter aktiv
- [ ] **Cross-Report:** Generated Quick Wins enthalten kein "Governance" mehr

## Out-of-Scope
- Validator-Logik ändern (Option B verworfen)
- Prompt-Härtung LLM-Output (Option 3 verworfen)
- Sprint 1027.2 (bleibt blockiert bis 1027.1.1 grün)

https://claude.ai/code/session_01NXshYX2FFWLZcwf2Dw3mtu

---
_Generated by [Claude Code](https://claude.ai/code/session_01NXshYX2FFWLZcwf2Dw3mtu)_