### PR TITLE
fix(pdf): KIS-1027.5.4 score-ring "58" oben-Clip + stale decision-atomicity Kommentar

### DIFF
--- a/templates/pdf_template_v7.html
+++ b/templates/pdf_template_v7.html
@@ -416,6 +416,7 @@ tr:last-child td { border-bottom: none; }
     overflow: hidden;
     max-width: 200px;
     max-height: 200px;
+    line-height: 0;
 }
 .score-ring-wrap svg {
     max-width: 100%;
@@ -427,6 +428,8 @@ tr:last-child td { border-bottom: none; }
     left: 50%;
     transform: translate(-50%, -50%);
     text-align: center;
+    line-height: 1.1;
+    width: 100%;
 }
 .score-number {
     font-size: 36pt;
@@ -684,10 +687,14 @@ tr:last-child td { border-bottom: none; }
    hier ergänzen wir die LLM-Direkt-HTML-Pfade. */
 /* FIX-1027.5.3: #decision ul/ol RAUS — atomare Liste > Seitenhoehe clippt in
    Chromium (R1 S.4, analysis.id=1064 und 1065: Tun-Bullet mid-sentence
-   abgeschnitten, Lassen + 3. Leitplanke verloren). Atomaritaet bleibt auf
-   <li>-Ebene (.exec-decision-box li, weiter unten unveraendert). Belegt via
-   DB: decision-span vollstaendig (1065: 21.737 Zeichen), Cutoff erst beim
-   PDF-Render. */
+   abgeschnitten, Lassen + 3. Leitplanke verloren).
+   KIS-1027.5.3-B (aecc08a): Atomaritaet auch auf <li>-Ebene ENTFERNT —
+   break-inside:avoid auf '#decision li' UND '.exec-decision-box li' war die
+   letzte Clipping-Quelle (Kette figure->container->li) und clippte S.4 trotz
+   #decision { break-before: page } (KIS-1210/1211). Beide li-Pfade jetzt auf
+   auto; keine atomare Ebene mehr in der Decision-Kette. Belegt via DB:
+   decision-span vollstaendig (1065: 21.737 Zeichen), Cutoff war reiner
+   PDF-Render-Effekt. */
 #decision li,
 #decision p,
 #decision .executive-decision-fallback,


### PR DESCRIPTION
## Problem

**(A) Score-Ring „58"-Clip:** Auf der Score-Ring-Kachel wurde die zentrierte Zahl (`{{ score_int }}`, z. B. „58") **oben angeschnitten**. Ursache: `.score-ring-wrap` hat `overflow:hidden` + `max-width/height:200px` (VU1-PDF-Schutz). Die absolut positionierte `.score-content` (`top:50% / translate(-50%,-50%)`) wurde durch den Baseline-/Inline-Gap der `inline-block`-Box leicht nach oben verschoben und am `overflow:hidden`-Rand geklippt.

**(B) Stale-Kommentar:** Der Block über `#decision li` (vormals Z.685–690) behauptete noch *„Atomaritaet bleibt auf <li>-Ebene"* — nach `aecc08a` (KIS-1027.5.3-B, PR #1050, inzwischen in `main`) sind aber **beide** li-Pfade auf `auto`. Kommentar nachgezogen.

## Fix (`KIS-1027.5.4`)

`templates/pdf_template_v7.html`:

**(A) Zentrierung stabilisiert — VU1-Schutz unverändert:**
```css
.score-ring-wrap {
    overflow: hidden; max-width: 200px; max-height: 200px;  /* VU1 — UNVERÄNDERT */
+   line-height: 0;        /* killt Baseline-Gap der inline-block-Box */
}
.score-content {
    position: absolute; top: 50%; left: 50%;
    transform: translate(-50%, -50%); text-align: center;
+   line-height: 1.1;      /* definierte Zeilenhöhe → stabile vertikale Zentrierung */
+   width: 100%;           /* zentriert über volle Ringbreite statt Content-Breite */
}
```

**(B)** Kommentarblock ersetzt: dokumentiert jetzt korrekt, dass `#decision li` UND `.exec-decision-box li` auf `auto` stehen (Kette figure→container→li, KIS-1210/1211), keine atomare Ebene mehr.

## Scope

Strikt **eine** Datei, **eine** Logikänderung (Score-Ring-Zentrierung) + Kommentar-Korrektur. `overflow:hidden` + `max-width/height:200px` (VU1) **nicht** angetastet.

## Validierung

- ✅ `tests/test_kis_1027_5_h1_render_cutoff.py` + `tests/test_decision_section_figure_wrapper.py` — 11 passed (Decision-Regressionen unberührt)
- ℹ️ Keine Score-Ring-CSS-Tests vorhanden (`test_security_score.py` = Scoring-Logik, nicht Ring-Markup)

### Verifikation (separat, durch Wolf)

Funnel-Run nach Deploy: Score-Ring-Kachel prüfen — „58" vollständig vertikal zentriert, kein Top-Clip.

🚫 Draft — nicht mergen. Wolf reviewt; Funnel-Verify nach Deploy.

_Nicht enthalten:_ (C) Klammer-/`))`-Artefakt — Ursache unlokalisiert (Quelle balanciert, kein Sanitizer-Paren-Eater gefunden), eigener Strang später.

https://claude.ai/code/session_01KofwMUQrm6TP3N6J3mXHTe

---
_Generated by [Claude Code](https://claude.ai/code/session_01KofwMUQrm6TP3N6J3mXHTe)_