### PR TITLE
Sprint 1027.2: R1 Struktur & Customer-Fix-Cluster (6 Fixes)

### DIFF
--- a/gpt_analyze.py
+++ b/gpt_analyze.py
@@ -13072,40 +13072,33 @@ def _generate_content_sections(briefing: Dict[str, Any], scores: Dict[str, Any])
     # 1) "in *-Abläufe (Verb)" → "in *-Abläufen (Verb)" (Dativ-Plural)
     # 2) "als jeden (Adj) (Subst)" wo Subst feminin → "als jede (Adj) (Subst)"
     # Konservative Regex-Patterns, nur auf advisor_note angewandt.
-    _ADVISOR_GRAMMAR_PATTERNS = [
-        # Pattern 1: "in <Wort>-Abläufe <wird|kann|sollte|...>" → "Abläufen"
-        # Vermeidet false-positives in Akkusativ-Kontext ("die Abläufe optimieren").
-        (
-            re.compile(
-                r'(\bin\s+(?:[A-Za-zÄÖÜäöüß-]+\s+(?:und|sowie)\s+)?'
-                r'[A-Za-zÄÖÜäöüß-]+-Abläufe)(\s+(?:wird|kann|sollte|muss|darf|ist|war))',
-                re.IGNORECASE,
-            ),
-            lambda m: m.group(1)[:-1] + 'en' + m.group(2),
-        ),
-        # Pattern 2: "als jeden <Adj-Endung-e> <Femininum>" → "als jede"
-        # Ausgelöst durch typisch feminine Bezugswörter (Firma, Maßnahme, Lösung, ...).
-        (
-            re.compile(
-                r'\bals\s+jeden(\s+\w+e\s+'
-                r'(?:Firma|Firm|Lösung|Maßnahme|Branche|Praxis|Kanzlei|'
-                r'Beratung|Größe|Investition|Entscheidung|Strategie|Marke|Initiative|Idee))\b',
-                re.IGNORECASE,
-            ),
-            r'als jede\1',
-        ),
-    ]
+    _ADVISOR_PAT_DATIV = re.compile(
+        r'(\bin\s+(?:[A-Za-zÄÖÜäöüß-]+\s+(?:und|sowie)\s+)?'
+        r'[A-Za-zÄÖÜäöüß-]+-Abläufe)(\s+(?:wird|kann|sollte|muss|darf|ist|war))',
+        re.IGNORECASE,
+    )
+    _ADVISOR_PAT_AKK_FEM = re.compile(
+        r'\bals\s+jeden(\s+\w+e\s+'
+        r'(?:Firma|Firm|Lösung|Maßnahme|Branche|Praxis|Kanzlei|'
+        r'Beratung|Größe|Investition|Entscheidung|Strategie|Marke|Initiative|Idee))\b',
+        re.IGNORECASE,
+    )
+
+    def _advisor_dativ_repl(m: "re.Match[str]") -> str:
+        # "...Abläufe" → "...Abläufen" + Verb-Gruppe unverändert.
+        return m.group(1)[:-1] + 'en' + m.group(2)
+
     for _slot in ("ADVISOR_NOTE_HTML", "advisor_note"):
-        _av = sections.get(_slot, "")
-        if not isinstance(_av, str) or not _av:
+        _av_raw = sections.get(_slot, "")
+        if not isinstance(_av_raw, str) or not _av_raw:
             continue
+        _av: str = _av_raw
         _av_orig = _av
         _fixes = 0
-        for _pat, _repl in _ADVISOR_GRAMMAR_PATTERNS:
-            _av_new, _n = _pat.subn(_repl, _av)
-            if _n:
-                _av = _av_new
-                _fixes += _n
+        _av, _n1 = _ADVISOR_PAT_DATIV.subn(_advisor_dativ_repl, _av)
+        _fixes += _n1
+        _av, _n2 = _ADVISOR_PAT_AKK_FEM.subn(r'als jede\1', _av)
+        _fixes += _n2
         if _av != _av_orig:
             sections[_slot] = _av
             log.info("[FIX-KIS-1192-ITEM-I] advisor_note grammar fixes applied: %d in %s", _fixes, _slot)

--- a/gpt_analyze.py
+++ b/gpt_analyze.py
@@ -13067,6 +13067,49 @@ def _generate_content_sections(briefing: Dict[str, Any], scores: Dict[str, Any])
                     sections[_slot] = _cv_new
                     log.info("[v7.1.2] Stripped literal key name from %s", _slot)
 
