### PR TITLE
FIX-1027.6: BAFA-Berlin, AI-Act-Risikoklasse-Konsistenz, Business-Case-Orphan

### DIFF
--- a/config/bafa.py
+++ b/config/bafa.py
@@ -34,18 +34,17 @@ _CODE_TO_NAME = {
     "th": "Thüringen",
 }
 
-# Berlin Sonderstatus: 60% (übliche Praxis)
-BERLIN_NAMES = frozenset({"Berlin", "be"})
+# Berlin hat KEINEN BAFA-Sonderstatus: Es fällt unter die Standard-Regel der
+# alten Bundesländer (50% / max 1.750 €). Der frühere 60%-Sonderzweig war
+# sachlich falsch und wurde entfernt (FIX-1027.6.1).
 
 # Förderquoten
 FOERDERQUOTE_NEUE_BL = 80   # %
 FOERDERQUOTE_ALTE_BL = 50   # %
-FOERDERQUOTE_BERLIN = 60    # % (Sonderstatus)
 
 # Abgeleitete Maximalbeträge
 BAFA_MAX_NEUE_BL = int(BAFA_MAX_BERATUNGSKOSTEN * FOERDERQUOTE_NEUE_BL / 100)   # 2.800 €
 BAFA_MAX_ALTE_BL = int(BAFA_MAX_BERATUNGSKOSTEN * FOERDERQUOTE_ALTE_BL / 100)    # 1.750 €
-BAFA_MAX_BERLIN = int(BAFA_MAX_BERATUNGSKOSTEN * FOERDERQUOTE_BERLIN / 100)      # 2.100 €
 
 
 def _normalize_bundesland(bundesland: str) -> str:
@@ -69,20 +68,10 @@ def is_neue_bundeslaender(bundesland: str) -> bool:
     return _normalize_bundesland(bundesland) in NEUE_BUNDESLAENDER
 
 
-def is_berlin(bundesland: str) -> bool:
-    """Check if Bundesland is Berlin (Sonderstatus 60%)."""
-    if not bundesland:
-        return False
-    bl = bundesland.strip().lower()
-    return bl in ("berlin", "be")
-
-
 def get_bafa_foerderquote(bundesland: str) -> int:
     """Return the BAFA Förderquote (%) for a given Bundesland."""
     if is_neue_bundeslaender(bundesland):
         return FOERDERQUOTE_NEUE_BL
-    if is_berlin(bundesland):
-        return FOERDERQUOTE_BERLIN
     return FOERDERQUOTE_ALTE_BL
 
 
@@ -90,8 +79,6 @@ def get_bafa_max_foerderung(bundesland: str) -> int:
     """Return the max BAFA funding amount (€) for a given Bundesland."""
     if is_neue_bundeslaender(bundesland):
         return BAFA_MAX_NEUE_BL
-    if is_berlin(bundesland):
-        return BAFA_MAX_BERLIN
     return BAFA_MAX_ALTE_BL
 
 

--- a/prompts/de/ki_stack_summary.md
+++ b/prompts/de/ki_stack_summary.md
@@ -87,8 +87,13 @@ INHALTLICHE STRUKTUR (5 feste Bausteine)
 
 5) Branch Badge + Risikoindikator
    - Branch-Label: {{BRANCH_SHORT_LABEL}}.
-   - AI-Act Risk Level (niedrig / mittel / erhöht) basierend auf Branche, Use Cases und Datenlage.
-   - 1–2 Sätze, was dieses Risikoniveau konkret bedeutet.
+   - AI-Act Risikoklasse: übernimm EXAKT den kanonischen Wert {{AI_ACT_RISK_LEVEL}}
+     (genau einer von: minimal / limited / high-risk). NICHT frei schätzen und NICHT
+     auf eine eigene niedrig/mittel/hoch-Skala übersetzen — der Wert MUSS mit Cover
+     und AI-Act-Kompakt übereinstimmen.
+   - Badge-Klasse passend zum Wert: minimal → risk-low, limited → risk-medium,
+     high-risk → risk-high.
+   - 1–2 Sätze, was diese Risikoklasse konkret bedeutet.
 
 SIZE-AWARE LOGIK
 
