### PR TITLE
Sprint 1027.2.1: KIS-1193 Hotfixes (F2-F6 done, F1 awaiting evidence)

### DIFF
--- a/gpt_analyze.py
+++ b/gpt_analyze.py
@@ -1383,6 +1383,10 @@ _SECTION_MAX_TOKENS = {
     "ai_act_summary": 4000,
     "reifegrad_sowhat": 4000,
     "quick_wins": 5000,
+    # Hotfix 1027.2.1 F2: Phase 3 (Verstetigung) verschwand bei tightem Budget.
+    # Naming-Konflikt mit executive_decision ist via Prompt-Rename gelöst;
+    # explizites Token-Budget verhindert Regression bei globalen Default-Änderungen.
+    "roadmap_90d_decision": 4000,
     "branch_deep_dive": 8000,  # FIX-B718: was 5000, LLM hits max_tokens → truncation
     # ── EFFIZIENT ──
     "transparency_box": 3000,

--- a/prompts/de/roadmap_90d_decision.md
+++ b/prompts/de/roadmap_90d_decision.md
@@ -69,7 +69,7 @@ VERBOTEN: <h1>, <h2>, <h3>, <h4>, <section>, <article>, <header>
 -->
 <!-- OUTPUT: HTML ONLY -->
 <!-- SIZE-AWARE: solo/team/kmu -->
-<!-- TOKEN-BUDGET: 600 -->
+<!-- TOKEN-BUDGET: 900 -->
 <!-- WORD_MINIMUM: 200 -->
 <!-- WORD_MAXIMUM: 300 -->
 
@@ -88,7 +88,7 @@ Titel: p > strong "90-Tage-Fahrplan – Entscheidungsfassung"
 Dann 3 Phasen-Blöcke:
 - Phase 1 (0–30 Tage): Fundament
 - Phase 2 (31–60 Tage): Pilotierung
-- Phase 3 (61–90 Tage): Entscheidung
+- Phase 3 (61–90 Tage): Verstetigung
 
 Pro Phase:
 - p > strong mit Phasenname

--- a/prompts/strategy_prompts.py
+++ b/prompts/strategy_prompts.py
@@ -707,7 +707,7 @@ CONFIDENCE-HINWEIS (BEI BEDARF): Wo Datenlage oder Marktvergleich erkennbar unsi
 AUFGABE:
 1. Beschreibe die 3-5 relevantesten Förderprogramme aus der VERIFIZIERTEN LISTE oben für {firmenname}.
 2. Für jedes Programm:
-   a) Name und Träger (EXAKT wie in der verifizierten Liste)
+   a) Name (Programmtitel) und Träger (EXAKT wie in der verifizierten Liste)
    b) Förderhöhe (EXAKT wie in der verifizierten Liste)
    c) Förderquote (EXAKT wie in der verifizierten Liste)
    d) Antragsfrist (falls bekannt)
@@ -716,6 +716,13 @@ AUFGABE:
 3. Zeige die Einzelprogramme mit jeweiligem Förderbetrag. Berechne KEINE programmübergreifende Gesamtsumme — Programme sind nicht kumulierbar und eine addierte Summe wäre irreführend.
 4. Gib eine Handlungsempfehlung: Welches Programm zuerst beantragen?
 5. Berücksichtige das Land ({country_name}) und die Region ({bundesland}).
+
+DATENINTEGRITÄT (KRITISCH, VERBINDLICH):
+- Übernimm Programmtitel und Träger für jedes Förderprogramm wörtlich aus der bereitgestellten Datenquelle (VERIFIZIERTE FÖRDERPROGRAMME / AUS REPORT 1).
+- Die Spalte „Programm" (bzw. Tabellen-Header für den Programmtitel) MUSS für jedes gelistete Programm den vollständigen Titel enthalten — niemals nur den Träger.
+- Lasse keine Tabellenzelle leer. Falls eine Information nicht in der Datenquelle steht: schreibe „Auf Anfrage" oder „Aktuell prüfen", aber NIEMALS eine leere Zelle.
+- Paraphrasiere Titel und Träger NICHT. Kein „Bayerisches Förderprogramm" statt „Digitalbonus Bayern".
+- Selbst-Prüfung vor Ausgabe: Jede Tabellenzeile auf vollständige Spaltenbefüllung kontrollieren (insbesondere Titel-Spalte).
 
 LÄNDER-REGEL (KRITISCH):
 - Land des Unternehmens: {country_name} ({country})