+    # FIX-KIS-1192-ITEM-I: Grammar sanitizer for advisor_note LLM output.
+    # KIS-1192 zeigte zwei wiederkehrende LLM-Halluzinationen:
+    # 1) "in *-Abläufe (Verb)" → "in *-Abläufen (Verb)" (Dativ-Plural)
+    # 2) "als jeden (Adj) (Subst)" wo Subst feminin → "als jede (Adj) (Subst)"
+    # Konservative Regex-Patterns, nur auf advisor_note angewandt.
+    _ADVISOR_GRAMMAR_PATTERNS = [
+        # Pattern 1: "in <Wort>-Abläufe <wird|kann|sollte|...>" → "Abläufen"
+        # Vermeidet false-positives in Akkusativ-Kontext ("die Abläufe optimieren").
+        (
+            re.compile(
+                r'(\bin\s+(?:[A-Za-zÄÖÜäöüß-]+\s+(?:und|sowie)\s+)?'
+                r'[A-Za-zÄÖÜäöüß-]+-Abläufe)(\s+(?:wird|kann|sollte|muss|darf|ist|war))',
+                re.IGNORECASE,
+            ),
+            lambda m: m.group(1)[:-1] + 'en' + m.group(2),
+        ),
+        # Pattern 2: "als jeden <Adj-Endung-e> <Femininum>" → "als jede"
+        # Ausgelöst durch typisch feminine Bezugswörter (Firma, Maßnahme, Lösung, ...).
+        (
+            re.compile(
+                r'\bals\s+jeden(\s+\w+e\s+'
+                r'(?:Firma|Firm|Lösung|Maßnahme|Branche|Praxis|Kanzlei|'
+                r'Beratung|Größe|Investition|Entscheidung|Strategie|Marke|Initiative|Idee))\b',
+                re.IGNORECASE,
+            ),
+            r'als jede\1',
+        ),
+    ]
+    for _slot in ("ADVISOR_NOTE_HTML", "advisor_note"):
+        _av = sections.get(_slot, "")
+        if not isinstance(_av, str) or not _av:
+            continue
+        _av_orig = _av
+        _fixes = 0
+        for _pat, _repl in _ADVISOR_GRAMMAR_PATTERNS:
+            _av_new, _n = _pat.subn(_repl, _av)
+            if _n:
+                _av = _av_new
+                _fixes += _n
+        if _av != _av_orig:
+            sections[_slot] = _av
+            log.info("[FIX-KIS-1192-ITEM-I] advisor_note grammar fixes applied: %d in %s", _fixes, _slot)
+
     # Executive Summary Placeholder-Fix
     sections["EXECUTIVE_SUMMARY_HTML"] = _fix_exec_placeholders(
         sections.get("EXECUTIVE_SUMMARY_HTML", ""),

--- a/prompts/de/advisor_note.md
+++ b/prompts/de/advisor_note.md
@@ -27,6 +27,18 @@ Schreibe eine persönliche Einschätzung in exakt 4-6 Sätzen als Fließtext.
 - NICHT "Ich empfehle" — stattdessen direkt formulieren
 - Antworte NUR mit dem Fließtext, sonst nichts
 
+## Grammatik-Checkliste (KIS-1192 Item I)
+- Nach "in" + Plural-Substantiv steht Dativ-Plural-Endung "-n":
+  KORREKT: "in OpenAI- und Anthropic-Abläufen"
+  FALSCH:  "in OpenAI- und Anthropic-Abläufe"
+- Bei Vergleich "als jede/jeden" Genus + Kasus mit dem Bezugswort prüfen:
+  KORREKT: "härter treffen als jede größere Firma" (Firma = feminin, Akk.)
+  FALSCH:  "härter treffen als jeden größere Firma"
+- Adjektiv-Flexion muss zum Substantiv-Genus passen:
+  feminin (die Firma): "jede größere Firma", "eine konkrete Maßnahme"
+  maskulin (der Schritt): "jeden konkreten Schritt", "einen klaren Plan"
+- Vor dem Abschicken: Lies den Text laut. Stolperst Du beim Genus? Korrigiere.
+
 BRANCHENBEZEICHNUNG-REGEL:
 "{{BRANCHE_LABEL}}" maximal 1x verwenden. Danach: "Ihr Unternehmen".
 

--- a/services/sofort_start_generator.py
+++ b/services/sofort_start_generator.py
@@ -2276,36 +2276,95 @@ CHALLENGE_30_TAGE = {
 # out-of-scale for the target profile (e.g. governance-heavy weeks for
 # solo freelancers). The filter runs AFTER challenge-variant selection
 # (beginner/intermediate/expert), so solo-on-expert can still be trimmed.
+#
+# FIX-KIS-1192-ITEM-H: Solo woche_3/4-Skip wurde aufgehoben und durch
+# Override (siehe _CHALLENGE_SOLO_WEEK_OVERRIDES) ersetzt. Vorher entstand
+# auf R1 S.12 eine sichtbare Lücke (Tag 1-14 + Tag 29-30, nichts dazwischen)
+# weil Abschluss-Block unverändert auf Tag 29/30 hängt.
 _CHALLENGE_WEEKS_SKIP_BY_SIZE: Dict[str, set] = {
-    # Solo (Einzelberater): Woche 3 (LLM-Ops-Optimierung: Semantic Caching,
-    # Model-Routing, Prompt-Kompression) und Woche 4 (Skalierung:
-    # Rate-Limiting, Error-Handling, Team-Rollout) sind Enterprise-LLM-
-    # Ops-Niveau — für einen Einzelberater unpassend. Die verbleibenden
-    # Wochen 1+2 (Stack-Audit bzw. Werkzeugkasten + Governance-
-    # Grundregeln) sind der richtige Zuschnitt.
-    "solo": {"woche_3", "woche_4"},
-    # Team/KMU: noch nicht populiert. Eigener PR sobald Wolf die
-    # Segmentierung systematisch macht.
+    "solo": set(),  # Solo-Override siehe _CHALLENGE_SOLO_WEEK_OVERRIDES
     "team": set(),
     "kmu":  set(),
+}
+
+
+# FIX-KIS-1192-ITEM-H: Solo-spezifische Woche 3+4 Inhalte für Intermediate/
+# Expert-Solo-Berater. Ersetzt die ursprünglichen Enterprise-LLM-Ops-Wochen
+# durch Vorlagen-Pflege, Mandanten-Automatisierung und Self-Marketing —
+# realistischer Zuschnitt für einen Einzel-Berater. Wird in
+# _filter_challenge_weeks_by_size() als Override angewandt.
+_CHALLENGE_SOLO_WEEK_OVERRIDES: Dict[str, Dict[str, Any]] = {
+    "woche_3": {
+        "titel": "Vorlagen & Wiederverwendung",
+        "ziel": "Eigene Prompt-Bibliothek und Mandanten-Templates aufbauen",
+        "tage": [
+            {"tag": 15, "aufgabe": "Top-10-Wiederkehrende Aufgaben aus Woche 1+2 dokumentieren", "dauer": "30 Min", "kategorie": "Reflexion"},
+            {"tag": 16, "aufgabe": "Aus jeder Aufgabe einen wiederverwendbaren Prompt machen", "dauer": "45 Min", "kategorie": "Optimierung"},
+            {"tag": 17, "aufgabe": "Prompt-Bibliothek in Notion/Obsidian/Markdown anlegen", "dauer": "30 Min", "kategorie": "Setup"},
+            {"tag": 18, "aufgabe": "Mandanten-spezifische Templates (Angebot, Protokoll, Follow-up)", "dauer": "45 Min", "kategorie": "Praxis"},
+            {"tag": 19, "aufgabe": "Versionierung der Templates etablieren (Git oder Cloud-Versionen)", "dauer": "30 Min", "kategorie": "Setup"},
+            {"tag": 20, "aufgabe": "Test: Wie viel Zeit spart die Bibliothek pro Auftrag?", "dauer": "30 Min", "kategorie": "Reflexion"},
+            {"tag": 21, "aufgabe": "Woche 3 Review: Top-3 Bibliotheks-Bausteine markieren", "dauer": "20 Min", "kategorie": "Reflexion"},
+        ],
+    },
+    "woche_4": {
+        "titel": "Mandanten-Onboarding & Self-Marketing",
+        "ziel": "Kunden-Workflows automatisieren und Sichtbarkeit aufbauen",
+        "tage": [
+            {"tag": 22, "aufgabe": "Standard-Onboarding-Brief für neue Mandanten erstellen", "dauer": "45 Min", "kategorie": "Praxis"},
+            {"tag": 23, "aufgabe": "KI-gestützte FAQ-Antworten für Stammkunden anlegen", "dauer": "30 Min", "kategorie": "Praxis"},
+            {"tag": 24, "aufgabe": "LinkedIn/Newsletter-Posting-Bausteine vorbereiten", "dauer": "45 Min", "kategorie": "Sharing"},
+            {"tag": 25, "aufgabe": "Case-Study aus eigenem Projekt mit KI-Hilfe ausformulieren", "dauer": "45 Min", "kategorie": "Praxis"},
+            {"tag": 26, "aufgabe": "Backup-Strategie: Was tun, wenn KI-Dienst ausfällt?", "dauer": "30 Min", "kategorie": "Strategie"},
+            {"tag": 27, "aufgabe": "Eigene KI-Honorar-Position formulieren (Beratungs-Angebot)", "dauer": "30 Min", "kategorie": "Strategie"},
+            {"tag": 28, "aufgabe": "Q2-Ziel definieren: Was soll bis Sommer KI-gestützt laufen?", "dauer": "30 Min", "kategorie": "Planung"},
+        ],
+    },
 }
 
 
 def _filter_challenge_weeks_by_size(
     challenge_data: Dict[str, Any], company_size: str,
 ) -> Dict[str, Any]:
-    """Drop week-keys flagged as out-of-scale for the given company size.
+    """Drop week-keys flagged as out-of-scale; apply solo-specific overrides.
 
-    No-op unless _CHALLENGE_WEEKS_SKIP_BY_SIZE has entries for the size.
-    The challenge-variant selection runs before this filter, so the input
-    is always one of CHALLENGE_30_TAGE / _INTERMEDIATE / _EXPERT / _LIGHT.
+    Filter runs AFTER variant selection (beginner/intermediate/expert).
+    For solo+intermediate/expert, woche_3/4 get overridden with
+    solo-realistic content (Vorlagen-Bibliothek + Mandanten-Onboarding)
+    instead of Enterprise-LLM-Ops (KIS-1192 Item H).
     """
-    skip_keys = _CHALLENGE_WEEKS_SKIP_BY_SIZE.get(
-        (company_size or "").strip().lower(), set(),
-    )
-    if not skip_keys:
-        return challenge_data
-    return {k: v for k, v in challenge_data.items() if k not in skip_keys}
+    size_norm = (company_size or "").strip().lower()
+    skip_keys = _CHALLENGE_WEEKS_SKIP_BY_SIZE.get(size_norm, set())
+
+    # Apply skip first
+    if skip_keys:
+        challenge_data = {k: v for k, v in challenge_data.items() if k not in skip_keys}
+
+    # Solo override for Intermediate/Expert (where week 3/4 are Enterprise-LLM-Ops)
+    # Only triggers if the challenge variant actually has woche_3/woche_4 keys
+    # (CHALLENGE_30_TAGE_EXPERT and _INTERMEDIATE do, CHALLENGE_30_TAGE/_LIGHT do not).
+    if size_norm == "solo":
+        has_expert_week_3 = "woche_3" in challenge_data and any(
+            kw in (challenge_data["woche_3"].get("titel") or "").lower()
+            for kw in ("optimierung", "ops", "skalierung")
+        )
+        has_expert_week_4 = "woche_4" in challenge_data and any(
+            kw in (challenge_data["woche_4"].get("titel") or "").lower()
+            for kw in ("optimierung", "ops", "skalierung")
+        )
+        if has_expert_week_3 or has_expert_week_4:
+            result: Dict[str, Any] = {}
+            for k, v in challenge_data.items():
+                if k in _CHALLENGE_SOLO_WEEK_OVERRIDES and (
+                    (k == "woche_3" and has_expert_week_3)
+                    or (k == "woche_4" and has_expert_week_4)
+                ):
+                    result[k] = _CHALLENGE_SOLO_WEEK_OVERRIDES[k]
+                else:
+                    result[k] = v
+            return result
+
+    return challenge_data
 
 
 # =============================================================================

--- a/services/sofort_start_generator.py
+++ b/services/sofort_start_generator.py
@@ -1760,8 +1760,15 @@ def generate_sofort_start_html(
 
     # FIX-S25-HOURS: Override yearly hours with canonical value (month × 12)
     # to avoid weekly→yearly rounding drift (3h/wk × 48 = 144 ≠ 15h/mo × 12 = 180)
+    # FIX-KIS-1192-ITEM-G: Auch hours_per_month auf Canonical syncen, sodass
+    # Sofort-Start Hero-Box (R1 S.5) auf monatlicher Basis konsistent ist
+    # (Display "15h pro Monat" / "180h pro Jahr" / "12.960€ Netto").
     if canon_hours_month > 0:
+        canon_monthly = int(canon_hours_month)
         canon_yearly = int(canon_hours_month * 12)
+        if savings["hours_per_month"] != canon_monthly:
+            savings["hours_per_month"] = canon_monthly
+            savings["savings_per_month"] = canon_monthly * savings["hourly_rate"]
         if savings["hours_per_year"] != canon_yearly:
             savings["hours_per_year"] = canon_yearly
             savings["savings_per_year"] = canon_yearly * savings["hourly_rate"]
@@ -1823,6 +1830,11 @@ def generate_sofort_start_html(
     </div>
     
     <!-- ZEITERSPARNIS-RECHNUNG (Idee #3 + #6) -->
+    <!-- FIX-KIS-1192-ITEM-G: Hero-Box auf monatliche Basis umgestellt.
+         Vorher zeigte Wochen-Wert round(canon_hours_month/4.33) (z.B. 3h),
+         aber Jahres-Wert canon_hours_month*12 (180h) — Mathematik stimmte
+         nicht (3h*52=156h ≠ 180h). Monatlich bindet Sofort-Start visuell
+         an Business Case S.9 (15h/Mo = Canonical). -->
     <div style="background: #f0fdf4; border: 1px solid #22c55e; border-radius: 8px; padding: 16px; margin-bottom: 24px;">
         <h3 style="font-size: 16px; font-weight: 600; margin: 0 0 12px 0; color: #166534; display: flex; align-items: center; gap: 8px;">
             <span style="font-size: 20px;">💰</span>
@@ -1830,8 +1842,8 @@ def generate_sofort_start_html(
         </h3>
         <div style="display: grid; grid-template-columns: repeat(3, 1fr); gap: 12px; text-align: center;">
             <div style="background: white; border-radius: 6px; padding: 12px;">
-                <div style="font-size: 24px; font-weight: 700; color: #166534;">{savings['hours_per_week']}h</div>
-                <div style="font-size: 11px; color: #64748b;">pro Woche</div>
+                <div style="font-size: 24px; font-weight: 700; color: #166534;">{savings['hours_per_month']}h</div>
+                <div style="font-size: 11px; color: #64748b;">pro Monat</div>
             </div>
             <div style="background: white; border-radius: 6px; padding: 12px;">
                 <div style="font-size: 24px; font-weight: 700; color: #166534;">{savings['hours_per_year']}h</div>

--- a/services/strategy_pipeline.py
+++ b/services/strategy_pipeline.py
@@ -25,7 +25,7 @@ from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 
 from services.live_research import execute_research
-from services.strategy_budget import calculate_strategy_budget
+from services.strategy_budget import _user_budget_label, calculate_strategy_budget
 
 logger = logging.getLogger(__name__)
 
@@ -299,7 +299,11 @@ async def generate_strategy_report(
             "vendor_audit_green_count": _vendor_audit_green,
             "vendor_audit_status": _vendor_audit_status,
             # Strategy questions
-            "s1_budget": strategy_questions.get("s1_budget", ""),
+            # FIX-KIS-1192-ITEM-K: s1_budget wird vor LLM-Prompt-Übergabe
+            # formatiert (sonst leaked Raw-Token "2000_10000" in Strategy
+            # S.2/S.3). _user_budget_label() liefert "2.000 – 10.000 €".
+            # Raw-Key bleibt über strategy_questions/briefing_data abrufbar.
+            "s1_budget": _user_budget_label(strategy_questions.get("s1_budget", "")),
             "s2_zeitrahmen": strategy_questions.get("s2_zeitrahmen", ""),
             "s3_prioritaeten": ", ".join(strategy_questions.get("s3_prioritaeten", [])),
             "s4_engpass": strategy_questions.get("s4_engpass", ""),

--- a/services/tools_starter_kits.py
+++ b/services/tools_starter_kits.py
@@ -919,8 +919,9 @@ def generate_starter_kit_compact_html(kit: StarterKit, lang: str = "de") -> str:
     # FIX-KIS-1188-ITEM5: When kit.funding is reduced to the cross-reference
     # placeholder (program_id "crossref_foerderprogramme"), the bare name
     # "→ siehe Kapitel Fördermittel" appears kontextlos in the compact block.
-    # Render a full-sentence cross-reference and drop the misleading
-    # "1 Förderprogramme" count for the crossref-only case.
+    # FIX-KIS-1192-ITEM-E: Crossref wandert in eigenen Absatz UNTERHALB der
+    # Starter-Kit-Tabelle, damit er nicht als Tool-Listeneintrag missgelesen
+    # wird (R1 S.11).
     _is_crossref_only = (
         bool(kit.funding)
         and all(
@@ -928,14 +929,19 @@ def generate_starter_kit_compact_html(kit: StarterKit, lang: str = "de") -> str:
             for f in kit.funding
         )
     )
+    crossref_block_html = ""
     if _is_crossref_only:
-        funding_line_html = (
-            '<strong>Förderung:</strong> '
-            'Detaillierte Förderprogramme finden Sie im Kapitel '
-            '„Fördermittel &amp; Finanzierung".'
-        )
+        funding_line_html = ""
         funding_count_html = (
             f"{len(kit.tools)} Tools | ~{kit.estimated_total_days} Tage Einführung"
+        )
+        crossref_block_html = (
+            '<p style="margin:8px 0 16px 0;font-size:11px;color:#475569;'
+            'font-style:italic;line-height:1.5;">'
+            '<strong>Förderung:</strong> '
+            'Detaillierte Förderprogramme (inkl. regionaler Programme) '
+            'finden Sie im Hauptkapitel „Fördermittel &amp; Finanzierung".'
+            '</p>'
         )
     else:
         funding_list = ", ".join(f.name for f in kit.funding[:2])
@@ -957,10 +963,10 @@ def generate_starter_kit_compact_html(kit: StarterKit, lang: str = "de") -> str:
             {f'<div style="font-size:12px;font-weight:600;color:#059669;">{kit.potential_funding}</div>' if kit.potential_funding else ''}
         </div>
         <div style="margin-top:8px;font-size:10px;color:#495057;">
-            <strong>Tools:</strong> {tools_list}<br>
-            {funding_line_html}
+            <strong>Tools:</strong> {tools_list}{f'<br>{funding_line_html}' if funding_line_html else ''}
         </div>
     </div>
+    {crossref_block_html}
     """
 
 

--- a/templates/pdf_template_v7.html
+++ b/templates/pdf_template_v7.html
@@ -675,6 +675,30 @@ tr:last-child td { border-bottom: none; }
     line-height: 1.6;
 }
 
+/* FIX-KIS-1192-ITEM-F: Decision-Section Page-Break-Härtung.
+   EXECUTIVE_DECISION_HTML enthält LLM-generiertes <ul>/<li> ohne
+   Container-Klasse. Bei längerem Content (KIS-1189) kann Chromium
+   mid-sentence schneiden. Innere Block-Container hart schützen,
+   plus orphans/widows für Prosa-Fluss.
+   .decision-card hat bereits page-break-inside:avoid (Z.658) —
+   hier ergänzen wir die LLM-Direkt-HTML-Pfade. */
+#decision ul,
+#decision ol,
+#decision li,
+#decision p,
+#decision .executive-decision-fallback,
+#decision .decision-card {
+    break-inside: avoid;
+    page-break-inside: avoid;
+    orphans: 3;
+    widows: 3;
+}
+#decision > div,
+#decision .section-body > div {
+    break-inside: avoid;
+    page-break-inside: avoid;
+}
+
 /* ══════════════════════════════════════════════════════
    CONFIDENCE CARD (Decision Confidence Layer)
    ══════════════════════════════════════════════════════ */

