### PR TITLE
[1027.5.4] migration comment: neutralize :analysis_id param token

### DIFF
--- a/migrations/2026-05-22_add_analyses_raw_sections_postgres.sql
+++ b/migrations/2026-05-22_add_analyses_raw_sections_postgres.sql
@@ -8,7 +8,7 @@
 --   SELECT raw_sections->'pre_healer'->>'EXECUTIVE_DECISION_HTML'
 --        = raw_sections->'post_healer'->>'EXECUTIVE_DECISION_HTML'
 --          AS healer_unchanged
---   FROM analyses WHERE id = :analysis_id;
+--   FROM analyses WHERE id = <analysis_id>;
 --
 -- GIN-Index begründet: Diagnose-Queries der Form
 --   WHERE raw_sections @> '{...}' / raw_sections ? 'key' / @?


### PR DESCRIPTION
## HOTFIX 1027.5.4 — Migration-Kommentar-Crash

### Problem (Railway-Boot-Log 03.06. 12:49:43)
Jeder Boot brach die Migration ab:
```
sqlalchemy.exc.InvalidRequestError: A value is required for bind parameter 'analysis_id'
```

### Root Cause (mechanisch präzisiert)
Der Runner führt Postgres-SQL-Files als **ein** `text(sql)`-Block aus (`core/migrate.py:234`, `conn.execute(text(sql))`). SQLAlchemy `text()` erkennt **`:name`** lexikalisch als Pflicht-Bind — auch innerhalb eines SQL-Kommentars. Der Diagnose-Query-Kommentar in der Datei enthielt auf Zeile 11 `:analysis_id`.

> Abweichung vom Handover: Der crashende Token ist **`:analysis_id` (colon-style)**, nicht `%(analysis_id)s` (pyformat). pyformat würde `text()` gar nicht als Bind interpretieren — nur der colon-style löst den Fehler aus. Die im Handover alternativ angebotene Fix-Option `:analysis_id` wäre folglich ein No-Op und schied aus.

### Fix
Eine Zeile (Z.11): `:analysis_id` → `<analysis_id>`. `<analysis_id>` matcht keinen Paramstyle (weder colon noch pyformat/qmark) → garantiert kein Bind. Keine DDL-Änderung, kein Statement-Splitting, kein Runner-Eingriff (Runner-Härtung bleibt 1027.6).

### Beleg (Dry-Run gegen `text(sql)`)
| Zustand | `text()._bindparams` | `construct_params()` ohne Wert |
|---|---|---|
| **Bug** (`:analysis_id`) | `['analysis_id']` | `InvalidRequestError: A value is required for bind parameter 'analysis_id'` ← identisch zum Boot-Log |
| **Fix** (`<analysis_id>`) | `[]` | OK — kein Pflicht-Bind |

Crash-Ursache ist damit nachweislich entfernt, nicht nur das Symptom.

### Phase-0-Kontext
- DDL re-run-safe (`ADD COLUMN IF NOT EXISTS` / `CREATE INDEX IF NOT EXISTS`), Spalte+Index in Prod bereits vorhanden — kein Nacherzwingen.
- Repo-weiter Scan `migrations/`: **kein** `%(...)s`, einziger `:name`-Bind war diese Zeile. Übrige Colon-Treffer sind `::jsonb`-Casts (von `text()` nicht als Bind behandelt). Kein weiterer latenter Crash-Kandidat.

### Validierung
- Volle Test-Suite: **6572 passed, 5 skipped** (= Baseline).
- `tests/test_core_migrate.py`: 4 passed.
- Prod-Boot verifiziert die Migration final beim nächsten Deploy.

---
_Generated by [Claude Code](https://claude.ai/code/session_014euTjYXg7D6PcW3Wiavf3x)_