### PR TITLE
FIX-1027.5.6: Decision-Box auf eigene Seite (break-before:page)

### DIFF
--- a/templates/pdf_template_v7.html
+++ b/templates/pdf_template_v7.html
@@ -722,8 +722,8 @@ tr:last-child td { border-bottom: none; }
 .exec-decision-box {
     /* break-inside: avoid !important; -- FIX-KIS-1027.5-H1: entfernt */
     /* page-break-inside: avoid !important; -- FIX-KIS-1027.5-H1: entfernt */
-    break-before: auto;
-    page-break-before: auto;
+    break-before: page;
+    page-break-before: always;   /* FIX-1027.5.6 — volle Seitenhöhe für 3 Leitplanken */
     break-after: auto;
     page-break-after: auto;
     break-inside: auto;


### PR DESCRIPTION
## 1027.5.6 — Decision-Box auf eigene Seite (break-before:page)

### Vorgeschichte (kein erneuter break-inside-Versuch)
- Inhalt vollständig im gerenderten DOM (4-rendered KIS-1213: alle 3 `<li>`).
- `break-inside`-Kette bereits komplett `auto` und im Render bestätigt (KIS-1214, analysis_id 1072): `.exec-decision-box`, `.exec-decision-box ul`, `.exec-decision-box li` — FIX-1027.5.5 ist live.
- Vorfahren sauber: `.section` nur padding + `break-inside:auto`; `#decision` nur `break-before:page`.
- **Trotzdem** clippt S.4 — mitten in der ERSTEN Leitplanke. Kein break-inside-Problem mehr, sondern Geometrie: nach Banner/level-indicator/h2/glance-box bleibt auf der angefangenen Decision-Seite zu wenig vertikaler Platz; die Box startet weit unten und wird am Seitenende abgeschnitten.

### Phase 0 — verifiziert
- DOM-Reihenfolge in `#decision`: level-indicator → badge → h2 → `.glance-box` → `.exec-decision-box` → abschließender `<p class="small muted">`. Bestätigt.
- `.exec-decision-box` trug nur `break-before: auto` (kein anderes `break-before` irgendwo). Bestätigt.

### Phase 1 — Fix (dieser Commit, Variante A)
`.exec-decision-box`: `break-before: auto` → `page`, `page-break-before: auto` → `always`. Marker `FIX-1027.5.6`. **Nur dieses eine Property.** Die `break-inside:auto`-Regeln auf box/ul/li aus FIX-1027.5.5 bleiben unverändert (Voraussetzung für Fluss über zwei Seiten bei Bedarf).

Erwartetes Nebenresultat (akzeptiert): glance-box + Header bleiben auf der vorigen Seite, die Box rückt auf eine eigene Seite mit voller Höhe. Der abschließende `<p>` ("eigenständige Entscheidungsvorlage für die Geschäftsführung") legitimiert das.

### Phase 2 — Verifikation (offen)
- [ ] CI grün gegen Baseline 6572
- [ ] Funnel-Run, neues R1-PDF: Decision-Seite zeigt alle 3 Leitplanken vollständig (Tun / Lassen / Risiko & Stop-Signal), kein mid-sentence-Cut
- [ ] Falls es DANN noch clippt → einzelnes `<li>` höher als volle Seite → Inhaltslänge, nicht Geometrie → STOPP, li-Kürzung im Prompt (kein CSS)

https://claude.ai/code/session_011nPDXj67HrEpUYeSyEiipq

---
_Generated by [Claude Code](https://claude.ai/code/session_011nPDXj67HrEpUYeSyEiipq)_