### PR TITLE
Sprint 1027.2.2: F1-Eskalation (figure-Wrapper) + Strategy-Chat-Flow-Fix

### DIFF
--- a/routes/chat.py
+++ b/routes/chat.py
@@ -1654,7 +1654,28 @@ async def chat_message(
 
         current_section = sections[min(_current_section, len(sections) - 1)]
 
-        log.info("[CHAT] Turn %d: normalized=%s, next=%s, no_extraction=%s", turn, list(normalized.keys()), next_fields, _no_extraction)
+        # Hotfix 1027.2.2-B: is_last_section korrekt über ALLE Sections
+        # berechnen — nicht nur über die aktuelle. KIS-1194 zeigte, dass das
+        # LLM-System-Prompt sonst nach Sektion 0 fälschlich den ABSCHLUSS-Block
+        # (mit "Strategiebericht wird jetzt erstellt"-Cue) bekommt. Die
+        # Bedingung ist binär und kombiniert: aktuelle Sektion IST die letzte
+        # UND es gibt global keine offenen Felder (required oder optional) mehr.
+        _is_last_section_complete = False
+        if _current_section >= len(sections) - 1:
+            _all_sections_complete = True
+            for _si in range(len(sections)):
+                _mr, _mo = get_missing_fields(collected, _si, rt)
+                if _mr or _mo:
+                    _all_sections_complete = False
+                    break
+            if _all_sections_complete and not next_fields:
+                _is_last_section_complete = True
+
+        log.info(
+            "[CHAT] Turn %d: normalized=%s, next=%s, no_extraction=%s, is_last_section=%s",
+            turn, list(normalized.keys()), next_fields, _no_extraction,
+            _is_last_section_complete,
+        )
 
         # Pre-compute next-field QR context so Sonnet can create
         # coherent transitions (KIS-1123 Fix 1).
@@ -1981,6 +2002,7 @@ async def chat_message(
                     current_block=_sonnet_block_id,
                     remaining_block_fields=_sonnet_block_remaining,
                     used_confirmations=_used_confirmations,
+                    is_last_section=_is_last_section_complete,
                 ):
                     await queue.put(token)
             except Exception as exc:

--- a/services/chat_conversation.py
+++ b/services/chat_conversation.py
@@ -931,7 +931,16 @@ AKTUELLER STAND:
 ALS NÄCHSTES ERFRAGEN:
 {next_fields_with_descriptions}
 
-ABSCHLUSS:
+{abschluss_block}
+"""
+
+# Hotfix 1027.2.2-B: ABSCHLUSS-Block ist conditional, damit der LLM die
+# "Strategiebericht wird jetzt erstellt"-Phrasen NUR an einem einzigen
+# wohldefinierten Punkt äußern darf — am Ende der letzten Sektion mit
+# global vollständigem Datenstand. KIS-1194 zeigte sonst Section-0-Hallu
+# (Turn 8: "Danke! Ihr individueller KI-Strategiebericht wird jetzt
+# erstellt…" obwohl Fragebogen weiterläuft).
+STRATEGY_ABSCHLUSS_BLOCK_LAST_SECTION = """ABSCHLUSS:
 Wenn alle Felder erfasst sind:
 - Schreiben Sie einen KURZEN Übergangssatz (max. 1 Satz), z.B.: \
 "Gut, ich habe alle Informationen für Ihren Strategiebericht."
@@ -941,8 +950,28 @@ Wenn alle Felder erfasst sind:
 WENN DER USER EINE ZUSAMMENFASSUNG BESTÄTIGT (z.B. "ja", "stimmt", "passt"):
 - Gehen Sie SOFORT zum nächsten Feld weiter.
 - Wiederholen Sie die Zusammenfassung NIEMALS.
-- Fragen Sie NICHT erneut ob die Angaben korrekt sind.
-"""
+- Fragen Sie NICHT erneut ob die Angaben korrekt sind."""
+
+# Für alle Nicht-Letzten Sektionen: KEIN ABSCHLUSS-Wording erlaubt.
+# Stattdessen expliziter Hinweis auf den Sektions-Übergang.
+STRATEGY_ABSCHLUSS_BLOCK_INTERIM_SECTION = """SEKTIONSÜBERGANG:
+Diese Sektion ist NICHT die letzte des Fragebogens. Auch wenn alle Felder \
+dieser Sektion erfasst sind, ist der Fragebogen NOCH NICHT abgeschlossen.
+- Schreiben Sie KEINEN Abschlusssatz à la "ich habe alle Informationen".
+- VERBOTEN: "Strategiebericht wird jetzt erstellt", \
+"wird jetzt erstellt", "Bericht wird generiert", \
+"Sie erhalten eine umfassende Analyse", \
+"Soll ich Ihren Strategiebericht jetzt erstellen?" \
+oder sinngleiche Formulierungen.
+- Stattdessen: KURZER Übergangssatz zur nächsten Sektion (max. 1 Satz), \
+z.B. "Gut. Weiter mit Erfahrung & Marktposition." oder "Notiert. \
+Letzte Themengruppe: Ihre Marktposition."
+- Dann die nächste Frage stellen.
+
+WENN DER USER EINE ZUSAMMENFASSUNG BESTÄTIGT (z.B. "ja", "stimmt", "passt"):
+- Gehen Sie SOFORT zum nächsten Feld weiter.
+- Wiederholen Sie die Zusammenfassung NIEMALS.
+- Fragen Sie NICHT erneut ob die Angaben korrekt sind."""
 
 STRATEGY_SECTION_HINTS: dict[int, str] = {
     0: "LOGOS+ETHOS: Budget und Zeitrahmen sind oft die schwierigsten Fragen. 'Unklar' ist valide — normalisieren (ETHOS). Bei Prioritäten (S3) konkret helfen (LOGOS): 'Kosten senken = z.B. Prozesse automatisieren. Compliance = z.B. DSGVO und EU AI Act.' Bei Engpass (S4) Verständnis zeigen: 'Die meisten KMU nennen Know-how oder fehlende Use Cases.'",
@@ -1705,6 +1734,7 @@ async def generate_response(
     current_block: str | None = None,
     remaining_block_fields: list[str] | None = None,
     used_confirmations: list[str] | None = None,
+    is_last_section: bool = False,
 ) -> AsyncGenerator[str, None]:
     """
     Generate streaming AI response.
@@ -1751,6 +1781,18 @@ async def generate_response(
         sections = get_sections_for_report(report_type)
         section_index: int = section["index"]
         prompt_template = _get_system_prompt(report_type)
+
+        # Hotfix 1027.2.2-B: ABSCHLUSS-Block conditional setzen. is_last_section
+        # ist vom Aufrufer in routes/chat.py über ALLE Sections iterativ
+        # berechnet — die lokale `missing_in_section`-Variable taugt nicht als
+        # Trigger, weil sie nach Sektion 0 leer sein kann während global
+        # noch Sektion 1 offen ist (das war genau der KIS-1194-Bug).
+        _abschluss_block = (
+            STRATEGY_ABSCHLUSS_BLOCK_LAST_SECTION
+            if is_last_section
+            else STRATEGY_ABSCHLUSS_BLOCK_INTERIM_SECTION
+        )
+
         system_prompt = prompt_template.format(
             section_name=section["name"],
             section_number=section_index + 1,
@@ -1758,6 +1800,7 @@ async def generate_response(
             collected_fields_summary=_format_collected_summary(collected_fields),
             missing_in_section=", ".join(missing_fields) if missing_fields else "alle erfasst",
             next_fields_with_descriptions=_format_next_fields(next_fields, report_type),
+            abschluss_block=_abschluss_block,
         )
 
         # Inject section-specific hint

--- a/templates/pdf_template_v7.html
+++ b/templates/pdf_template_v7.html
@@ -687,27 +687,30 @@ tr:last-child td { border-bottom: none; }
 #decision li,
 #decision p,
 #decision .executive-decision-fallback,
-#decision .decision-card {
+#decision .decision-card,
+#decision figure {
     break-inside: avoid;
     page-break-inside: avoid;
     orphans: 3;
     widows: 3;
 }
 #decision > div,
-#decision .section-body > div {
+#decision .section-body > div,
+#decision > figure,
+#decision .section-body > figure {
     break-inside: avoid;
     page-break-inside: avoid;
 }
-/* Hotfix-1027.2.1-F1: Container-Level-Härtung für .exec-decision-box.
-   DIAG für Briefing 1076 (KIS-1193) zeigte: LLM-Output sauber
-   (open_li=close_li=3, len≈820, terminal-Punkt), Persistence == Render
-   identisch — Truncation erst beim Chromium-PDF-Render. Sprint 1027.2
-   Item F deckte ul/li/p ab; der äußere Container <div class="exec-decision-box">
-   wurde aber nur über das generische `#decision > div` mitgenommen, was
-   Chromium bei Content > ½ Seitenhöhe ignoriert. Container-Level-Selector
-   plus widows:4/orphans:4 auf die innere ul plus min-height-Floor erzwingen
-   atomare Behandlung. */
-.exec-decision-box {
+/* Hotfix-1027.2.1-F1 / 1027.2.2-A: Container-Level-Härtung.
+   Eskalation in 1027.2.2: KIS-1194 zeigte trotz break-inside:avoid +
+   min-height:12em auf .exec-decision-box den gleichen Cutoff
+   (content_hash f8ef847f255a == saubere Persistence). Chromium ignoriert
+   break-inside auf generischen divs zuverlässig erst bei <figure>-
+   Wrappern. Backup-Plan aus 1027.2.1-Daily-Report aktiviert.
+   .exec-decision-figure trägt die Härtung primär; .exec-decision-box
+   bleibt als Defense-in-Depth-Layer. */
+.exec-decision-figure {
+    margin: 0;
     break-inside: avoid !important;
     page-break-inside: avoid !important;
     break-before: auto;
@@ -715,18 +718,29 @@ tr:last-child td { border-bottom: none; }
     break-after: auto;
     page-break-after: auto;
     min-height: 12em;
+    display: block;
 }
+.exec-decision-figure ul,
 .exec-decision-box ul {
     break-inside: avoid !important;
     page-break-inside: avoid !important;
     orphans: 4;
     widows: 4;
 }
+.exec-decision-figure li,
 .exec-decision-box li {
     break-inside: avoid !important;
     page-break-inside: avoid !important;
     orphans: 3;
     widows: 3;
+}
+.exec-decision-box {
+    break-inside: avoid !important;
+    page-break-inside: avoid !important;
+    break-before: auto;
+    page-break-before: auto;
+    break-after: auto;
+    page-break-after: auto;
 }
 
 /* ══════════════════════════════════════════════════════
@@ -1553,7 +1567,15 @@ h1, h2, h3, h4 {
     </div>
 
     {% if EXECUTIVE_DECISION_HTML and EXECUTIVE_DECISION_HTML|trim %}
-    {{ EXECUTIVE_DECISION_HTML|safe }}
+    {# Hotfix-1027.2.2-A: <figure>-Wrapper für Chromium-Atomic-Layout.
+       1027.2.1 setzte break-inside:avoid + min-height:12em auf
+       .exec-decision-box; KIS-1194 zeigte trotzdem Cutoff (DIAG
+       content_hash f8ef847f255a beweist sauberen Generator-Output).
+       Chromium honoriert break-inside auf generischen divs unzuverlässig,
+       behandelt <figure> aber als atomare Layout-Einheit. Wrapper trägt
+       die Härtungs-Regeln, .exec-decision-box selbst bleibt aus
+       Defense-in-Depth-Gründen erhalten. #}
+    <figure class="exec-decision-figure">{{ EXECUTIVE_DECISION_HTML|safe }}</figure>
     {% elif FINAL_CHECK_DECISIONS %}
     {% for decision in FINAL_CHECK_DECISIONS %}
     <div class="decision-card">

--- a/tests/test_decision_section_figure_wrapper.py
+++ b/tests/test_decision_section_figure_wrapper.py
@@ -1,0 +1,121 @@
+"""Hotfix 1027.2.2-A: Source-level guard für den figure-Wrapper-Backup
+um EXECUTIVE_DECISION_HTML in templates/pdf_template_v7.html.
+
+KIS-1193 (1027.2.1) + KIS-1194 (1027.2.2) zeigten: Chromium honoriert
+break-inside:avoid auf generischen <div>-Containern unzuverlässig, wenn
+der Box-Content > halbe Seitenhöhe ist. Wrapping in <figure> behebt das
+laut Chromium-Verhalten (atomare Layout-Einheit), aber nur wenn beide
+Teile zusammen ankommen — der Wrapper im Template UND die CSS-Regeln,
+die die Härtung tatsächlich tragen.
+
+Statt eine vollständige Jinja-Rendering-Umgebung mit Asset-Pipeline
+aufzusetzen, prüfen die Tests die Template-Quelle direkt — analog zu
+TestTemplateSkipHintUsesExpertiseLevel in test_kis_1142_p3_woche_1_skip.py.
+"""
+from __future__ import annotations
+
+import os
+import re
+
+TEMPLATE_PATH = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+    "templates",
+    "pdf_template_v7.html",
+)
+
+
+def _read_template() -> str:
+    with open(TEMPLATE_PATH, encoding="utf-8") as f:
+        return f.read()
+
+
+class TestFigureWrapperPresent:
+    def test_executive_decision_html_wrapped_in_figure(self) -> None:
+        """EXECUTIVE_DECISION_HTML muss in <figure class="exec-decision-figure">
+        gewrappt sein — der Wrapper ist der Hebel für Chromium-Atomic-Layout."""
+        tpl = _read_template()
+        # Suche das exakte Markup im decision-Block
+        pattern = re.compile(
+            r'<figure\s+class="exec-decision-figure"\s*>'
+            r'\s*\{\{\s*EXECUTIVE_DECISION_HTML\s*\|\s*safe\s*\}\}\s*'
+            r'</figure>',
+        )
+        assert pattern.search(tpl), (
+            "EXECUTIVE_DECISION_HTML ist nicht in <figure class='exec-decision-figure'> "
+            "gewrappt — 1027.2.2-A-Wrapper fehlt."
+        )
+
+    def test_figure_wrapper_only_in_decision_section(self) -> None:
+        """Der figure-Wrapper darf nicht in eine andere Section gewandert sein
+        (Smoke-Test gegen Copy-Paste-Fehler)."""
+        tpl = _read_template()
+        # Section-Header steht direkt vor dem Wrapper
+        match = re.search(
+            r'<div class="section" id="decision"[^>]*>'
+            r'(.*?)<figure\s+class="exec-decision-figure"',
+            tpl,
+            re.DOTALL,
+        )
+        assert match, (
+            "figure-Wrapper steht nicht innerhalb der #decision-Section — "
+            "1027.2.2-A im falschen Block?"
+        )
+        # Keine zweite <figure class="exec-decision-figure"> außerhalb #decision
+        all_figures = re.findall(r'<figure\s+class="exec-decision-figure"', tpl)
+        assert len(all_figures) == 1, (
+            f"Erwarte genau einen exec-decision-figure-Wrapper, gefunden: {len(all_figures)}"
+        )
+
+
+class TestCssHardeningOnFigure:
+    def test_exec_decision_figure_has_break_inside_avoid(self) -> None:
+        """CSS-Regel .exec-decision-figure muss break-inside:avoid (mit !important)
+        UND page-break-inside:avoid setzen — beide Properties, weil
+        Chromium-Versionen unterschiedlich strikt sind."""
+        tpl = _read_template()
+        rule_match = re.search(
+            r'\.exec-decision-figure\s*\{([^}]*)\}',
+            tpl,
+            re.DOTALL,
+        )
+        assert rule_match, ".exec-decision-figure CSS-Regel fehlt"
+        body = rule_match.group(1)
+        assert re.search(r'break-inside\s*:\s*avoid\s*!important', body), (
+            f".exec-decision-figure fehlt break-inside:avoid !important: {body!r}"
+        )
+        assert re.search(r'page-break-inside\s*:\s*avoid\s*!important', body), (
+            f".exec-decision-figure fehlt page-break-inside:avoid !important: {body!r}"
+        )
+
+    def test_exec_decision_figure_has_min_height(self) -> None:
+        """Wolf-Anweisung 1027.2.2: min-height aus 1027.2.1 von .exec-decision-box
+        auf .exec-decision-figure verschieben (Floor zwingt Chromium zur
+        Atomic-Behandlung)."""
+        tpl = _read_template()
+        rule_match = re.search(
+            r'\.exec-decision-figure\s*\{([^}]*)\}',
+            tpl,
+            re.DOTALL,
+        )
+        assert rule_match, ".exec-decision-figure CSS-Regel fehlt"
+        body = rule_match.group(1)
+        assert re.search(r'min-height\s*:\s*\d+(?:\.\d+)?(?:em|rem|px|%)', body), (
+            f".exec-decision-figure fehlt min-height-Floor: {body!r}"
+        )
+
+    def test_decision_section_selector_covers_figure(self) -> None:
+        """Section-Level-Regel #decision … figure muss im selben Selector-
+        Block stehen wie ul/li/p — sonst greift die Härtung nicht für den
+        äußeren Container."""
+        tpl = _read_template()
+        # Multi-Selector-Block mit #decision-Prefix
+        block_match = re.search(
+            r'(#decision\s+ul,[^{]*?#decision\s+figure[^{]*)\{',
+            tpl,
+            re.DOTALL,
+        )
+        assert block_match, (
+            "Section-Level-Regel deckt '#decision figure' nicht ab — "
+            "1027.2.2-A-Wrapper bekommt nur Eigen-Regel, nicht den "
+            "kombinierten Section-Schutz."
+        )

--- a/tests/test_strategy_chat_abschluss_gating.py
+++ b/tests/test_strategy_chat_abschluss_gating.py
@@ -1,0 +1,172 @@
+"""Hotfix 1027.2.2-B: Tests für die conditional ABSCHLUSS-Block-Injektion
+im STRATEGY_CONVERSATION_PROMPT, gegated über is_last_section.
+
+KIS-1194 zeigte, dass der LLM nach Abschluss der ersten Strategy-Sektion
+(s1_budget … s7_entscheidung) den Satz "Danke! Ihr individueller
+KI-Strategiebericht wird jetzt erstellt…" hallucinierte, obwohl der
+Fragebogen noch Sektion 1 (Erfahrung & Marktposition) zu durchlaufen
+hatte. Trigger war der ABSCHLUSS-Block im System-Prompt, der schlicht
+auf `missing_in_section == "alle erfasst"` ansprach — und das ist für
+Sektion 0 nach Turn 7 wahr, obwohl der Fragebogen noch nicht fertig ist.
+
+Fix: zwei separate Block-Konstanten und ein `is_last_section`-Flag, das
+vom Aufrufer (routes/chat.py) explizit über ALLE Sections iterativ
+berechnet wird — nicht über die lokale `missing_in_section`-Variable.
+"""
+from __future__ import annotations
+
+
+class TestAbschlussBlockPlaceholder:
+    def test_strategy_prompt_has_abschluss_block_placeholder(self) -> None:
+        from services.chat_conversation import STRATEGY_CONVERSATION_PROMPT
+        assert "{abschluss_block}" in STRATEGY_CONVERSATION_PROMPT, (
+            "Placeholder {abschluss_block} fehlt im STRATEGY_CONVERSATION_PROMPT"
+        )
+
+    def test_strategy_prompt_no_longer_hardcodes_abschluss(self) -> None:
+        from services.chat_conversation import STRATEGY_CONVERSATION_PROMPT
+        sentinel = "Soll ich Ihren Strategiebericht jetzt erstellen?"
+        assert sentinel not in STRATEGY_CONVERSATION_PROMPT, (
+            f"Sentinel '{sentinel}' findet sich noch hardcoded im "
+            "STRATEGY_CONVERSATION_PROMPT — Conditional-Gate umgangen."
+        )
+
+
+class TestAbschlussBlockContents:
+    def test_last_section_block_contains_abschluss_wording(self) -> None:
+        from services.chat_conversation import STRATEGY_ABSCHLUSS_BLOCK_LAST_SECTION
+        assert "Soll ich Ihren Strategiebericht jetzt erstellen?" in STRATEGY_ABSCHLUSS_BLOCK_LAST_SECTION
+
+    def test_interim_section_block_forbids_abschluss_wording(self) -> None:
+        from services.chat_conversation import STRATEGY_ABSCHLUSS_BLOCK_INTERIM_SECTION
+        body = STRATEGY_ABSCHLUSS_BLOCK_INTERIM_SECTION
+        assert "VERBOTEN" in body
+        assert "wird jetzt erstellt" in body
+        assert "Strategiebericht wird jetzt erstellt" in body
+        assert "Soll ich Ihren Strategiebericht jetzt erstellen?" in body
+
+    def test_interim_section_block_offers_transition_template(self) -> None:
+        from services.chat_conversation import STRATEGY_ABSCHLUSS_BLOCK_INTERIM_SECTION
+        body = STRATEGY_ABSCHLUSS_BLOCK_INTERIM_SECTION
+        assert "Übergangssatz" in body
+
+    def test_both_blocks_carry_summary_confirmation_rule(self) -> None:
+        from services.chat_conversation import (
+            STRATEGY_ABSCHLUSS_BLOCK_INTERIM_SECTION,
+            STRATEGY_ABSCHLUSS_BLOCK_LAST_SECTION,
+        )
+        for block_name, block in [
+            ("LAST_SECTION", STRATEGY_ABSCHLUSS_BLOCK_LAST_SECTION),
+            ("INTERIM_SECTION", STRATEGY_ABSCHLUSS_BLOCK_INTERIM_SECTION),
+        ]:
+            assert "ZUSAMMENFASSUNG BESTÄTIGT" in block, block_name
+            assert "SOFORT zum nächsten Feld" in block, block_name
+
+
+class TestAbschlussBlockSelection:
+    """Funktionaler Test: format() mit dem richtigen Block je nach
+    is_last_section-Flag — analog zur Logik in chat_conversation.py."""
+
+    def _render(self, is_last_section: bool) -> str:
+        from services.chat_conversation import (
+            STRATEGY_ABSCHLUSS_BLOCK_INTERIM_SECTION,
+            STRATEGY_ABSCHLUSS_BLOCK_LAST_SECTION,
+            STRATEGY_CONVERSATION_PROMPT,
+        )
+        block = (
+            STRATEGY_ABSCHLUSS_BLOCK_LAST_SECTION
+            if is_last_section
+            else STRATEGY_ABSCHLUSS_BLOCK_INTERIM_SECTION
+        )
+        return STRATEGY_CONVERSATION_PROMPT.format(
+            section_name="Umsetzungsplanung",
+            section_number=1,
+            total_sections=2,
+            collected_fields_summary="Branche: Beratung",
+            missing_in_section="alle erfasst",
+            next_fields_with_descriptions="s8_erfahrung — KI-Erfahrung",
+            abschluss_block=block,
+        )
+
+    def test_interim_section_omits_kis_1194_phrase_as_instruction(self) -> None:
+        """is_last_section=False: ABSCHLUSS-Cue darf NICHT als positive
+        Anweisung im Prompt stehen."""
+        prompt = self._render(is_last_section=False)
+        assert "VERBOTEN" in prompt
+        assert "Fragen Sie: \"Soll ich Ihren Strategiebericht" not in prompt, (
+            "Interim-Section darf den ABSCHLUSS-Cue NICHT als Anweisung bekommen"
+        )
+
+    def test_last_section_keeps_kis_1194_phrase_as_instruction(self) -> None:
+        """is_last_section=True: ABSCHLUSS-Frage IST die Anweisung."""
+        prompt = self._render(is_last_section=True)
+        assert "Fragen Sie: \"Soll ich Ihren Strategiebericht" in prompt, (
+            "Letzte Sektion muss die ABSCHLUSS-Frage als Anweisung tragen"
+        )
+
+
+class TestGenerateResponseSignature:
+    """Smoke-Test, dass generate_response den is_last_section-Parameter
+    akzeptiert. Verifiziert die API-Brücke routes/chat.py <-> chat_conversation."""
+
+    def test_generate_response_has_is_last_section_param(self) -> None:
+        import inspect
+        from services.chat_conversation import generate_response
+        sig = inspect.signature(generate_response)
+        assert "is_last_section" in sig.parameters, (
+            "generate_response muss is_last_section akzeptieren — sonst kommt "
+            "der Flag aus routes/chat.py nirgends an."
+        )
+        param = sig.parameters["is_last_section"]
+        assert param.default is False, (
+            "Default muss False sein — Interim-Block ist der sichere Default, "
+            "damit nicht versehentlich ein neuer Aufrufer den ABSCHLUSS-Block "
+            "ohne explizites Setzen bekommt."
+        )
+
+
+class TestRoutesChatIsLastSectionComputation:
+    """Source-level Guard für die is_last_section-Berechnung in routes/chat.py.
+    Wolf-Anweisung 1027.2.2: explizit über alle Sections iterieren, NICHT
+    über die lokale missing_in_section-Variable — das war genau der
+    KIS-1194-Bug-Trigger."""
+
+    def _read_chat_routes(self) -> str:
+        import os
+        path = os.path.join(
+            os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+            "routes",
+            "chat.py",
+        )
+        with open(path, encoding="utf-8") as f:
+            return f.read()
+
+    def test_is_last_section_complete_var_present(self) -> None:
+        src = self._read_chat_routes()
+        assert "_is_last_section_complete" in src, (
+            "routes/chat.py muss _is_last_section_complete berechnen und an "
+            "generate_response durchreichen."
+        )
+
+    def test_global_completion_uses_iteration(self) -> None:
+        """Die Berechnung MUSS über range(len(sections)) iterieren und für
+        jede _si get_missing_fields aufrufen. Negativ-Test: missing_in_section
+        darf NICHT als alleiniger Trigger genutzt werden."""
+        src = self._read_chat_routes()
+        # Iteration über alle Sections
+        assert "for _si in range(len(sections))" in src, (
+            "is_last_section muss über alle Sections iterieren, nicht über "
+            "die lokale missing_in_section-Variable."
+        )
+        # Per-Section-Check via get_missing_fields
+        assert "get_missing_fields(collected, _si, rt)" in src, (
+            "Pro Section get_missing_fields aufrufen, damit required+optional "
+            "Felder zusammen geprüft werden."
+        )
+
+    def test_passed_to_generate_response(self) -> None:
+        src = self._read_chat_routes()
+        assert "is_last_section=_is_last_section_complete" in src, (
+            "Der berechnete Flag muss als is_last_section= an generate_response "
+            "übergeben werden."
+        )


### PR DESCRIPTION
## Summary

Sprint 1027.2.2 — F1-Eskalation aus 1027.2.1 plus Strategy-Chat-Flow-Fix.

Zwei atomare Commits, beide Items aus KIS-1194-Validierung.

Ref: KIS-1194 (Briefing-IDs 1076 für Item A, 1077 für Item B)

## Item A — Decision-Section Cutoff persistiert (`3bfbf36e`)

**Problem:** 1027.2.1-F1 (`.exec-decision-box` mit `break-inside:avoid` + `min-height:12em`) hat den Cutoff NICHT verhindert. KIS-1194 zeigte Bruch bei `…nach dem Schema Input`, danach `Lassen:` + `Prüfen:` verschwunden.

**Evidenz:** DIAG-Log KIS-1194 — `len=881 open_li=3 close_li=3 last_chars='hung oder Einstellung geboten.' content_hash=f8ef847f255a`. Drei vollständige Bullets in der Persistence, terminal Punkt — Truncation entsteht erst beim Chromium-PDF-Render.

**Fix:** Backup-Plan aus 1027.2.1-Daily-Report aktiviert.
- `EXECUTIVE_DECISION_HTML` jetzt in `<figure class="exec-decision-figure">` gewrappt. Chromium behandelt `<figure>` zuverlässiger als atomare Layout-Einheit als generische `<div>`-Container.
- CSS-Härtung primär auf `.exec-decision-figure` (`break-inside:avoid !important`, `page-break-inside:avoid !important`, `break-before/after:auto` explizit, `min-height:12em`-Floor, `display:block`).
- `.exec-decision-box` bleibt als Defense-in-Depth-Layer.
- `#decision figure` und `#decision > figure` / `#decision .section-body > figure` in Section-Level-Selectoren mitgezogen.

**Tests:** +5 source-level Guards in `tests/test_decision_section_figure_wrapper.py` (figure-Wrapper im Template präsent, genau einmal, in #decision-Section, mit `break-inside:avoid !important` + `page-break-inside:avoid !important` + `min-height`-Floor, Section-Level-Block deckt figure ab).

**Lokale Render-Verifikation NICHT erfolgt:** Container hat kein Chromium/Puppeteer-Setup und kein KIS-1194-Debug-HTML aus `/tmp/report_debug_R-*`. Verifikation läuft über Folge-Funnel KIS-1195.

**Akzeptanzkriterium:** KIS-1195 zeigt R1 S.4 mit drei vollständigen Bullets (Tun/Lassen/Prüfen), kein Cutoff. DIAG `content_hash` gegen `f8ef847f255a` abgleichen.

**Fallback wenn auch figure nicht reicht (Wolf-Ping-Trigger):** Strukturentscheidung — Decision-Section forciert auf eigene Seite (break-before:page hat sie schon, zusätzlich Section-Höhe hart begrenzen) oder Content-Limit im Generator (250 Wörter Hard-Cap statt 70-90).

## Item B — Strategy-Chat "Report wird erstellt"-Hallu nach Section 0 (`f3e6d113`)

**Problem:** KIS-1194 (briefing_id=1077) Turn 8 emittierte Sonnet "Danke! Ihr individueller KI-Strategiebericht wird jetzt erstellt..." — obwohl der Fragebogen noch bis Turn 16 läuft (echter START REPORT bei `[CHAT] Summary action: user chose START REPORT → Status → researching`).

**Diagnose:**
- Text ist LLM-generiert. Trigger: ABSCHLUSS-Block in `STRATEGY_CONVERSATION_PROMPT` (chat_conversation.py Z.934-944) mit Anweisung *"Wenn alle Felder erfasst sind: Fragen Sie 'Soll ich Ihren Strategiebericht jetzt erstellen?'"*.
- `routes/chat.py` Z.1647 berechnet `all_missing` nur für die aktuelle Sektion. Nach Sektion 0 Turn 7 ist diese leer → `missing_in_section="alle erfasst"` → LLM hält das fälschlich für globalen Abschluss.
- Der ECHTE deterministische Trigger steht in chat.py Z.1956 (`"Ihre Auswertung wird jetzt erstellt …"`) — wird nur bei `_report_start_requested` ausgelöst. LLM-Hallu unterscheidet sich textlich (`individueller KI-Strategiebericht` vs. `Auswertung`).

**Fix (per Wolf-Ping V1, kein Belt-and-Suspenders):**
1. Neue Konstanten: `STRATEGY_ABSCHLUSS_BLOCK_LAST_SECTION` (trägt die Erstellungs-Frage) + `STRATEGY_ABSCHLUSS_BLOCK_INTERIM_SECTION` (verbietet sie explizit + bietet Übergangssatz als konstruktive Alternative).
2. `STRATEGY_CONVERSATION_PROMPT` bekommt `{abschluss_block}`-Placeholder statt hardcoded.
3. `generate_response()` bekommt `is_last_section: bool = False`-Parameter.
4. `routes/chat.py` berechnet `_is_last_section_complete` EXPLIZIT über alle Sections via `for _si in range(len(sections)): get_missing_fields(...)`. Per Wolf-Anweisung wird die lokale `missing_in_section`-Variable NICHT als Trigger genutzt — das war der KIS-1194-Bug.
5. Flag durchgereicht und gated den ABSCHLUSS-Block in der `prompt_template.format()`-Stelle.

**Verifikation gegen die 2-Section-Struktur:**
- Section 0 abgeschlossen, Section 1 offen → `_is_last_section_complete=False` → INTERIM-Block ✓
- Section 1 last alle Felder erfasst, Section 0 auch komplett → `True` → LAST-Block ✓
- Edge: Section 1 last aber Section 0 hat noch missing → Iteration deckt auf → `False` ✓

**Logging:** `[CHAT] Turn %d: ... is_last_section=%s` für Worker-Log-Verifikation per Wolf-Anweisung.

**Tests:** +12 Cases in `tests/test_strategy_chat_abschluss_gating.py` — Placeholder-Präsenz, Block-Inhalte (LAST hat Cue, INTERIM listet VERBOTEN), `format()`-Output gegated, `generate_response`-Signatur hat den Default `False`-Parameter, Source-level Guards in routes/chat.py (Iteration über `range(len(sections))`, `get_missing_fields(collected, _si, rt)` pro Section, Übergabe als `is_last_section=`).

**Akzeptanzkriterium:** KIS-1195 — *"Strategiebericht wird jetzt erstellt"* / *"Soll ich ... erstellen?"* erscheint NUR einmal, am echten Ende vor `Status → researching`. Nach Section 0 und Section 1 kommt ein neutraler Übergangssatz ohne Report-Erwähnung.

## Test plan

- [x] **Test-Suite grün:** 6507 passed, 11 skipped, 0 failed (lokal)
- [x] Item A: +5 source-level Tests im neuen Test-Modul
- [x] Item B: +12 functional + source-level Tests im neuen Test-Modul
- [ ] **Funnel-Lauf KIS-1195** verifiziert beide Items zusammen:
  - [ ] A: R1 S.4 zeigt alle drei Bullets, kein Cutoff. `content_hash` im DIAG gegen `f8ef847f255a` abgleichen.
  - [ ] B: Strategy-Chat — *"wird jetzt erstellt"* erst im START-REPORT-Turn, nicht nach Section 0. Worker-Log `is_last_section=False` für alle Turns vor dem letzten.

## Out-of-Scope (per Briefing, Backlog 1027.4)

- Vendor-Audit `s5_software`-Mapping: KIS-1194 zeigte Microsoft Copilot im Vendor-Audit, obwohl User Perplexity gewählt hatte. Phantom-Eintrag, Score-Sprung 0%→12%.
- Strategy S.10 Bayern-Zelle leer: FIX-B26-FUNDING-BL entfernt `Digitalbonus`-Zeilen und überstimmt die F5-Prompt-Härtung aus 1027.2.1. Funktional ok (Bayern=niedrig für Berlin), aber nicht sauber.
- Amortisation/Break-Even-Definitionsdrift R1/KPA/Strategy.

https://claude.ai/code/session_012ZFXqFTVdVHG62o71qhX5u

---
_Generated by [Claude Code](https://claude.ai/code/session_012ZFXqFTVdVHG62o71qhX5u)_