@@ -200,7 +205,7 @@ HTML-ANFORDERUNGEN & DESIGN (G21 PLATIN++)
       </div>
       <div class="badge-block-item risk-low">
         <span class="badge-block-label">AI Act Risiko</span>
-        <span class="badge-block-value">Niedrig</span>
+        <span class="badge-block-value">minimal</span>
       </div>
     </div>
     <p>Erklärung zum Risikoniveau...</p>

--- a/prompts/en/ki_stack_summary.md
+++ b/prompts/en/ki_stack_summary.md
@@ -57,8 +57,13 @@ Create a compact, C‑level‑appropriate **AI‑Stack Summary Card** as an HTML
 
 5. **Branch badge + risk indicator**
    - **Branch label**: {{BRANCH_SHORT_LABEL}}.
-   - **AI‑Act risk level** (low / medium / elevated) based on industry, use cases and data situation.
-   - 1–2 sentences explaining what this risk level means in concrete terms.
+   - **AI‑Act risk class**: use the canonical value {{AI_ACT_RISK_LEVEL}} EXACTLY
+     (exactly one of: minimal / limited / high-risk). Do NOT guess and do NOT
+     translate it into a custom low/medium/high scale — the value MUST match the
+     cover and the AI‑Act compact section.
+   - Badge class matching the value: minimal → risk-low, limited → risk-medium,
+     high-risk → risk-high.
+   - 1–2 sentences explaining what this risk class means in concrete terms.
 
 ### Size‑aware logic
 
@@ -163,7 +168,7 @@ Create a compact, C‑level‑appropriate **AI‑Stack Summary Card** as an HTML
       </div>
       <div class="badge-block-item risk-low">
         <span class="badge-block-label">AI Act risk</span>
-        <span class="badge-block-value">Low</span>
+        <span class="badge-block-value">minimal</span>
       </div>
     </div>
     <p>Explanation of the risk level …</p>

