### PR TITLE
Sprint 1027.5.1 — Hotfix (5.1-A Trace, 5.1-B Text-Patch, 5.1-C/D Doku)

### DIFF
--- a/docs/5-C-key-rename-clarification.md
+++ b/docs/5-C-key-rename-clarification.md
@@ -1,0 +1,121 @@
+# 5-C — Spec-Drift Schlüsselname (KIS-1200 NO-GO)
+
+**Status (1027.5.1):** Wolf-Entscheid α bestätigt — finaler Name bleibt
+`_chat_blocks_skipped`. **Kein Code-Patch in 1027.5.1.**
+
+## Anlass
+
+Handover-Spec für 5-C nannte den Ziel-Schlüsselnamen
+`_chat_blocks_without_freetext`. Das Production-DB-Audit am 30.05.2026
+zeigte:
+
+| Schlüsselname | Briefings (Anzahl) | Status |
+|---|---|---|
+| `_chat_unsurveyed_blocks` | 23 | alter Name, pre-1027.5 |
+| `_chat_blocks_without_freetext` | 0 | **Handover-Spec-Name, nirgends** |
+| `_chat_blocks_skipped` | 1 (KIS-1200) | **post-1027.5-Patch** |
+| `_chat_surveyed_blocks` | 24 | paralleler, nicht betroffener Schlüssel |
+
+Timeline:
+- briefing 1082 (30.05. 11:37, pre-Deploy): `_chat_unsurveyed_blocks`
+- briefing 1083 (30.05. 13:01, post-Deploy): `_chat_blocks_skipped`
+
+→ Der 1027.5-Patch hat den Rename durchgeführt, aber unter Name
+`_chat_blocks_skipped` statt `_chat_blocks_without_freetext`.
+
+**Wolf-Entscheid:** `_chat_blocks_skipped` bleibt der finale Name
+(kürzer, semantisch klarer als `_chat_blocks_without_freetext`).
+
+## Code-Bestätigung
+
+### 1. Finaler Schlüssel im Code
+
+**Schreibseite (routes/chat.py):**
+
+```python
+# routes/chat.py:3096 (in _complete_r1)
+if unsurveyed:
+    answers["_chat_blocks_skipped"] = unsurveyed
+    answers["_chat_surveyed_blocks"] = surveyed_blocks
+    log.info("[CHAT] Complete R1: skipped blocks %s → defaults applied", unsurveyed)
+```
+
+```python
+# routes/chat.py:3112 (in _complete_r1, KIS-1136 Fix 3-Pfad)
+answers["_chat_blocks_skipped"] = unsurveyed
+answers["_chat_surveyed_blocks"] = surveyed_blocks
+```
+
+**Leseseite (gpt_analyze.py):**
+
+```python
+# gpt_analyze.py:1283-1289
+# KIS-1124 Sprint 4 S4-BE-2: Signal unsurveyed areas to LLM.
+# FIX-KIS-1027.5-C: Field renamed from _chat_unsurveyed_blocks to
+# _chat_blocks_skipped (clearer semantics: "user opted out / never entered").
+# Backward-compat read covers existing DB rows with the old key.
+unsurveyed = (
+    answers.get("_chat_blocks_skipped")
+    or answers.get("_chat_unsurveyed_blocks")
+    or []
+)
+```
+
+### 2. `_chat_blocks_without_freetext` nirgends im Code
+
+```bash
+$ grep -rn "_chat_blocks_without_freetext" .
+# (kein Treffer)
+```
+
+Bestätigt: der Handover-Spec-Name wird nirgendwo im Code geschrieben
+ODER gelesen. Keine Spec-Konformitäts-Korrektur nötig — der Code ist
+in sich konsistent.
+
+### 3. Backward-Compat-Read
+
+`gpt_analyze.py:1287-1289` liest **beide** Namen via `or`-Verkettung:
+
+- `_chat_blocks_skipped` (neuer Name, 1 Briefing seit Deploy)
+- `_chat_unsurveyed_blocks` (alter Name, 23 Briefings vor Deploy)
+
+→ Alte und neue DB-Rows sind beide funktional. Alte Rows werden über
+die Zeit organisch durch neue Briefings ersetzt; keine DB-Migration
+nötig.
+
+## Begründung Spec-Drift
+
+Bei Sprint 1027.5-Item-C wurde `_chat_blocks_skipped` als Rename-Ziel
+gewählt:
+- Kürzer (2 statt 3 Wörter)
+- Semantisch identisch ("user hat Block übersprungen" ≡ "Block ohne
+  Freetext-Antwort"), aber prägnanter
+- Konsistent mit dem komplementären `_chat_surveyed_blocks` (gleiche
+  Wortform "blocks_X" statt "blocks_X_Y")
+
+Handover-Spec wurde nachträglich von Wolf bestätigt; der gewählte
+Name bleibt.
+
+## Empfehlung für künftige Sprints
+
+Bei Schlüsselnamen-Änderungen, die DB-State betreffen:
+
+1. **Doku-Sync vor Merge:** Final-Name in Sprint-Briefing AKTIV
+   einfrieren, nicht aus der Beschreibung "rückwärts" ableiten.
+2. **DB-Audit-Tabelle im Sprint-Daily-Report:** Anzahl Rows je
+   Schlüsselname vor + nach Deploy.
+3. **Sprint-Pre-Commitment-Check:** "Heißt der finale Schlüsselname
+   X oder Y? Wenn unklar, Wolf-Ping vor Patch."
+
+Diese drei Punkte würden den drift von `_chat_blocks_without_freetext`
+↔ `_chat_blocks_skipped` schon im 1027.5-Sprint sichtbar gemacht haben.
+
+## Wolf-Ping — Befund
+
+- **Code-Konsistenz:** ✓ Final-Name `_chat_blocks_skipped` wird sauber
+  geschrieben und gelesen.
+- **Backward-Compat:** ✓ Alte Rows mit `_chat_unsurveyed_blocks` bleiben
+  funktional via `or`-Verkettung in `gpt_analyze.py:1287-1289`.
+- **Handover-Spec-Konformität:** **abgelehnt** — Spec-Name
+  `_chat_blocks_without_freetext` wird nicht eingeführt (Wolf-Entscheid α).
+- **Aktion:** Doku abgeschlossen, kein Code-Patch.

--- a/docs/5-H2-spec-clarification.md
+++ b/docs/5-H2-spec-clarification.md
@@ -1,0 +1,150 @@
+# 5-H2 — Spec-Klarstellung (KIS-1200 NO-GO)
+
+**Status (1027.5.1):** 5-H2 ist defensive API-Erweiterung — **kein
+Code-Pfad ruft sie heute auf**. Empfehlung: Refactor-Kandidat 1027.6.
+
+## Anlass
+
+KIS-1200-Funnel wurde laut Sprint-1027.5.1-Briefing OHNE Tools-Vertiefung
+gefahren. `briefing.answers` enthielt KEIN `s5_software`. R1 PDF S.15
+Vendor-Audit zeigte 2 Tools (ChatGPT, Claude). Im Strategy-Report
+(`strategy_reports.sections->'S4'`) wird Perplexity 6× im Fließtext
+erwähnt, aber kein strukturiertes Audit-Objekt.
+
+Die Handover-Spec für 5-H2 (aus Sprint 1027.5):
+> "4 Tools inkl. Perplexity im Strategy-Vendor-Audit"
+> "strategy_data->'vendor_audit'->'vendors' jsonb_array_length = 4"
+
+ist nicht verifizierbar:
+
+- `analyses`-Tabelle hat **keine** `strategy_data`-Spalte
+  (Spalten: `id, user_id, briefing_id, html, meta, created_at, raw_sections`)
+- Es gibt **kein** strukturiertes `vendor_audit`-JSON-Objekt
+- `strategy_reports.sections->'S4'` ist HTML-String, kein JSONB-Array
+
+Die Handover-Query wurde versehentlich auf ein nicht existierendes
+DB-Schema geschrieben.
+
+## Code-Pfad (was 5-H2 tatsächlich tut)
+
+### Definition
+
+| Datei | Symbol | Beschreibung |
+|---|---|---|
+| `services/vendor_audit_engine.py:918` | `_extract_vendors_from_briefing(briefing, strategy_answers=None)` | Akzeptiert optional `strategy_answers`-dict, merged es nicht-zerstörend in eine Briefing-Kopie (briefing-Werte gewinnen, nur leere Felder werden gefüllt) |
+| `services/vendor_audit_engine.py:1244` | `generate_vendor_audit_report(..., strategy_answers=None)` | Reicht den Param an `_extract_vendors_from_briefing` weiter (Z. 1297) |
+
+Mit `strategy_answers` werden zusätzlich diese source-Keys auditierbar:
+- `s5_software`
+- `S5_SOFTWARE`
+- `bestehende_software`
+
+(Sprint-1027.4-2D source_keys-Mapping)
+
+### Production-Call-Site
+
+**Nur eine** Stelle ruft `generate_vendor_audit_report` in der live-
+Pipeline auf:
+
+```python
+# gpt_analyze.py:16058 — R1-Generation
+vendor_audit_report = generate_vendor_audit_report(
+    context=None,
+    tools_data=sections.get("_tools_data"),
+    risk_report_v2=sections.get("_risk_report"),
+    risk_report_v3=sections.get("_risk_report_v3"),
+    briefing=answers,
+    llm_response=None,
+    sections=sections,
+)
+```
+
+`strategy_answers` wird **nicht** gesetzt → `_extract_vendors_from_briefing`
+fällt auf reines `briefing`-Argument zurück. Der 5-H2-Fix hat hier
+**keine Wirkung**.
+
+`services/strategy_pipeline.py` ruft `generate_vendor_audit_report`
+nicht auf — Strategy-Pipeline liest nur die *bereits berechneten*
+VENDOR_AUDIT_RED/GREEN/STATUS-Counts aus `_r1_sections` (Z. 260-262)
+und nutzt sie als Prompt-Variablen für Strategy-Section-Generation.
+
+## Wo SOLLTE 5-H2 wirken, und tut es das?
+
+| Section / Datenstruktur | Erwartete Änderung mit `strategy_answers` | Tatsächlich beobachtbar? |
+|---|---|---|
+| R1 `VENDOR_AUDIT_HTML` (Sections S.14/15) | Würde zusätzliche Vendor-Einträge zeigen — wenn aus strategy `s5_software` extrahierbar | **Nein** — `gpt_analyze.py:16058` passt strategy_answers nicht durch |
+| Strategy `S4` HTML | Wird über LLM-Prompts generiert, nicht über vendor_audit_engine | **Nein** — kein Code-Pfad |
+| Eigenes vendor_audit-JSON-Objekt | — | **Existiert nicht im DB-Schema** |
+
+→ **5-H2-Fix ist heute defensiv-only.** Er hat keinen User-visible
+Effekt, solange kein Caller `strategy_answers` setzt.
+
+## Warum greift der Pfad nicht "by design"?
+
+Pipeline-Reihenfolge bei normalem Funnel-Run:
+
+1. R1-Generation (worker) → liest `briefing.answers`, generiert R1-PDF
+   inkl. Vendor-Audit
+2. R1-`report_ready`-Mail (mit PDF)
+3. Strategy-Chat (user füllt s5_software ein)
+4. Strategy-Pipeline → liest s5_software, generiert Strategy-PDF
+
+Zwischen 1 und 3 ist die `strategy_answers`-Existenz unbekannt. Beim
+R1-Re-Render (1027.4-3A-Pfad) wird `_send_admin_briefing_email` mit
+`strategy_answers` aufgerufen, aber `_send_admin_briefing_email`
+re-rendert das Briefing-PDF, nicht den R1-Report.
+
+Das `/api/strategy/admin/r1-re-render`-Endpoint (routes/strategy.py:874)
+liest R1 aus `analyses.meta['sections']` und rendert mit
+`heal_report_html` + `b25_enforcer` + `render`, **ohne**
+`generate_vendor_audit_report` neu aufzurufen. Vendor-Audit-HTML im
+PDF stammt also weiterhin von der ursprünglichen R1-Generation.
+
+## Validierungs-Query (statt der falschen Handover-Query)
+
+Statt `strategy_data->'vendor_audit'->'vendors'` (existiert nicht):
+
+```sql
+-- Was R1-Vendor-Audit tatsächlich enthält
+SELECT briefing_id,
+       length(meta->'sections'->>'VENDOR_AUDIT_HTML') AS audit_html_len
+FROM analyses
+WHERE briefing_id = :briefing_id
+ORDER BY id DESC
+LIMIT 1;
+
+-- Anzahl Vendor-Einträge im gerenderten Audit (HTML-Pattern-Zählung):
+-- Audit-Tabelle erzeugt ein <tr class="vendor-row"> oder ähnlich pro Vendor.
+SELECT briefing_id,
+       (
+         SELECT count(*) FROM regexp_matches(
+           meta->'sections'->>'VENDOR_AUDIT_HTML',
+           '<tr[^>]*class="[^"]*vendor[^"]*"',
+           'g'
+         )
+       ) AS vendor_row_count
+FROM analyses
+WHERE briefing_id = :briefing_id;
+```
+
+(Exakter Selektor-Pattern siehe `services/vendor_audit_engine.py:vendor_audit_report_to_html`.)
+
+## Wolf-Ping — Empfehlung
+
+**Einordnung:** "wirkt nicht" + Refactor-Kandidat 1027.6.
+
+Begründung:
+
+- 5-H2-Defensive ist in-Code, aber ohne Caller. Keine Lasten, aber auch
+  kein Wert für User.
+- Echte Lösung für "Perplexity erscheint im R1-Vendor-Audit": R1
+  muss zum Strategy-Chat-Abschluss-Zeitpunkt re-gerendert werden, mit
+  `strategy_answers` durchgereicht an `generate_vendor_audit_report`.
+- Aufwand für vollständigen Fix: 1027.6-Item-Größe (touches Chat-
+  Abschluss-Hook, R1-Re-Render-Pfad, Renderer-Schnittstellen,
+  Email-Versand-Zeitpunkt).
+
+**Vorschlag:** 5-H2 als "API-Erweiterung erfolgt, kein Caller" im
+Daily Report markieren; 1027.6 nimmt den Wire-up-Refactor auf (siehe
+Backlog-Item "Vendor-Audit-Refactor: Briefing-State zu Strategy-Time
+vollständig").

--- a/routes/strategy.py
+++ b/routes/strategy.py
@@ -897,6 +897,37 @@ async def admin_r1_re_render(
     if not sections:
         raise HTTPException(status_code=400, detail="Keine Sections in Analysis.meta")
 
+    # FIX-KIS-1027.5.1-A: Decision-Cutoff-Trace Checkpoint 0/N (post DB-Read).
+    # Erste Stelle nach dem analyses.meta-Read. Wenn EXECUTIVE_DECISION_HTML
+    # hier 3 <li> hat aber im finalen PDF nur 1, liegt der Cutoff irgendwo
+    # in der Pipeline render() -> pdf_client -> Chromium.
+    try:
+        import hashlib as _hashlib
+        import re as _re_dt
+        _dec_db = sections.get("EXECUTIVE_DECISION_HTML") or ""
+        if isinstance(_dec_db, str) and _dec_db:
+            _li_db = len(_re_dt.findall(r'<li\b', _dec_db, _re_dt.IGNORECASE))
+            _sha_db = _hashlib.sha256(
+                _dec_db.encode("utf-8", errors="replace"), usedforsecurity=False,
+            ).hexdigest()[:16]
+            log.info(
+                "[DECISION-CUTOFF-TRACE] stage=0_db_read_admin_re_render "
+                "run_id=re-render-%s briefing_id=%s len=%d li=%d sha=%s mode=section",
+                briefing_id, briefing_id, len(_dec_db), _li_db, _sha_db,
+            )
+        else:
+            log.info(
+                "[DECISION-CUTOFF-TRACE] stage=0_db_read_admin_re_render "
+                "run_id=re-render-%s briefing_id=%s NOT-FOUND-OR-EMPTY mode=section",
+                briefing_id, briefing_id,
+            )
+    except Exception as _trace_err:
+        log.warning(
+            "[DECISION-CUTOFF-TRACE] stage=0_db_read_admin_re_render "
+            "briefing_id=%s TRACE-ERROR=%s",
+            briefing_id, _trace_err,
+        )
+
     briefing = db.query(Briefing).filter(Briefing.id == briefing_id).first()
     if not briefing:
         raise HTTPException(status_code=404, detail="Briefing nicht gefunden")

--- a/services/pdf_client.py
+++ b/services/pdf_client.py
@@ -262,6 +262,41 @@ def render_pdf_from_html(
     meta = meta or {}
     rid = meta.get("request_id") or meta.get("run_id") or meta.get("analysis_id") or uuid4().hex
     rid = _as_str(rid)
+
+    # FIX-KIS-1027.5.1-A: Decision-Cutoff-Trace Checkpoint 7/N
+    # (HTTP-payload boundary to make-ki-pdfservice — letzte Backend-Stelle
+    # vor Chromium-Render). Wenn der Decision-Block hier noch 3 <li> hat,
+    # liegt der Cutoff in Chromium/Puppeteer; wenn schon kuerzer, ist
+    # er backend-seitig.
+    try:
+        import hashlib
+        import re as _re
+        _dec_re = _re.compile(
+            r'<div\b[^>]*\bid="decision"[^>]*>.*?(?=<!--|<div\b[^>]*\bclass="section\b)',
+            _re.DOTALL | _re.IGNORECASE,
+        )
+        _match = _dec_re.search(html or "")
+        if _match:
+            _target = _match.group(0)
+            _li = len(_re.findall(r'<li\b', _target, _re.IGNORECASE))
+            _sha = hashlib.sha256(_target.encode("utf-8", errors="replace"), usedforsecurity=False).hexdigest()[:16]
+            log.info(
+                "[DECISION-CUTOFF-TRACE] stage=7_pdf_client_http_send run_id=%s "
+                "len=%d li=%d sha=%s mode=html",
+                rid, len(_target), _li, _sha,
+            )
+        else:
+            log.info(
+                "[DECISION-CUTOFF-TRACE] stage=7_pdf_client_http_send run_id=%s "
+                "NOT-FOUND mode=html",
+                rid,
+            )
+    except Exception as _trace_err:
+        log.warning(
+            "[DECISION-CUTOFF-TRACE] stage=7_pdf_client_http_send run_id=%s "
+            "TRACE-ERROR=%s",
+            rid, _trace_err,
+        )
     url = f"{PDF_SERVICE_URL}/generate-pdf"
 
     # Build payload with optional PDF options

--- a/services/report_renderer.py
+++ b/services/report_renderer.py
@@ -70,6 +70,75 @@ def _strip_emojis(text: str) -> str:
     return _EMOJI_RE.sub("", text)
 
 
+# =========================================================================
+# FIX-KIS-1027.5.1-A: Render-Pipeline-Instrumentierung fuer
+# EXECUTIVE_DECISION_HTML-Cutoff-Diagnose.
+#
+# KIS-1200 zeigte 675-char / 3-li post_healer-Inhalt in DB, aber gerendertes
+# PDF zeigt nur 1 mid-sentence-abgeschnittenen Bullet (~162 chars / 1 li).
+# 513 chars + 2 <li> gehen zwischen DB-Read und PDF verloren — 3 CSS-
+# basierte Iterationen (1027.2.3, 1027.4, 1027.5) haben den Bug nicht
+# behoben. Hypothese "Container-Atomaritaet via CSS" wird verworfen.
+#
+# Diese Instrumentierung gibt KEINEN Code-Fix, sondern lokalisiert die
+# Verlust-Stufe per [DECISION-CUTOFF-TRACE]-Log-Marker mit length,
+# li_count, sha256 an mehreren Checkpoints zwischen DB-Read und
+# pdf_client-Aufruf.
+# =========================================================================
+_DECISION_HTML_RE = re.compile(
+    r'<div\b[^>]*\bid="decision"[^>]*>.*?(?=<!--|<div\b[^>]*\bclass="section\b)',
+    re.DOTALL | re.IGNORECASE,
+)
+_DECISION_LI_RE = re.compile(r'<li\b', re.IGNORECASE)
+
+
+def _trace_decision_cutoff(
+    stage: str,
+    run_id: Any,
+    content: Any,
+    mode: str = "section",
+) -> None:
+    """Log a [DECISION-CUTOFF-TRACE] entry for EXECUTIVE_DECISION_HTML.
+
+    Args:
+        stage: stage name (e.g. "render_entry", "pre_jinja", "post_jinja")
+        run_id: run identifier for correlation
+        content: either the section string (mode="section") or full HTML
+                 (mode="html" — extracts the #decision-section first)
+        mode: "section" or "html"
+    """
+    try:
+        import hashlib
+        if content is None:
+            target = ""
+        elif mode == "html":
+            text = str(content) if not isinstance(content, str) else content
+            match = _DECISION_HTML_RE.search(text)
+            target = match.group(0) if match else ""
+        else:
+            target = str(content) if not isinstance(content, str) else content
+
+        if not target:
+            log.info(
+                "[DECISION-CUTOFF-TRACE] stage=%s run_id=%s NOT-FOUND mode=%s",
+                stage, run_id, mode,
+            )
+            return
+
+        encoded = target.encode("utf-8", errors="replace")
+        li_count = len(_DECISION_LI_RE.findall(target))
+        sha = hashlib.sha256(encoded, usedforsecurity=False).hexdigest()[:16]
+        log.info(
+            "[DECISION-CUTOFF-TRACE] stage=%s run_id=%s len=%d li=%d sha=%s mode=%s",
+            stage, run_id, len(target), li_count, sha, mode,
+        )
+    except Exception as _trace_err:  # never break rendering on trace failure
+        log.warning(
+            "[DECISION-CUTOFF-TRACE] stage=%s run_id=%s TRACE-ERROR=%s",
+            stage, run_id, _trace_err,
+        )
+
+
 def _strip_emojis_from_context(context: dict) -> dict:
     """Strip emojis from all *_HTML template variables in the render context."""
     for key in list(context.keys()):
@@ -612,6 +681,11 @@ def render(briefing_obj: Any,
     # Context
     sections = dict(generated_sections or {})
 
+    # FIX-KIS-1027.5.1-A: Decision-Cutoff-Trace Checkpoint 1/N (render entry)
+    _trace_decision_cutoff(
+        "1_render_entry", run_id, sections.get("EXECUTIVE_DECISION_HTML"), mode="section",
+    )
+
     # Alias FUNDING if necessary
     if not sections.get("FUNDING_HTML") and sections.get("FOERDERPROGRAMME_HTML"):
         sections["FUNDING_HTML"] = sections["FOERDERPROGRAMME_HTML"]
@@ -1070,7 +1144,15 @@ def render(briefing_obj: Any,
     except Exception as _e:  # never break rendering on audit failure
         log.debug("audit_render_context failed: %s", _e)
 
+    # FIX-KIS-1027.5.1-A: Decision-Cutoff-Trace Checkpoint 2/N (pre-Jinja)
+    _trace_decision_cutoff(
+        "2_pre_jinja", run_id, ctx.get("EXECUTIVE_DECISION_HTML"), mode="section",
+    )
+
     html = env.get_template(tpl_name).render(**ctx)
+
+    # FIX-KIS-1027.5.1-A: Decision-Cutoff-Trace Checkpoint 3/N (post-Jinja, full HTML mode)
+    _trace_decision_cutoff("3_post_jinja", run_id, html, mode="html")
 
     # Q3: Fix Kl→KI globally in final HTML (common OCR/input error)
     html = re.sub(r'\bKl-Readiness', 'KI-Readiness', html)
@@ -1491,9 +1573,13 @@ def render(briefing_obj: Any,
     # =========================================================================
     # P0.4: Pagebreak cleanup - prevent empty/low-value pages
     # =========================================================================
+    # FIX-KIS-1027.5.1-A: Decision-Cutoff-Trace Checkpoint 4/N (pre-pagebreak)
+    _trace_decision_cutoff("4_pre_pagebreak_cleanup", run_id, html, mode="html")
     html, pagebreak_removed = cleanup_pagebreaks(html, run_id=run_id)
     if pagebreak_removed > 0:
         log.info(f"[P0.4] Pagebreak cleanup: removed {pagebreak_removed} artifacts for run={run_id}")
+    # FIX-KIS-1027.5.1-A: Decision-Cutoff-Trace Checkpoint 5/N (post-pagebreak)
+    _trace_decision_cutoff("5_post_pagebreak_cleanup", run_id, html, mode="html")
 
     # =========================================================================
     # FIX-BATCH-497: Code fence removal (hard requirement for premium PDF)
@@ -2091,4 +2177,6 @@ def render(briefing_obj: Any,
 
             log.info(f"[DEBUG-503D] Collected {len(debug_attachments)} debug artifacts for admin email")
 
+    # FIX-KIS-1027.5.1-A: Decision-Cutoff-Trace Checkpoint 6/N (render exit)
+    _trace_decision_cutoff("6_render_exit", run_id, html, mode="html")
     return {"html": html, "meta": meta or {}, "debug_attachments": debug_attachments_for_email}

--- a/templates/pdf_template_v7.html
+++ b/templates/pdf_template_v7.html
@@ -1689,8 +1689,10 @@ h1, h2, h3, h4 {
         </table>
         <p style="margin: 8px 0 0 0; font-size: 0.85em; color: #475569; line-height: 1.5;">
             Beide Werte sind korrekt — sie unterscheiden sich nur in der Investitionsbasis.
-            Der KI-Strategiebericht (sofern beauftragt) nutzt die Gesamt-Sicht; daher
-            erscheinen die beiden ROI-Zahlen dort konsistent zur Gesamt-Sicht hier.
+            Der KI-Strategiebericht (sofern beauftragt) nutzt eine eigene
+            12-Monats-TCO-Methodik mit anderer Kostenstruktur (inkl. Implementierung,
+            Schulung, Koordination); die dortigen ROI-Werte sind methodisch bedingt
+            abweichend, nicht widersprüchlich.
         </p>
     </div>
     {% endif %}

--- a/tests/test_kis_1027_5_1_a_cutoff_trace.py
+++ b/tests/test_kis_1027_5_1_a_cutoff_trace.py
@@ -1,0 +1,160 @@
+# -*- coding: utf-8 -*-
+"""FIX-KIS-1027.5.1-A: Decision-Cutoff-Trace-Instrumentierung.
+
+KIS-1200 zeigte 675-char / 3-li post_healer-Inhalt in DB, gerendertes PDF
+zeigt nur 1 mid-sentence-abgeschnittenen Bullet (~162 chars / 1 li). 3
+CSS-basierte Iterationen (1027.2.3, 1027.4, 1027.5) haben den Bug nicht
+behoben. Diese Tests verifizieren NUR die Instrumentierung — kein Fix.
+
+Sieben Checkpoints im Pipeline-Fluss DB-Read -> render() -> pdf_client:
+  0_db_read_admin_re_render  (routes/strategy.py admin-re-render)
+  1_render_entry             (report_renderer.render Eintritt)
+  2_pre_jinja                (vor env.get_template().render())
+  3_post_jinja               (direkt nach Jinja-Render)
+  4_pre_pagebreak_cleanup    (vor cleanup_pagebreaks)
+  5_post_pagebreak_cleanup   (nach cleanup_pagebreaks)
+  6_render_exit              (vor render-Return)
+  7_pdf_client_http_send     (pdf_client HTTP-Boundary zu make-ki-pdfservice)
+
+Logging-Marker: [DECISION-CUTOFF-TRACE] stage=X run_id=Y len=N li=M sha=Z mode=...
+"""
+from __future__ import annotations
+
+import logging
+import re
+
+import pytest
+
+from services.report_renderer import _trace_decision_cutoff
+
+
+_DECISION_HTML_3_LI = (
+    '<div class="exec-decision-box">'
+    '  <p><strong>Ihre Entscheidung in 3 Punkten</strong></p>'
+    '  <ul>'
+    '    <li><strong>Tun:</strong> Standard-Workflow Input → KI-Entwurf → Review → Freigabe einführen.</li>'
+    '    <li><strong>Lassen:</strong> Ad-hoc-Prompts ohne dokumentierte Quellen vermeiden.</li>'
+    '    <li><strong>Risiko &amp; Stop-Signal:</strong> Nach 14 Tagen ohne messbaren Effekt stoppen.</li>'
+    '  </ul>'
+    '</div>'
+)
+
+
+_FULL_HTML_WITH_DECISION = f'''
+<html><body>
+<div class="section" id="other" data-category="strategy">
+<p>Andere Section</p>
+</div>
+<div class="section" id="decision" data-category="strategy">
+    <h2>Entscheidungsvorlage</h2>
+    {_DECISION_HTML_3_LI}
+</div>
+<!-- ═══════ NACH DECISION ═══════ -->
+<div class="section" id="footer-section" data-category="strategy">
+<p>Footer-Section</p>
+</div>
+</body></html>
+'''
+
+
+def test_trace_logs_section_mode(caplog):
+    """Mode='section' loggt direkt das uebergebene HTML-Fragment."""
+    with caplog.at_level(logging.INFO, logger="services.report_renderer"):
+        _trace_decision_cutoff("test_stage", "RUN-1", _DECISION_HTML_3_LI, mode="section")
+    matches = [r for r in caplog.records if "[DECISION-CUTOFF-TRACE]" in r.getMessage()]
+    assert len(matches) == 1, f"Erwartete 1 TRACE-Eintrag, gefunden {len(matches)}"
+    msg = matches[0].getMessage()
+    assert "stage=test_stage" in msg
+    assert "run_id=RUN-1" in msg
+    assert "li=3" in msg, f"3 <li> erwartet, message={msg!r}"
+    assert "len=" in msg
+    assert "sha=" in msg
+
+
+def test_trace_logs_html_mode_extracts_decision_section(caplog):
+    """Mode='html' extrahiert nur den #decision-Section-Block aus Full-HTML."""
+    with caplog.at_level(logging.INFO, logger="services.report_renderer"):
+        _trace_decision_cutoff("test_html", "RUN-2", _FULL_HTML_WITH_DECISION, mode="html")
+    matches = [r for r in caplog.records if "[DECISION-CUTOFF-TRACE]" in r.getMessage()]
+    assert len(matches) == 1
+    msg = matches[0].getMessage()
+    assert "li=3" in msg, f"3 <li> aus #decision erwartet, message={msg!r}"
+    # Andere Sections (footer/other) duerfen die <li>-Zahl NICHT beeinflussen
+    # (sie haben keine <li>); Length muss < Full-HTML-Length sein
+    full_len = len(_FULL_HTML_WITH_DECISION)
+    match = re.search(r'len=(\d+)', msg)
+    assert match
+    extracted_len = int(match.group(1))
+    assert extracted_len < full_len, (
+        f"Extracted len={extracted_len} sollte < full {full_len} sein"
+    )
+
+
+def test_trace_handles_empty_content(caplog):
+    """Empty/None Content loggt NOT-FOUND statt zu crashen."""
+    with caplog.at_level(logging.INFO, logger="services.report_renderer"):
+        _trace_decision_cutoff("test_empty", "RUN-3", None, mode="section")
+        _trace_decision_cutoff("test_empty_str", "RUN-3", "", mode="html")
+    matches = [r for r in caplog.records if "[DECISION-CUTOFF-TRACE]" in r.getMessage()]
+    assert len(matches) == 2
+    assert all("NOT-FOUND" in m.getMessage() for m in matches)
+
+
+def test_trace_handles_html_without_decision_section(caplog):
+    """HTML ohne #decision-Section loggt NOT-FOUND, kein Crash."""
+    html_no_decision = '<html><body><div class="section" id="other">Nichts</div></body></html>'
+    with caplog.at_level(logging.INFO, logger="services.report_renderer"):
+        _trace_decision_cutoff("test_no_dec", "RUN-4", html_no_decision, mode="html")
+    matches = [r for r in caplog.records if "[DECISION-CUTOFF-TRACE]" in r.getMessage()]
+    assert len(matches) == 1
+    assert "NOT-FOUND" in matches[0].getMessage()
+
+
+def test_trace_never_raises_on_internal_error(caplog):
+    """Trace-Helper soll Render-Pipeline NIE brechen — auch bei kaputten Inputs."""
+    class _Unencodable:
+        def __str__(self):
+            raise RuntimeError("intentional")
+
+    # darf NICHT propagieren
+    with caplog.at_level(logging.WARNING, logger="services.report_renderer"):
+        _trace_decision_cutoff("test_robust", "RUN-5", _Unencodable(), mode="section")
+    # Erwartung: entweder NOT-FOUND-Log ODER TRACE-ERROR-Warning, aber kein crash
+    # (caplog captures both INFO und WARNING above)
+
+
+def test_renderer_has_all_six_in_module_checkpoints():
+    """Verifiziere, dass alle 6 Checkpoints (1..6) im report_renderer-Quellcode stehen."""
+    import inspect
+    from services import report_renderer
+    src = inspect.getsource(report_renderer)
+    for marker in (
+        '"1_render_entry"',
+        '"2_pre_jinja"',
+        '"3_post_jinja"',
+        '"4_pre_pagebreak_cleanup"',
+        '"5_post_pagebreak_cleanup"',
+        '"6_render_exit"',
+    ):
+        assert marker in src, f"Checkpoint {marker} fehlt im report_renderer"
+
+
+def test_pdf_client_has_http_send_checkpoint():
+    """Checkpoint 7 (pdf_client HTTP-Boundary) ist im pdf_client-Quellcode."""
+    import inspect
+    from services import pdf_client
+    src = inspect.getsource(pdf_client)
+    assert "7_pdf_client_http_send" in src, (
+        "pdf_client Checkpoint 7 fehlt"
+    )
+    assert "DECISION-CUTOFF-TRACE" in src
+
+
+def test_strategy_routes_has_db_read_checkpoint():
+    """Checkpoint 0 (admin r1-re-render DB-Read) ist im routes/strategy.py."""
+    import inspect
+    from routes import strategy as strategy_routes
+    src = inspect.getsource(strategy_routes)
+    assert "0_db_read_admin_re_render" in src, (
+        "routes/strategy.py Checkpoint 0 fehlt"
+    )

--- a/tests/test_kis_1027_5_1_b_methodik_neutralisierung.py
+++ b/tests/test_kis_1027_5_1_b_methodik_neutralisierung.py
@@ -1,0 +1,84 @@
+# -*- coding: utf-8 -*-
+"""FIX-KIS-1027.5.1-B: R1 S.10 Methodik-Hinweis neutralisieren.
+
+KIS-1200-Verdikt: Der 5-A-Methodik-Hinweis behauptete falsche Konsistenz:
+"Der KI-Strategiebericht (sofern beauftragt) nutzt die Gesamt-Sicht;
+daher erscheinen die beiden ROI-Zahlen dort konsistent zur Gesamt-Sicht hier."
+
+Tatsaechlich:
+- R1 CAPEX-Sicht:         8% ROI (Basis 12.000 EUR CAPEX)
+- R1 Gesamt-Sicht:         7% ROI (Basis 13.440 EUR = CAPEX + OPEX 1.440 EUR)
+- Strategy realistisch:   20% ROI (Basis 12.000 EUR Gesamt-TCO, OPEX 300 EUR/Mon)
+- Strategy mit Foerderung: 300% ROI (Basis 3.600 EUR Netto)
+
+Strategy nutzt eine eigene Kostenstruktur (inkl. Implementierung, Schulung,
+Koordination), nicht "die Gesamt-Sicht von R1". Die behauptete Konsistenz
+existiert nicht.
+
+Fix: Text-Patch im Methodik-Hinweis-Block. KEINE Aenderung an ROI-Werten,
+R1-Tabelle, Strategy-Werten.
+"""
+from __future__ import annotations
+
+import os
+import re
+
+TEMPLATE_PATH = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+    "templates",
+    "pdf_template_v7.html",
+)
+
+
+def _read_template() -> str:
+    with open(TEMPLATE_PATH, encoding="utf-8") as f:
+        return f.read()
+
+
+def test_methodik_hinweis_does_not_claim_konsistenz():
+    """Die falsche Konsistenz-Behauptung ist entfernt."""
+    tpl = _read_template()
+    assert "konsistent zur Gesamt-Sicht hier" not in tpl, (
+        "Alte falsche Konsistenz-Behauptung ist noch im Template."
+    )
+
+
+def test_methodik_hinweis_uses_neutral_tco_wording():
+    """Neuer Text betont eigene TCO-Methodik der Strategy mit anderer "
+    "Kostenstruktur und 'methodisch bedingt abweichend'."""
+    tpl = _read_template()
+    assert "12-Monats-TCO-Methodik" in tpl, (
+        "Neuer TCO-Methodik-Begriff fehlt im Methodik-Hinweis."
+    )
+    assert "andere" in tpl.lower() and "Kostenstruktur" in tpl
+    assert "methodisch bedingt" in tpl
+    assert "abweichend, nicht widersprüchlich" in tpl
+
+
+def test_methodik_hinweis_mentions_implementation_schulung_koordination():
+    """Konkrete Kostenkomponenten der Strategy-Methodik werden genannt."""
+    tpl = _read_template()
+    # Klammer-Liste im neuen Text
+    assert "Implementierung" in tpl
+    assert "Schulung" in tpl
+    assert "Koordination" in tpl
+
+
+def test_roi_views_table_block_intact():
+    """Der eingebettende roi-views-table-Block bleibt strukturell unveraendert."""
+    tpl = _read_template()
+    # Block-Marker aus 5-A muss noch da sein
+    assert "roi-views-table" in tpl
+    assert "ROI_12M_GESAMT_DISPLAY_DE" in tpl
+    assert "CAPEX-Sicht" in tpl
+    assert "Gesamt-Sicht" in tpl
+    # Methodik-Hinweis steht im Block (heuristisch: zwischen den ROI-Sichten
+    # und dem closing </div> des Blocks)
+    block_match = re.search(
+        r'<div class="roi-views-table".*?</div>',
+        tpl,
+        re.DOTALL,
+    )
+    assert block_match, "roi-views-table-Block nicht gefunden"
+    block = block_match.group(0)
+    assert "12-Monats-TCO-Methodik" in block


### PR DESCRIPTION
## Daily Report — Sprint 1027.5.1 (Hotfix nach KIS-1200 NO-GO)

4 Items committed. **Volle Regression grün** (6566 tests passed, 10 skipped, 0 fail, +12 neue Tests), mypy clean.

### Item-Übersicht

| # | Commit | Item | Typ | Status |
|---|---|---|---|---|
| 5.1-A | `7570aef` | Decision-Cutoff Render-Pipeline-Instrumentierung | Diagnose-only, **kein Fix** | ⚠️ Wolf-Ping nach Trace |
| 5.1-B | `beadbe0` | R1 S.10 Methodik-Hinweis neutralisieren | Text-Patch | ✅ |
| 5.1-C | `e5d8662` | 5-H2 Spec-Klarstellung | Doku | ⚠️ Wolf-Ping zur Einordnung |
| 5.1-D | `d503a49` | 5-C Spec-Drift Doku (Entscheid α) | Doku | ✅ abgeschlossen |

---

### 5.1-A — Render-Pipeline-Instrumentierung (Diagnose, KEIN Fix)

**KEIN Code-Eingriff am Rendering, KEIN CSS-Patch.** 8 Logging-Checkpoints mit Marker `[DECISION-CUTOFF-TRACE] stage=X run_id=Y len=N li=M sha=Z mode=...` zwischen DB-Read und PDF-Service-Boundary:

| # | Stage-Name | Datei |
|---|---|---|
| 0 | `0_db_read_admin_re_render` | `routes/strategy.py:898` (admin r1-re-render) |
| 1 | `1_render_entry` | `services/report_renderer.py:render` Eintritt |
| 2 | `2_pre_jinja` | vor `env.get_template().render()` |
| 3 | `3_post_jinja` | direkt nach Jinja-Render (Full-HTML) |
| 4 | `4_pre_pagebreak_cleanup` | vor `cleanup_pagebreaks` |
| 5 | `5_post_pagebreak_cleanup` | nach `cleanup_pagebreaks` |
| 6 | `6_render_exit` | vor `render`-Return |
| 7 | `7_pdf_client_http_send` | `pdf_client.render_pdf_from_html` HTTP-Boundary |

Helper `_trace_decision_cutoff(stage, run_id, content, mode)` in `services/report_renderer.py`. Mode `"html"` extrahiert per Regex die `#decision`-Section aus Full-HTML, mode `"section"` loggt das übergebene Fragment direkt. Try/Except umschließt jeden Aufruf — Trace-Fehler können die Render-Pipeline nicht brechen.

**Wolf-Ping Plan:** Wolf triggert KIS-1201-Funnel oder admin r1-re-render auf KIS-1200, sammelt `[DECISION-CUTOFF-TRACE]`-Zeilen aus Railway-Logs. Per Stage-Reihenfolge zeigt sich, wo `EXECUTIVE_DECISION_HTML` von 675 chars / 3 li auf ~162 chars / 1 li schrumpft → konkreter Fix-Vorschlag in eigenem Sprint 1027.5.2.

---

### 5.1-B — R1 S.10 Methodik-Hinweis (Text-Patch)

`templates/pdf_template_v7.html:1690+`:

```diff
- "...nutzt die Gesamt-Sicht; daher erscheinen die beiden ROI-Zahlen
-  dort konsistent zur Gesamt-Sicht hier."
+ "...nutzt eine eigene 12-Monats-TCO-Methodik mit anderer
+  Kostenstruktur (inkl. Implementierung, Schulung, Koordination);
+  die dortigen ROI-Werte sind methodisch bedingt abweichend, nicht
+  widersprüchlich."
```

ROI-Werte unverändert (8 % / 7 % / 20 % / 300 %). 4 neue Regression-Tests, 5-A-Tests (6/6) bleiben grün.

---

### 5.1-C — 5-H2 Spec-Klarstellung (Doku)

**Befund:** 5-H2-Fix ist defensive-only. Handover-Spec-Query `strategy_data->'vendor_audit'->'vendors'` ist nicht verifizierbar — `analyses`-Tabelle hat **keine** `strategy_data`-Spalte, kein strukturiertes `vendor_audit`-JSON-Objekt existiert.

Code-Pfad:
- `services/vendor_audit_engine.py:918` `_extract_vendors_from_briefing(..., strategy_answers=None)` — defensiv-merged
- `services/vendor_audit_engine.py:1244` `generate_vendor_audit_report(..., strategy_answers=None)` — reicht durch
- **Production-Call-Site** `gpt_analyze.py:16058` — passt `strategy_answers` **nicht** durch
- `strategy_pipeline.py` ruft `generate_vendor_audit_report` **nicht** auf

→ Heute kein User-visible Effekt. R1 wird vor Strategy-Chat generiert; `/api/strategy/admin/r1-re-render` ruft `generate_vendor_audit_report` nicht neu auf.

Validierungs-Query (korrekt, statt der falschen Handover-Variante):

```sql
SELECT briefing_id, length(meta->'sections'->>'VENDOR_AUDIT_HTML') AS audit_html_len
FROM analyses WHERE briefing_id = :briefing_id;
```

**Wolf-Ping-Empfehlung:** 5-H2 als "wirkt nicht" + **Refactor-Kandidat 1027.6**. Vollständige Lösung erfordert R1-Re-Render-Trigger am Chat-Abschluss mit `strategy_answers`-Durchreichung. Doku in `docs/5-H2-spec-clarification.md`.

---

### 5.1-D — 5-C Spec-Drift Doku (Wolf-Entscheid α bestätigt)

DB-Audit-Tabelle in der Doku:

| Schlüsselname | Briefings | Status |
|---|---|---|
| `_chat_unsurveyed_blocks` | 23 | alter Name, pre-1027.5 |
| `_chat_blocks_without_freetext` | 0 | Handover-Spec-Name, **nirgends im Code** |
| `_chat_blocks_skipped` | 1 (KIS-1200) | post-1027.5-Patch |

Code-Konsistenz verifiziert:
- Schreibseite: `routes/chat.py:3096, 3112` → `_chat_blocks_skipped`
- Leseseite: `gpt_analyze.py:1287-1289` → Backward-Compat-OR-Verkettung (`_chat_blocks_skipped or _chat_unsurveyed_blocks`)
- `_chat_blocks_without_freetext`: `grep -r` liefert **0 Treffer**

Wolf-Entscheid α bestätigt: `_chat_blocks_skipped` bleibt finaler Name. Doku in `docs/5-C-key-rename-clarification.md` inkl. Empfehlung für künftige Sprints (Doku-Sync vor Merge, DB-Audit-Tabelle im Daily Report).

**Status:** Abgeschlossen, kein Code-Patch.

---

### Bestätigte Designentscheidungen

- **5-B (Briefing-Anhang in R1-Admin-Mail):** Wolf-Entscheid liegt vor — Anhang bleibt dran. Keine Code-Änderung.

### Nicht in 1027.5.1

- **5-V Cadence-Verifikation:** Wolf-Task, Railway-Logs separat
- **1027.6-Backlog:** 5-E Refactor, DDL-Cleanup, Migration-Runner-Belastungstest, mypy-Config-Konsolidierung, Vendor-Audit-Refactor (5-H2-Wire-up)

### Test plan (KIS-1201 Funnel post-Merge)

- [ ] Inputs: Beratung / Solo / hoch / „Beratung"; Strategy-Chat **mit Tools-Vertiefung** (s5_software, damit 5-H2-Refactor-Frage greifbar bleibt)
- [ ] `[DECISION-CUTOFF-TRACE]`-Zeilen in Railway-Logs sammeln, Stages 0→7 mit `len`/`li`/`sha` korrelieren
- [ ] R1 S.10: Neuer Methodik-Hinweis sichtbar (TCO-Wortlaut, kein "konsistent")
- [ ] R1 S.4: Wenn weiterhin Cutoff: konkreter Fix-Vorschlag im Wolf-Ping nach Trace-Befund
- [ ] Cross-Report-Regression: Sprints 1026/1027.x grün

### Wolf-Ping vor Merge

**Empfehlung: GO** für alle 4 Items. 5.1-B ist deterministischer Text-Patch. 5.1-C/D sind Doku ohne Code-Risiko. 5.1-A liefert die Diagnose-Grundlage — Fix folgt im Sprint 1027.5.2 nach Trace-Befund.

https://claude.ai/code/session_019Eu3NNWB1BVxzqSn7vmsUG

---
_Generated by [Claude Code](https://claude.ai/code/session_019Eu3NNWB1BVxzqSn7vmsUG)_