### PR TITLE
FIX-1027.5.3: Add roadmap_90d_decision to SEGMENT_BUDGETS (Phase 3 trim)

### DIFF
--- a/services/report_healer.py
+++ b/services/report_healer.py
@@ -3026,6 +3026,9 @@ SEGMENT_BUDGETS: Dict[str, Dict[str, int]] = {
         "unternehmensprofil_markt": 5000,
         "roadmap": 5000,
         "roadmap_90d": 3000,
+        # FIX-1027.5.3: roadmap_90d_decision fehlte in SEGMENT_BUDGETS, Phase 3 wurde getrimmt (analog FIX-B43)
+        "roadmap_90d_decision": 4000,
+        "ROADMAP_90D_DECISION_HTML": 4000,
         "data_readiness": 2500,
         "ki_stack_summary": 2500,
         "pilot_plan": 2000,
@@ -3138,6 +3141,9 @@ SEGMENT_BUDGETS: Dict[str, Dict[str, int]] = {
         "unternehmensprofil_markt": 7000,
         "roadmap": 7000,
         "roadmap_90d": 5000,  # FIX-B43: was 4000 — Phase 3 wurde abgeschnitten
+        # FIX-1027.5.3: roadmap_90d_decision fehlte in SEGMENT_BUDGETS, Phase 3 wurde getrimmt (analog FIX-B43)
+        "roadmap_90d_decision": 4500,
+        "ROADMAP_90D_DECISION_HTML": 4500,
         "data_readiness": 3500,
         "ki_stack_summary": 3500,
         "pilot_plan": 3000,
@@ -3260,6 +3266,9 @@ SEGMENT_BUDGETS: Dict[str, Dict[str, int]] = {
         "unternehmensprofil_markt": 10000,
         "roadmap": 10000,
         "roadmap_90d": 6000,
+        # FIX-1027.5.3: roadmap_90d_decision fehlte in SEGMENT_BUDGETS, Phase 3 wurde getrimmt (analog FIX-B43)
+        "roadmap_90d_decision": 5000,
+        "ROADMAP_90D_DECISION_HTML": 5000,
         "data_readiness": 5000,
         "ki_stack_summary": 5000,
         "pilot_plan": 4000,


### PR DESCRIPTION
## Problem

The 90-day roadmap **decision** section was losing **Phase 3 (Verstetigung, 61–90 Tage)** in the rendered PDF. The section intro promises three phases ("Von der Vorbereitung (Tag 30) über Pilotierung (Tag 60) zur Verstetigung (Tag 90)"), but only Phase 1 and Phase 2 appeared in the body.

## Root cause (DB-verified + code-diagnosed)

`ROADMAP_90D_DECISION_HTML` / `roadmap_90d_decision` was **missing from `SEGMENT_BUDGETS`** in `services/report_healer.py`, so it fell through to `_default` (solo 1500 / team 2000 / kmu 3000). Fix G `apply_segment_budget` then found the ~2617-char block over budget and trimmed it from the tail — and Phase 3, being the **last** block, was dropped (purely positional, not a dedup/redundancy rule).

**DB evidence — `analysis.id 1066`, `raw_sections`:**
| snapshot | Phase 3 present | length |
|---|---|---|
| `pre_healer.ROADMAP_90D_DECISION_HTML` | ✅ yes | 2617 |
| `post_healer.ROADMAP_90D_DECISION_HTML` | ❌ no | 1185 |

The LLM emits 3 phases correctly — the loss happens entirely in the healer's budget trim.

This is the **same bug class as FIX-B43**, which already fixed it for the sister section `ROADMAP_90D_HTML` (7500) and `roadmap_90d` (5000). The decision variant was simply forgotten.

## Fix

Add explicit budgets for the decision roadmap in **all three** segment tables, generous and analogous to the sister section:

| segment | budget |
|---|---|
| solo | 4000 |
| team | 4500 |
| kmu | 5000 |

Both key variants are added per table (`roadmap_90d_decision` **and** `ROADMAP_90D_DECISION_HTML`). The DB-flowing key is the **uppercase** `ROADMAP_90D_DECISION_HTML`, which the lookup fallback in `apply_segment_budget` cannot resolve (it already ends with `_HTML`), so the explicit uppercase entry is required; the lowercase variant is added too, mirroring how the sister section registers both.

## Deliberately untouched

- `_SECTION_MAX_TOKENS["roadmap_90d_decision"] = 4000` (`gpt_analyze.py`) — the token budget was never the cause; the LLM produces 3 phases correctly.
- `ROADMAP_90D_HTML` / `roadmap_90d` budgets — unchanged.
- Fix G trim logic itself — unchanged.

## Validation

- ✅ `grep` confirms both decision keys are now present in all 3 segment tables (solo/team/kmu).
- ✅ Runtime lookup check: `apply_segment_budget` resolution for the uppercase DB key returns 4000/4500/5000 per segment; the 2617-char block from 1066 is now under budget in every segment (no trim).
- ✅ `services/report_healer.py` parses (AST OK); 339 healer/budget-direct tests pass locally (the only local failures are unrelated `gpt_analyze` imports blocked by missing sandbox deps — `sqlalchemy`/`fastapi`/`pydantic_settings` — resolved in CI).

### Functional verification (pending, separate)

Render a solo run with a long roadmap and check the new `analysis.id`'s `raw_sections`: `post_healer.ROADMAP_90D_DECISION_HTML` should now contain Phase 3 (`ilike '%Phase 3%'` = true) with `post_len ≈ pre_len` (no trim). Wolf to verify via funnel run.

🚫 Draft — do not merge. Awaiting Wolf's review.

https://claude.ai/code/session_01PU2qYDiQwEHVstL8WdtWMp

---
_Generated by [Claude Code](https://claude.ai/code/session_01PU2qYDiQwEHVstL8WdtWMp)_