### PR TITLE
FIX-1027.5.3: #decision ul/ol aus Atomaritaets-Regel entfernen

### DIFF
--- a/templates/pdf_template_v7.html
+++ b/templates/pdf_template_v7.html
@@ -682,8 +682,12 @@ tr:last-child td { border-bottom: none; }
    plus orphans/widows für Prosa-Fluss.
    .decision-card hat bereits page-break-inside:avoid (Z.658) —
    hier ergänzen wir die LLM-Direkt-HTML-Pfade. */
-#decision ul,
-#decision ol,
+/* FIX-1027.5.3: #decision ul/ol RAUS — atomare Liste > Seitenhoehe clippt in
+   Chromium (R1 S.4, analysis.id=1064 und 1065: Tun-Bullet mid-sentence
+   abgeschnitten, Lassen + 3. Leitplanke verloren). Atomaritaet bleibt auf
+   <li>-Ebene (.exec-decision-box li, weiter unten unveraendert). Belegt via
+   DB: decision-span vollstaendig (1065: 21.737 Zeichen), Cutoff erst beim
+   PDF-Render. */
 #decision li,
 #decision p,
 #decision .executive-decision-fallback,

--- a/tests/test_decision_section_figure_wrapper.py
+++ b/tests/test_decision_section_figure_wrapper.py
@@ -160,13 +160,15 @@ class TestDecisionBoxAtomicity:
 
 class TestDecisionSectionLevelSelector:
     def test_section_level_rule_no_longer_targets_figure(self) -> None:
-        """Section-Level-Regel #decision ul/ol/li/p/… darf nicht mehr
-        '#decision figure' enthalten — der Selektor wurde mit dem
-        figure-Wrapper aus 1027.2.2-A entfernt."""
+        """Section-Level-Haertungs-Block (#decision li/p/…) darf kein
+        '#decision figure' enthalten — figure-Wrapper aus 1027.2.2-A
+        bleibt entfernt. Anker seit FIX-1027.5.3 auf 'li,' (ul/ol wurden
+        aus dem break-inside:avoid-Block entfernt, damit die <ul>-Klammer
+        ueber die Seitengrenze fliessen darf; <li> bleiben atomar)."""
         tpl = _read_template()
         # Block, der #decision ul / ol / li / p / … gemeinsam härtet.
         block_match = re.search(
-            r'(#decision\s+ul,[^{]*?)\{',
+            r'(#decision\s+li,[^{]*?)\{',
             tpl,
             re.DOTALL,
         )


### PR DESCRIPTION
## Änderung

In `templates/pdf_template_v7.html` (Z.685ff) werden die Selektoren `#decision ul,` und `#decision ol,` aus der `break-inside: avoid`-Regel entfernt.

### Grund
Eine atomare Liste, die größer als die Seitenhöhe ist, clippt in Chromium beim PDF-Render (R1 S.4, analysis.id=1064/1065: Tun-Bullet mid-sentence abgeschnitten, Lassen + 3. Leitplanke verloren). Belegt via DB: decision-span vollständig (1065: 21.737 Zeichen), Cutoff erst beim Render.

### Erhalten bleibt
- Atomarität auf `<li>`-Ebene (`#decision li` und `.exec-decision-box li`, Z.719ff unverändert)
- `#decision p`, `.executive-decision-fallback`, `.decision-card` unverändert

https://claude.ai/code/session_011wdBWMNH6qcjjoCxDYozv9

---
_Generated by [Claude Code](https://claude.ai/code/session_011wdBWMNH6qcjjoCxDYozv9)_