### PR TITLE
Sprint 1027.3: Architektur-Doku + Pre-/Post-Healer-Section-Persistence

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,267 @@
+# Architektur-Übersicht — api-ki-backend-neu
+
+Onboarding- und Diagnose-Referenz für die Wolf-Achtung-KI-Sicherheit-Pipeline.
+Beantwortet die Fragen, die bei jeder neuen Session / jedem neuen Sprint
+zuerst geklärt werden müssen: welche ID wo, welcher Repo macht was, welche
+ENV-Defaults gelten, wo querye ich was.
+
+> Komplementär: `docs/ARCHITECTURE.md` (uppercase) beschreibt die
+> PLATIN++-v5.3-Komponenten-Pipeline (Prompt-Loader, Guardrails, Healer,
+> Validator). Dieses Doku-File fokussiert auf Infrastruktur, IDs und
+> Deploy-Topologie.
+
+---
+
+## ID-System
+
+| ID-Typ | Format | Wo? |
+|---|---|---|
+| **DB-ID** (`briefing_id`) | Integer Primary Key in `briefings.id` | Coach-URL, API-Endpunkte, Worker-Logs, DB-Queries, `analyses.briefing_id` FK |
+| **Display-ID** | `KIS-NNNN` (z. B. `KIS-1196`) | Mail-Subject, PDF-Cover, R1-Header, KPA-Header, Strategy-Header, Admin-Mails |
+
+### Umrechnung
+
+```
+Display-ID = "KIS-" + (DB-ID + REPORT_DISPLAY_OFFSET)
+DB-ID      = int(Display-ID-Nummer) − REPORT_DISPLAY_OFFSET
+```
+
+`REPORT_DISPLAY_OFFSET` ist ENV-konfigurierbar (`utils/report_display_id.py:12`):
+
+```python
+offset = int(os.getenv("REPORT_DISPLAY_OFFSET", "0"))
+```
+
+- **Code-Default:** `0`
+- **Production-Wert:** `117` (verifiziert via Real-Daten: Briefing 1078 → KIS-1195, Briefing 1079 → KIS-1196)
+
+### Beispiele (verifiziert)
+
+| DB-ID | Display-ID |
+|---|---|
+| 1078 | KIS-1195 |
+| 1079 | KIS-1196 |
+
+### Coach-URL-Schema (verifiziert)
+
+```
+https://make.ki-sicherheit.jetzt/coach/{briefing_id}
+```
+
+- Parameter `{briefing_id}` ist die **DB-ID**, nicht die Display-ID
+- Quelle: `services/email_templates.py:23` (`render_coach_cta(briefing_id: int)`)
+- Backend-Route-Prefix `/api/coach` (`routes/coach.py:21`) für API-Endpunkte (`/init`, `/message`)
+
+---
+
+## Repo-Struktur
+
+### `api-ki-backend-neu` (dieser Repo)
+
+- **Aufgabe:** HTML-Generation für R1 (KI-Readiness), KPA (Key-Pain-Areas), Strategy-Report
+- **Sprache:** Python 3.11, FastAPI
+- **Deploy:** Railway, Service `api-ki-backend-neu`
+- **Worker:** `api-ki-backend-neu-worker` (R1-Generation asynchron via background-task)
+- **Public Domain:** `api-ki-backend-neu-production.up.railway.app`
+- **MCP-Scope:** wolf-achtung/api-ki-backend-neu
+
+### `make-ki-pdfservice` (separater Repo)
+
+- **Aufgabe:** HTML → PDF Rendering
+- **Engine:** Puppeteer/Chromium *(Version: unverifiziert, Stand Erstbriefing — siehe TODO unten)*
+- **Deploy:** Railway, Service `make-ki-pdfservice-production`
+- **Public Domain:** `make-ki-pdfservice-production.up.railway.app`
+- **Backend-Aufruf:** `POST {PDF_SERVICE_URL}/generate-pdf` mit JSON-Body `{html, meta, pdf_options}` (`services/pdf_client.py:265`)
+- **MCP-Scope:** **NICHT zugreifbar** aus Sessions auf `api-ki-backend-neu`
+
+---
+
+## PDF-Service ENV-Defaults — *(unverifiziert)*
+
+> **Status: UNVERIFIZIERT, Stand Erstbriefing 2026-05-22.**
+> Die folgenden Werte stammen aus dem Wolf-Briefing für Sprint 1027.3 und
+> wurden in dieser Session **nicht** gegen den `make-ki-pdfservice`-Repo-Code
+> geprüft, da der Service-Repo außerhalb des MCP-Scope dieser
+> Backend-Session lag. Erst nach Verifizierung gegen `package.json` /
+> `index.js` / `.env.example` des Service-Repos als Fakt übernehmen.
+
+| ENV-Variable | Vermuteter Default | Status |
+|---|---|---|
+| `PDF_SCALE` | `0.94` | unverifiziert |
+| `PDF_PRINT_BACKGROUND` | `0` | unverifiziert |
+| `PDF_MINIFY_HTML` | `1` | unverifiziert |
+| `PDF_STRIP_PAGE_AT_RULES` | `1` | unverifiziert — **besonders prüfbedürftig**: falls zutreffend, würden `@page`-Regeln aus dem Template generell gestrippt; das berührt rückwirkend die KIS-1195-Analyse zu CSS-`@page`- vs. Backend-Margins. Page-Setup müsste dann zwingend Inline-CSS oder `pdf_options.margin`-Pfad sein. |
+| `PDF_STRIP_SCRIPTS` | `1` | unverifiziert |
+
+**Backend-Sicht (verifiziert):**
+- `services/pdf_client.py:26` liest **nur** `PDF_SERVICE_URL`. Keine der oben gelisteten `PDF_*`-Variablen wird Backend-seitig gesetzt oder gelesen.
+- Backend sendet via `pdf_options` (`routes/report.py:432-439`): `format=A4`, `printBackground=true`, `displayHeaderFooter=true`, `margin={top:12mm, right:12mm, bottom:20mm, left:12mm}`, plus `footerTemplate`.
+- **NICHT** gesetzt vom Backend: `preferCSSPageSize`, `emulateMediaType`, `scale`, `viewport` — Service-Defaults greifen.
+
+### TODO: Service-Repo-Verifikation
+
+Wenn der `make-ki-pdfservice`-Repo aus einer Session zugreifbar ist (eigene MCP-Session auf `wolf-achtung/make-ki-pdfservice`):
+
+1. `package.json` → Puppeteer-Version übernehmen
+2. `index.js` / `server.js` → `page.pdf()`-Aufruf inspizieren: `preferCSSPageSize`, `emulateMediaType`, `scale`, `setViewport`
+3. `.env.example` / `README.md` → ENV-Defaults extrahieren
+4. Die fünf `PDF_*`-Werte in dieser Doku bestätigen oder korrigieren, `(unverifiziert)`-Markierung entfernen
+
+---
+
+## Tech-Stack-Anker
+
+### LLM-Modelle
+
+Production-Werte aus dem 1027.3-Briefing (Code-Defaults siehe Klammer):
+
+| ENV-Variable | Production-Wert | Code-Default | Quelle |
+|---|---|---|---|
+| `OPENAI_MODEL` | `gpt-5.5-2026-04-23` | `gpt-4o` | `services/llm_client.py:269`, `services/strategy_pipeline.py:756` |
+| `ANTHROPIC_MODEL_DEFAULT` | `claude-sonnet-4-6` | *(je Service)* | siehe `services/anthropic_client.py` |
+| `ANTHROPIC_MODEL_OPUS` | `claude-opus-4-7` | `claude-opus-4-6` | `services/anthropic_client.py:84` |
+| `ANTHROPIC_MODEL_COACH` *(optional)* | unset → fällt auf `ANTHROPIC_MODEL_OPUS` zurück | — | `services/coach_service.py:59-60` |
+| → effektiver Coach-Model | `claude-opus-4-7` | `claude-opus-4-6` | abgeleitet |
+
+### Datenbank
+
+- **DBMS:** PostgreSQL
+- **Railway-Service:** `Postgres-_HAO` (im KI-Sicherheit-Projekt)
+- **Schema:** `public`
+- **Connection:** `DATABASE_URL` (intern, Railway-VPC) bzw. `DATABASE_PUBLIC_URL` (TCP-Proxy für externe `psql`-Zugriffe)
+- **Engine:** SQLAlchemy 2.x, psycopg (v3 bevorzugt, psycopg2 fallback) — `core/db.py`
+- **Auto-Reconnect:** `pool_pre_ping=True`
+
+### Wichtige Tabellen (Auszug)
+
+| Tabelle | Zweck | Schreibpfad |
+|---|---|---|
+| `briefings` | Roh-Antworten R1-Fragebogen, JSONB `answers` | `routes/briefing.py` (Frontend POST) |
+| `analyses` | Gerendertes R1-HTML + meta-JSONB | R1-Pipeline (worker), `models.py:103` |
+| `strategy_questions` | Strategiefragebogen S1–S10, separate Tabelle | `routes/strategy.py:279`, `routes/chat.py:3219` |
+| `strategy_reports` | Strategy-Report-Status + PDF-Bytes | `services/strategy_pipeline.py` |
+| `reports` | PDF-Versand-Tracking | `models.py:145` |
+
+### Zeitzone
+
+- **Server-Zeitzone:** Europe/Berlin
+- **Sommer (CEST):** UTC+2 (März–Oktober)
+- **Winter (CET):** UTC+1 (Oktober–März)
+- Backend-Code arbeitet intern in **UTC** (`datetime.now(timezone.utc)`), Display-Conversion erfolgt an Render-/Mail-Boundary
+
+---
+
+## Diagnose-Workflow für künftige Sprints
+
+### Briefing-ID-Auflösung
+
+```python
+# Display-ID "KIS-1196" → DB-ID:
+db_id = 1196 - 117  # = 1079
+
+# DB-ID → Display-ID:
+from utils.report_display_id import get_report_display_id
+display = get_report_display_id(1079)  # = "KIS-1196"
+```
+
+### Worker-Logs
+
+```bash
+railway logs --service api-ki-backend-neu-worker
+# Filter auf eine Briefing-ID:
+railway logs --service api-ki-backend-neu-worker | grep -E "\[(Strategy|ADMIN-BRIEFING|KIS|run)[- ]*1079\b"
+```
+
+### DB-Access
+
+```bash
+# Production (TCP-Proxy):
+psql "$DATABASE_PUBLIC_URL"
+
+# Schema:
+\d analyses
+\d briefings
+\d strategy_questions
+```
+
+### Migration-Apply-Workflow
+
+**Wichtig: `migrations/*.sql` werden NICHT automatisch appliziert.**
+
+`core/migrate.py:migrate_all` (aufgerufen beim FastAPI-Startup in `main.py:81-86`) führt **nur eine hardcoded DDL-Liste** in `core/migrate.py:DDL` aus. Es gibt **keinen** File-Iterator über `migrations/*.sql`, kein Alembic, keinen Versions-Tracker. Die SQL-Files im Verzeichnis sind Dokumentations-Artefakte und müssen **manuell** gegen die Production-DB ausgeführt werden — sonst existieren die neu definierten Spalten/Tabellen nicht, und Backend-Code-Pfade, die darauf zugreifen, werfen `UndefinedColumn`/`UndefinedTable`-Errors (im besten Fall in try/except gefangen und nur als Warning geloggt; im schlimmsten Fall ungefangen).
+
+**Nach jedem Merge mit neuer `migrations/*.sql`-Datei: manueller Apply nötig.**
+
+Beispiel-Befehle (Substituiere den File-Namen für andere Migrationen):
+
+```bash
+# Variante 1 — File-Apply von lokaler Repo-Kopie:
+psql "$DATABASE_PUBLIC_URL" \
+  -f migrations/2026-05-22_add_analyses_raw_sections_postgres.sql
+
+# Variante 2 — Inline (von beliebigem Host mit psql + DATABASE_PUBLIC_URL):
+psql "$DATABASE_PUBLIC_URL" -c "
+ALTER TABLE analyses
+  ADD COLUMN IF NOT EXISTS raw_sections JSONB DEFAULT NULL;
+CREATE INDEX IF NOT EXISTS idx_analyses_raw_sections_gin
+  ON analyses USING GIN (raw_sections);
+"
+
+# Variante 3 — Via Railway-CLI mit Backend-internem DATABASE_URL:
+railway run --service api-ki-backend-neu \
+  psql "$DATABASE_URL" \
+  -f migrations/2026-05-22_add_analyses_raw_sections_postgres.sql
+
+# Verify (jede Variante):
+psql "$DATABASE_PUBLIC_URL" -c "\d+ analyses" | grep raw_sections
+# erwartet: raw_sections | jsonb | | |
+```
+
+**Konvention:** alle Migrations sind idempotent (`IF NOT EXISTS`-Klauseln), wiederholtes Anwenden ist gefahrlos. Bei zweistufiger Migration (Postgres + SQLite) gelten beide Files je nach Ziel-Engine — Production nutzt nur die `_postgres.sql`-Variante, lokale Dev-/Test-SQLite nutzt die `_sqlite.sql`-Variante.
+
+**Backlog-Item für Sprint 1027.4:** `core/migrate.py:migrate_all` soll `migrations/*.sql` per glob iterieren statt die hardcoded DDL-Liste exklusiv zu fahren. Betrifft auch die Alt-Migration `2026-03-15_add_raw_sections_strategy.sql`, die ebenfalls nie im Auto-Runner war.
+
+### Gerendertes R1-HTML (faktischer Render-Input)
+
+```sql
+SELECT id, briefing_id, created_at, LENGTH(html) AS html_len
+FROM analyses
+WHERE briefing_id = :db_id
+ORDER BY created_at DESC
+LIMIT 5;
+```
+
+Die `analyses.html`-Spalte ist der **exakte** HTML-String, der per `POST /generate-pdf` an den PDF-Service geht. Page-/Render-Bugs (KIS-1195-Klasse: Chromium clippt obwohl Backend korrekt liefert) sind nur durch Vergleich `analyses.html` ↔ erzeugtes PDF zu fassen.
+
+### Pre-/Post-Healer-Section-Snapshots (ab Sprint 1027.3 / Item H)
+
+Neue Spalte `analyses.raw_sections JSONB` mit Stage-Keys `pre_healer` und `post_healer`. Diagnose-Query:
+
+```sql
+SELECT raw_sections->'pre_healer'->>'exec_decision_html'
+     = raw_sections->'post_healer'->>'exec_decision_html'
+       AS healer_unchanged
+FROM analyses WHERE id = :analysis_id;
+```
+
+Siehe Sprint-1027.3-Item-H für Schema-Details.
+
+---
+
+## Verifizierungs-Status
+
+Stand: Sprint 1027.3-G (2026-05-22, Berlin)
+
+| Inhalt | Status |
+|---|---|
+| ID-System (`REPORT_DISPLAY_OFFSET=117`, Display-Konvention) | ✅ verifiziert |
+| Coach-URL-Schema + briefing_id-Typ | ✅ verifiziert (`services/email_templates.py:23`) |
+| Beispiel-IDs 1078→KIS-1195, 1079→KIS-1196 | ✅ verifiziert |
+| Repo-Struktur api-ki-backend-neu | ✅ verifiziert (lokaler Code) |
+| Repo-Struktur make-ki-pdfservice | ⚠️ Code-Inspektion in dieser Session **nicht möglich** (MCP-Scope-Restriction) |
+| Puppeteer/Chromium-Version | ❌ unverifiziert — TODO oben |
+| PDF-Service ENV-Defaults (PDF_SCALE/PRINT_BACKGROUND/MINIFY/STRIP_*) | ❌ unverifiziert — TODO oben |
+| Backend-PDF-Optionen (`pdf_options`) | ✅ verifiziert (`routes/report.py:432-439`, `services/pdf_client.py`) |
+| LLM-Modell-Code-Defaults | ✅ verifiziert (Code-Pfade dokumentiert) |
+| LLM-Modell-Production-Werte | ⚠️ aus Briefing übernommen, nicht gegen Railway-Env geprüft |
+| DB-Tabellen-Schema | ✅ verifiziert (`models.py`) |

