### PR TITLE
FIX-1027.5.5: break-inside auto auf .exec-decision-box und ul

### DIFF
--- a/templates/pdf_template_v7.html
+++ b/templates/pdf_template_v7.html
@@ -726,6 +726,12 @@ tr:last-child td { border-bottom: none; }
     page-break-before: auto;
     break-after: auto;
     page-break-after: auto;
+    break-inside: auto;
+    page-break-inside: auto;   /* FIX-1027.5.5 */
+}
+.exec-decision-box ul {
+    break-inside: auto;
+    page-break-inside: auto;    /* FIX-1027.5.5 */
 }
 .exec-decision-box li {
     break-inside: auto;


### PR DESCRIPTION
## 1027.5.5 — Decision-Cutoff: ul/Container break-inside

### Ursache (belegt via 4-rendered-Dump, post-Chromium-DOM)
Inhalt vollständig im gerenderten DOM (alle 3 `<li>`), reines Paginierungs-Clipping. Im gerenderten CSS hatte `.exec-decision-box` nur `break-before/after: auto`, **kein** `break-inside`. Das `<ul>` innerhalb der Box war von keiner Regel adressiert → blieb atomar → höher als die Restseite → Chromium clippte. Die `li` hatten `break-inside: auto`, aber der `<ul>`-Vorfahr hebelte das aus.

### Phase 1 — Fix (dieser Commit)
In `templates/pdf_template_v7.html`:
- `.exec-decision-box` um `break-inside: auto; page-break-inside: auto;` ergänzt
- neue Regel `.exec-decision-box ul { break-inside: auto; page-break-inside: auto; }`

Marker `FIX-1027.5.5`. Nur diese beiden Regeln — keine anderen Sections, kein `.glance-box`/`.decision-card`.

### Phase 2 — Verifikation (offen)
- [ ] CI grün gegen Baseline 6572
- [ ] Render-Beweis: Funnel-Run, im neuen `4-rendered` prüfen, dass `.exec-decision-box` jetzt `break-inside: auto` trägt UND eine `.exec-decision-box ul`-Regel mit `auto` existiert
- [ ] PDF: Seite 4 zeigt alle 3 Leitplanken (ggf. mit Umbruch auf zweite Decision-Seite), kein Clip

https://claude.ai/code/session_011nPDXj67HrEpUYeSyEiipq

---
_Generated by [Claude Code](https://claude.ai/code/session_011nPDXj67HrEpUYeSyEiipq)_