--- a/services/business_case_engine_v2.py
+++ b/services/business_case_engine_v2.py
@@ -349,7 +349,7 @@ class ROIExplanation:
                     </div>{roi_conclusion}
                 </div>
                 <div style="margin-top:8px;padding:6px 8px;background:#f0f4f8;border-radius:4px;font-size:10px;color:#64748b;line-height:1.4;">
-                    <strong>Methodik-Hinweis:</strong> Diese ROI-Berechnung basiert auf der einmaligen Startinvestition (CAPEX). Der KI-Strategiebericht kalkuliert mit einer Gesamtinvestition über 12 Monate (inkl. Schulung, Koordination) — abweichende ROI-Werte sind methodisch bedingt, nicht widersprüchlich.
+                    <strong>Methodik-Hinweis:</strong> Diese ROI-Berechnung basiert auf der einmaligen Startinvestition (CAPEX) und ist konservativ bei 200% gedeckelt. Die KI-Potenzial-Analyse zeigt zusätzlich den ungedeckelten ROI für höhere Sensitivitätsszenarien. Der KI-Strategiebericht kalkuliert mit einer Gesamtinvestition über 12 Monate (inkl. Schulung, Koordination) — abweichende ROI-Werte sind methodisch bedingt, nicht widersprüchlich.
                 </div>
             </div>
         </div>

--- a/services/prompt_enhancer.py
+++ b/services/prompt_enhancer.py
@@ -917,6 +917,27 @@ PROTECTED_PRODUCT_NAMES: List[str] = [
     "MS Teams",
 ]
 