--- a/gpt_analyze.py
+++ b/gpt_analyze.py
@@ -20332,6 +20332,23 @@ NUR HTML ausgeben. Keine Erklärungen, keine Markdown-Fences."""
             log.warning(f"[{run_id}] [SIZE-PASS] Section-level pass failed: {e}")
 
     # =========================================================================
+    # Sprint 1027.3 / Item H: Pre-Healer-Section-Snapshot für Diagnose.
+    # Filter: nur String-Values (HTML), keine _-prefixed Internal-Reports.
+    # Speicherung erfolgt nach analysis-Row-INSERT (siehe Hook unten).
+    # =========================================================================
+    _raw_pre_healer_sections: Optional[Dict[str, str]] = None
+    _raw_post_healer_sections: Optional[Dict[str, str]] = None
+    try:
+        import copy as _copy_rs
+        _raw_pre_healer_sections = {
+            k: v for k, v in sections.items()
+            if isinstance(v, str) and not k.startswith("_")
+        }
+        _raw_pre_healer_sections = _copy_rs.deepcopy(_raw_pre_healer_sections)
+    except Exception as _rs_err:
+        log.debug(f"[{run_id}] [RAW-SECTIONS] pre-healer snapshot failed: {_rs_err}")
+
+    # =========================================================================
     # FIX-A-G: REPORT HEALER - Sanitize and heal sections before rendering
     # Runs AFTER all LLM content generation, BEFORE template rendering
     # Fixes: A=template phrases, B=persona language, C=redundancy, D=ROI rules,
@@ -20366,6 +20383,18 @@ NUR HTML ausgeben. Keine Erklärungen, keine Markdown-Fences."""
 
         # Replace sections with healed version
         sections = healing_result.sections