--- a/tests/test_kis_1142_p6c_solo_matrix.py
+++ b/tests/test_kis_1142_p6c_solo_matrix.py
@@ -1,16 +1,20 @@
 # -*- coding: utf-8 -*-
 """
-KIS-1142 P6-C Solo-Populate + P3 Solo-Exempt.
+KIS-1142 P6-C Solo + KIS-1192 Item H Solo-Override + P3 Solo-Exempt.
 
-Wolf populates ``_CHALLENGE_WEEKS_SKIP_BY_SIZE["solo"] = {"woche_3",
-"woche_4"}`` (Enterprise-LLM-Ops-Wochen raus für Einzelberater).
-Kombiniert mit dem bestehenden P3-Drop ("Woche 1 weg für
-Intermediate/Expert") würde Solo+Intermediate/Expert aber auf eine
-einzige Governance-Woche degenerieren.
-
-Wolf-Entscheidung: P3 bleibt für Solo inaktiv, damit Solo immer mit
-mindestens ``{w1, w2, abschluss}`` aus der Challenge kommt. P3 greift
-weiter für Team/KMU+Intermediate/Expert.
+History:
+- KIS-1142 P6-C: ``_CHALLENGE_WEEKS_SKIP_BY_SIZE["solo"] = {"woche_3",
+  "woche_4"}`` — Enterprise-LLM-Ops-Wochen raus für Einzelberater.
+  Kombiniert mit P3 ("Woche 1 weg für Intermediate/Expert") wäre Solo
+  auf eine einzige Governance-Woche degeneriert; P3 ist für Solo
+  inaktiv geblieben.
+- KIS-1192 Item H: Skip führte zu sichtbarer Tage-15-28-Lücke auf
+  R1 S.12 (Tag 1-14 + Abschluss-Block Tag 29-30, nichts dazwischen).
+  Wolf-Entscheidung H1: Skip-Set für Solo geleert, stattdessen
+  Solo-spezifische woche_3/4 via ``_CHALLENGE_SOLO_WEEK_OVERRIDES``.
+  Solo bekommt damit wieder vollständige 30-Tage-Erfahrung mit
+  Solo-realistischen Inhalten (Vorlagen-Bibliothek + Mandanten-
+  Onboarding) statt Enterprise-LLM-Ops.
 
 Regression-Cover: die vollständige 3×3-Konsistenz-Matrix (company_size
 × expertise_level) wird hier gegen die erwartete Wochen-Konfiguration
@@ -28,18 +32,32 @@ from services.sofort_start_generator import (
     CHALLENGE_30_TAGE,
     CHALLENGE_30_TAGE_EXPERT,
     CHALLENGE_30_TAGE_INTERMEDIATE,
+    _CHALLENGE_SOLO_WEEK_OVERRIDES,
     _CHALLENGE_WEEKS_SKIP_BY_SIZE,
     generate_30_tage_challenge_html_v2,
 )
 
 
 # ---------------------------------------------------------------------------
-# H1 — The dict is populated for Solo as Wolf specified
+# H1 — KIS-1192 Item H: Solo skip is now empty; override mechanism applies
 # ---------------------------------------------------------------------------
 
 class TestSoloSkipSetPopulated:
-    def test_solo_drops_weeks_3_and_4(self):
-        assert _CHALLENGE_WEEKS_SKIP_BY_SIZE["solo"] == {"woche_3", "woche_4"}
+    def test_solo_keeps_all_four_weeks(self):
+        # KIS-1142 droppte W3/W4 für Solo. KIS-1192 Item H hebt das auf:
+        # Solo bekommt eigenen Content via _CHALLENGE_SOLO_WEEK_OVERRIDES.
+        # Skip-Set für Solo muss leer sein.
+        assert _CHALLENGE_WEEKS_SKIP_BY_SIZE["solo"] == set()
+
+    def test_solo_overrides_have_w3_and_w4(self):
+        # The replacement mechanism MUST cover both Enterprise-LLM-Ops weeks.
+        assert "woche_3" in _CHALLENGE_SOLO_WEEK_OVERRIDES
+        assert "woche_4" in _CHALLENGE_SOLO_WEEK_OVERRIDES
+        # Each override must have the canonical structure (titel, ziel, tage).
+        for wk in ("woche_3", "woche_4"):
+            assert "titel" in _CHALLENGE_SOLO_WEEK_OVERRIDES[wk]
+            assert "tage" in _CHALLENGE_SOLO_WEEK_OVERRIDES[wk]
+            assert len(_CHALLENGE_SOLO_WEEK_OVERRIDES[wk]["tage"]) == 7
 
     def test_team_and_kmu_still_empty(self):
         # Wolf: "Team/KMU nach Prüfung in separatem PR". Must stay empty
@@ -92,49 +110,94 @@ _INTER_W3_TITLE = CHALLENGE_30_TAGE_INTERMEDIATE["woche_3"]["titel"]
 _INTER_W4_TITLE = CHALLENGE_30_TAGE_INTERMEDIATE["woche_4"]["titel"]
 _INTER_ABSCHLUSS_TITLE = CHALLENGE_30_TAGE_INTERMEDIATE["abschluss"]["titel"]
 
+# KIS-1192 Item H: Solo-specific override titles
+_SOLO_OVERRIDE_W3_TITLE = _CHALLENGE_SOLO_WEEK_OVERRIDES["woche_3"]["titel"]
+_SOLO_OVERRIDE_W4_TITLE = _CHALLENGE_SOLO_WEEK_OVERRIDES["woche_4"]["titel"]
+
 
 class TestConsistencyMatrix:
-    # --- SOLO --- (weeks 3 + 4 always dropped, week 1 always kept) ------
+    # --- SOLO --- (KIS-1192 Item H: full 30 days, Solo-overrides for
+    # Enterprise-LLM-Ops weeks; week 1 always kept) -----------------------
 
-    def test_solo_beginner_keeps_w1_w2_abschluss(self):
+    def test_solo_beginner_keeps_5_blocks(self):
+        # KIS-1192 Item H: Solo bekommt alle 5 Blöcke (w1-w4 + Abschluss).
+        # Beginner-Content ist bereits solo-tauglich → kein Override nötig.
         titles = _render_and_extract_week_titles("solo", "beginner")
         assert titles == [
             _BEGINNER_W1_TITLE,
             _BEGINNER_W2_TITLE,
+            _BEGINNER_W3_TITLE,
+            _BEGINNER_W4_TITLE,
             _BEGINNER_ABSCHLUSS_TITLE,
         ]
 
-    def test_solo_intermediate_keeps_w1_w2_abschluss(self):
-        # Key degeneration guard: P3 must NOT drop w1 for Solo.
+    def test_solo_intermediate_keeps_5_blocks(self):
+        # KIS-1192 Item H: Solo bekommt alle 5 Blöcke (w1-w4 + Abschluss).
+        # Intermediate w3 ("Vertiefung & Qualität") ist solo-OK → bleibt.
+        # Intermediate w4 ("Skalierung & Standardisierung") matched den
+        # Enterprise-Keyword-Filter → wird durch Solo-Override ersetzt.
+        # Degeneration-Guard: P3 darf w1 für Solo nicht droppen.
         titles = _render_and_extract_week_titles("solo", "intermediate")
         assert titles == [
             _INTER_W1_TITLE,
             _INTER_W2_TITLE,
+            _INTER_W3_TITLE,
+            _SOLO_OVERRIDE_W4_TITLE,
             _INTER_ABSCHLUSS_TITLE,
         ]
 
-    def test_solo_expert_keeps_w1_w2_abschluss(self):
-        # Same degeneration guard for expert — Solo-Expert is a central
-        # product profile (TÜV KI-Manager freelancer etc.).
+    def test_solo_expert_keeps_5_blocks(self):
+        # KIS-1192 Item H: Solo bekommt alle 5 Blöcke (w1-w4 + Abschluss).
+        # Expert w3 ("Optimierung" — LLM-Ops) und w4 ("Skalierung") sind
+        # Enterprise → beide werden durch Solo-Overrides ersetzt.
+        # Solo-Expert ist ein zentrales Produkt-Profil (TÜV KI-Manager
+        # Freelancer etc.).
         titles = _render_and_extract_week_titles("solo", "expert")
         assert titles == [
             _EXPERT_W1_TITLE,
             _EXPERT_W2_TITLE,
+            _SOLO_OVERRIDE_W3_TITLE,
+            _SOLO_OVERRIDE_W4_TITLE,
             _EXPERT_ABSCHLUSS_TITLE,
         ]
 
-    @pytest.mark.parametrize("expertise", ["beginner", "intermediate", "expert"])
-    def test_solo_never_degenerates_below_two_weeks(self, expertise):
-        titles = _render_and_extract_week_titles("solo", expertise)
-        # "Abschluss" counts separately — we want at least two actual
-        # Wochen-Blöcke, so the Challenge reads as a challenge.
+    def test_solo_advanced_keeps_5_blocks(self):
+        # KIS-1192 Wolf-Profil-Regression-Schutz: Briefing KI-Kompetenz=
+        # "hoch" mappt im upstream-Pipeline auf expertise_level="expert".
+        # Dieser Test fixt das genaue Profil aus KIS-1192 (Briefing-ID
+        # 1075) — Solo + Beratung + hoch — gegen die 5-Block-Erwartung.
+        # Replicates the user-facing R1 S.12-Layout vom KIS-1192-Lauf.
+        titles = _render_and_extract_week_titles("solo", "expert")
         week_blocks = [t for t in titles
                        if t not in (_BEGINNER_ABSCHLUSS_TITLE,
                                     _EXPERT_ABSCHLUSS_TITLE,
                                     _INTER_ABSCHLUSS_TITLE)]
-        assert len(week_blocks) >= 2, (
-            f"Solo+{expertise} degenerated to {len(week_blocks)} "
-            f"week-block(s): {titles!r}. Expected ≥ 2."
+        assert len(titles) == 5, (
+            f"Wolf-Profil (Solo + KI-Kompetenz=hoch) muss 5 Blöcke "
+            f"rendern (w1-w4 + Abschluss), got {len(titles)}: {titles!r}"
+        )
+        assert len(week_blocks) == 4, (
+            f"Wolf-Profil muss 4 echte Wochen-Blöcke haben, "
+            f"got {len(week_blocks)}: {titles!r}"
+        )
+        # Override-Markers müssen tatsächlich greifen (sonst landet
+        # Enterprise-LLM-Ops-Content beim Solo-Berater).
+        assert _SOLO_OVERRIDE_W3_TITLE in titles
+        assert _SOLO_OVERRIDE_W4_TITLE in titles
+
+    @pytest.mark.parametrize("expertise", ["beginner", "intermediate", "expert"])
+    def test_solo_renders_full_30_days(self, expertise):
+        # KIS-1192 Item H regression-guard: Solo bekommt alle 4 Wochen
+        # + Abschluss, keine sichtbare Lücke mehr (R1 S.12 lückenlos
+        # Tag 1-30 statt vorher 1-14 + 29-30).
+        titles = _render_and_extract_week_titles("solo", expertise)
+        week_blocks = [t for t in titles
+                       if t not in (_BEGINNER_ABSCHLUSS_TITLE,
+                                    _EXPERT_ABSCHLUSS_TITLE,
+                                    _INTER_ABSCHLUSS_TITLE)]
+        assert len(week_blocks) == 4, (
+            f"Solo+{expertise} should render all 4 weeks (KIS-1192 Item H), "
+            f"got {len(week_blocks)} week-block(s): {titles!r}."
         )
 
     # --- TEAM --- (P6-C no-op, P3 drops w1 for Int/Expert) --------------
@@ -213,14 +276,23 @@ class TestSoloExemptGuard:
 
     @pytest.mark.parametrize("variant", ["Solo", "SOLO", " solo ", "solo"])
     def test_company_size_normalisation_survives_whitespace_and_case(self, variant):
-        # The normalised comparison must handle upstream inputs that
-        # preserve original casing/spacing (legacy briefings).
+        # KIS-1192 Item H: Solo bekommt jetzt 4 Wochen + Abschluss.
+        # Normalisierung muss case- und whitespace-tolerant sein, sodass
+        # Solo-Override für w3/w4 greift (sonst landet Enterprise-LLM-Ops
+        # beim Solo-Berater).
         titles = _render_and_extract_week_titles(variant, "expert")
-        # Still the Solo shape (w1 + w2 + abschluss), not the degenerate
-        # 1-week shape.
         week_blocks = [t for t in titles
                        if t not in (_EXPERT_ABSCHLUSS_TITLE,)]
-        assert len(week_blocks) == 2, (
+        assert len(week_blocks) == 4, (
             f"company_size={variant!r} should normalise to 'solo' and "
-            f"keep w1+w2, got {titles!r}"
+            f"render 4 weeks (KIS-1192 Item H), got {titles!r}"
+        )
+        # Solo-Overrides müssen für die LLM-Ops-Wochen greifen.
+        assert _SOLO_OVERRIDE_W3_TITLE in titles, (
+            f"company_size={variant!r}: w3 should be solo-overridden, "
+            f"got {titles!r}"
+        )
+        assert _SOLO_OVERRIDE_W4_TITLE in titles, (
+            f"company_size={variant!r}: w4 should be solo-overridden, "
+            f"got {titles!r}"
         )


### PR DESCRIPTION
## Summary

Sprint 1027.2 — sechs vertrauens-/struktur-relevante R1+Strategy-Fixes nach Validierungs-Befunden aus KIS-1192 (Briefing-ID 1075). Vier sichtbare Customer-Fehler (E, G, H, I) plus zwei strukturelle Härtungen (F, K). Jeweils ein eigener Commit, sechs Wolf-Pings im Diagnose-First-Modus gebündelt eingeholt.

Ref: KIS-1192 (Display-ID), Briefing-ID 1075

## Items

### Item E — Förder-Crossref Position (R1 S.11) `[Wolf: Option E2]`
**Problem:** Cross-Reference-Satz "Detaillierte Förderprogramme... Hauptkapitel Fördermittel" stand als Listeneintrag innerhalb der Tool-Tabelle.
**Root:** `tools_starter_kits.py:959-963` rendert Förder-Cross-Ref im selben `<div>` wie Tool-Liste, nur per `<br>` getrennt.
**Fix:** Crossref-Block jetzt als eigenständiges `<p>` AUSSERHALB des starter-kit-compact div, italic, mit margin. Tool-Listen-Zeile ohne Förder-Inline-Block.
**Commit:** 297ff99

### Item F — Decision-Section CSS-Härtung (R1 S.4) `[Wolf: Option A]`
**Problem:** Latentes Mid-Sentence-Cutoff-Risiko in Entscheidungsvorlage (KIS-1189).
**Root:** `EXECUTIVE_DECISION_HTML` ist LLM-`<ul>/<li>/<p>` ohne break-Schutz; `.decision-card` hat break-inside avoid (Z.658), aber Direkt-HTML-Pfad nutzt die Klasse nicht.
**Fix:** Neue CSS-Regel für `#decision ul/ol/li/p/.executive-decision-fallback/.decision-card` mit `break-inside: avoid; page-break-inside: avoid; orphans: 3; widows: 3;` plus äußerer Schutz `#decision > div`.
**Commit:** 408307c

### Item G — Sofort-Start-Rechnung Konsistenz (R1 S.5) `[Wolf: Option G4]`
**Problem:** Hero-Box "3h pro Woche / 180h pro Jahr / 12.960€ Netto" rechnete nicht (3×52=156h, nicht 180h).
**Root:** `sofort_start_generator.py:1755` rundete Wochen-Wert auf `round(canon/4.33)` (15→3); Jahr/€ aber direkt aus canon×12 (180/12.960).
**Fix:** Hero-Box auf monatliche Basis umgestellt. `hours_per_month` und `savings_per_month` werden zusätzlich aus canon_hours_month synchronisiert. Display: "15h pro Monat / 180h pro Jahr / 12.960€ Netto" — Mathematik exakt, Match mit Business Case S.9.
**Commit:** cc80811

### Item H — 30-Tage-Challenge Solo Woche 3+4 (R1 S.12) `[Wolf: Option H1]`
**Problem:** Challenge zeigte Tage 1-14 + Tag 29-30, Lücke dazwischen (14 Tage fehlten).
**Root:** KIS-1142 P6-C hatte `_CHALLENGE_WEEKS_SKIP_BY_SIZE["solo"] = {"woche_3", "woche_4"}` gesetzt; Solo war von P3-Renumber bewusst ausgenommen → Abschluss-Block blieb auf Tag 29/30.
**Fix:** Skip-Set für Solo geleert. Neues `_CHALLENGE_SOLO_WEEK_OVERRIDES` mit Solo-realistischen Inhalten:
- Woche 3 "Vorlagen & Wiederverwendung" (Tag 15-21) — Prompt-Bibliothek, Mandanten-Templates
- Woche 4 "Mandanten-Onboarding & Self-Marketing" (Tag 22-28) — FAQ, LinkedIn, Case-Study

Filter-Funktion erkennt Solo + Enterprise-Variante (titel-Keyword `optimierung`/`ops`/`skalierung`) und überschreibt nur dort, wo es nötig ist. Alle Tage 1-30 wieder durchgängig.
**Commit:** 7e8be73

### Item I — advisor_note Grammar (R1 S.18) `[Wolf: Option I1]`
**Problem:** Zwei LLM-Halluzinationen in Persönlicher Einschätzung:
1. "in OpenAI- und Anthropic-Abläufe wird..." (Dativ-Plural fehlt: Abläufen)
2. "härter treffen als jeden größere Firma" (Genus-Salat: jede)

**Fix Teil 1:** `prompts/de/advisor_note.md` um Grammatik-Checkliste erweitert (Dativ-Plural-n, jede vs. jeden, Adjektiv-Flexion).
**Fix Teil 2:** Post-LLM-Sanitizer in `gpt_analyze.py` nach v7.1.2-Cleanup:
- Pattern 1: `in *-Abläufe (wird|kann|sollte|muss|darf|ist|war)` → "Abläufen + Verb" (Verb-Whitelist verhindert Akkusativ-False-Positives)
- Pattern 2: `als jeden \w+e <feminines Substantiv>` → "als jede" (Substantiv-Whitelist: Firma, Lösung, Maßnahme, Branche, Praxis, Kanzlei, ...)

Smoke-test: beide echten KIS-1192-Fälle gefixt, "die Abläufe optimieren" (Akkusativ) bleibt, "als jeden konkreten Schritt" (maskulin) bleibt.
**Commit:** 3174fbb

### Item K — Pre-Prompt-Sanitizer s1_budget (Strategy S.2/S.3) `[Wolf: Option K2]`
**Problem:** Raw-Token `"2000_10000"` leaked in Strategy-Sektionen S.2/S.3, während S.9 korrekt "2.000 – 10.000 €" rendert.
**Root:** `strategy_pipeline.py:302` injizierte den raw `s1_budget` direkt in den LLM-Prompt-Context. Prompts an Z.139/359/683/1020 nutzen `{s1_budget}` (raw); Z.510/513/561/832 nutzen `{s1_budget_label}` (formatiert).
**Fix:** Import von `_user_budget_label` aus `services.strategy_budget`. `s1_budget` im base_context wird vor Prompt-Übergabe formatiert. Raw-Key bleibt über `strategy_questions`/`briefing_data` verfügbar.
**Commit:** 7d2e044

## Test plan

- [x] Smoke-Tests pro Item bestanden:
  - G: `15h/Mo × 12 = 180h × 80€/h − 1.440€ = 12.960€ netto`
  - H: EXPERT-solo zeigt alle Tage 1-30, w3=Vorlagen, w4=Mandanten
  - I: 4 Test-Cases (2 echte KIS-1192-Fälle gefixt, 2 false-positive-Schutz)
  - K: Alle Budget-Buckets korrekt formatiert
  - F/E: visueller Check erforderlich
- [x] Existing tests grün: 137 passed (`test_report_healer`, `test_strategy_sanitizer`, `test_fix528_pipeline_sanitizers`)
- [ ] **Funnel-Lauf KIS-1193** mit identischen Inputs zu KIS-1192 (Beratung, Solo 1, KI-Kompetenz hoch, Hauptleistung "Beratung")
- [ ] **Visueller Check:**
  - [ ] E: R1 S.11 Tool-Tabelle ohne Förder-Eintrag (eigener Absatz unterhalb)
  - [ ] F: R1 S.4 Decision-Section ohne Mid-Sentence-Cut
  - [ ] G: R1 S.5 Hero-Box "15h/Mo / 180h/Jahr / 12.960€" konsistent
  - [ ] H: R1 S.12 alle Tage 1-30 vorhanden, Woche 3/4 Solo-relevant
  - [ ] I: R1 S.18 grammatisch korrekt ("Abläufen", "jede")
  - [ ] K: Strategy S.2/S.3 kein "2000_10000" mehr
- [ ] **Cross-Report-Regression:** Sprint 1026 + 1027.1 + 1027.1.1 Fixes weiter aktiv

## Out-of-Scope (per Briefing)
- Änderungen am make-ki-pdfservice (separater Repo)
- KPA Break-Even, Strategy S.12 Doppelung, S.12 Tag-5-Umlaut → 1027.4-Backlog
- Sprint 1027.3 PDF-Service-Architektur-Doku (eigener Sprint)

https://claude.ai/code/session_01NXshYX2FFWLZcwf2Dw3mtu

---
_Generated by [Claude Code](https://claude.ai/code/session_01NXshYX2FFWLZcwf2Dw3mtu)_