+# Hotfix 1027.2.1 F4: Standalone "Teams" als Tool-Name (z.B. „Zoom oder Teams")
+# wurde von der Kette SOLO_GOVERNANCE_REPLACEMENTS (teams→Kapazitäten) und
+# content_quality_enforcer (Kapazitäten→Zeitbudget) als „Kapazitäten" missdeutet
+# → Output: „Zoom oder Zeitbudget". PROTECTED_PRODUCT_NAMES nutzt re.escape
+# und kann nur Literale; für kontextuelle Erkennung („Teams" als Tool im
+# Meeting-Tool-Cluster) brauchen wir Regex-Patterns. Match-Text wird durch
+# Placeholder vor der Filter-Pipeline ersetzt und nach den Replacements
+# 1:1 rekonstruiert (siehe apply_solo_persona_filter Z.998+).
+#
+# Heuristik: „Teams" gilt als Tool-Name, wenn es in einer Liste mit anderen
+# bekannten Meeting-/Collaboration-Tools (Zoom, Google Meet, Webex, Slack,
+# Otter, Loom, Jitsi) steht (durch /,/und/oder/„or"/„and" verbunden). In
+# allen anderen Kontexten greift die bisherige Solo-Lexicon-Ersetzung.
+_TOOL_NEIGHBORS = r"(?:Zoom|Google\s+Meet|Webex|Slack|Otter|Loom|Jitsi|GoToMeeting|BlueJeans|Skype)"
+PROTECTED_PRODUCT_PATTERNS: List[str] = [
+    # „Zoom oder Teams" / „Zoom, Teams" / „Zoom und Teams"
+    rf"\b{_TOOL_NEIGHBORS}\s*(?:,|/|\s+oder\s+|\s+und\s+|\s+or\s+|\s+and\s+)\s*Teams\b",
+    # „Teams oder Zoom" / „Teams, Zoom" / „Teams und Zoom"
+    rf"\bTeams\s*(?:,|/|\s+oder\s+|\s+und\s+|\s+or\s+|\s+and\s+)\s*{_TOOL_NEIGHBORS}\b",
+]
+
 SOLO_FORBIDDEN_TERMS: List[str] = [
     # Team-specific terms (German)
     "team",
@@ -989,6 +1010,19 @@ def apply_solo_persona_filter(text: str) -> str:
                 original = match.group(0)
                 protected_map[placeholder] = original
                 result = pattern.sub(placeholder, result)
+
+    # Hotfix 1027.2.1 F4: Kontextuelle Regex-Patterns für „Teams" als Tool-Name
+    # im Meeting-Tool-Cluster. Jedes Match wird per Index-Placeholder maskiert,
+    # damit Mehrfachvorkommen mit unterschiedlicher Schreibweise erhalten bleiben.
+    for i, regex_pattern in enumerate(PROTECTED_PRODUCT_PATTERNS):
+        compiled = re.compile(regex_pattern, re.IGNORECASE)
+        # Use callback to capture each match's actual text individually
+        def _replace(match: 're.Match[str]', start_idx=i) -> str:
+            idx = len(protected_map)
+            placeholder = f"__PROTECTED_PATTERN_{start_idx}_{idx}__"
+            protected_map[placeholder] = match.group(0)
+            return placeholder
+        result = compiled.sub(_replace, result)
 
     # 1) Apply phrase replacements FIRST (multi-word patterns)
     for phrase, replacement in SOLO_PHRASE_REPLACEMENTS.items():

--- a/services/report_healer.py
+++ b/services/report_healer.py
@@ -3685,11 +3685,19 @@ def apply_segment_budget(
                 _diag_text = re.sub(r'<[^>]+>', ' ', _exec_content)
                 _diag_text = re.sub(r'\s+', ' ', _diag_text).strip()
             _diag_last_chars = _diag_text[-30:].replace('\n', ' ').replace('\r', ' ')
+            # Hotfix-1027.2.1-F1: content_hash für Korrelation Persistence vs.
+            # Render. KIS-1193 DIAG zeigte sauberen Generator-Output; Render-PDF
+            # war trotzdem truncated → Render-Pfad-Issue. Hash macht das ohne
+            # Volltext-Diff sofort verifizierbar.
+            _diag_content_hash = hashlib.md5(
+                _exec_content.encode('utf-8'), usedforsecurity=False
+            ).hexdigest()[:12]
             log.info(
                 "[FIX-EXEC-DECISION-DIAG] section=%s len=%d open_li=%d close_li=%d "
-                "p_total=%d p_strong_prefix=%d last_chars=%r tags=%s",
+                "p_total=%d p_strong_prefix=%d last_chars=%r tags=%s content_hash=%s",
                 _exec_key, len(_exec_content), _open_count, _close_count,
                 _diag_p_total, _diag_p_strong, _diag_last_chars, _diag_tags,
+                _diag_content_hash,
             )
         except Exception as _diag_err:
             log.info(

--- a/services/sofort_start_generator.py
+++ b/services/sofort_start_generator.py
@@ -2855,11 +2855,15 @@ def generate_30_tage_challenge_html_v2(
         challenge_data = _drop_first_week_and_renumber(challenge_data)
 
     # KIS-1132: Expertise-aware subtitle
-    # KIS-1142 P3: Wochen-Anzahl ist jetzt 3 für Int/Expert (Woche 1 gedroppt).
+    # KIS-1142 P3: Wochen-Anzahl ist 3 für Team/KMU Int/Expert (Woche 1 gedroppt).
+    # Hotfix 1027.2.1 F3: Solo behält nach Item H alle 4 Wochen — Subtitle muss
+    # company_size-aware sein, sonst widerspricht S.3 Management Summary dem
+    # gerenderten Inhalt auf S.13-14.
+    _wochen_label = "4 Wochen" if _company_size_norm == "solo" else "3 Wochen"
     if expertise_level == "expert":
-        _subtitle = "Stack-Optimierung und Governance in 3 Wochen"
+        _subtitle = f"Stack-Optimierung und Governance in {_wochen_label}"
     elif expertise_level == "intermediate":
-        _subtitle = "Vom Anwender zum Workflow-Profi in 3 Wochen"
+        _subtitle = f"Vom Anwender zum Workflow-Profi in {_wochen_label}"
     else:
         _subtitle = "Von Null auf KI-Profi – angepasst an Ihr Zeitbudget"
 

--- a/templates/pdf_template_v7.html
+++ b/templates/pdf_template_v7.html
@@ -698,6 +698,36 @@ tr:last-child td { border-bottom: none; }
     break-inside: avoid;
     page-break-inside: avoid;
 }
+/* Hotfix-1027.2.1-F1: Container-Level-Härtung für .exec-decision-box.
+   DIAG für Briefing 1076 (KIS-1193) zeigte: LLM-Output sauber
+   (open_li=close_li=3, len≈820, terminal-Punkt), Persistence == Render
+   identisch — Truncation erst beim Chromium-PDF-Render. Sprint 1027.2
+   Item F deckte ul/li/p ab; der äußere Container <div class="exec-decision-box">
+   wurde aber nur über das generische `#decision > div` mitgenommen, was
+   Chromium bei Content > ½ Seitenhöhe ignoriert. Container-Level-Selector
+   plus widows:4/orphans:4 auf die innere ul plus min-height-Floor erzwingen
+   atomare Behandlung. */
+.exec-decision-box {
+    break-inside: avoid !important;
+    page-break-inside: avoid !important;
+    break-before: auto;
+    page-break-before: auto;
+    break-after: auto;
+    page-break-after: auto;
+    min-height: 12em;
+}
+.exec-decision-box ul {
+    break-inside: avoid !important;
+    page-break-inside: avoid !important;
+    orphans: 4;
+    widows: 4;
+}
+.exec-decision-box li {
+    break-inside: avoid !important;
+    page-break-inside: avoid !important;
+    orphans: 3;
+    widows: 3;
+}
 
 /* ══════════════════════════════════════════════════════
    CONFIDENCE CARD (Decision Confidence Layer)

--- a/templates/pdf_template_v7.html
+++ b/templates/pdf_template_v7.html
@@ -1502,11 +1502,11 @@ h1, h2, h3, h4 {
        so viele Wochen, dass Woche 1 erhalten bleiben muss. Der Hinweis muss
        das widerspiegeln, sonst widerspricht er dem gerenderten Inhalt. #}
     {% elif expertise_level == "expert" and company_size == "solo" %}
-    <div class="skip-hint"><strong>Für Ihr Kompetenzniveau (fortgeschritten):</strong> Die 30-Tage-Challenge ist auf Solo-Berater zugeschnitten und fokussiert auf Werkzeugkasten-Optimierung und Spielregeln in 3 Wochen. Fokussieren Sie auf: Quick Wins, Vendor-Audit und KI-Potenzial-Analyse.</div>
+    <div class="skip-hint"><strong>Für Ihr Kompetenzniveau (fortgeschritten):</strong> Die 30-Tage-Challenge ist auf Solo-Berater zugeschnitten und fokussiert auf Werkzeugkasten-Optimierung und Spielregeln in 4 Wochen. Fokussieren Sie auf: Quick Wins, Vendor-Audit und KI-Potenzial-Analyse.</div>
     {% elif expertise_level == "expert" %}
     <div class="skip-hint"><strong>Für Ihr Kompetenzniveau (fortgeschritten):</strong> Die 30-Tage-Challenge startet direkt mit Stack-Optimierung und Governance — die Einstiegs-Woche entfällt. Fokussieren Sie auf: Quick Wins, Vendor-Audit und KI-Potenzial-Analyse.</div>
     {% elif expertise_level == "intermediate" and company_size == "solo" %}
-    <div class="skip-hint"><strong>Für Ihr Kompetenzniveau (erfahren):</strong> Die 30-Tage-Challenge ist auf Solo-Berater zugeschnitten und kombiniert Workflow-Analyse mit Automatisierung in 3 Wochen. Fokussieren Sie auf: Quick Wins, 90-Tage-Roadmap und Business Case.</div>
+    <div class="skip-hint"><strong>Für Ihr Kompetenzniveau (erfahren):</strong> Die 30-Tage-Challenge ist auf Solo-Berater zugeschnitten und kombiniert Workflow-Analyse mit Automatisierung in 4 Wochen. Fokussieren Sie auf: Quick Wins, 90-Tage-Roadmap und Business Case.</div>
     {% elif expertise_level == "intermediate" %}
     <div class="skip-hint"><strong>Für Ihr Kompetenzniveau (erfahren):</strong> Die 30-Tage-Challenge überspringt die Grundlagen-Woche und startet mit Workflow-Integration. Fokussieren Sie auf: Quick Wins, 90-Tage-Roadmap und Business Case.</div>
     {% endif %}

--- a/tests/test_exec_decision_clean.py
+++ b/tests/test_exec_decision_clean.py
@@ -17,6 +17,8 @@ Test contract:
   TRUNCATED_LI warning for the offending bullet even when the section
   ends cleanly.
 """
+import re
+
 import pytest
 
 
@@ -342,6 +344,8 @@ class TestExecDecisionDiagMarker:
         assert "p_strong_prefix=" in msg
         assert "last_chars=" in msg
         assert "tags=" in msg
+        # Hotfix-1027.2.1-F1: content_hash für Persistence-vs-Render-Korrelation
+        assert "content_hash=" in msg
 
     def test_diag_marker_emitted_on_clean_section(self, caplog):
         """When the LLM honors the contract and no bullet is truncated, the
@@ -366,4 +370,7 @@ class TestExecDecisionDiagMarker:
         assert "close_li=3" in msg
         # Tail must end on the Risiko bullet's terminal punctuation
         assert "last_chars=" in msg
-        assert msg.rstrip().endswith("}") or "tags={" in msg
+        # Hotfix-1027.2.1-F1: content_hash gehört in jede DIAG-Zeile
+        assert "content_hash=" in msg
+        # Trailing position-Invariant: nach dem Hash steht nichts mehr
+        assert re.search(r"content_hash=[0-9a-f]{12}\s*$", msg), msg

--- a/tests/test_kis_1142_p3_woche_1_skip.py
+++ b/tests/test_kis_1142_p3_woche_1_skip.py
@@ -126,26 +126,43 @@ class TestRendererDropsWocheOneForIntExpert:
         # Beginner must still see the original Woche 1 "Erste Schritte".
         assert CHALLENGE_30_TAGE["woche_1"]["titel"] in html
 
-    def test_subtitle_announces_three_weeks_for_advanced(self):
+    def test_subtitle_announces_three_weeks_for_team_advanced(self):
+        # Team/KMU + intermediate/expert dropt Woche 1 → 3 Wochen Subtitle.
         expert_html = generate_30_tage_challenge_html_v2(
-            expertise_level="expert", zeitbudget="2_5",
+            company_size="team", expertise_level="expert", zeitbudget="2_5",
         )
         inter_html = generate_30_tage_challenge_html_v2(
-            expertise_level="intermediate", zeitbudget="2_5",
+            company_size="team", expertise_level="intermediate", zeitbudget="2_5",
         )
-        # The advanced subtitles previously claimed "in 4 Wochen" — now 3.
         assert "in 3 Wochen" in expert_html
         assert "in 3 Wochen" in inter_html
         assert "in 4 Wochen" not in expert_html
         assert "in 4 Wochen" not in inter_html
+
+    def test_subtitle_announces_four_weeks_for_solo_advanced(self):
+        # Hotfix 1027.2.1 F3: Solo + intermediate/expert behält nach Item H
+        # alle 4 Wochen (Woche 3+4 Overrides) — Subtitle muss das spiegeln,
+        # sonst widerspricht S.3 Management Summary dem S.13-14 Inhalt.
+        expert_html = generate_30_tage_challenge_html_v2(
+            company_size="solo", expertise_level="expert", zeitbudget="2_5",
+        )
+        inter_html = generate_30_tage_challenge_html_v2(
+            company_size="solo", expertise_level="intermediate", zeitbudget="2_5",
+        )
+        assert "in 4 Wochen" in expert_html
+        assert "in 4 Wochen" in inter_html
+        assert "in 3 Wochen" not in expert_html
+        assert "in 3 Wochen" not in inter_html
 
     def test_day_1_appears_only_once_in_advanced(self):
         # After renumber, the first visible day is Tag 1. Before the fix,
         # expert saw Tag 1 in (dropped) Woche 1 and again nowhere — but
         # after the drop + renumber, Tag 1 must be present exactly once
         # per HTML (no stale "Tag 8" rendering).
+        # Hotfix 1027.2.1 F3: company_size="team" damit Woche 1 wirklich
+        # gedroppt wird (Solo behält nach Item H alle Wochen).
         html = generate_30_tage_challenge_html_v2(
-            expertise_level="expert", zeitbudget="2_5",
+            company_size="team", expertise_level="expert", zeitbudget="2_5",
         )
         # Count discrete "Tag 1<" occurrences (< terminates the number so
         # we don't count "Tag 10", "Tag 15" etc).

--- a/tests/test_product_name_protection.py
+++ b/tests/test_product_name_protection.py
@@ -76,6 +76,59 @@ class TestProductNameProtection:
                 f"'MS Kapazitäten' found in output!\nInput: {input_text}\nOutput: {result}"
 
 
+class TestStandaloneTeamsInToolContext:
+    """Hotfix 1027.2.1 F4: Standalone 'Teams' als Tool-Name (im Cluster mit
+    Zoom/Meet/Webex/Slack/Otter etc.) darf NICHT von SOLO_GOVERNANCE_REPLACEMENTS
+    erfasst werden. Sonst kette: Teams->Kapazitaeten->Zeitbudget -> 'Zoom oder
+    Zeitbudget' in S.8 Quick Win Meeting-Nachbereitung (KIS-1193)."""
+
+    def test_zoom_oder_teams_protected(self) -> None:
+        from services.prompt_enhancer import apply_solo_persona_filter
+        result = apply_solo_persona_filter(
+            "Nutzen Sie Otter zur automatischen Transkription Ihrer "
+            "Kundengespräche in Zoom oder Teams."
+        )
+        assert "Zoom oder Teams" in result, f"Teams wurde faelschlich ersetzt: {result}"
+        assert "Zeitbudget" not in result, f"Zoom->Zeitbudget-Bug: {result}"
+        assert "Kapazitäten" not in result, f"Teams->Kapazitaeten-Replace: {result}"
+
+    def test_teams_oder_zoom_protected(self) -> None:
+        from services.prompt_enhancer import apply_solo_persona_filter
+        result = apply_solo_persona_filter("Wählen Sie Teams oder Zoom.")
+        assert "Teams oder Zoom" in result, result
+
+    def test_zoom_comma_teams_protected(self) -> None:
+        from services.prompt_enhancer import apply_solo_persona_filter
+        result = apply_solo_persona_filter("Tools wie Zoom, Teams und Webex.")
+        assert "Teams" in result, result
+        assert "Kapazitäten" not in result, result
+
+    def test_slash_separator_protected(self) -> None:
+        from services.prompt_enhancer import apply_solo_persona_filter
+        result = apply_solo_persona_filter("Tools: Zoom / Teams")
+        assert "Teams" in result, result
+        assert "Kapazitäten" not in result, result
+
+    def test_otter_teams_protected(self) -> None:
+        from services.prompt_enhancer import apply_solo_persona_filter
+        result = apply_solo_persona_filter("Otter und Teams kombinieren.")
+        assert "Otter und Teams" in result, result
+
+    def test_google_meet_teams_protected(self) -> None:
+        from services.prompt_enhancer import apply_solo_persona_filter
+        result = apply_solo_persona_filter("Google Meet oder Teams einsetzen.")
+        assert "Teams" in result, result
+        assert "Kapazitäten" not in result, result
+
+    def test_standalone_teams_without_tool_context_still_replaced(self) -> None:
+        """Negative Kontrolle: ohne Tool-Cluster greift weiter die Solo-Ersetzung."""
+        from services.prompt_enhancer import apply_solo_persona_filter
+        result = apply_solo_persona_filter("Sie organisieren mehrere Teams im Unternehmen.")
+        assert "Teams" not in result or "Microsoft" in result, (
+            f"Standalone Teams ohne Tool-Kontext muss weiter ersetzt werden: {result}"
+        )
+
+
 class TestSafetyNetSeatbelt:
     """Tests für Safety Net (seatbelt) im content_quality_enforcer."""
 


### PR DESCRIPTION
## Summary

Sprint 1027.2.1 — Hotfix-Cluster nach KIS-1193 Validierung. Sechs Befunde, davon fünf in diesem PR adressiert; F1 (Decision-Section Truncation) wartet auf Production-Snapshot zur Root-Cause-Bestimmung (kein blindes Härten ohne Evidenz).

PR #1035 (Sprint 1027.2) wurde bereits gemerged — dies ist die Nachschleife.

Ref: KIS-1193 (Briefing-ID 1076)

## Status pro Item

### F1 — R1 S.4 Decision-Section abgeschnitten — **OFFEN, Evidenz angefordert**
Sprint 1027.2 Item F hat bereits CSS gehärtet, Test `test_exec_decision_clean.py` deckt das exakte `den Ablauf Input`-Muster ab. Persistenz spricht gegen reines Layout-Issue. Diagnose-First erfordert Snapshot + Logs aus Production (Wolf liefert).

### F2 — R1 S.9 Phase 3 fehlt — `[Wolf: beides in einen Commit]` ✓
**Problem:** R1 S.9 zeigte nur Phase 1 + 2, Phase 3 (61-90 Tage) ersatzlos verschwunden.
**Root:** Naming-Kollision (Prompt nannte Phase 3 "Entscheidung" — kollidiert mit Decision-Section). Doc-Header TOKEN-BUDGET 600 < real-cap.
**Fix:** Phase 3 "Entscheidung" → "Verstetigung" (alignt mit Template + Strategy-Narrativ). Doc-Header 600 → 900. Explizite `_SECTION_MAX_TOKENS` mit 4000 schützt vor Default-Drift.
**Commit:** f719e190

### F3 — R1 S.3 "in 3 Wochen" → "in 4 Wochen" für Solo ✓
**Problem:** S.3 Management Summary sagte "in 3 Wochen", S.13-14 zeigt aber Woche 1-4 + Abschluss — innere Inkonsistenz.
**Root:** Sprint 1027.2 Item H restaurierte Solo Woche 3+4 (Override), aber Subtitle und Skip-Hint waren noch auf KIS-1142-P3-Stand (3 Wochen für advanced).
**Fix:** Subtitle in `sofort_start_generator.py` company_size-aware (solo → 4 Wochen, team/kmu → 3 Wochen). Skip-Hints in Template Z.1505/1509 (Solo) auf "in 4 Wochen" gesetzt. Test test_kis_1142_p3_woche_1_skip in zwei Tests gesplittet (team-3-Wochen + solo-4-Wochen).
**Commit:** 61d53e87

### F4 — Quick Win "Zoom oder Zeitbudget" Solo-Lexicon-Bug ✓
**Problem:** R1 S.8 "Nutzen Sie Otter… in Zoom oder Zeitbudget" — "Zeitbudget" semantisch falsch.
**Root:** LLM → "Zoom oder Teams" → `apply_solo_persona_filter` mapped 'teams' → 'Kapazitäten' (PROTECTED_PRODUCT_NAMES schützt nur "Microsoft Teams" / "MS Teams"/ "Google Teams" / "Teams Copilot", nicht standalone) → `content_quality_enforcer` mapped 'Kapazitäten' → 'Zeitbudget'.
**Fix:** Neue `PROTECTED_PRODUCT_PATTERNS`-Liste mit Regex für 'Teams' im Tool-Cluster (Nachbar: Zoom/Meet/Webex/Slack/Otter/Loom/Jitsi/GoToMeeting/BlueJeans/Skype, Trenner: `,` `/` `oder` `und` `or` `and`). `apply_solo_persona_filter` um Regex-Pattern-Pfad erweitert. +7 Regression-Tests in `test_product_name_protection.py`.
**Commit:** c282ecea

### F5 — Strategy S.10 Bayern Programmname fehlt ✓
**Problem:** Bayern-Zeile zeigte nur Träger ("Bayerisches Staatsministerium für Wirtschaft"), Programm-Spalte leer.
**Root:** Daten korrekt (`Digitalbonus Bayern` in JSON). R1-Renderer deterministisch korrekt. Strategy S7 ist LLM-generiert — LLM hat title vergessen.
**Fix:** Strategy S7-Prompt um DATENINTEGRITÄT-Block erweitert: Titel und Träger wörtlich aus Datenquelle, niemals leere Zellen (Fallback "Auf Anfrage"), keine Paraphrasen, Selbst-Prüfung vor Ausgabe explizit gefordert. AUFGABE 2a "Name und Träger" → "Name (Programmtitel) und Träger" zur Begriffsklärung.
**Commit:** 034c7d9a

### F6 — R1 S.10 Methodik-Hinweis um Deckelungs-Nuance erweitern ✓
**Briefing-Korrektur per Wolf-Antwort:** Diagnose zeigte KPA ist methodisch korrekt (zeigt tatsächlich `roi_raw` ungedeckelt). R1-Hauptanzeige cappt bei 200% (`(gedeckelt)`). Fix-Richtung umgedreht: KPA bleibt, R1 wird ehrlicher.
**Fix:** `business_case_engine_v2.py` Z.352 — Methodik-Hinweis erweitert um (1) "konservativ bei 200% gedeckelt" (Cap-Nuance, bisher verschwiegen) und (2) Cross-Report-Brücke zur KPA "zeigt zusätzlich den ungedeckelten ROI für höhere Sensitivitätsszenarien". Strategy-Brücke bleibt.
**Commit:** 82b96ed6

## Test plan

- [x] **Test-Suite grün:** 6490 passed, 11 skipped, 0 failed (lokal)
- [x] F3-Regression: `test_kis_1142_p3_woche_1_skip` (16 tests) ✓
- [x] F4-Regression: `test_product_name_protection` (19 tests, +7 neu) ✓
- [ ] **F1 Evidenz beschaffen:** psql + railway-logs (Queries unten)
- [ ] **Funnel-Lauf KIS-1194** mit identischen Inputs zu KIS-1193 (Beratung, Solo, Berlin)
- [ ] **Visueller Check:**
  - [ ] F2: R1 S.9 zeigt alle 3 Phasen (Fundament/Pilotierung/Verstetigung)
  - [ ] F3: R1 S.3 sagt "in 4 Wochen" (Solo)
  - [ ] F4: R1 S.8 sagt "Zoom oder Teams" (kein "Zeitbudget")
  - [ ] F5: Strategy S.10 Bayern-Zeile hat Titel "Digitalbonus Bayern"
  - [ ] F6: R1 S.10 erwähnt 200%-Cap + Cross-Ref zur KPA

## F1 Investigation Queries (Wolf führt aus, liefert Daten zurück)

**psql für EXECUTIVE_DECISION_HTML aus Briefing 1076 (KIS-1193):**
```sql
SELECT
  a.id AS analysis_id,
  a.briefing_id,
  a.created_at,
  jsonb_pretty(a.meta -> 'sections' -> 'EXECUTIVE_DECISION_HTML') AS executive_decision_html,
  jsonb_pretty(a.meta -> 'sections' -> 'executive_decision') AS executive_decision
FROM analyses a
WHERE a.briefing_id = 1076
ORDER BY a.created_at DESC
LIMIT 5;
```

(Schema: Modell `Analysis` in `models.py` Z.103-142, Tabelle `analyses`, Spalte `meta` JSONB, Pfad `meta.sections.EXECUTIVE_DECISION_HTML`. Logischer Key `executive_decision` und Render-Key `EXECUTIVE_DECISION_HTML` werden beide identisch gesetzt — siehe `gpt_analyze.py` Z.13037-13039.)

**Railway-Logs-Filter für `[FIX-EXEC-DECISION-DIAG]`:**
```bash
railway logs --service api-ki-backend-neu-worker \
  | grep -E "\[FIX-EXEC-DECISION-(DIAG|CLEAN)\]" \
  | tail -200
```

Falls Briefing-Zeitfenster bekannt:
```bash
railway logs --service api-ki-backend-neu-worker --since 2h \
  | grep -E "(briefing_id=1076|\[FIX-EXEC-DECISION-(DIAG|CLEAN)\])"
```

Die DIAG-Lines folgen dem Format (siehe `services/report_healer.py` Z.3688-3692):
```
[FIX-EXEC-DECISION-DIAG] section=EXECUTIVE_DECISION_HTML len=NNNN open_li=N close_li=N p_total=N p_strong_prefix=N last_chars='...' tags={'div': N, 'p': N, 'ul': N, 'li': N, 'strong': N}
```

Mit diesen Daten klärt sich Generator (LLM-Output kaputt vor Healer) vs. Renderer (Healer + CSS ok, Chromium ignoriert break-inside).

## Out-of-Scope (per Briefing 1027.2.1)
- R1 S.13 Tag 5 "Uebersicht" Umlaut-Encoding
- Strategy S.12 "besonders schwer"-Doppelung
- KPA Break-Even/Amortisation-Definitions-Inkonsistenz
- R1 Tool-Empfehlung S.6/S.11 vs. Vendor-Audit S.15 Disclaimer-Brücke
- R1 Cover "Reifegrad: Solo-Berater" vs. "Builder" Segment/Tier-Klärung

Diese bleiben 1027.4-Backlog.

https://claude.ai/code/session_012ZFXqFTVdVHG62o71qhX5u

---
_Generated by [Claude Code](https://claude.ai/code/session_012ZFXqFTVdVHG62o71qhX5u)_