+
+        # Sprint 1027.3 / Item H: Post-Healer-Section-Snapshot.
+        # Vor _healer_stats-Injection, damit der Snapshot reine
+        # Healed-Sections enthält und nicht das Stats-Meta-Key.
+        try:
+            _raw_post_healer_sections = {
+                k: v for k, v in sections.items()
+                if isinstance(v, str) and not k.startswith("_")
+            }
+            _raw_post_healer_sections = _copy_rs.deepcopy(_raw_post_healer_sections)
+        except Exception as _rs_err:
+            log.debug(f"[{run_id}] [RAW-SECTIONS] post-healer snapshot failed: {_rs_err}")
 
         # Log healing stats
         log.info(
@@ -21133,7 +21162,28 @@ NUR HTML ausgeben. Keine Erklärungen, keine Markdown-Fences."""
     db.add(an)
     db.commit()
     db.refresh(an)
-    
+
+    # Sprint 1027.3 / Item H: Persist Pre-/Post-Healer-Snapshots.
+    # Nicht-blockierend: bei Schreibfehler nur warnen, Pipeline läuft durch.
+    try:
+        if _raw_pre_healer_sections is not None or _raw_post_healer_sections is not None:
+            an.raw_sections = {
+                "pre_healer": _raw_pre_healer_sections or {},
+                "post_healer": _raw_post_healer_sections or {},
+            }
+            db.commit()
+            log.info(
+                "[%s] [RAW-SECTIONS] persisted analysis=%s pre=%d keys post=%d keys",
+                run_id, an.id,
+                len(_raw_pre_healer_sections or {}),
+                len(_raw_post_healer_sections or {}),
+            )
+    except Exception as _rs_err:
+        log.warning(
+            "[%s] [RAW-SECTIONS] persistence failed for analysis=%s: %r",
+            run_id, an.id, _rs_err,
+        )
+
     log.info("[%s] ✅ Analysis created (v5.4.3-PLATIN+++): id=%s", run_id, an.id)
     # Return 4 values: debug_attachments contains bytes for email (NOT stored in DB)
     return an.id, result["html"], result.get("meta", {}), result.get("debug_attachments")

--- a/migrations/2026-05-22_add_analyses_raw_sections_postgres.sql
+++ b/migrations/2026-05-22_add_analyses_raw_sections_postgres.sql
@@ -1,0 +1,21 @@
+-- Sprint 1027.3 / Item H: Pre-/Post-Healer-Section-Snapshots in analyses.
+--
+-- Spalte raw_sections speichert ein zweistufiges JSONB-Dict:
+--   {"pre_healer":  {"EXECUTIVE_DECISION_HTML": "<html>...", ...},
+--    "post_healer": {"EXECUTIVE_DECISION_HTML": "<html>...", ...}}
+--
+-- Diagnose-Query-Beispiel:
+--   SELECT raw_sections->'pre_healer'->>'EXECUTIVE_DECISION_HTML'
+--        = raw_sections->'post_healer'->>'EXECUTIVE_DECISION_HTML'
+--          AS healer_unchanged
+--   FROM analyses WHERE id = :analysis_id;
+--
+-- GIN-Index begründet: Diagnose-Queries der Form
+--   WHERE raw_sections @> '{...}' / raw_sections ? 'key' / @?
+-- sind ohne Index Full-Scan auf einer wachsenden Tabelle.
+
+ALTER TABLE analyses
+  ADD COLUMN IF NOT EXISTS raw_sections JSONB DEFAULT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_analyses_raw_sections_gin
+  ON analyses USING GIN (raw_sections);

--- a/migrations/2026-05-22_add_analyses_raw_sections_sqlite.sql
+++ b/migrations/2026-05-22_add_analyses_raw_sections_sqlite.sql
@@ -1,0 +1,8 @@
+-- Sprint 1027.3 / Item H: Pre-/Post-Healer-Section-Snapshots in analyses.
+-- SQLite-Variant: Spalte als JSON (= TEXT mit JSON1-Extension);
+-- kein GIN-Index (SQLite kennt keine GIN-Indizes — JSON1 erlaubt
+-- json_extract über regulärem Index, falls künftig nötig).
+-- Tests/Lokal-Dev werden auf SQLite gefahren; Production läuft auf
+-- Postgres (siehe migrations/2026-05-22_add_analyses_raw_sections_postgres.sql).
+
+ALTER TABLE analyses ADD COLUMN raw_sections JSON DEFAULT NULL;

--- a/models.py
+++ b/models.py
@@ -112,6 +112,10 @@ class Analysis(Base):
     )
     html: Mapped[str] = mapped_column(Text, nullable=False)
     meta: Mapped[dict] = mapped_column(JSONType, default=dict, nullable=False)
+    # Sprint 1027.3 / Item H: Pre-/Post-Healer-Section-Snapshots für
+    # Diagnose-Queries. Struktur: {"pre_healer": {...}, "post_healer": {...}}.
+    # NULL für vor-1027.3 Rows; Schreibhook in gpt_analyze.analyze_briefing.
+    raw_sections: Mapped[Optional[dict]] = mapped_column(JSONType, nullable=True)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         default=lambda: datetime.now(timezone.utc),

--- a/tests/test_raw_sections_persistence.py
+++ b/tests/test_raw_sections_persistence.py
@@ -159,3 +159,95 @@ class TestPipelineHooks:
             "DB-Write-Hook ist nicht non-blocking — erwarte try/except + "
             "log.warning, nie raise"
         )
+
+
+class TestSnapshotIsTrueCopy:
+    """Functional Test: Pre- und Post-Healer-Snapshots sind echte
+    Trennung, nicht zweimal dasselbe Objekt.
+
+    Methodik: Reproduziert die EXAKTE Snapshot-Logik aus
+    gpt_analyze.py:20340-20347 + :20371-20381 gegen ein fixiertes
+    sections-Dict mit zwei Sections:
+      - Mutated:  enthält "<p></p>" — Fix-A in heal_report_html
+        (sanitize_template_phrases Z.874) entfernt empty-paragraphs
+        unbedingt → garantierte Mutation.
+      - Control: neutraler HTML-Text ohne Trigger-Pattern → vom
+        Healer nicht mutiert.
+
+    Assertion-Kern:
+      - pre[mutated]  !=  post[mutated]   (echte Trennung)
+      - pre[control]  ==  post[control]   (Snapshot stabil)
+      - pre[mutated]  enthält noch "<p></p>" (Pre unverändert)
+      - post[mutated] enthält "<p></p>" nicht mehr (Healer hat gewirkt)
+
+    Wenn die Snapshot-Logik versehentlich auf eine Reference statt
+    Comprehension-Copy umgestellt würde, würden pre und post auf
+    dasselbe (geheilte) Dict zeigen und die erste Assertion failed.
+    """
+
+    def test_pre_post_are_independent_objects(self) -> None:
+        os.environ.setdefault("JWT_SECRET", "test-only")
+        os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
+
+        import copy
+
+        from services.report_healer import heal_report_html
+
+        sections = {
+            "EXECUTIVE_DECISION_HTML": (
+                "<p>Realer Inhalt vor dem Cleanup.</p>"
+                "<p></p>"
+                "<p>Realer Inhalt danach.</p>"
+            ),
+            "EXECUTIVE_SUMMARY_HTML": "<p>Ein neutraler Hinweis.</p>",
+        }
+
+        # === Snapshot Pre-Healer (identisch zu gpt_analyze.py:20340-20347) ===
+        pre = {
+            k: v for k, v in sections.items()
+            if isinstance(v, str) and not k.startswith("_")
+        }
+        pre = copy.deepcopy(pre)
+
+        # === Run real healer ===
+        result = heal_report_html(sections, segment="solo")
+        healed = result.sections
+
+        # === Snapshot Post-Healer (identisch zu gpt_analyze.py:20371-20381) ===
+        post = {
+            k: v for k, v in healed.items()
+            if isinstance(v, str) and not k.startswith("_")
+        }
+        post = copy.deepcopy(post)
+
+        # === Assertions ===
+        # 1. Mutated section: pre != post (echte Trennung)
+        assert pre["EXECUTIVE_DECISION_HTML"] != post["EXECUTIVE_DECISION_HTML"], (
+            "Pre und Post sind IDENTISCH für EXECUTIVE_DECISION_HTML — "
+            "Snapshot ist vermutlich Reference statt Copy, oder Healer hat "
+            "die erwartete Fix-A-Mutation nicht durchgeführt.\n"
+            f"  pre={pre['EXECUTIVE_DECISION_HTML']!r}\n"
+            f"  post={post['EXECUTIVE_DECISION_HTML']!r}"
+        )
+
+        # 2. Pre ist unverändert (enthält noch das Trigger-Pattern)
+        assert "<p></p>" in pre["EXECUTIVE_DECISION_HTML"], (
+            "Pre-Snapshot wurde nach-mutiert — Reference-Bug? "
+            f"pre={pre['EXECUTIVE_DECISION_HTML']!r}"
+        )
+
+        # 3. Post ist sauber (Healer hat <p></p> entfernt)
+        assert "<p></p>" not in post["EXECUTIVE_DECISION_HTML"], (
+            "Post-Snapshot enthält noch <p></p> — Fix-A hat nicht gegriffen, "
+            "Healer-Annahme falsch (Test-Fixture muss aktualisiert werden)."
+            f" post={post['EXECUTIVE_DECISION_HTML']!r}"
+        )
+
+        # 4. Control section: pre == post (Snapshot stabil, kein False-Positive)
+        assert pre["EXECUTIVE_SUMMARY_HTML"] == post["EXECUTIVE_SUMMARY_HTML"], (
+            "Control-Section wurde unerwartet mutiert — entweder hat der "
+            "Healer einen unerwarteten Fix angewendet, oder Pre-Snapshot "
+            "ist eine Reference.\n"
+            f"  pre={pre['EXECUTIVE_SUMMARY_HTML']!r}\n"
+            f"  post={post['EXECUTIVE_SUMMARY_HTML']!r}"
+        )

--- a/tests/test_raw_sections_persistence.py
+++ b/tests/test_raw_sections_persistence.py
@@ -1,0 +1,161 @@
+"""Sprint 1027.3 / Item H: Source-level guard für Pre-/Post-Healer-
+Section-Snapshot-Persistence in R1.
+
+Prüft direkt am Source (analog test_decision_section_figure_wrapper.py),
+ohne einen vollen analyze_briefing()-Run zu fahren (würde LLM-Calls,
+DB-Setup, Briefing-Fixture etc. erfordern).
+
+Coverage:
+- Migration-Files für Postgres + SQLite existieren mit erwartetem DDL.
+- Analysis-Model hat raw_sections-Spalte (Mapped[Optional[dict]]).
+- gpt_analyze.analyze_briefing hat die drei Hooks (Init, Pre-Snapshot,
+  Post-Snapshot, DB-Write).
+"""
+from __future__ import annotations
+
+import os
+import re
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+GPT_ANALYZE = os.path.join(REPO_ROOT, "gpt_analyze.py")
+MODELS = os.path.join(REPO_ROOT, "models.py")
+MIG_PG = os.path.join(
+    REPO_ROOT, "migrations", "2026-05-22_add_analyses_raw_sections_postgres.sql"
+)
+MIG_SQ = os.path.join(
+    REPO_ROOT, "migrations", "2026-05-22_add_analyses_raw_sections_sqlite.sql"
+)
+
+
+def _read(path: str) -> str:
+    with open(path, encoding="utf-8") as f:
+        return f.read()
+
+
+class TestMigrationFiles:
+    def test_postgres_migration_exists_with_jsonb_and_gin(self) -> None:
+        assert os.path.exists(MIG_PG), f"missing migration: {MIG_PG}"
+        sql = _read(MIG_PG)
+        assert re.search(
+            r"ALTER\s+TABLE\s+analyses\s+ADD\s+COLUMN\s+IF\s+NOT\s+EXISTS\s+raw_sections\s+JSONB",
+            sql,
+            re.IGNORECASE,
+        ), "Postgres-Migration fehlt JSONB-Spaltendefinition"
+        assert re.search(
+            r"CREATE\s+INDEX\s+IF\s+NOT\s+EXISTS\s+idx_analyses_raw_sections_gin\s+ON\s+analyses\s+USING\s+GIN\s*\(\s*raw_sections\s*\)",
+            sql,
+            re.IGNORECASE,
+        ), "Postgres-Migration fehlt GIN-Index"
+
+    def test_sqlite_migration_exists_with_json_column(self) -> None:
+        assert os.path.exists(MIG_SQ), f"missing migration: {MIG_SQ}"
+        sql = _read(MIG_SQ)
+        assert re.search(
+            r"ALTER\s+TABLE\s+analyses\s+ADD\s+COLUMN\s+raw_sections\s+JSON",
+            sql,
+            re.IGNORECASE,
+        ), "SQLite-Migration fehlt JSON-Spaltendefinition"
+        # SQLite hat kein GIN — sicherstellen dass kein versehentlich
+        # mitgewanderter GIN-Index in einem DDL-Statement steht
+        # (Kommentare mit dem Wort "GIN" sind erlaubt — die Erklärung
+        # WARUM kein GIN-Index gehört in die SQLite-Variant-Doku).
+        sql_no_comments = re.sub(r"--[^\n]*", "", sql)
+        assert not re.search(
+            r"\bUSING\s+GIN\b|\bGIN\s*\(", sql_no_comments, re.IGNORECASE
+        ), "SQLite-Migration enthält GIN-Index-DDL — SQLite kennt keine GIN-Indizes"
+
+
+class TestAnalysisModelColumn:
+    def test_analysis_has_raw_sections_column(self) -> None:
+        os.environ.setdefault("JWT_SECRET", "test-only-for-model-import")
+        os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
+        from models import Analysis
+
+        columns = [c.name for c in Analysis.__table__.columns]
+        assert "raw_sections" in columns, (
+            f"Analysis-Model fehlt raw_sections-Spalte. cols={columns}"
+        )
+        # Spalte muss nullable sein (NULL für vor-1027.3 Rows)
+        col = Analysis.__table__.columns["raw_sections"]
+        assert col.nullable is True, (
+            "raw_sections muss nullable sein (Backfill-Konvention)"
+        )
+
+
+class TestPipelineHooks:
+    def test_pre_healer_snapshot_hook_present(self) -> None:
+        src = _read(GPT_ANALYZE)
+        # Init der beiden Vars (vor Healer-try-Block)
+        assert re.search(
+            r"_raw_pre_healer_sections\s*:\s*Optional\[Dict\[str,\s*str\]\]\s*=\s*None",
+            src,
+        ), "Pre-Healer-Var-Init fehlt"
+        assert re.search(
+            r"_raw_post_healer_sections\s*:\s*Optional\[Dict\[str,\s*str\]\]\s*=\s*None",
+            src,
+        ), "Post-Healer-Var-Init fehlt"
+        # Pre-Snapshot-Assignment via dict-comprehension (String-Filter)
+        pre_snap = re.search(
+            r"_raw_pre_healer_sections\s*=\s*\{\s*k\s*:\s*v\s+for\s+k,\s*v\s+in\s+sections\.items\(\)\s+if\s+isinstance\(v,\s*str\)",
+            src,
+        )
+        assert pre_snap, "Pre-Healer-Snapshot-Comprehension fehlt"
+
+    def test_post_healer_snapshot_hook_present(self) -> None:
+        src = _read(GPT_ANALYZE)
+        # Post-Snapshot direkt nach `sections = healing_result.sections`
+        m = re.search(
+            r"sections\s*=\s*healing_result\.sections.*?_raw_post_healer_sections\s*=\s*\{\s*k\s*:\s*v\s+for\s+k,\s*v\s+in\s+sections\.items\(\)\s+if\s+isinstance\(v,\s*str\)",
+            src,
+            re.DOTALL,
+        )
+        assert m, (
+            "Post-Healer-Snapshot fehlt oder steht nicht direkt nach "
+            "`sections = healing_result.sections`"
+        )
+
+    def test_post_healer_snapshot_runs_before_healer_stats(self) -> None:
+        """Snapshot muss VOR _healer_stats-Injection laufen, sonst
+        landet das Stats-Meta-Key versehentlich im Snapshot."""
+        src = _read(GPT_ANALYZE)
+        m_snap = re.search(
+            r"_raw_post_healer_sections\s*=\s*_copy_rs\.deepcopy",
+            src,
+        )
+        m_stats = re.search(
+            r'sections\[\s*"_healer_stats"\s*\]\s*=\s*_json_healer\.dumps',
+            src,
+        )
+        assert m_snap and m_stats, "Snapshot- oder Stats-Marker fehlt"
+        assert m_snap.start() < m_stats.start(), (
+            "Post-Healer-Snapshot läuft NACH _healer_stats-Injection — "
+            "Stats würden im Snapshot landen, Reihenfolge umdrehen."
+        )
+
+    def test_db_write_hook_present_after_analysis_refresh(self) -> None:
+        src = _read(GPT_ANALYZE)
+        # DB-Write: nach db.refresh(an), nutzt an.raw_sections + db.commit().
+        m = re.search(
+            r"db\.refresh\(an\).*?an\.raw_sections\s*=\s*\{.*?\"pre_healer\".*?\"post_healer\".*?\}.*?db\.commit\(\)",
+            src,
+            re.DOTALL,
+        )
+        assert m, (
+            "DB-Write-Hook fehlt — erwarte nach db.refresh(an) einen "
+            "an.raw_sections-Assignment mit pre_healer/post_healer-Keys "
+            "gefolgt von db.commit()."
+        )
+
+    def test_db_write_hook_is_non_blocking(self) -> None:
+        """Schreibfehler dürfen nicht raisen (Pipeline läuft durch)."""
+        src = _read(GPT_ANALYZE)
+        # Hook muss in try/except gewrappt sein, mit log.warning, nicht raise.
+        m = re.search(
+            r"try:\s*\n\s*if\s+_raw_pre_healer_sections\s+is\s+not\s+None\s+or\s+_raw_post_healer_sections\s+is\s+not\s+None.*?except\s+Exception\s+as\s+_rs_err.*?log\.warning",
+            src,
+            re.DOTALL,
+        )
+        assert m, (
+            "DB-Write-Hook ist nicht non-blocking — erwarte try/except + "
+            "log.warning, nie raise"
+        )


### PR DESCRIPTION
## Sprint 1027.3 — Infrastruktur-Cluster (Doku + Raw-Persistence)

Infrastruktur-Sprint nach Abschluss der 1027.2-Kette (KIS-1195 Decision-Cutoff via PR #1038 behoben, KIS-1196-Baseline). Zwei Items, drei Commits, keine Customer-sichtbaren Änderungen.

### Item G — Architektur-Doku (Commit `0d83ffb4`)

Neue Onboarding-/Diagnose-Referenz `docs/architecture.md`, komplementär zur bestehenden `docs/ARCHITECTURE.md` (PLATIN++-Component-Diagramm, anderer Scope).

**Verifizierte Inhalte:**
- Coach-URL-Schema `https://make.ki-sicherheit.jetzt/coach/{briefing_id}` mit `briefing_id` = DB-ID (Quelle `services/email_templates.py:23 render_coach_cta(briefing_id: int)`)
- `REPORT_DISPLAY_OFFSET`-Mechanik (`utils/report_display_id.py:9-12`), Code-Default `0`, Production `117`, Real-Daten-Beispiele 1078→KIS-1195, 1079→KIS-1196
- Backend-pdf_options (`routes/report.py:432-439`)
- LLM-Modell-Code-Defaults vs. Production-Werte (getrennt ausgewiesen)

**Als `(unverifiziert)` markiert** (mit TODO-Block):
- Puppeteer/Chromium-Version
- 5× PDF_*-ENV-Defaults (PDF_SCALE, PDF_PRINT_BACKGROUND, PDF_MINIFY_HTML, PDF_STRIP_PAGE_AT_RULES, PDF_STRIP_SCRIPTS)

**Grund:** `make-ki-pdfservice`-Repo ist außerhalb MCP-Scope dieser Session (Access denied: nur `wolf-achtung/api-ki-backend-neu`). Backend referenziert keine dieser fünf Variablen (verifiziert via grep). Wolf-Briefing-Fallback gefolgt: nicht raten, explizit als `(unverifiziert, Stand Erstbriefing)` markiert.

### Item H-Migration — DB-Spalte (Commit `50591cea`)

Neue Spalte `analyses.raw_sections JSONB` (Postgres) bzw. `JSON` (SQLite) plus GIN-Index (nur Postgres). Komplementär zum bestehenden `strategy_reports.raw_sections`-Pattern, aber Zwei-Stage-Struktur `{pre_healer: {...}, post_healer: {...}}` statt Single-Dict.

Begründung Zwei-Stage: Bei KIS-1195-Diagnose stand tagelang die Pfad-B-Hypothese im Raum ("Backend-Mutator nach Healer"). Single-Snapshot kann das nicht beantworten — Pre-/Post-Paar erlaubt SQL-Diff in einer Query:

```sql
SELECT raw_sections->'pre_healer'->>'EXECUTIVE_DECISION_HTML'
     = raw_sections->'post_healer'->>'EXECUTIVE_DECISION_HTML'
       AS healer_unchanged
FROM analyses WHERE id = :analysis_id;
```

### Item H-Pipeline — Schreibhook (Commit `a3dab797`)

Drei Hooks in `gpt_analyze.analyze_briefing`:

| Hook | Position | Zweck |
|---|---|---|
| Pre-Healer-Snapshot | ~Z.20334 | Vor REPORT-HEALER-try-Block; alle LLM/Post-Processor-Outputs |
| Post-Healer-Snapshot | ~Z.20381 | Direkt nach `sections = healing_result.sections`, vor `_healer_stats`-Injection |
| DB-Write | ~Z.21135 | Direkt nach `db.refresh(an)`; separater `db.commit()` für `raw_sections`-UPDATE |

Filter: nur String-Values (HTML-Sections), keine `_`-prefixed Internal-Reports. Alle drei Hooks try/except + `log.warning` bei Fehler, **kein raise** (Pipeline läuft an Diagnose-Write nicht scheitern).

### Tests

`tests/test_raw_sections_persistence.py` — Source-level Guard (analog 1027.2.3-Pattern), 8 Tests:
- Migration-Files Postgres + SQLite mit erwartetem DDL
- Analysis-Model hat `raw_sections`, nullable
- Pre-/Post-Healer-Var-Init + Snapshot-Comprehensions
- Post-Snapshot läuft VOR `_healer_stats`-Injection (Stats nicht im Snapshot)
- DB-Write nach `db.refresh(an)`, mit `an.raw_sections` + `db.commit()`
- DB-Write ist non-blocking (try/except + log.warning, kein raise)

Cross-Regression: Decision-Tests (1027.2 + 1027.2.3) weiter grün → **65 passed** im targeted Sweep.

### Test plan

- [ ] CI grün auf PR
- [ ] Migration auf Staging Postgres applied (`psql -f migrations/2026-05-22_add_analyses_raw_sections_postgres.sql`)
- [ ] Neuer R1-Funnel-Run liefert in der Analysis-Row gefülltes `raw_sections`:
  ```sql
  SELECT jsonb_object_keys(raw_sections) FROM analyses
  WHERE id = <neue-id>;
  -- erwartet: pre_healer, post_healer
  ```
- [ ] Pre-/Post-Snapshot enthält EXECUTIVE_DECISION_HTML (HTML-String, nicht NULL)
- [ ] PDF unverändert (Persistence ist read-only, kein Render-Impact)

### Akzeptanzkriterien (aus Wolf-Briefing)

**Item G:** docs/architecture.md existiert, alle Mindest-Sektionen, Beispiel-IDs auflösbar, `[ZU VERIFIZIEREN]`-Werte verifiziert ODER als `(unverifiziert)` markiert ✓

**Item H:**
- `\d analyses` zeigt `raw_sections JSONB`-Spalte (nach Migration-Apply)
- `SELECT jsonb_object_keys(raw_sections) ...` → `pre_healer`, `post_healer`
- `SELECT raw_sections->'pre_healer'->>'ADVISOR_NOTE_HTML'` → HTML-String (nicht NULL, vorausgesetzt der Section-Key existiert in R1)
- `SELECT raw_sections->'post_healer'->>'EXECUTIVE_DECISION_HTML'` → HTML-String

### Caveats

- Bestehende Analysis-Rows (vor 1027.3) bleiben mit `raw_sections IS NULL`. Backfill nicht implementiert (Diagnose-Wert beschränkt sich auf neue Runs)
- Section-Inventory: persistiert das KOMPLETTE String-Section-Dict statt Wolf-Whitelist (Begründung im Commit-Body). Falls Wolf eine engere Whitelist möchte, kann der Filter-Block in `gpt_analyze.py` minimalinvasiv angepasst werden
- PDF-Service-ENV-Defaults bleiben unverifiziert bis `make-ki-pdfservice`-Repo aus einer Session zugreifbar ist (TODO im Doku-File)

---
_Generated by [Claude Code](https://claude.ai/code/session_012ZFXqFTVdVHG62o71qhX5u)_