--- a/services/business_case_engine_v2.py
+++ b/services/business_case_engine_v2.py
@@ -2322,15 +2322,15 @@ def business_case_report_to_html(
     # KPI Targets Section
     if report.kpi_targets_6m or report.kpi_targets_12m:
         html_parts.append(f'''
-        <div class="kpi-targets-section" style="margin-bottom:24px;">
+        <div class="kpi-targets-section" style="margin-bottom:24px;page-break-inside:avoid;break-inside:avoid;">
             <p style="margin:0 0 12px 0;font-weight:600;color:#1e293b;">{labels["kpi_title"]}</p>
-            <div style="display:flex;gap:16px;">
+            <div style="display:flex;gap:16px;page-break-inside:avoid;break-inside:avoid;">
         ''')
 
         # 6-month targets
         if report.kpi_targets_6m:
             html_parts.append(f'''
-                <div style="flex:1;padding:12px;background:#f0f9ff;border-radius:8px;">
+                <div style="flex:1;padding:12px;background:#f0f9ff;border:1px solid #bae6fd;border-radius:8px;print-color-adjust:exact;-webkit-print-color-adjust:exact;page-break-inside:avoid;break-inside:avoid;">
                     <p style="margin:0 0 8px 0;font-weight:600;color:#0284c7;font-size:10pt;">{labels["kpi_6m"]}</p>
             ''')
             for key, value in list(report.kpi_targets_6m.items())[:4]:
@@ -2349,7 +2349,7 @@ def business_case_report_to_html(
         # 12-month targets
         if report.kpi_targets_12m:
             html_parts.append(f'''
-                <div style="flex:1;padding:12px;background:#f0fdf4;border-radius:8px;">
+                <div style="flex:1;padding:12px;background:#f0fdf4;border:1px solid #bbf7d0;border-radius:8px;print-color-adjust:exact;-webkit-print-color-adjust:exact;page-break-inside:avoid;break-inside:avoid;">
                     <p style="margin:0 0 8px 0;font-weight:600;color:#16a34a;font-size:10pt;">{labels["kpi_12m"]}</p>
             ''')
             for key, value in list(report.kpi_targets_12m.items())[:4]:


### PR DESCRIPTION
Sprint-Serie **1027.6** — drei separate Fixes, ein Commit pro Fix, in dieser Reihenfolge.

## FIX-1027.6.1 (BAFA) — `8c1b4d3`
`config/bafa.py`: Berlin hatte eine sachlich falsche BAFA-Sonderregel (60 % / max 2.100 €). Berlin hat keinen Sonderstatus und fällt unter die Standard-Regel der alten Bundesländer (**50 % / max 1.750 €**, Bemessungsgrundlage 3.500 € unverändert).

**Varianten-Entscheidung: Variante A (vollständige Entfernung).** `is_berlin()` wurde ausschließlich in den beiden BAFA-Berechnungsfunktionen (`get_bafa_foerderquote`, `get_bafa_max_foerderung`) genutzt — keine externen Konsumenten, `BERLIN_NAMES` war ungenutzt. Daher `is_berlin()`, `FOERDERQUOTE_BERLIN`, `BAFA_MAX_BERLIN` und `BERLIN_NAMES` entfernt statt einen toten `=50`-Sonderzweig zu hinterlassen.

Verifiziert: Berlin/`be` → 50 % / 1.750 €; neue Bundesländer weiter 80 % / 2.800 €.

## FIX-1027.6.2 (AI-Act-Skala) — `b075f0c`
`prompts/de/ki_stack_summary.md` + EN-Pendant: Der KI-Stack-Summary-Block (Business-Case-KPIs) gab das AI-Act-Risiko auf einer eigenen `niedrig/mittel/erhöht`-Skala aus, entkoppelt vom kanonischen `AI_ACT_RISK_LEVEL`. Dadurch widersprach die Kennzahl-Zeile „AI Act Risiko: Niedrig" dem Cover/AI-Act-Kompakt („minimal").

- Anweisung: Wert EXAKT aus `{{AI_ACT_RISK_LEVEL}}` übernehmen (`minimal` / `limited` / `high-risk`), nicht frei schätzen.
- Explizites Badge-Klassen-Mapping: `minimal → risk-low`, `limited → risk-medium`, `high-risk → risk-high`.
- Few-Shot-Beispielwert `Niedrig`/`Low` → `minimal`. DE + EN synchron.
- `content_quality_enforcer.py` bewusst **unverändert** — der Prompt ist der Hebel; deterministische Absicherung erst, falls ein Funnel-Test zeigt, dass das LLM die Anweisung ignoriert.

## FIX-1027.6.3 (Orphan) — `765606a`
`services/business_case_engine_v2.py`: Die 6-/12-Monats-Zielboxen hatten nur eine Hintergrundfarbe — ohne Rahmen, ohne `print-color-adjust`, ohne `break-inside:avoid`. Im PDF wurde der Hintergrund verworfen und der Container konnte über die Seitengrenze brechen, sodass die vier Datenpunkte (Zeitersparnis / Monatl. Ersparnis, 6 + 12 Monate) als lose Zeilen ohne Box über dem Business-Case-Header erschienen.

- Sichtbarer Rahmen (analog zu den Szenario-Karten), `print-color-adjust:exact`, `page-break-inside/break-inside:avoid` auf Section, Flex-Container und beiden Boxen.

## Tests
Lokal grün (pytest): `test_strategy_foerder_cap_explanation`, `test_b1_funding_stress`, `test_r1_compact_snippet_context`, `test_g20_ki_stack_summary`, `test_fix512_ki_stack_sanitize`, `test_business_case_consistency`, `test_g30_business_case_engine_v2`, `test_g8_business_case`, `test_g9_e2e_business_case_modifiers` — **201 passed**.

https://claude.ai/code/session_01XGTaeK1eVynoJzkQSsWxDz

---
_Generated by [Claude Code](https://claude.ai/code/session_01XGTaeK1eVynoJzkQSsWxDz)_